### PR TITLE
wrong mpath folder (detected by rpmbuild)

### DIFF
--- a/modules/osp/Makefile
+++ b/modules/osp/Makefile
@@ -1,4 +1,3 @@
-
 # osp module makefile
 
 # WARNING: do not run this directly, it should be run by the master Makefile
@@ -33,7 +32,7 @@ include ../../Makefile.modules
 install_module_custom: 
 	echo "OSP module overwrites the default configuration file"
 	sed  \
-		-e "s#/usr/local/lib/opensips#$(modules-prefix)/$(lib-dir)#g" \
+		-e "s#/usr/local/lib/opensips#$(modules-target)/$(lib-dir)#g" \
 		< etc/sample-osp-opensips.cfg \
 		> $(cfg-prefix)/$(cfg-dir)/opensips.cfg
 


### PR DESCRIPTION
change modules-prefix (tmp folder) to modules-target (installation folder)
