### PR TITLE
Update to 1.10

### DIFF
--- a/packaging/rpm/opensips.spec.CentOS
+++ b/packaging/rpm/opensips.spec.CentOS
@@ -1,6 +1,6 @@
 %define name    opensips
-%define ver     1.9.1
-%define rel     5
+%define ver     1.10.0
+%define rel     1
 %define _sharedir %{_prefix}/share
 
 Summary:      OpenSIPS, very fast and flexible SIP Server
@@ -270,6 +270,17 @@ This module implements a xmlrpc server that handles xmlrpc requests and generate
 When a xmlrpc message is received a default method is executed.  
 
 
+%package  mi_xmlrpc_ng
+Summary:  opensips mi_xmlrpc_ng implementation.
+Group:    System Environment/Daemons
+Requires: opensips = %ver
+BuildRequires:  xmlrpc-c-devel
+
+%description mi_xmlrpc_ng
+This module implements a xmlrpc_ng server that handles xmlrpc_ng requests and generates xmlrpc_ng responses.
+When a xmlrpc_ng message is received a default method is executed.  
+
+
 %package  db_http
 Summary:  opensips db_http implementation.
 Group:    System Environment/Daemons
@@ -337,6 +348,15 @@ The Perl Virtual Database (VDB) provides a virtualization framework for
 OpenSIPS's database access. It does not handle a particular database engine
 itself but lets the user relay database requests to arbitrary Perl functions.
 
+%package  sngtc
+Summary:  Sangoma media transcoding interface for the OpenSIPS
+Group:    System Environment/Daemons
+Requires: opensips = %ver
+
+%description  sngtc
+The sngtc package implements interface to Sangoma media transcoding.
+
+
 %package  tlsops
 Summary:  TLS-relating functions for the OpenSIPS
 Group:    System Environment/Daemons
@@ -353,7 +373,7 @@ parameters.
 %setup -n %{name}-%{ver}-tls
 
 %build
-make all exclude_modules="" ORAVERSION=11.2/client cfg-target=/%{_sysconfdir}/opensips/
+make all exclude_modules="" ORAVERSION=11.2/client cfg-target=%{_sysconfdir}/opensips/
 
 
 %install
@@ -410,6 +430,7 @@ fi
 %doc %{_docdir}/opensips/README.cfgutils
 %doc %{_docdir}/opensips/README.closeddial
 %doc %{_docdir}/opensips/README.db_flatstore
+%doc %{_docdir}/opensips/README.db_cachedb
 %doc %{_docdir}/opensips/README.db_text
 %doc %{_docdir}/opensips/README.db_virtual
 %doc %{_docdir}/opensips/README.dialog
@@ -430,6 +451,7 @@ fi
 %doc %{_docdir}/opensips/README.load_balancer
 %doc %{_docdir}/opensips/README.lua
 %doc %{_docdir}/opensips/README.mangler
+%doc %{_docdir}/opensips/README.mathops
 %doc %{_docdir}/opensips/README.maxfwd
 %doc %{_docdir}/opensips/README.mediaproxy
 %doc %{_docdir}/opensips/README.mi_datagram
@@ -449,6 +471,7 @@ fi
 %doc %{_docdir}/opensips/README.qos
 %doc %{_docdir}/opensips/README.ratelimit
 %doc %{_docdir}/opensips/README.registrar
+%doc %{_docdir}/opensips/README.rest_client
 %doc %{_docdir}/opensips/README.rr
 %doc %{_docdir}/opensips/README.rtpproxy
 %doc %{_docdir}/opensips/README.seas
@@ -494,6 +517,7 @@ fi
 %{_libdir}/opensips/modules/call_control.so
 %{_libdir}/opensips/modules/cfgutils.so
 %{_libdir}/opensips/modules/closeddial.so
+%{_libdir}/opensips/modules/db_cachedb.so
 %{_libdir}/opensips/modules/db_flatstore.so
 %{_libdir}/opensips/modules/db_text.so
 %{_libdir}/opensips/modules/db_virtual.so
@@ -515,6 +539,7 @@ fi
 %{_libdir}/opensips/modules/load_balancer.so
 %{_libdir}/opensips/modules/lua.so
 %{_libdir}/opensips/modules/mangler.so
+%{_libdir}/opensips/modules/mathops.so
 %{_libdir}/opensips/modules/maxfwd.so
 %{_libdir}/opensips/modules/mediaproxy.so
 %{_libdir}/opensips/modules/mi_datagram.so
@@ -535,6 +560,7 @@ fi
 %{_libdir}/opensips/modules/qos.so
 %{_libdir}/opensips/modules/ratelimit.so
 %{_libdir}/opensips/modules/registrar.so
+%{_libdir}/opensips/modules/rest_client.so
 %{_libdir}/opensips/modules/rr.so
 %{_libdir}/opensips/modules/rtpproxy.so
 %{_libdir}/opensips/modules/seas.so
@@ -790,6 +816,13 @@ fi
 %{_libdir}/opensips/modules/mi_xmlrpc.so
 
 
+%files mi_xmlrpc_ng
+%defattr(-,root,root)
+%doc %{_docdir}/opensips/README.mi_xmlrpc_ng
+
+%{_libdir}/opensips/modules/mi_xmlrpc_ng.so
+
+
 %files db_http
 %defattr(-,root,root)
 %doc %{_docdir}/opensips/README.db_http
@@ -856,6 +889,13 @@ fi
 %{_libdir}/opensips/perl/OpenSIPS/VDB/VTab.pm
 %{_libdir}/opensips/perl/OpenSIPS/VDB/Value.pm
 
+%files sngtc
+%defattr(-,root,root,-)
+%doc %{_docdir}/opensips/README.sngtc
+
+%{_libdir}/opensips/modules/sngtc.so
+
+
 %files tlsops
 %defattr(-,root,root,-)
 %doc %{_docdir}/opensips/README.tlsops
@@ -863,6 +903,10 @@ fi
 %{_libdir}/opensips/modules/tlsops.so
 
 
+%changelog
+* Tue Aug 06 2013 Fabrizio Picconi <fabrizio.picconi@tiscali.it>
+- Some new rpm optional modules are added:
+  mi_xmlrpc_ng,sngtc,db_cachedb,mathops,rest_client
 %changelog
 * Sun Jul 21 2013 Fabrizio Picconi <fabrizio.picconi@tiscali.it>
 - Some new rpm optional modules are added:


### PR DESCRIPTION
Some new rpm optional modules are added:
mi_xmlrpc_ng,sngtc,db_cachedb,mathops,rest_client
