### PR TITLE
Set the dialog lifetime before running the callbacks.

### DIFF
--- a/modules/dialog/dlg_handlers.c
+++ b/modules/dialog/dlg_handlers.c
@@ -1215,13 +1215,17 @@ after_unlock5:
 		LM_DBG("sequential request successfully processed (dst_leg=%d)\n",
 			dst_leg);
 
+		/* if there is a lifetime update, the dlg_callbacks will want
+		 * to know. fetch it before running the callbacks */
+		timeout = get_dlg_timeout_update(req);
+		if (timeout != 0)
+			dlg->lifetime = timeout;
+
 		/* within dialog request */
 		run_dlg_callbacks( DLGCB_REQ_WITHIN, dlg, req, dir, 0);
 
-		timeout = get_dlg_timeout_update(req);
 		/* update timer during sequential request? */
 		if (timeout != 0) {
-			dlg->lifetime = timeout;
 			if (update_dlg_timer( &dlg->tl, dlg->lifetime )==-1)
 				LM_ERR("failed to update dialog lifetime\n");
 		}


### PR DESCRIPTION
When the timeout_avp is used to shorten the life of dialogs that never
receive an ACK, the timeout_avp is set to a low value at first and later
increased when the ACK is received.

```
modparam("dialog", "timeout_avp", "$avp(10)")
...
# If this is an initial INVITE we want the timeout reduced
# drastically. The B2BUA's use the default timeout of about
# ~24 seconds. We need to use the same, or a failed call
# without an ACK may keep lingering for 7200 seconds here.
# And that, in turn, may trigger call limits, effectively
# denying the caller access.
# (The counter starts when the 200 is received.)
if (is_method("INVITE")) {
    $avp(10) = 24;
}
...
if (is_method("ACK")) {
    $avp(10) = 7200;  # 2 hours should be enough for everyone :P
}
```

Before this change, the `pua_dialoginfo` callback would get the original
value of 24, which it would happily pass along to the presence server.

After this change, the updated value of 7200 is passed along as Expires
value and the presence server doesn't "forget" calls after a while
anymore.
