### PR TITLE
Fixed presentity naming.

### DIFF
--- a/modules/presence/presentity.c
+++ b/modules/presence/presentity.c
@@ -53,8 +53,8 @@ char* dialog_states[]= {  "trying",
                            "early",
                        "confirmed",
                      "terminated"};
-char* presence_notes[]={ "Calling",
-                         "Calling",
+char* presence_notes[]={ "Proceeding",
+                         "Proceeding",
                     "On the phone",
                                ""};
 


### PR DESCRIPTION
'Calling' is disturbing especially when the given peer is _receiving_ a
call.

If accepted, please credit Damien Sandras from Be IP s.a. @ http://www.beip.be
