### PR TITLE
Fixed SST timer being reset to the lowest value on session refresh.

### DIFF
--- a/modules/sst/sst_handlers.c
+++ b/modules/sst/sst_handlers.c
@@ -441,10 +441,6 @@ static void sst_dialog_request_within_CB(struct dlg_cell* did, int type,
                                 else
                                       info->interval = MAX(minfo.se, sst_min_se);
                        }
-                       else {
-                                param = find_param_export("dialog", "default_timeout", INT_PARAM);
-                                info->interval = param?*param:12*3600;
-                       }
 	               info->supported = (minfo.supported?SST_UAC:SST_UNDF);
                        set_timeout_avp(msg, info->interval);
 		}


### PR DESCRIPTION
If accepted, please credit Damien Sandras from Be IP s.a. @ http://www.beip.be
