### PR TITLE
Compilation problem under CentOS 6

### DIFF
--- a/utils/db_oracle/Makefile
+++ b/utils/db_oracle/Makefile
@@ -40,12 +40,28 @@ ifeq ($(ORAPATH),)
 	    echo $(SYSBASE)/lib64/oracle$(ORAVERDIR) )
 endif
 ifeq ($(ORAPATH),)
-    ORAPATH=$(shell [ -f $(SYSBASE)/lib/oracle$(ORAVERDIR)/libocci.so ] && \
-	    echo $(SYSBASE)/lib/oracle$(ORAVERDIR) )
+    ORAPATH=$(shell [ -f $(LOCALBASE)/lib64/oracle$(ORAVERDIR)/lib/libocci.so ] && \
+	    echo $(LOCALBASE)/lib64/oracle$(ORAVERDIR)/lib )
+endif
+ifeq ($(ORAPATH),)
+    ORAPATH=$(shell [ -f $(SYSBASE)/lib64/oracle$(ORAVERDIR)/lib/libocci.so ] && \
+	    echo $(SYSBASE)/lib64/oracle$(ORAVERDIR)/lib )
+endif
+ifeq ($(ORAPATH),)
+    ORAPATH=$(shell [ -f $(LOCALBASE)/lib/oracle$(ORAVERDIR)/libocci.so ] && \
+	    echo $(LOCALBASE)/lib/oracle$(ORAVERDIR) )
 endif
 ifeq ($(ORAPATH),)
     ORAPATH=$(shell [ -f $(SYSBASE)/lib/oracle$(ORAVERDIR)/libocci.so ] && \
 	    echo $(SYSBASE)/lib/oracle$(ORAVERDIR) )
+endif
+ifeq ($(ORAPATH),)
+    ORAPATH=$(shell [ -f $(LOCALBASE)/lib/oracle$(ORAVERDIR)/lib/libocci.so ] && \
+	    echo $(LOCALBASE)/lib/oracle$(ORAVERDIR)/lib )
+endif
+ifeq ($(ORAPATH),)
+    ORAPATH=$(shell [ -f $(SYSBASE)/lib/oracle$(ORAVERDIR)/lib/libocci.so ] && \
+	    echo $(SYSBASE)/lib/oracle$(ORAVERDIR)/lib )
 endif
 
 ifneq ($(ORAPATH),)


### PR DESCRIPTION
The installation of oracle-instantclient11.2-11.2.0.3.0-1.i386.rpm put the libocci into /usr/lib/oracle/11.2/client/lib folder.
 This path add this folder in the search list.
