### PR TITLE
Compilation problem under CentOS 6

### DIFF
--- a/modules/db_oracle/Makefile
+++ b/modules/db_oracle/Makefile
@@ -38,12 +38,28 @@ ifeq ($(ORAPATH),)
 	    echo $(SYSBASE)/lib64/oracle$(ORAVERDIR) )
 endif
 ifeq ($(ORAPATH),)
-    ORAPATH=$(shell [ -f $(SYSBASE)/lib/oracle$(ORAVERDIR)/libocci.so ] && \
-	    echo $(SYSBASE)/lib/oracle$(ORAVERDIR) )
+    ORAPATH=$(shell [ -f $(LOCALBASE)/lib64/oracle$(ORAVERDIR)/lib/libocci.so ] && \
+	    echo $(LOCALBASE)/lib64/oracle$(ORAVERDIR)/lib )
+endif
+ifeq ($(ORAPATH),)
+    ORAPATH=$(shell [ -f $(SYSBASE)/lib64/oracle$(ORAVERDIR)/lib/libocci.so ] && \
+	    echo $(SYSBASE)/lib64/oracle$(ORAVERDIR)/lib )
+endif
+ifeq ($(ORAPATH),)
+    ORAPATH=$(shell [ -f $(LOCALBASE)/lib/oracle$(ORAVERDIR)/libocci.so ] && \
+	    echo $(LOCALBASE)/lib/oracle$(ORAVERDIR) )
 endif
 ifeq ($(ORAPATH),)
     ORAPATH=$(shell [ -f $(SYSBASE)/lib/oracle$(ORAVERDIR)/libocci.so ] && \
 	    echo $(SYSBASE)/lib/oracle$(ORAVERDIR) )
+endif
+ifeq ($(ORAPATH),)
+    ORAPATH=$(shell [ -f $(LOCALBASE)/lib/oracle$(ORAVERDIR)/lib/libocci.so ] && \
+	    echo $(LOCALBASE)/lib/oracle$(ORAVERDIR)/lib )
+endif
+ifeq ($(ORAPATH),)
+    ORAPATH=$(shell [ -f $(SYSBASE)/lib/oracle$(ORAVERDIR)/lib/libocci.so ] && \
+	    echo $(SYSBASE)/lib/oracle$(ORAVERDIR)/lib )
 endif
 
 ifneq ($(ORAPATH),)


### PR DESCRIPTION
The installation of oracle-instantclient11.2-11.2.0.3.0-1.i386.rpm put the libocci into /usr/lib/oracle/11.2/client/lib folder.
This path add this folder in the search list.
