### PR TITLE
remove warning compilation

### DIFF
--- a/tcp_read.c
+++ b/tcp_read.c
@@ -935,7 +935,7 @@ skip:
  */
 inline static int handle_io(struct fd_map* fm, int idx,int event_type)
 {	
-	int ret;
+	int ret=0;
 	int n;
 	struct tcp_connection* con;
 	int s,rw;


### PR DESCRIPTION
remove warning: ‘ret’ may be used uninitialized in this function
