### PR TITLE
Trigger exactly one callback per early state change.

### DIFF
--- a/modules/dialog/dlg_handlers.c
+++ b/modules/dialog/dlg_handlers.c
@@ -470,10 +470,9 @@ static void dlg_onreply(struct cell* t, int type, struct tmcb_params *param)
 
 	next_state_dlg( dlg, event, &old_state, &new_state, &unref);
 
-	if (new_state==DLG_STATE_EARLY) {
+	if (new_state==DLG_STATE_EARLY && old_state!=DLG_STATE_EARLY) {
 		run_dlg_callbacks(DLGCB_EARLY, dlg, rpl, DLG_DIR_UPSTREAM, 0);
-		if (old_state!=DLG_STATE_EARLY)
-			if_update_stat(dlg_enable_stats, early_dlgs, 1);
+	        if_update_stat(dlg_enable_stats, early_dlgs, 1);
 		return;
 	}
 


### PR DESCRIPTION
There are several reasons behind this change:
1) Other callbacks are only triggered once for each state change.
2) SNOM phones send several 180 Ringing messages in a row. That triggers
several early dialog callbacks, which in turn trigger several PUBLISH
and NOTIFY through the pua_dialoginfo module. This can potentially lead
to problems.

If accepted, please credit Damien Sandras from Be IP s.a. @ http://www.beip.be
