### PR TITLE
spec file update to CentOS 6

### DIFF
--- a/packaging/rpm/opensips.spec.CentOS
+++ b/packaging/rpm/opensips.spec.CentOS
@@ -3,16 +3,37 @@
 %define rel     0
 %define _sharedir %{_prefix}/share
 
-%define EXCLUDED_MODULES	aaa_radius b2b_entities b2b_logic db_http json memcached jabber cpl-c xmpp rls mi_xmlrpc xcap_client db_mysql db_postgres db_unixodbc db_oracle db_berkeley osp perl snmpstats db_perlvdb peering carrierroute mmgeoip presence presence_xml presence_mwi presence_dialoginfo pua pua_bla pua_mi pua_usrloc pua_xmpp pua_dialoginfo xcap xcap_client ldap h350 identity regex
+%define EXCLUDED_MODULES	aaa_radius b2b_logic cachedb_cassandra cachedb_couchbase cachedb_memcached cachedb_mongodb cachedb_redis carrierroute cpl-c db_berkeley db_http db_mysql db_oracle db_perlvdb db_postgres db_unixodbc dialplan event_rabbitmq h350 identity jabber json ldap lua httpd pi_http mi_xmlrpc mmgeoip osp perl presence presence_dialoginfo presence_mwi presence_xml pua pua_bla pua_dialoginfo pua_mi pua_usrloc pua_xmpp regex rls snmpstats xcap xcap_client xmpp
 %define MYSQL_MODULES		modules/db_mysql
 %define UNIXODBC_MODULES	modules/db_unixodbc
 %define POSTGRES_MODULES	modules/db_postgres
 %define XMPP_MODULES		modules/jabber modules/xmpp
-%define CPL_MODULES			modules/cpl-c
+%define CPL_MODULES		modules/cpl-c
 %define SNMPSTATS_MODULES	modules/snmpstats
 %define PRESENCE_MODULES	modules/presence modules/presence_dialoginfo modules/presence_xml modules/presence_mwi modules/presence_xcapdiff modules/pua modules/pua_bla modules/pua_dialoginfo modules/pua_mi modules/pua_usrloc modules/pua_xmpp modules/rls modules/xcap modules/xcap_client
 %define RADIUS_MODULES		modules/aaa_radius modules/peering
 %define B2BUA_MODULES		modules/b2b_entities modules/b2b_logic
+%define HTTP_MODULES		modules/db_http modules/httpd modules/pi_http
+%define JSON_MODULES		modules/json
+%define     CASSANDRA_MODULES	modules/cachedb_cassandra
+%define COUCHBASE_MODULES	modules/cachedb_couchbase
+%define MEMCACHED_MODULES	modules/cachedb_memcached
+%define     MONGODB_MODULES	modules/cachedb_mongodb
+%define REDIS_MODULES		modules/cachedb_redis
+%define RABBITMQ_MODULES	modules/event_rabbitmq
+%define XMLRPC_MODULES		modules/mi_xmlrpc
+%define ORACLE_MODULES		modules/db_oracle
+%define BERKELEY_MODULES	modules/db_berkeley
+%define     OSP_MODULES		modules/osp
+%define PERL_MODULES		modules/perl modules/db_perlvdb
+%define CARRIERROUTE_MODULES	modules/carrierroute
+%define MMGEOIP_MODULES		modules/mmgeoip
+%define LDAP_MODULES		modules/ldap modules/h350
+%define IDENTITY_MODULES	modules/identity
+%define REGEX_MODULES		modules/regex modules/dialplan
+
+
+
 
 Summary:      OpenSIPS, very fast and flexible SIP Server
 Name:         %name
@@ -21,14 +42,14 @@ Release:      %rel
 Packager:     Bogdan-Andrei Iancu <bogdan@opensips.org>
 License:      GPL
 Group:        System Environment/Daemons
-Source0:      http://opensips.org/pub/opensips/%{ver}/src/%{name}-%{ver}-tls_src.tar.gz
+Source0:      http://opensips.org/pub/opensips/%{ver}/src/%{name}-%{ver}_src.tar.gz
 Source1:      opensips.init
 Source2:      opensips.default
 URL:          http://opensips.org/
 Vendor:       opensips.org
 BuildRoot:    %{_tmppath}/%{name}-%{ver}-buildroot
 Conflicts:    opensips-mysql < %ver, opensips-xmpp < %ver, opensips-radius < %ver, opensips-cpl < %ver, opensips-unixodbc < %ver, opensips-presence < %ver, opensips-postgres < %ver, opensips-snmpstats < %ver
-BuildPrereq:  make flex bison pcre-devel
+BuildRequires:  make flex bison pcre-devel
 
 
 %description
@@ -48,7 +69,7 @@ interface.
 Summary:  MySQL connectivity for the OpenSIPS.
 Group:    System Environment/Daemons
 Requires: opensips = %ver
-BuildPrereq:  mysql-devel, zlib-devel
+BuildRequires:  mysql-devel, zlib-devel
 
 %description mysql
 The opensips-mysql package contains MySQL database connectivity that you
@@ -59,7 +80,7 @@ entries.
 Summary:  MPOSTGRES connectivity for the OpenSIPS.
 Group:    System Environment/Daemons
 Requires: opensips = %ver
-BuildPrereq:  postgresql-devel
+BuildRequires:  postgresql-devel
 
 %description postgres
 The opensips-postgres package contains Postgres database connectivity that you
@@ -70,7 +91,7 @@ entries.
 Summary:  UNIXODBC connectivity for OpenSIPS.
 Group:    System Environment/Daemons
 Requires: opensips = %ver
-BuildPrereq:  unixODBC-devel
+BuildRequires:  unixODBC-devel
 
 %description unixodbc
 The opensips-unixodbc package contains UNIXODBC database connectivity support
@@ -80,7 +101,7 @@ that is required by other modules with database dependencies.
 Summary:  sip 2 xmpp/jabber message translation support for the OpenSIPS.
 Group:    System Environment/Daemons
 Requires: opensips = %ver
-BuildPrereq:  expat-devel
+BuildRequires:  expat-devel
 
 %description xmpp
 The opensips-xmpp package contains a sip to xmpp/jabber message translator.
@@ -89,7 +110,7 @@ The opensips-xmpp package contains a sip to xmpp/jabber message translator.
 Summary:  CPL interpreter engine for the OpenSIPS.
 Group:    System Environment/Daemons
 Requires: opensips = %ver
-BuildPrereq:  libxml2-devel
+BuildRequires:  libxml2-devel
 
 %description cpl
 The opensips-cpl package contains a SIP CPL interpreter engine.
@@ -98,7 +119,7 @@ The opensips-cpl package contains a SIP CPL interpreter engine.
 Summary:  sip presence user agent support for the OpenSIPS.
 Group:    System Environment/Daemons
 Requires: opensips = %ver
-BuildPrereq:  libxml2-devel, curl-devel
+BuildRequires:  libxml2-devel, curl-devel
 
 %description presence
 The opensips-pua package contains a sip Presence Agent.
@@ -107,7 +128,7 @@ The opensips-pua package contains a sip Presence Agent.
 Summary:  opensips radius support for AAA API.
 Group:    System Environment/Daemons
 Requires: opensips = %ver
-BuildPrereq:  radiusclient-ng-devel
+BuildRequires:  radiusclient-ng-devel
 
 %description radius
 The opensips-radius package contains modules for radius authentication, group
@@ -117,7 +138,7 @@ The opensips-radius package contains modules for radius authentication, group
 Summary:  opensips b2bua implementation.
 Group:    System Environment/Daemons
 Requires: opensips = %ver
-BuildPrereq:  libxml2-devel
+BuildRequires:  libxml2-devel
 
 %description b2bua
 The opensips-b2bua package contains modules implement b2bua scenarios.
@@ -126,7 +147,7 @@ The opensips-b2bua package contains modules implement b2bua scenarios.
 Summary:  SNMP AgentX subagent module for OpenSIPS
 Group:    System Environment/Daemons
 Requires: opensips = %ver, net-snmp-utils
-BuildPrereq:  lm_sensors-devel net-snmp-devel
+BuildRequires:  lm_sensors-devel net-snmp-devel
 
 %description snmpstats
 OpenSIPS is a very fast and flexible SIP (RFC3261)
@@ -135,12 +156,170 @@ per second even on low-budget hardware.
 This package provides the snmpstats module for OpenSIPS. This module acts
 as an AgentX subagent which connects to a master agent.
 
+%package  ldap
+Summary:  opensips ldap implementation.
+Group:    System Environment/Daemons
+Requires: opensips = %ver
+BuildRequires:  openldap-devel
+
+%description ldap
+The LDAP module implements an LDAP search interface for OpenSIPS.
+It exports script functions to perform an LDAP search operation and to store the search results as OpenSIPS AVPs.
+This allows for using LDAP directory data in the OpenSIPS SIP message routing script. 
+
+
+%package  identity
+Summary:  opensips identity implementation.
+Group:    System Environment/Daemons
+Requires: opensips = %ver
+BuildRequires:  openssl-devel
+
+%description identity
+This module adds support for SIP Identity (see RFC 4474).
+
+
+%package  regex
+Summary:  opensips identity implementation.
+Group:    System Environment/Daemons
+Requires: opensips = %ver
+BuildRequires:  pcre-devel
+
+%description regex
+This module offers matching operations against regular expressions using the powerful PCRE library. 
+
+
+%package  mmgeoip
+Summary:  opensips mmgeoip implementation.
+Group:    System Environment/Daemons
+Requires: opensips = %ver
+BuildRequires:  GeoIP-devel
+
+%description mmgeoip
+This module is a lightweight wrapper for the MaxMind GeoIP API.
+It adds IP address-to-location lookup capability to OpenSIPS scripts.
+
+
+%package  json
+Summary:  opensips json implementation.
+Group:    System Environment/Daemons
+Requires: opensips = %ver
+BuildRequires:  json-c-devel
+
+%description json
+This module introduces a new type of variable that provides both serialization and de-serialization from JSON format. 
+
+
+%package  carrierroute
+Summary:  opensips carrierroute implementation.
+Group:    System Environment/Daemons
+Requires: opensips = %ver
+BuildRequires:  libconfuse-devel
+
+%description carrierroute
+A module which provides routing, balancing and blacklisting capabilities.
+
+
+%package  cachedb_memcached
+Summary:  opensips cachedb_memcached implementation.
+Group:    System Environment/Daemons
+Requires: opensips = %ver
+BuildRequires:  libconfuse-devel
+
+%description cachedb_memcached
+This module is an implementation of a cache system designed to work with a memcached server.
+It uses libmemcached client library to connect to several memcached servers that store data.
+It registers the three functions for storing, fetching and removing a value to the core memcache management interface. 
+
+
+%package  cachedb_couchbase
+Summary:  opensips cachedb_couchbase implementation.
+Group:    System Environment/Daemons
+Requires: opensips = %ver
+BuildRequires:  libcouchbase-devel
+
+%description cachedb_couchbase
+This module is an implementation of a cache system designed to work with a Couchbase server.
+It uses the libcouchbase client library to connect to the server instance,
+It uses the Key-Value interface exported from the core.  
+
+
+%package  event_rabbitmq
+Summary:  opensips event_rabbitmq implementation.
+Group:    System Environment/Daemons
+Requires: opensips = %ver
+BuildRequires:  librabbitmq-devel
+
+%description event_rabbitmq
+This module provides the implementation of a RabbitMQ client for the Event Interface.
+It is used to send AMQP messages to a RabbitMQ server each time the Event Interface triggers an event subscribed for.  
+
+
+%package  cachedb_redis
+Summary:  opensips cachedb_redis implementation.
+Group:    System Environment/Daemons
+Requires: opensips = %ver
+BuildRequires:  hiredis-devel
+
+%description cachedb_redis
+This module is an implementation of a cache system designed to work with a Redis server.
+It uses hiredis client library to connect to either a single Redis server instance,
+or to a Redis Server inside a Redis Cluster.
+It uses the Key-Value interface exported from the core.  
+
+
+%package  db_berkeley
+Summary:  opensips db_berkeley implementation.
+Group:    System Environment/Daemons
+Requires: opensips = %ver
+BuildRequires:  db4-devel
+
+%description db_berkeley
+This is a module which integrates the Berkeley DB into OpenSIPS. It implements the DB API defined in OpenSIPS.  
+
+
+%package  db_oracle
+Summary:  opensips db_oracle implementation.
+Group:    System Environment/Daemons
+Requires: opensips = %ver
+BuildRequires:  oracle-instantclient11.2-devel
+
+%description db_oracle
+This is a module which provides Oracle connectivity for OpenSIPS.
+It implements the DB API defined in OpenSIPS.
+If you want to use the nathelper module,
+or any other modules that calls the get_all_ucontacts API export from usrloc,
+then you need to set the DORACLE_USRLOC define in the Makefile.defs file before compilation.  
+
+
+%package  mi_xmlrpc
+Summary:  opensips mi_xmlrpc implementation.
+Group:    System Environment/Daemons
+Requires: opensips = %ver
+BuildRequires:  xmlrpc-c-devel
+
+%description mi_xmlrpc
+This module implements a xmlrpc server that handles xmlrpc requests and generates xmlrpc responses.
+When a xmlrpc message is received a default method is executed.  
+
+
+%package  db_http
+Summary:  opensips db_http implementation.
+Group:    System Environment/Daemons
+Requires: opensips = %ver
+BuildRequires:  libcurl-devel libmicrohttpd-devel
+
+%description db_http
+This module provides access to a database that is implemented as a HTTP server.
+It may be used in special cases where traversing firewalls is a problem,
+or where data encryption is required. 
+
+
 
 %prep
 %setup -n %{name}-%{ver}-tls
 
 %build
-make all skip_modules="%EXCLUDED_MODULES"         cfg-target=/%{_sysconfdir}/opensips/
+make all exclude_modules="%EXCLUDED_MODULES" cfg-target=/%{_sysconfdir}/opensips/
 make modules modules="%MYSQL_MODULES"     cfg-target=/%{_sysconfdir}/opensips/
 make modules modules="%POSTGRES_MODULES"  cfg-target=/%{_sysconfdir}/opensips/
 make modules modules="%UNIXODBC_MODULES"  cfg-target=/%{_sysconfdir}/opensips/
@@ -150,6 +329,22 @@ make modules modules="%PRESENCE_MODULES"  cfg-target=/%{_sysconfdir}/opensips/
 make modules modules="%RADIUS_MODULES"    cfg-target=/%{_sysconfdir}/opensips/
 make modules modules="%B2BUA_MODULES"     cfg-target=/%{_sysconfdir}/opensips/
 make modules modules="%SNMPSTATS_MODULES" cfg-target=/%{_sysconfdir}/opensips/
+make modules modules="%LDAP_MODULES"	  cfg-target=/%{_sysconfdir}/opensips/
+make modules modules="%IDENTITY_MODULES"  cfg-target=/%{_sysconfdir}/opensips/
+make modules modules="%REGEX_MODULES"	  cfg-target=/%{_sysconfdir}/opensips/
+make modules modules="%MMGEOIP_MODULES"	  cfg-target=/%{_sysconfdir}/opensips/
+make modules modules="%CARRIERROUTE_MODULES" cfg-target=/%{_sysconfdir}/opensips/
+make modules modules="%MEMCACHED_MODULES" cfg-target=/%{_sysconfdir}/opensips/
+make modules modules="%JSON_MODULES"      cfg-target=/%{_sysconfdir}/opensips/
+make modules modules="%RABBITMQ_MODULES"  cfg-target=/%{_sysconfdir}/opensips/
+make modules modules="%COUCHBASE_MODULES" cfg-target=/%{_sysconfdir}/opensips/
+make modules modules="%REDIS_MODULES"     cfg-target=/%{_sysconfdir}/opensips/
+make modules modules="%BERKELEY_MODULES"  cfg-target=/%{_sysconfdir}/opensips/
+make utils modules="%BERKELEY_MODULES"  cfg-target=/%{_sysconfdir}/opensips/
+make modules modules="%ORACLE_MODULES"  ORAVERSION=11.2/client cfg-target=/%{_sysconfdir}/opensips/
+make utils modules="%ORACLE_MODULES"  ORAVERSION=11.2/client cfg-target=/%{_sysconfdir}/opensips/
+make modules modules="%XMLRPC_MODULES"  cfg-target=/%{_sysconfdir}/opensips/
+make modules modules="%HTTP_MODULES"	  cfg-target=/%{_sysconfdir}/opensips/
 
 
 %install
@@ -250,6 +445,146 @@ make install-doc modules="%SNMPSTATS_MODULES" \
 		prefix=/usr \
 		cfg-prefix=$RPM_BUILD_ROOT \
 		cfg-target=/%{_sysconfdir}/opensips/ 
+make install-modules modules="%LDAP_MODULES" \
+		basedir=$RPM_BUILD_ROOT \
+		prefix=/usr \
+		cfg-prefix=$RPM_BUILD_ROOT \
+		cfg-target=/%{_sysconfdir}/opensips/ 
+make install-doc modules="%LDAP_MODULES" \
+		basedir=$RPM_BUILD_ROOT \
+		prefix=/usr \
+		cfg-prefix=$RPM_BUILD_ROOT \
+		cfg-target=/%{_sysconfdir}/opensips/ 
+make install-modules modules="%IDENTITY_MODULES" \
+		basedir=$RPM_BUILD_ROOT \
+		prefix=/usr \
+		cfg-prefix=$RPM_BUILD_ROOT \
+		cfg-target=/%{_sysconfdir}/opensips/ 
+make install-doc modules="%IDENTITY_MODULES" \
+		basedir=$RPM_BUILD_ROOT \
+		prefix=/usr \
+		cfg-prefix=$RPM_BUILD_ROOT \
+		cfg-target=/%{_sysconfdir}/opensips/ 
+make install-modules modules="%REGEX_MODULES" \
+		basedir=$RPM_BUILD_ROOT \
+		prefix=/usr \
+		cfg-prefix=$RPM_BUILD_ROOT \
+		cfg-target=/%{_sysconfdir}/opensips/ 
+make install-doc modules="%REGEX_MODULES" \
+		basedir=$RPM_BUILD_ROOT \
+		prefix=/usr \
+		cfg-prefix=$RPM_BUILD_ROOT \
+		cfg-target=/%{_sysconfdir}/opensips/ 
+make install-modules modules="%MMGEOIP_MODULES" \
+		basedir=$RPM_BUILD_ROOT \
+		prefix=/usr \
+		cfg-prefix=$RPM_BUILD_ROOT \
+		cfg-target=/%{_sysconfdir}/opensips/ 
+make install-doc modules="%MMGEOIP_MODULES" \
+		basedir=$RPM_BUILD_ROOT \
+		prefix=/usr \
+		cfg-prefix=$RPM_BUILD_ROOT \
+		cfg-target=/%{_sysconfdir}/opensips/ 
+make install-modules modules="%CARRIERROUTE_MODULES" \
+		basedir=$RPM_BUILD_ROOT \
+		prefix=/usr \
+		cfg-prefix=$RPM_BUILD_ROOT \
+		cfg-target=/%{_sysconfdir}/opensips/ 
+make install-doc modules="%CARRIERROUTE_MODULES" \
+		basedir=$RPM_BUILD_ROOT \
+		prefix=/usr \
+		cfg-prefix=$RPM_BUILD_ROOT \
+		cfg-target=/%{_sysconfdir}/opensips/ 
+make install-modules modules="%MEMCACHED_MODULES" \
+		basedir=$RPM_BUILD_ROOT \
+		prefix=/usr \
+		cfg-prefix=$RPM_BUILD_ROOT \
+		cfg-target=/%{_sysconfdir}/opensips/ 
+make install-doc modules="%MEMCACHED_MODULES" \
+		basedir=$RPM_BUILD_ROOT \
+		prefix=/usr \
+		cfg-prefix=$RPM_BUILD_ROOT \
+		cfg-target=/%{_sysconfdir}/opensips/ 
+make install-modules modules="%JSON_MODULES" \
+		basedir=$RPM_BUILD_ROOT \
+		prefix=/usr \
+		cfg-prefix=$RPM_BUILD_ROOT \
+		cfg-target=/%{_sysconfdir}/opensips/ 
+make install-doc modules="%JSON_MODULES" \
+		basedir=$RPM_BUILD_ROOT \
+		prefix=/usr \
+		cfg-prefix=$RPM_BUILD_ROOT \
+		cfg-target=/%{_sysconfdir}/opensips/ 
+make install-modules modules="%RABBITMQ_MODULES" \
+		basedir=$RPM_BUILD_ROOT \
+		prefix=/usr \
+		cfg-prefix=$RPM_BUILD_ROOT \
+		cfg-target=/%{_sysconfdir}/opensips/ 
+make install-doc modules="%RABBITMQ_MODULES" \
+		basedir=$RPM_BUILD_ROOT \
+		prefix=/usr \
+		cfg-prefix=$RPM_BUILD_ROOT \
+		cfg-target=/%{_sysconfdir}/opensips/ 
+make install-modules modules="%COUCHBASE_MODULES" \
+		basedir=$RPM_BUILD_ROOT \
+		prefix=/usr \
+		cfg-prefix=$RPM_BUILD_ROOT \
+		cfg-target=/%{_sysconfdir}/opensips/ 
+make install-doc modules="%COUCHBASE_MODULES" \
+		basedir=$RPM_BUILD_ROOT \
+		prefix=/usr \
+		cfg-prefix=$RPM_BUILD_ROOT \
+		cfg-target=/%{_sysconfdir}/opensips/ 
+make install-modules modules="%REDIS_MODULES" \
+		basedir=$RPM_BUILD_ROOT \
+		prefix=/usr \
+		cfg-prefix=$RPM_BUILD_ROOT \
+		cfg-target=/%{_sysconfdir}/opensips/ 
+make install-doc modules="%REDIS_MODULES" \
+		basedir=$RPM_BUILD_ROOT \
+		prefix=/usr \
+		cfg-prefix=$RPM_BUILD_ROOT \
+		cfg-target=/%{_sysconfdir}/opensips/ 
+make install-modules modules="%BERKELEY_MODULES" \
+		basedir=$RPM_BUILD_ROOT \
+		prefix=/usr \
+		cfg-prefix=$RPM_BUILD_ROOT \
+		cfg-target=/%{_sysconfdir}/opensips/ 
+make install-doc modules="%BERKELEY_MODULES" \
+		basedir=$RPM_BUILD_ROOT \
+		prefix=/usr \
+		cfg-prefix=$RPM_BUILD_ROOT \
+		cfg-target=/%{_sysconfdir}/opensips/ 
+make install-modules modules="%ORACLE_MODULES" \
+		basedir=$RPM_BUILD_ROOT \
+		prefix=/usr \
+		cfg-prefix=$RPM_BUILD_ROOT \
+		cfg-target=/%{_sysconfdir}/opensips/ 
+make install-doc modules="%ORACLE_MODULES" \
+		basedir=$RPM_BUILD_ROOT \
+		prefix=/usr \
+		cfg-prefix=$RPM_BUILD_ROOT \
+		cfg-target=/%{_sysconfdir}/opensips/ 
+make install-modules modules="%XMLRPC_MODULES" \
+		basedir=$RPM_BUILD_ROOT \
+		prefix=/usr \
+		cfg-prefix=$RPM_BUILD_ROOT \
+		cfg-target=/%{_sysconfdir}/opensips/ 
+make install-doc modules="%XMLRPC_MODULES" \
+		basedir=$RPM_BUILD_ROOT \
+		prefix=/usr \
+		cfg-prefix=$RPM_BUILD_ROOT \
+		cfg-target=/%{_sysconfdir}/opensips/ 
+make install-modules modules="%HTTP_MODULES" \
+		basedir=$RPM_BUILD_ROOT \
+		prefix=/usr \
+		cfg-prefix=$RPM_BUILD_ROOT \
+		cfg-target=/%{_sysconfdir}/opensips/ 
+make install-doc modules="%HTTP_MODULES" \
+		basedir=$RPM_BUILD_ROOT \
+		prefix=/usr \
+		cfg-prefix=$RPM_BUILD_ROOT \
+		cfg-target=/%{_sysconfdir}/opensips/ 
 
 mkdir -p $RPM_BUILD_ROOT/%{_sysconfdir}/rc.d/init.d
 install -m755 $RPM_SOURCE_DIR/opensips.init \
@@ -288,7 +623,10 @@ fi
 %doc %{_docdir}/opensips/README.auth_db
 %doc %{_docdir}/opensips/README.auth_diameter
 %doc %{_docdir}/opensips/README.avpops
+%doc %{_docdir}/opensips/README.b2b_entities
 %doc %{_docdir}/opensips/README.benchmark
+%doc %{_docdir}/opensips/README.cachedb_local
+%doc %{_docdir}/opensips/README.cachedb_sql
 %doc %{_docdir}/opensips/README.call_control
 %doc %{_docdir}/opensips/README.cfgutils
 %doc %{_docdir}/opensips/README.closeddial
@@ -298,17 +636,19 @@ fi
 %doc %{_docdir}/opensips/README.dialog
 %doc %{_docdir}/opensips/README.dispatcher
 %doc %{_docdir}/opensips/README.diversion
+%doc %{_docdir}/opensips/README.dns_cache
 %doc %{_docdir}/opensips/README.domain
 %doc %{_docdir}/opensips/README.domainpolicy
 %doc %{_docdir}/opensips/README.drouting
 %doc %{_docdir}/opensips/README.enum
 %doc %{_docdir}/opensips/README.event_datagram
+%doc %{_docdir}/opensips/README.event_route
+%doc %{_docdir}/opensips/README.event_xmlrpc
 %doc %{_docdir}/opensips/README.exec
 %doc %{_docdir}/opensips/README.gflags
 %doc %{_docdir}/opensips/README.group
 %doc %{_docdir}/opensips/README.imc
 %doc %{_docdir}/opensips/README.load_balancer
-%doc %{_docdir}/opensips/README.localcache
 %doc %{_docdir}/opensips/README.mangler
 %doc %{_docdir}/opensips/README.maxfwd
 %doc %{_docdir}/opensips/README.mediaproxy
@@ -320,8 +660,11 @@ fi
 %doc %{_docdir}/opensips/README.options
 %doc %{_docdir}/opensips/README.path
 %doc %{_docdir}/opensips/README.pdt
+%doc %{_docdir}/opensips/README.peering
 %doc %{_docdir}/opensips/README.permissions
 %doc %{_docdir}/opensips/README.pike
+%doc %{_docdir}/opensips/README.presence_callinfo
+%doc %{_docdir}/opensips/README.presence_xcapdiff
 %doc %{_docdir}/opensips/README.qos
 %doc %{_docdir}/opensips/README.ratelimit
 %doc %{_docdir}/opensips/README.registrar
@@ -329,6 +672,8 @@ fi
 %doc %{_docdir}/opensips/README.rtpproxy
 %doc %{_docdir}/opensips/README.seas
 %doc %{_docdir}/opensips/README.signaling
+%doc %{_docdir}/opensips/README.sipcapture
+%doc %{_docdir}/opensips/README.sipmsgops
 %doc %{_docdir}/opensips/README.siptrace
 %doc %{_docdir}/opensips/README.sl
 %doc %{_docdir}/opensips/README.sms
@@ -361,7 +706,10 @@ fi
 %{_libdir}/opensips/modules/auth_db.so
 %{_libdir}/opensips/modules/auth_diameter.so
 %{_libdir}/opensips/modules/avpops.so
+%{_libdir}/opensips/modules/b2b_entities.so
 %{_libdir}/opensips/modules/benchmark.so
+%{_libdir}/opensips/modules/cachedb_local.so
+%{_libdir}/opensips/modules/cachedb_sql.so
 %{_libdir}/opensips/modules/call_control.so
 %{_libdir}/opensips/modules/cfgutils.so
 %{_libdir}/opensips/modules/closeddial.so
@@ -371,17 +719,19 @@ fi
 %{_libdir}/opensips/modules/dialog.so
 %{_libdir}/opensips/modules/dispatcher.so
 %{_libdir}/opensips/modules/diversion.so
+%{_libdir}/opensips/modules/dns_cache.so
 %{_libdir}/opensips/modules/domain.so
 %{_libdir}/opensips/modules/domainpolicy.so
 %{_libdir}/opensips/modules/drouting.so
 %{_libdir}/opensips/modules/enum.so
 %{_libdir}/opensips/modules/event_datagram.so
+%{_libdir}/opensips/modules/event_route.so
+%{_libdir}/opensips/modules/event_xmlrpc.so
 %{_libdir}/opensips/modules/exec.so
 %{_libdir}/opensips/modules/gflags.so
 %{_libdir}/opensips/modules/group.so
 %{_libdir}/opensips/modules/imc.so
 %{_libdir}/opensips/modules/load_balancer.so
-%{_libdir}/opensips/modules/localcache.so
 %{_libdir}/opensips/modules/mangler.so
 %{_libdir}/opensips/modules/maxfwd.so
 %{_libdir}/opensips/modules/mediaproxy.so
@@ -393,8 +743,11 @@ fi
 %{_libdir}/opensips/modules/options.so
 %{_libdir}/opensips/modules/path.so
 %{_libdir}/opensips/modules/pdt.so
+%{_libdir}/opensips/modules/peering.so
 %{_libdir}/opensips/modules/permissions.so
 %{_libdir}/opensips/modules/pike.so
+%{_libdir}/opensips/modules/presence_callinfo.so
+%{_libdir}/opensips/modules/presence_xcapdiff.so
 %{_libdir}/opensips/modules/qos.so
 %{_libdir}/opensips/modules/ratelimit.so
 %{_libdir}/opensips/modules/registrar.so
@@ -402,6 +755,8 @@ fi
 %{_libdir}/opensips/modules/rtpproxy.so
 %{_libdir}/opensips/modules/seas.so
 %{_libdir}/opensips/modules/signaling.so
+%{_libdir}/opensips/modules/sipcapture.so
+%{_libdir}/opensips/modules/sipmsgops.so
 %{_libdir}/opensips/modules/siptrace.so
 %{_libdir}/opensips/modules/sl.so
 %{_libdir}/opensips/modules/sms.so
@@ -421,10 +776,13 @@ fi
 
 %{_sbindir}/opensips
 %{_sbindir}/osipsconsole
+%{_sbindir}/osipsconfig
 %{_sbindir}/opensipsctl
 %{_sbindir}/opensipsdbctl
 %{_sbindir}/opensipsunix
 %{_libdir}/opensips/opensipsctl/dbtextdb/dbtextdb.py
+%{_libdir}/opensips/opensipsctl/dbtextdb/dbtextdb.pyc
+%{_libdir}/opensips/opensipsctl/dbtextdb/dbtextdb.pyo
 %{_libdir}/opensips/opensipsctl/opensipsctl.base
 %{_libdir}/opensips/opensipsctl/opensipsctl.ctlbase
 %{_libdir}/opensips/opensipsctl/opensipsctl.dbtext
@@ -438,6 +796,7 @@ fi
 %{_mandir}/man8/*
 
 %{_sharedir}/opensips/dbtext/opensips/*
+%{_sharedir}/opensips/menuconfig_templates/
 
 %files mysql
 %defattr(-,root,root)
@@ -494,6 +853,7 @@ fi
 %doc %{_docdir}/opensips/README.pua_usrloc
 %doc %{_docdir}/opensips/README.pua_xmpp
 %doc %{_docdir}/opensips/README.rls
+%doc %{_docdir}/opensips/README.xcap
 %doc %{_docdir}/opensips/README.xcap_client
 
 %{_libdir}/opensips/modules/presence.so
@@ -509,6 +869,7 @@ fi
 %{_libdir}/opensips/modules/pua_usrloc.so
 %{_libdir}/opensips/modules/pua_xmpp.so
 %{_libdir}/opensips/modules/rls.so
+%{_libdir}/opensips/modules/xcap.so
 %{_libdir}/opensips/modules/xcap_client.so
 
 
@@ -542,7 +903,290 @@ fi
 %{_libdir}/opensips/modules/b2b_logic.so
 
 
+%files ldap
+%defattr(-,root,root)
+%doc %{_docdir}/opensips/README.ldap
+%doc %{_docdir}/opensips/README.h350
+
+%{_libdir}/opensips/modules/ldap.so
+%{_libdir}/opensips/modules/h350.so
+
+
+%files identity
+%defattr(-,root,root)
+%doc %{_docdir}/opensips/README.identity
+
+%{_libdir}/opensips/modules/identity.so
+
+
+%files regex
+%defattr(-,root,root)
+%doc %{_docdir}/opensips/README.regex
+%doc %{_docdir}/opensips/README.dialplan
+
+%{_libdir}/opensips/modules/regex.so
+%{_libdir}/opensips/modules/dialplan.so
+
+
+%files mmgeoip
+%defattr(-,root,root)
+%doc %{_docdir}/opensips/README.mmgeoip
+
+%{_libdir}/opensips/modules/mmgeoip.so
+
+
+%files json
+%defattr(-,root,root)
+%doc %{_docdir}/opensips/README.json
+
+%{_libdir}/opensips/modules/json.so
+
+
+%files carrierroute
+%defattr(-,root,root)
+%doc %{_docdir}/opensips/README.carrierroute
+
+%{_libdir}/opensips/modules/carrierroute.so
+
+
+%files cachedb_memcached
+%defattr(-,root,root)
+%doc %{_docdir}/opensips/README.cachedb_memcached
+
+%{_libdir}/opensips/modules/cachedb_memcached.so
+
+
+%files event_rabbitmq
+%defattr(-,root,root)
+%doc %{_docdir}/opensips/README.event_rabbitmq
+
+%{_libdir}/opensips/modules/event_rabbitmq.so
+
+
+%files cachedb_couchbase
+%defattr(-,root,root)
+%doc %{_docdir}/opensips/README.cachedb_couchbase
+
+%{_libdir}/opensips/modules/cachedb_couchbase.so
+
+
+%files cachedb_redis
+%defattr(-,root,root)
+%doc %{_docdir}/opensips/README.cachedb_redis
+
+%{_libdir}/opensips/modules/cachedb_redis.so
+
+
+%files db_berkeley
+%defattr(-,root,root)
+%doc %{_docdir}/opensips/README.db_berkeley
+
+%{_sbindir}/bdb_recover
+%{_libdir}/opensips/modules/db_berkeley.so
+%{_libdir}/opensips/opensipsctl/opensipsctl.db_berkeley
+%{_libdir}/opensips/opensipsctl/opensipsdbctl.db_berkeley
+%{_sharedir}/opensips/db_berkeley/opensips/acc
+%{_sharedir}/opensips/db_berkeley/opensips/active_watchers
+%{_sharedir}/opensips/db_berkeley/opensips/address
+%{_sharedir}/opensips/db_berkeley/opensips/aliases
+%{_sharedir}/opensips/db_berkeley/opensips/b2b_entities
+%{_sharedir}/opensips/db_berkeley/opensips/b2b_logic
+%{_sharedir}/opensips/db_berkeley/opensips/cachedb
+%{_sharedir}/opensips/db_berkeley/opensips/carrierfailureroute
+%{_sharedir}/opensips/db_berkeley/opensips/carrierroute
+%{_sharedir}/opensips/db_berkeley/opensips/closeddial
+%{_sharedir}/opensips/db_berkeley/opensips/cpl
+%{_sharedir}/opensips/db_berkeley/opensips/dbaliases
+%{_sharedir}/opensips/db_berkeley/opensips/dialog
+%{_sharedir}/opensips/db_berkeley/opensips/dialplan
+%{_sharedir}/opensips/db_berkeley/opensips/dispatcher
+%{_sharedir}/opensips/db_berkeley/opensips/domain
+%{_sharedir}/opensips/db_berkeley/opensips/domainpolicy
+%{_sharedir}/opensips/db_berkeley/opensips/dr_carriers
+%{_sharedir}/opensips/db_berkeley/opensips/dr_gateways
+%{_sharedir}/opensips/db_berkeley/opensips/dr_groups
+%{_sharedir}/opensips/db_berkeley/opensips/dr_gw_lists
+%{_sharedir}/opensips/db_berkeley/opensips/dr_rules
+%{_sharedir}/opensips/db_berkeley/opensips/globalblacklist
+%{_sharedir}/opensips/db_berkeley/opensips/grp
+%{_sharedir}/opensips/db_berkeley/opensips/imc_members
+%{_sharedir}/opensips/db_berkeley/opensips/imc_rooms
+%{_sharedir}/opensips/db_berkeley/opensips/load_balancer
+%{_sharedir}/opensips/db_berkeley/opensips/location
+%{_sharedir}/opensips/db_berkeley/opensips/missed_calls
+%{_sharedir}/opensips/db_berkeley/opensips/pdt
+%{_sharedir}/opensips/db_berkeley/opensips/presentity
+%{_sharedir}/opensips/db_berkeley/opensips/pua
+%{_sharedir}/opensips/db_berkeley/opensips/re_grp
+%{_sharedir}/opensips/db_berkeley/opensips/registrant
+%{_sharedir}/opensips/db_berkeley/opensips/rls_presentity
+%{_sharedir}/opensips/db_berkeley/opensips/rls_watchers
+%{_sharedir}/opensips/db_berkeley/opensips/route_tree
+%{_sharedir}/opensips/db_berkeley/opensips/rtpproxy_sockets
+%{_sharedir}/opensips/db_berkeley/opensips/silo
+%{_sharedir}/opensips/db_berkeley/opensips/sip_trace
+%{_sharedir}/opensips/db_berkeley/opensips/speed_dial
+%{_sharedir}/opensips/db_berkeley/opensips/subscriber
+%{_sharedir}/opensips/db_berkeley/opensips/uri
+%{_sharedir}/opensips/db_berkeley/opensips/userblacklist
+%{_sharedir}/opensips/db_berkeley/opensips/usr_preferences
+%{_sharedir}/opensips/db_berkeley/opensips/version
+%{_sharedir}/opensips/db_berkeley/opensips/watchers
+%{_sharedir}/opensips/db_berkeley/opensips/xcap
+
+
+%files db_oracle
+%defattr(-,root,root)
+%doc %{_docdir}/opensips/README.db_oracle
+
+%{_sbindir}/opensips_orasel
+%{_libdir}/opensips/modules/db_oracle.so
+%{_libdir}/opensips/opensipsctl/opensipsctl.oracle
+%{_libdir}/opensips/opensipsctl/opensipsdbctl.oracle
+%{_libdir}/opensips/opensipsctl/opensipsdbfunc.oracle
+%{_sharedir}/opensips/oracle/README.TYPES
+%{_sharedir}/opensips/oracle/acc-create.sql
+%{_sharedir}/opensips/oracle/admin/README
+%{_sharedir}/opensips/oracle/admin/_create_as_sys.tmpl
+%{_sharedir}/opensips/oracle/admin/_drop_as_sys.tmpl
+%{_sharedir}/opensips/oracle/alias_db-create.sql
+%{_sharedir}/opensips/oracle/auth_db-create.sql
+%{_sharedir}/opensips/oracle/avpops-create.sql
+%{_sharedir}/opensips/oracle/b2b-create.sql
+%{_sharedir}/opensips/oracle/cachedb_sql-create.sql
+%{_sharedir}/opensips/oracle/carrierroute-create.sql
+%{_sharedir}/opensips/oracle/closeddial-create.sql
+%{_sharedir}/opensips/oracle/cpl-create.sql
+%{_sharedir}/opensips/oracle/dialog-create.sql
+%{_sharedir}/opensips/oracle/dialplan-create.sql
+%{_sharedir}/opensips/oracle/dispatcher-create.sql
+%{_sharedir}/opensips/oracle/domain-create.sql
+%{_sharedir}/opensips/oracle/domainpolicy-create.sql
+%{_sharedir}/opensips/oracle/drouting-create.sql
+%{_sharedir}/opensips/oracle/group-create.sql
+%{_sharedir}/opensips/oracle/imc-create.sql
+%{_sharedir}/opensips/oracle/inc/_create_compat.sql
+%{_sharedir}/opensips/oracle/inc/_createsch.tmpl
+%{_sharedir}/opensips/oracle/inc/_dropsch.tmpl
+%{_sharedir}/opensips/oracle/inc/_grantfunc.tmpl
+%{_sharedir}/opensips/oracle/inc/_grantroot.tmpl
+%{_sharedir}/opensips/oracle/load_balancer-create.sql
+%{_sharedir}/opensips/oracle/msilo-create.sql
+%{_sharedir}/opensips/oracle/pdt-create.sql
+%{_sharedir}/opensips/oracle/permissions-create.sql
+%{_sharedir}/opensips/oracle/presence-create.sql
+%{_sharedir}/opensips/oracle/registrant-create.sql
+%{_sharedir}/opensips/oracle/registrar-create.sql
+%{_sharedir}/opensips/oracle/rls-create.sql
+%{_sharedir}/opensips/oracle/rtpproxy-create.sql
+%{_sharedir}/opensips/oracle/siptrace-create.sql
+%{_sharedir}/opensips/oracle/speeddial-create.sql
+%{_sharedir}/opensips/oracle/standard-create.sql
+%{_sharedir}/opensips/oracle/uri_db-create.sql
+%{_sharedir}/opensips/oracle/userblacklist-create.sql
+%{_sharedir}/opensips/oracle/usrloc-create.sql
+
+
+%files mi_xmlrpc
+%defattr(-,root,root)
+%doc %{_docdir}/opensips/README.mi_xmlrpc
+
+%{_libdir}/opensips/modules/mi_xmlrpc.so
+
+
+%files db_http
+%defattr(-,root,root)
+%doc %{_docdir}/opensips/README.db_http
+%doc %{_docdir}/opensips/README.httpd
+%doc %{_docdir}/opensips/README.pi_http
+
+%{_libdir}/opensips/modules/db_http.so
+%{_libdir}/opensips/modules/httpd.so
+%{_libdir}/opensips/modules/pi_http.so
+%{_sharedir}/opensips/pi_http/acc-mod
+%{_sharedir}/opensips/pi_http/acc-table
+%{_sharedir}/opensips/pi_http/alias_db-mod
+%{_sharedir}/opensips/pi_http/alias_db-table
+%{_sharedir}/opensips/pi_http/auth_db-mod
+%{_sharedir}/opensips/pi_http/auth_db-table
+%{_sharedir}/opensips/pi_http/avpops-mod
+%{_sharedir}/opensips/pi_http/avpops-table
+%{_sharedir}/opensips/pi_http/b2b-mod
+%{_sharedir}/opensips/pi_http/b2b-table
+%{_sharedir}/opensips/pi_http/cachedb_sql-mod
+%{_sharedir}/opensips/pi_http/cachedb_sql-table
+%{_sharedir}/opensips/pi_http/carrierroute-mod
+%{_sharedir}/opensips/pi_http/carrierroute-table
+%{_sharedir}/opensips/pi_http/closeddial-mod
+%{_sharedir}/opensips/pi_http/closeddial-table
+%{_sharedir}/opensips/pi_http/cpl-mod
+%{_sharedir}/opensips/pi_http/cpl-table
+%{_sharedir}/opensips/pi_http/dialog-mod
+%{_sharedir}/opensips/pi_http/dialog-table
+%{_sharedir}/opensips/pi_http/dialplan-mod
+%{_sharedir}/opensips/pi_http/dialplan-table
+%{_sharedir}/opensips/pi_http/dispatcher-mod
+%{_sharedir}/opensips/pi_http/dispatcher-table
+%{_sharedir}/opensips/pi_http/domain-mod
+%{_sharedir}/opensips/pi_http/domain-table
+%{_sharedir}/opensips/pi_http/domainpolicy-mod
+%{_sharedir}/opensips/pi_http/domainpolicy-table
+%{_sharedir}/opensips/pi_http/drouting-mod
+%{_sharedir}/opensips/pi_http/drouting-table
+%{_sharedir}/opensips/pi_http/group-mod
+%{_sharedir}/opensips/pi_http/group-table
+%{_sharedir}/opensips/pi_http/imc-mod
+%{_sharedir}/opensips/pi_http/imc-table
+%{_sharedir}/opensips/pi_http/load_balancer-mod
+%{_sharedir}/opensips/pi_http/load_balancer-table
+%{_sharedir}/opensips/pi_http/msilo-mod
+%{_sharedir}/opensips/pi_http/msilo-table
+%{_sharedir}/opensips/pi_http/pdt-mod
+%{_sharedir}/opensips/pi_http/pdt-table
+%{_sharedir}/opensips/pi_http/permissions-mod
+%{_sharedir}/opensips/pi_http/permissions-table
+%{_sharedir}/opensips/pi_http/pi_framework-00
+%{_sharedir}/opensips/pi_http/pi_framework-01
+%{_sharedir}/opensips/pi_http/pi_framework-02
+%{_sharedir}/opensips/pi_http/pi_framework.xml
+%{_sharedir}/opensips/pi_http/pi_framework_example.xml
+%{_sharedir}/opensips/pi_http/presence-mod
+%{_sharedir}/opensips/pi_http/presence-table
+%{_sharedir}/opensips/pi_http/registrant-mod
+%{_sharedir}/opensips/pi_http/registrant-table
+%{_sharedir}/opensips/pi_http/registrar-mod
+%{_sharedir}/opensips/pi_http/registrar-table
+%{_sharedir}/opensips/pi_http/rls-mod
+%{_sharedir}/opensips/pi_http/rls-table
+%{_sharedir}/opensips/pi_http/rtpproxy-mod
+%{_sharedir}/opensips/pi_http/rtpproxy-table
+%{_sharedir}/opensips/pi_http/siptrace-mod
+%{_sharedir}/opensips/pi_http/siptrace-table
+%{_sharedir}/opensips/pi_http/speeddial-mod
+%{_sharedir}/opensips/pi_http/speeddial-table
+%{_sharedir}/opensips/pi_http/standard-mod
+%{_sharedir}/opensips/pi_http/standard-table
+%{_sharedir}/opensips/pi_http/uri_db-mod
+%{_sharedir}/opensips/pi_http/uri_db-table
+%{_sharedir}/opensips/pi_http/userblacklist-mod
+%{_sharedir}/opensips/pi_http/userblacklist-table
+%{_sharedir}/opensips/pi_http/usrloc-mod
+%{_sharedir}/opensips/pi_http/usrloc-table
+
+
 %changelog
+* Sun Jun 02 2013 Fabrizio Picconi <fabrizio.picconi@tiscali.it>
+- CentOS 6 support
+  Remove rpmbuild warning on BuildPrereq now deprecated for BuildRequires
+- opensips 1.9.1 support
+  Updated list of excluded modules
+  Updated list of file in rpm of core and modules
+- Some new rpm optional modules are added:
+  db_http pi_http json cachedb_couchbase cachedb_memcached
+  cachedb_redis event_rabbitmq db_berkeley perl db_perlvdb
+  carrierroute mmgeoip ldap h350 identity regex dialplan
+  Xlog mi_xmlrpc db_oracle
+
 * Mon Oct 18 2010 Marc Leurent <marc.leurent@vtx-telecom.ch>
 - Add missing dependencies pcre-devel for compilation
 - Xlog Module has been merged into core.


### PR DESCRIPTION
- CentOS 6 support
  Remove rpmbuild warning on BuildPrereq now deprecated for BuildRequires
- opensips 1.9 (centos) support
  Updated list of excluded modules
  Updated list of file in rpm of core and modules
- Some new rpm (centos) optional modules are added:
  db_http pi_http json cachedb_couchbase cachedb_memcached   cachedb_redis event_rabbitmq db_berkeley perl db_perlvdb carrierroute mmgeoip ldap h350 identity regex dialplan Xlog mi_xmlrpc db_oracle
