### PR TITLE
Added presence federation algorithm.

### DIFF
--- a/modules/presence/notify.c
+++ b/modules/presence/notify.c
@@ -1723,14 +1723,7 @@ int publ_notify(presentity_t* p, str pres_uri, str* body, str* offline_etag,
 	int ret_code= -1;
 	free_body_t* free_fct = 0;
 
-	subs_array= get_subs_dialog(&pres_uri, p->event , p->sender);
-	if(subs_array == NULL)
-	{
-		LM_DBG("Could not find subs_dialog\n");
-		ret_code= 0;
-		goto done;
-	}
-
+        LM_INFO("NOTIFY for uri %.*s\n", pres_uri.len, pres_uri.s);
 	/* if the event does not require aggregation - we have the final body */
 	if(p->event->agg_nbody)
 	{
@@ -1739,11 +1732,19 @@ int publ_notify(presentity_t* p, str pres_uri, str* body, str* offline_etag,
 				p->extra_hdrs?p->extra_hdrs:&notify_extra_hdrs, &free_fct);
 	}
 
+	subs_array= get_subs_dialog(&pres_uri, p->event , p->sender);
+	if(subs_array == NULL)
+	{
+		LM_DBG("Could not find subs_dialog\n");
+		ret_code= 0;
+		goto done;
+	}
+
 	s= subs_array;
 	while(s)
 	{
 		s->auth_rules_doc= rules_doc;
-		LM_INFO("notify\n");
+		LM_INFO("will notify\n");
 		if(notify(s, NULL, notify_body?notify_body:body,
 			0, p->extra_hdrs?p->extra_hdrs:&notify_extra_hdrs)< 0 )
 		{
@@ -1998,10 +1999,16 @@ jump_over_body:
 		goto error;
 	}
 
-	LM_INFO("NOTIFY %.*s via %.*s on behalf of %.*s for event %.*s, to_tag=%.*s, cseq=%d\n",
-		td->rem_uri.len, td->rem_uri.s, td->hooks.next_hop->len, td->hooks.next_hop->s,
-		td->loc_uri.len, td->loc_uri.s, subs->event->name.len, subs->event->name.s,
-		td->id.loc_tag.len, td->id.loc_tag.s, td->loc_seq.value);
+        if (notify_body)
+          LM_INFO("NOTIFY %.*s on behalf of %.*s for event %.*s with body %s\n",
+                  td->rem_uri.len, td->rem_uri.s,
+                  td->loc_uri.len, td->loc_uri.s, subs->event->name.len, subs->event->name.s,
+                  notify_body->s);
+        else
+          LM_INFO("NOTIFY %.*s ,via %.*s on behalf of %.*s for event %.*s, to_tag=%.*s, cseq=%d\n",
+                  td->rem_uri.len, td->rem_uri.s, td->hooks.next_hop->len, td->hooks.next_hop->s,
+                  td->loc_uri.len, td->loc_uri.s, subs->event->name.len, subs->event->name.s,
+                  td->id.loc_tag.len, td->id.loc_tag.s, td->loc_seq.value);
 
 	free_tm_dlg(td);
 	

--- a/modules/presence/presentity.c
+++ b/modules/presence/presentity.c
@@ -583,8 +583,8 @@ int update_presentity(struct sip_msg* msg, presentity_t* presentity, int* sent_r
 
 		if(!p || body.s)
 		{
-			lock_release(&pres_htable[hash_code].lock);
-                        p= NULL;
+			if (!p) lock_release(&pres_htable[hash_code].lock);
+
 			/* search also in db */
 			if (pa_dbf.use_table(pa_db, &presentity_table) < 0)
 			{

--- a/modules/presence/presentity.c
+++ b/modules/presence/presentity.c
@@ -647,13 +647,6 @@ int update_presentity(struct sip_msg* msg, presentity_t* presentity, int* sent_r
 			}
 			*sent_reply= 1;
 
-			if(publ_notify(presentity, pres_uri, body.s ? &body : 0, 
-			&presentity->etag, rules_doc, NULL) < 0)
-			{
-				LM_ERR("while sending notify\n");
-				goto error;
-			}
-
 			if(publ_notify(presentity, pres_uri, body.s ? &body : 0, &presentity->etag,
 			   rules_doc, NULL) < 0)
 			{

--- a/modules/presence/presentity.c
+++ b/modules/presence/presentity.c
@@ -226,6 +226,34 @@ int bla_same_dialog(unsigned char* n_callid, unsigned char* n_fromtag, unsigned 
 	return 1;
 }
 
+int snom_fix_is_unchanged_publish_refresh(str body, str cur_body)
+{
+	xmlDocPtr doc = NULL;
+	xmlDocPtr cur_doc = NULL;
+	xmlNodePtr node;
+	xmlNodePtr cur_node;
+
+	doc = xmlParseMemory(body.s, body.len);
+	cur_doc = xmlParseMemory(cur_body.s, cur_body.len);
+	if (!doc || !cur_doc)
+                goto error;
+
+        node = XMLDocGetNodeByName(doc, "im", NULL);
+        cur_node = XMLDocGetNodeByName(cur_doc, "im", NULL);
+        if(node && cur_node && xmlStrcasecmp((unsigned char*)xmlNodeGetContent(node), (unsigned char*)xmlNodeGetContent(cur_node)) == 0) {
+		xmlFreeDoc(cur_doc);
+		xmlFreeDoc(doc);
+                return 1;
+        }
+error:
+	if (cur_doc)
+		xmlFreeDoc(cur_doc);
+	if (doc)
+		xmlFreeDoc(doc);
+
+	return 0;
+}
+
 int dialog_fix_remote_target(str *body, str *fixed_body)
 {
 	xmlDocPtr doc = NULL;
@@ -399,21 +427,25 @@ int update_presentity(struct sip_msg* msg, presentity_t* presentity, int* sent_r
 //	static db_ps_t my_ps_insert = NULL, my_ps_update_no_body = NULL,
 //		   my_ps_update_body = NULL;
 //	static db_ps_t my_ps_delete = NULL, my_ps_query = NULL;
-	db_key_t query_cols[13], update_keys[8], result_cols[1];
+	db_key_t query_cols[13], update_keys[8], result_cols[2];
 	db_op_t  query_ops[13];
 	db_val_t query_vals[13], update_vals[8];
 	int n_query_cols = 0;
 	int n_update_cols = 0;
 	str etag= {NULL, 0};
 	str notify_body = {NULL, 0};
+	str cur_body= {NULL, 0};
 	str cur_etag= {NULL, 0};
 	str* rules_doc= NULL;
 	str pres_uri= {NULL, 0};
 	pres_entry_t* p= NULL;
 	unsigned int hash_code;
+        unsigned int different_body = 0;
 	str body = presentity->body;
 	str *extra_hdrs = presentity->extra_hdrs;
 	db_res_t *result= NULL;
+
+
 
 	*sent_reply= 0;
 	if(presentity->event->req_auth)
@@ -462,6 +494,7 @@ int update_presentity(struct sip_msg* msg, presentity_t* presentity, int* sent_r
 	n_query_cols++;
 
 	result_cols[0] = &str_etag_col;
+	result_cols[1] = &str_body_col;
 
 	if(presentity->etag_new)
 	{
@@ -548,9 +581,10 @@ int update_presentity(struct sip_msg* msg, presentity_t* presentity, int* sent_r
 		p = search_phtable_etag(&pres_uri, presentity->event->evp->parsed,
 				&presentity->etag, hash_code);
 
-		if(!p)
+		if(!p || body.s)
 		{
 			lock_release(&pres_htable[hash_code].lock);
+                        p= NULL;
 			/* search also in db */
 			if (pa_dbf.use_table(pa_db, &presentity_table) < 0)
 			{
@@ -558,7 +592,7 @@ int update_presentity(struct sip_msg* msg, presentity_t* presentity, int* sent_r
 					goto error;
 			}
 			if (pa_dbf.query (pa_db, query_cols, query_ops, query_vals,
-					 result_cols, n_query_cols, 1, 0, &result) < 0)
+					 result_cols, n_query_cols, 2, 0, &result) < 0)
 			{
 					LM_ERR("unsuccessful sql query\n");
 					goto error;
@@ -579,7 +613,17 @@ int update_presentity(struct sip_msg* msg, presentity_t* presentity, int* sent_r
 					*sent_reply= 1;
 					goto done;
 			}
+                        else if (body.s) {
+                                different_body= 1;
 
+                                cur_body.s= (char*)RES_ROWS(result)[0].values[1].val.str_val.s;
+                                cur_body.len = RES_ROWS(result)[0].values[1].val.str_val.len;
+                                cur_body.s[cur_body.len] = '\0';
+
+                                if (snom_fix_is_unchanged_publish_refresh(body, cur_body)) {
+                                        different_body= 0;
+                                }
+                        }
 
 			pa_dbf.free_result(pa_db, result);
 			LM_INFO("*** found in db but not in htable [%.*s]\n",
@@ -605,6 +649,13 @@ int update_presentity(struct sip_msg* msg, presentity_t* presentity, int* sent_r
 
 			if(publ_notify(presentity, pres_uri, body.s ? &body : 0, 
 			&presentity->etag, rules_doc, NULL) < 0)
+			{
+				LM_ERR("while sending notify\n");
+				goto error;
+			}
+
+			if(publ_notify(presentity, pres_uri, body.s ? &body : 0, &presentity->etag,
+			   rules_doc, NULL) < 0)
 			{
 				LM_ERR("while sending notify\n");
 				goto error;
@@ -672,12 +723,6 @@ int update_presentity(struct sip_msg* msg, presentity_t* presentity, int* sent_r
 			(int)time(NULL);
 		n_update_cols++;
 
-		update_keys[n_update_cols] = &str_received_time_col;
-		update_vals[n_update_cols].type = DB_INT;
-		update_vals[n_update_cols].nul = 0;
-		update_vals[n_update_cols].val.int_val= presentity->received_time;
-		n_update_cols++;
-
 		update_keys[n_update_cols] = &str_sender_col;
 		update_vals[n_update_cols].type = DB_STR;
 		update_vals[n_update_cols].nul = 0;
@@ -701,6 +746,14 @@ int update_presentity(struct sip_msg* msg, presentity_t* presentity, int* sent_r
 			update_vals[n_update_cols].val.str_val = *extra_hdrs;
 			n_update_cols++;
 		}
+
+                if(different_body) {
+		         update_keys[n_update_cols] = &str_received_time_col;
+                        update_vals[n_update_cols].type = DB_INT;
+                        update_vals[n_update_cols].nul = 0;
+                        update_vals[n_update_cols].val.int_val= presentity->received_time;
+                        n_update_cols++;
+                }
 
 		if(body.s)
 		{

--- a/modules/presence/presentity.c
+++ b/modules/presence/presentity.c
@@ -232,6 +232,8 @@ int snom_fix_is_unchanged_publish_refresh(str body, str cur_body)
 	xmlDocPtr cur_doc = NULL;
 	xmlNodePtr node;
 	xmlNodePtr cur_node;
+        unsigned char* node_val = NULL;
+        unsigned char* cur_node_val = NULL;
 
 	doc = xmlParseMemory(body.s, body.len);
 	cur_doc = xmlParseMemory(cur_body.s, cur_body.len);
@@ -240,12 +242,24 @@ int snom_fix_is_unchanged_publish_refresh(str body, str cur_body)
 
         node = XMLDocGetNodeByName(doc, "im", NULL);
         cur_node = XMLDocGetNodeByName(cur_doc, "im", NULL);
-        if(node && cur_node && xmlStrcasecmp((unsigned char*)xmlNodeGetContent(node), (unsigned char*)xmlNodeGetContent(cur_node)) == 0) {
+        if (!node || !cur_node)
+                goto error;
+        node_val = xmlNodeGetContent(node);
+        cur_node_val = xmlNodeGetContent(cur_node);
+        if (!node_val || !cur_node_val)
+                goto error;
+        if (xmlStrcasecmp(node_val, cur_node_val) == 0) {
+                xmlFree(node_val);
+                xmlFree(cur_node_val);
 		xmlFreeDoc(cur_doc);
 		xmlFreeDoc(doc);
                 return 1;
         }
 error:
+        if (node_val)
+                xmlFree(node_val);
+        if (cur_node_val)
+                xmlFree(cur_node_val);
 	if (cur_doc)
 		xmlFreeDoc(cur_doc);
 	if (doc)

--- a/modules/presence_xml/add_events.c
+++ b/modules/presence_xml/add_events.c
@@ -1,5 +1,5 @@
 /*
- * $Id$
+ * $Id: add_events.c 8628 2011-12-19 14:20:30Z bogdan_iancu $
  *
  * presence_xml module - 
  *
@@ -50,9 +50,6 @@ static str pu_415_rpl  = str_init("Unsupported media type");
  */
 int	xml_publ_handl(struct sip_msg* msg, int* sent_reply)
 {	
-	str pres_uri= {0, 0};
-	str pres_user= {0, 0};
-	str pres_domain= {0, 0};
 	str body= {0, 0};
 	xmlDocPtr doc= NULL;
 
@@ -69,14 +66,7 @@ int	xml_publ_handl(struct sip_msg* msg, int* sent_reply)
 		        LM_ERR("parsing Request URI\n");
 		        goto error;
 	        }
-	        pres_user= msg->parsed_uri.user;
-	        pres_domain= msg->parsed_uri.host;
-                if(uandd_to_uri(pres_user, pres_domain, &pres_uri)< 0)
-                {
-                        LM_ERR("constructing uri from user and domain\n");
-                        goto error;
-                }
-                cachedb_update_merged_presence_state (&body, &pres_user);
+                cachedb_update_merged_presence_state (&body, &msg->parsed_uri.user);
 
 		return 1;
         }
@@ -98,8 +88,6 @@ int	xml_publ_handl(struct sip_msg* msg, int* sent_reply)
 	return 1;
 
 error:
-	if(pres_uri.s)
-		pkg_free(pres_uri.s);
 	xmlFreeDoc(doc);
 	xmlCleanupParser();
 	xmlMemoryDump();

--- a/modules/presence_xml/doc/presence_xml_admin.xml
+++ b/modules/presence_xml/doc/presence_xml_admin.xml
@@ -190,6 +190,85 @@ modparam("presence_xml", "integrated_xcap_server", 1)
 		</example>
 	</section>
 	<section>
+		<title><varname>merge</varname> (int)</title>
+		<para>
+                Some presentities can publish different (R)PIDF presence documents.
+                In that case, the default behavior is to notify subscribers with an
+                aggregated presence document. However, some UAs do not support
+                receiving aggregated presence documents containing different presence
+                states and randomly choose one to display to the user. To prevent this,
+                it is possible to ask the presence server to merge the various presence
+                documents and always notify the most up to date document to the subscribers.
+		</para>
+                <para>
+                For example, if a UA publishes a first document valid for 60 minutes
+                indicating the presentity is available, and another UA publishes a second
+                document for the same presentity indicating it is away, subscribers will
+                be notified with the away state until it expires and the available state
+                is valid again.
+                </para>
+		<emphasis>Default value is <quote>0</quote>.
+		</emphasis>
+		</para>
+		<example>
+		<title>Set <varname>merge</varname> parameter</title>
+		<programlisting format="linespecific">
+...
+modparam("presence_xml", "merge", 1)
+...
+</programlisting>
+		</example>
+	</section>
+	<section>
+		<title><varname>merge_primary_source</varname> (str)</title>
+		<para>
+                Allows a specific presence source to have priority over others even
+                if it is not the last one having been published.
+                The <quote>merge_primary_source</quote> string needs to appear in
+                the tuple id for the source to be recognized as primary.
+		</para>
+                <para>
+                Requires the <quote>merge</quote> parameter to be set to 1.
+                </para>
+		<emphasis>Default value is <quote>primary</quote>.
+		</emphasis>
+		</para>
+		<example>
+		<title>Set <varname>merge_primary_source</varname> parameter</title>
+		<programlisting format="linespecific">
+...
+modparam("presence_xml", "merge_primary_source", "calendar")
+...
+</programlisting>
+		</example>
+	</section>
+	<section>
+		<title><varname>cachedb_url</varname> (str)</title>
+		<para>
+                Allows caching the RPIDF activities and note elements in
+                the cachedb database.
+                If there is no RPIDF, stores the basic element or
+                the im element values.
+		</para>
+                <para>
+                It allows presence based routing.
+		</para>
+                <para>
+                Requires the <quote>merge</quote> parameter to be set to 1.
+                </para>
+		<emphasis>Default value is <quote>empty</quote>.
+		</emphasis>
+		</para>
+		<example>
+		<title>Set <varname>cachedb_url</varname> parameter</title>
+		<programlisting format="linespecific">
+...
+modparam("presence_xml", "cachedb_url", "db://")
+...
+</programlisting>
+		</example>
+	</section>
+	<section>
 		<title><varname>xcap_server</varname> (str)</title>
 		<para>
 		The address of the xcap servers used for storage.

--- a/modules/presence_xml/notify_body.c
+++ b/modules/presence_xml/notify_body.c
@@ -526,22 +526,22 @@ void cachedb_update_merged_presence_state (str* body, str* pres_user)
         {
                 if (cdbf.get(con, &activities_key_op, &value_op) < 0)
                 {
-                        LM_ERR("failed to get key\n");
+                        LM_DBG("failed to get activities key for %.*s\n", pres_user->len, pres_user->s);
                         goto error;
                 }
                 else if (cdbf.set(con, &activities_key_op, &value_op, max_expires_publish) < 0)
-                        LM_ERR("failed to set key\n");
+                        LM_ERR("failed to set activities key for %.*s\n", pres_user->len, pres_user->s);
                 LM_INFO("refreshed cachedb activities %.*s for user %.*s\n",
                         value_op.len, value_op.s, pres_user->len, pres_user->s);
                 pkg_free (value_op.s);
 
                 if (cdbf.get(con, &note_key_op, &value_op) < 0)
                 {
-                        LM_ERR("failed to get key\n");
+                        LM_DBG("failed to get notes key for %.*s\n", pres_user->len, pres_user->s);
                         goto error;
                 }
                 else if (cdbf.set(con, &note_key_op, &value_op, max_expires_publish) < 0)
-                        LM_ERR("failed to set key\n");
+                        LM_ERR("failed to set notes key for %.*s\n", pres_user->len, pres_user->s);
                 pkg_free (value_op.s);
 
                 goto error;

--- a/modules/presence_xml/notify_body.c
+++ b/modules/presence_xml/notify_body.c
@@ -553,7 +553,7 @@ void cachedb_update_merged_presence_state (str* body, str* pres_user)
 
 
         node = xmlDocGetNodeByName(doc, "activities", "rpid");
-        if (node== NULL)
+        if (node== NULL || node->children== NULL)
         {
                node = xmlDocGetNodeByName(doc, "basic", NULL);
                if (node!= NULL)

--- a/modules/presence_xml/notify_body.h
+++ b/modules/presence_xml/notify_body.h
@@ -35,5 +35,5 @@ str* presence_agg_nbody(str* pres_user, str* pres_domain, str** body_array,
 		int n, int off_index);
 int pres_apply_auth(str* notify_body, subs_t* subs, str** final_nbody);
 void free_xml_body(char* body);
-
+void cachedb_update_merged_presence_state (str* body, str* pres_user);
 #endif

--- a/modules/presence_xml/presence_xml.h
+++ b/modules/presence_xml/presence_xml.h
@@ -30,6 +30,7 @@
 #define _PRES_XML_H_
 
 #include "../../db/db.h"
+#include "../../cachedb/cachedb.h"
 #include "../signaling/signaling.h"
 #include "../presence/event_list.h"
 #include "../presence/presence.h"
@@ -47,8 +48,13 @@ extern str xcap_table;
 extern add_event_t pres_add_event;
 extern db_con_t *pxml_db;
 extern db_func_t pxml_dbf;
+extern cachedb_funcs cdbf;
+extern cachedb_con *con;
 extern int force_active;
 extern int pidf_manipulation;
+extern int im_to_rpidf;
+extern int merge;
+extern str merge_primary_source;
 extern int integrated_xcap_server;
 extern xcap_serv_t* xs_list;
 extern xcapGetNewDoc_t xcap_GetNewDoc;
@@ -57,5 +63,6 @@ extern struct sig_binds xml_sigb;
 extern str pres_rules_auid;
 extern str pres_rules_filename;
 extern int generate_offline_body;
+extern str cachedb_url;
 
 #endif

--- a/modules/pua_usrloc/ul_publish.c
+++ b/modules/pua_usrloc/ul_publish.c
@@ -133,6 +133,7 @@ str* build_pidf(ucontact_t* c)
 	xmlNewProp(root_node, BAD_CAST "entity", BAD_CAST pres_uri.s);
 
 	tuple_node =xmlNewChild(root_node, NULL, BAD_CAST "tuple", NULL) ;
+        xmlNewProp(tuple_node, BAD_CAST "id", BAD_CAST "pua_register");
 	if( tuple_node ==NULL)
 	{
 		LM_ERR("while adding child\n");


### PR DESCRIPTION
This patch relies on received_time being unchanged when a publish is
refreshed.

The aggregation merges the different presence states so that the last
published one is considered as the correct presence status. A primary
presence source can be defined. Call events are also considered as
primary. PUA fake presence generation is considered as secondary.

This is particularly useful with most hardware phones as they are not
able to handle several aggregated presence states.

SNOM phones being buggy, they send a body with a PUBLISH refresh
despite the RFC states it MUST NOT happen. We added a workaround for that.

The current short presence status is written in CacheDB. This allows presence-based routing.

If accepted, please credit Damien Sandras from Be IP s.a. @ http://www.beip.be
