### PR TITLE
pua.c sets int min_expires= 300, not 0 as documentation states.

### DIFF
--- a/modules/pua/README
+++ b/modules/pua/README
@@ -2,16 +2,15 @@ Presence User Agent Module
 
 Anca-Maria Vamanu
 
-   voice-system.ro
+   Voice Sistem SRL
 
 Edited by
 
 Anca-Maria Vamanu
 
-   Copyright © 2006 voice-system.ro
+   Copyright © 2006 Voice Sistem SRL
    Revision History
-   Revision $Revision$ $Date: 2009-07-21 10:45:05 +0300
-                              (Tue, 21 Jul 2009) $
+   Revision $Revision$ $Date$
      __________________________________________________________
 
    Table of Contents
@@ -143,7 +142,7 @@ modparam("pua", "db_table", "pua")
 
    The inferior expires limit for both Publish and Subscribe.
 
-   Default value is “0”.
+   Default value is “300”.
 
    Example 1.4. Set min_expires parameter
 ...

--- a/modules/pua/doc/pua_admin.xml
+++ b/modules/pua/doc/pua_admin.xml
@@ -130,7 +130,7 @@ modparam("pua", "db_table", "pua")
 		The inferior expires limit for both Publish and Subscribe.
 		</para>
 		<para>
-		<emphasis>Default value is <quote>0</quote>.
+		<emphasis>Default value is <quote>300</quote>.
 		</emphasis>
 		</para>
 		<example>


### PR DESCRIPTION
While looking for an issue with publishes that expire too soon -- turned out to be the dialog timeout_avp setting which I set low until receiving the ACK -- I found this documentation mismatch.

Cheers,
Walter
