### PR TITLE
Revert commit 4b29352e.

### DIFF
--- a/modules/presence/notify.c
+++ b/modules/presence/notify.c
@@ -1967,11 +1967,6 @@ jump_over_body:
 	if (notify_body && subs->event->aux_body_processing)
 		aux_body = subs->event->aux_body_processing(subs, notify_body);
 
-#ifdef USE_TCP
-        /* don't open new TCP connections if connection is down */
-	tcp_no_new_conn = 1;
-#endif
-
 	result = tmb.t_request_within
 		(&met,                          /* method*/
 		&str_hdr,                       /* extra headers*/
@@ -1980,10 +1975,6 @@ jump_over_body:
 		p_tm_callback,                  /* callback function*/
 		(void*)cb_param,                /* callback parameter*/
 		NULL);
-
-#ifdef USE_TCP
-	tcp_no_new_conn = 0;
-#endif
 
 	if(aux_body) {
 		if(aux_body->s)

--- a/modules/registrar/doc/registrar_admin.xml
+++ b/modules/registrar/doc/registrar_admin.xml
@@ -483,6 +483,44 @@ modparam("registrar", "gruu_secret", "top_secret")
 		</programlisting>
 		</example>
 	</section>
+	<section>
+		<title><varname>disable_gruu</varname> (int)</title>
+		<para>
+			Globally disable GRUU handling
+		</para>
+		<para>
+		<emphasis>
+			Default value is 0 ( GRUU will be handled ).
+		</emphasis>
+		</para>
+		<example>
+		<title>Set <varname>gruu_secret</varname> parameter</title>
+		<programlisting format="linespecific">
+...
+modparam("registrar", "gruu_secret", 1)
+...
+		</programlisting>
+		</example>
+	</section>
+	<section>
+		<title><varname>disable_gruu</varname> (int)</title>
+		<para>
+			Globally disable GRUU handling
+		</para>
+		<para>
+		<emphasis>
+			Default value is 0 ( GRUU will be handled ).
+		</emphasis>
+		</para>
+		<example>
+		<title>Set <varname>gruu_secret</varname> parameter</title>
+		<programlisting format="linespecific">
+...
+modparam("registrar", "gruu_secret", 1)
+...
+		</programlisting>
+		</example>
+	</section>
 	</section>
 
 	<section>

--- a/modules/rls/notify.c
+++ b/modules/rls/notify.c
@@ -695,7 +695,7 @@ int rls_send_notify(subs_t* subs, str* body, str* start_cid,
 		LM_ERR("while building dlg_t structure\n");
 		goto error;	
 	}
-
+	
 	LM_DBG("constructed dlg_t struct\n");
 	size= sizeof(dialog_id_t)+(subs->to_tag.len+ subs->callid.len+ 
 			subs->from_tag.len) *sizeof(char);
@@ -729,12 +729,6 @@ int rls_send_notify(subs_t* subs, str* body, str* start_cid,
 		goto error;
 	}
 	LM_DBG("str_hdr= %.*s\n", str_hdr.len, str_hdr.s);
-
-#ifdef USE_TCP
-        /* don't open new TCP connections if connection is down */
-	tcp_no_new_conn = 1;
-#endif
-
 	rt = tmb.t_request_within
 		(&met,
 		&str_hdr,
@@ -743,10 +737,6 @@ int rls_send_notify(subs_t* subs, str* body, str* start_cid,
 		rls_notify_callback,
 		(void*)cb_param,
 		NULL);
-
-#ifdef USE_TCP
-	tcp_no_new_conn = 0;
-#endif
 
 	if(rt < 0)
 	{


### PR DESCRIPTION
There is no reason why we should not create new
TCP Connections on notifications. Imagine an architecture with two
redundant servers handling eachother part of the calls. Dialog notifications
would only work when the call is going through the server which handled the
subscription.

If accepted, please credit Damien Sandras from Be IP s.a. @ http://www.beip.be
