### PR TITLE
Support returning the new value from cache_add/cache_sub

### DIFF
--- a/cfg.y
+++ b/cfg.y
@@ -2789,6 +2789,32 @@ cmd:	 FORWARD LPAREN STRING RPAREN	{ mk_action2( $$, FORWARD_T,
 								elems[3].u.number = $9;
 								$$ = mk_action(CACHE_ADD_T, 4, elems, line); 
 							}
+		| CACHE_ADD LPAREN STRING COMMA STRING COMMA NUMBER COMMA NUMBER COMMA script_var RPAREN { 
+								elems[0].type = STR_ST; 
+								elems[0].u.data = $3; 
+								elems[1].type = STR_ST; 
+								elems[1].u.data = $5; 
+								elems[2].type = NUMBER_ST;
+								elems[2].u.number = $7;
+								elems[3].type = NUMBER_ST;
+								elems[3].u.number = $9;
+								elems[4].type = SCRIPTVAR_ST;
+								elems[4].u.data = $11;
+								$$ = mk_action(CACHE_ADD_T, 5, elems, line); 
+							}
+		| CACHE_ADD LPAREN STRING COMMA STRING COMMA script_var COMMA NUMBER COMMA script_var RPAREN { 
+								elems[0].type = STR_ST; 
+								elems[0].u.data = $3; 
+								elems[1].type = STR_ST; 
+								elems[1].u.data = $5; 
+								elems[2].type = SCRIPTVAR_ST;
+								elems[2].u.data = $7;
+								elems[3].type = NUMBER_ST;
+								elems[3].u.number = $9;
+								elems[4].type = SCRIPTVAR_ST;
+								elems[4].u.data = $11;
+								$$ = mk_action(CACHE_ADD_T, 5, elems, line); 
+							}
 		| CACHE_SUB LPAREN STRING COMMA STRING COMMA NUMBER COMMA NUMBER RPAREN { 
 								elems[0].type = STR_ST; 
 								elems[0].u.data = $3; 
@@ -2810,6 +2836,32 @@ cmd:	 FORWARD LPAREN STRING RPAREN	{ mk_action2( $$, FORWARD_T,
 								elems[3].type = NUMBER_ST;
 								elems[3].u.number = $9;
 								$$ = mk_action(CACHE_SUB_T, 4, elems, line); 
+							}
+		| CACHE_SUB LPAREN STRING COMMA STRING COMMA NUMBER COMMA NUMBER COMMA script_var RPAREN { 
+								elems[0].type = STR_ST; 
+								elems[0].u.data = $3; 
+								elems[1].type = STR_ST; 
+								elems[1].u.data = $5; 
+								elems[2].type = NUMBER_ST;
+								elems[2].u.number = $7;
+								elems[3].type = NUMBER_ST;
+								elems[3].u.number = $9;
+								elems[4].type = SCRIPTVAR_ST;
+								elems[4].u.data = $11;
+								$$ = mk_action(CACHE_SUB_T, 5, elems, line); 
+							}
+		| CACHE_SUB LPAREN STRING COMMA STRING COMMA script_var COMMA NUMBER COMMA script_var RPAREN { 
+								elems[0].type = STR_ST; 
+								elems[0].u.data = $3; 
+								elems[1].type = STR_ST; 
+								elems[1].u.data = $5; 
+								elems[2].type = SCRIPTVAR_ST;
+								elems[2].u.data = $7;
+								elems[3].type = NUMBER_ST;
+								elems[3].u.number = $9;
+								elems[4].type = SCRIPTVAR_ST;
+								elems[4].u.data = $11;
+								$$ = mk_action(CACHE_SUB_T, 5, elems, line); 
 							}
 		| CACHE_RAW_QUERY LPAREN STRING COMMA STRING COMMA STRING RPAREN { 
 								elems[0].type = STR_ST; 

--- a/route.c
+++ b/route.c
@@ -657,6 +657,14 @@ static int fix_actions(struct action* a)
 							goto error;
 						}
 					}
+				} else if (t->type==CACHE_ADD_T || t->type==CACHE_SUB_T) {
+					if(t->elem[4].u.data != NULL && ((pv_spec_p)t->elem[4].u.data)->setf == NULL)
+					{
+						LM_ERR("Fourth argument cannot be a read-only pvar\n");
+						ret=E_CFG;
+						goto error;
+					}
+
 				}
 				break;
 			case SET_ADV_ADDR_T:


### PR DESCRIPTION
Adds support to cache_add/cache_sub for returning the newly update value in a pvar.

Tested against couchbase and memcached backends.
