### PR TITLE
Fixed processing TCP messages that come in multiple chunks

### DIFF
--- a/tcp_conn.h
+++ b/tcp_conn.h
@@ -190,6 +190,7 @@ struct tcp_connection{
 
 #define init_tcp_req( r) \
 	do{ \
+	        memset( (r), 0, sizeof(struct tcp_req)); \
 		(r)->parsed=(r)->pos=(r)->start=(r)->buf; \
 		(r)->error=TCP_REQ_OK;\
 		(r)->state=H_SKIP_EMPTY; \

--- a/tcp_read.c
+++ b/tcp_read.c
@@ -744,6 +744,7 @@ again:
 			}
 
 			con->con_req->content_len = req->content_len;
+			con->con_req->has_content_len = req->has_content_len;
 			con->con_req->bytes_to_go = req->bytes_to_go;
 			con->con_req->error = req->error;
 			con->con_req->state = req->state;


### PR DESCRIPTION
- Completely zero-out tcp_req structure on initialization
- Copy has_content_len from the global req buffer to the per-connection
  one

@vladpaiu please have a look and let me know if it looks kosher to you, if so I'll push it.
