### PR TITLE
Added new dns_try_naptr option.

### DIFF
--- a/cfg.lex
+++ b/cfg.lex
@@ -291,6 +291,7 @@ AUTO_ALIASES	auto_aliases
 DNS		 dns
 REV_DNS	 rev_dns
 DNS_TRY_IPV6    dns_try_ipv6
+DNS_TRY_NAPTR   dns_try_naptr
 DNS_RETR_TIME   dns_retr_time
 DNS_RETR_NO     dns_retr_no
 DNS_SERVERS_NO  dns_servers_no
@@ -582,6 +583,8 @@ IMPORTFILE      "import_file"
 <INITIAL>{REV_DNS}	{ count(); yylval.strval=yytext; return REV_DNS; }
 <INITIAL>{DNS_TRY_IPV6}		{ count(); yylval.strval=yytext;
 								return DNS_TRY_IPV6; }
+<INITIAL>{DNS_TRY_NAPTR}	{ count(); yylval.strval=yytext;
+								return DNS_TRY_NAPTR; }
 <INITIAL>{DNS_RETR_TIME}	{ count(); yylval.strval=yytext;
 								return DNS_RETR_TIME; }
 <INITIAL>{DNS_RETR_NO}		{ count(); yylval.strval=yytext;

--- a/cfg.y
+++ b/cfg.y
@@ -71,6 +71,7 @@
  *  2007-01-25  disable_dns_failover option added (bogdan)
  *  2012-01-19  added TCP keepalive support
  *  2012-12-06  added event_route (razvanc)
+ *  2013-05-23  added NAPTR lookup option (dsandras)
  */
 
 
@@ -312,6 +313,7 @@ extern int line;
 %token DNS
 %token REV_DNS
 %token DNS_TRY_IPV6
+%token DNS_TRY_NAPTR
 %token DNS_RETR_TIME
 %token DNS_RETR_NO
 %token DNS_SERVERS_NO
@@ -652,6 +654,8 @@ assign_stm: DEBUG EQUAL snumber {
 		| REV_DNS EQUAL error { yyerror("boolean value expected"); }
 		| DNS_TRY_IPV6 EQUAL NUMBER   { dns_try_ipv6=$3; }
 		| DNS_TRY_IPV6 error { yyerror("boolean value expected"); }
+		| DNS_TRY_NAPTR EQUAL NUMBER   { dns_try_naptr=$3; }
+		| DNS_TRY_NAPTR error { yyerror("boolean value expected"); }
 		| DNS_RETR_TIME EQUAL NUMBER   { dns_retr_time=$3; }
 		| DNS_RETR_TIME error { yyerror("number expected"); }
 		| DNS_RETR_NO EQUAL NUMBER   { dns_retr_no=$3; }

--- a/resolve.c
+++ b/resolve.c
@@ -67,6 +67,7 @@ struct dns_val {
 #define local_free   pkg_free
 
 int dns_try_ipv6=0; /*!< default off */
+int dns_try_naptr=1; /*!< default on */
 /* declared in globals.h */
 int dns_retr_time=-1;
 int dns_retr_no=-1;
@@ -1823,6 +1824,10 @@ struct hostent* sip_resolvehost( str* name, unsigned short* port,
 		goto do_srv;
 	}
 
+	if ( dns_try_naptr==0 ) {
+		*proto = (is_sips)?PROTO_TLS:PROTO_UDP;
+		goto do_srv;
+	}
 	LM_DBG("no port, no proto -> do NAPTR lookup!\n");
 	/* no proto, no port -> do NAPTR lookup */
 	if (name->len >= MAX_DNS_NAME) {

--- a/resolve.h
+++ b/resolve.h
@@ -152,6 +152,7 @@ void free_rdata_list(struct rdata* head);
 
 
 extern int dns_try_ipv6;
+extern int dns_try_naptr;
 
 
 #define HEX2I(c) \


### PR DESCRIPTION
The rationale behind this is that many stacks do not implement NAPTR
correctly and rely only on DNS SRV. With misconfigured DNS servers, it
can lead to useless lookups generating potentially long delays.

This can now be disabled if not needed.
