### PR TITLE
Fix free_sdp()

### DIFF
--- a/parser/sdp/sdp.c
+++ b/parser/sdp/sdp.c
@@ -752,6 +752,7 @@ int parse_sdp(struct sip_msg* _m)
 void free_sdp(sdp_info_t** sdp)
 {
 	__free_sdp(*sdp);
+	pkg_free(*sdp);
 	*sdp = NULL;
 }
 


### PR DESCRIPTION
Fix free_sdp() : don't try to free part of a sip_msg structure (bug introduced by commit bde8c0a045 )
