### PR TITLE
mod registrar: correcting min_expires, max_expires ; mod tm: forcing retrans and fr timers to be started before request is relayed

### DIFF
--- a/modules/registrar/save.c
+++ b/modules/registrar/save.c
@@ -749,6 +749,8 @@ int save_aux(struct sip_msg* _m, str* forced_binding, char* _d, char* _f, char* 
 	sctx.max_contacts = -1;
 
 	sctx.flags = 0;
+	sctx.min_expires = min_expires;
+	sctx.max_expires = max_expires;
 	if ( _f ) {
 		if (fixup_get_svalue( _m, (gparam_p)_f, &flags_s)!=0) {
 			LM_ERR("invalid flags parameter");


### PR DESCRIPTION
Hello, 
here is my attempt to correct these two issues:
https://github.com/OpenSIPS/opensips/issues/32
  registrar:save is ignoring min_expires, max_expires from cfg
https://github.com/OpenSIPS/opensips/issues/25
  tm:t_forward_nonack relay message before starting retrans and fr timers.

regards,
Takeshi
