### PR TITLE
Return payload ids in case of a dynamic payload instead of a simple 1 or -1.

### DIFF
--- a/modules/sipmsgops/codecs.c
+++ b/modules/sipmsgops/codecs.c
@@ -32,6 +32,7 @@
 #include "codecs.h"
 #include "../../route.h"
 #include "../../mod_fix.h"
+#include "../../ut.h"
 
 #define MAX_STREAMS 64
 
@@ -527,7 +528,9 @@ static int stream_process(struct sip_msg * msg, struct sdp_stream_cell *cell,
 
 				if(op == FIND)
 				{
-					ret = 1;
+					str2sint(&(payload->rtp_payload), &ret);
+					if( (ret >= 0) && (ret <= 34) ) /* if a fixed payload ID then just return 1 */
+						ret = 1;
 					goto end;
 				}
 


### PR DESCRIPTION
Right now it's not possible to find out what's the actual payload id for a given codec (although it's possible to know if it exists in SDP). With these two patches it's possible to lookup and retrieve a payload ID, e.g.:

loadmodule "simpsgops.so"
...
$avp(dtmf_id) = codec_exists("telephone-event", "8000");
$avp(opus8k_id) = codec_exists("opus", "8000");
$avp(opus16k_id) = codec_exists("opus", "16000");

These values can be reused later for transcoding.

Functions codec_find, codec_find_re, codec_find_clock, will return -1 if no codec found, 1 if found codec with statis mapping (0 =< payload id =< 34), or actual payload id in case of a dynamic mapping. So I'm basically extending return values from -1,1 to -1,1,35...127. This will not affect current configs (e.g. if (codec_exists("PCMU") || codec_exists("OPUS")) will still work as expected).
