### PR TITLE
Use additional auth field - Sip-Source-IP-Address

### DIFF
--- a/aaa/aaa_avp.h
+++ b/aaa/aaa_avp.h
@@ -56,7 +56,8 @@
 #define	A_TIME_STAMP					28
 #define	A_SIP_CALL_ID					29
 #define	A_SIP_REQUEST_HASH				30
-#define	A_MAX							31
+#define	A_SIP_SOURCE_IP_ADDRESS				31
+#define	A_MAX						32
 
 #define	V_STATUS_START			0
 #define	V_STATUS_STOP			1

--- a/modules/auth_aaa/authaaa_mod.c
+++ b/modules/auth_aaa/authaaa_mod.c
@@ -162,6 +162,7 @@ static int mod_init(void)
 	attrs[A_SERVICE_TYPE].name			= "Service-Type";
 	attrs[A_SIP_URI_USER].name			= "Sip-URI-User";
 	attrs[A_SIP_URI_HOST].name			= "SIP-URI-Host";
+	attrs[A_SIP_SOURCE_IP_ADDRESS].name			= "Sip-Source-IP-Address";
 	attrs[A_DIGEST_RESPONSE].name		= "Digest-Response";
 	attrs[A_DIGEST_ALGORITHM].name		= "Digest-Algorithm";
 	attrs[A_DIGEST_BODY_DIGEST].name	= "Digest-Body-Digest";

--- a/modules/auth_aaa/sterman.c
+++ b/modules/auth_aaa/sterman.c
@@ -87,6 +87,7 @@ int aaa_authorize_sterman(struct sip_msg* _msg, dig_cred_t* _cred, str* _method,
 	uint32_t service;
 	str method, user, user_name;
 	str *ruri;
+	str ip;
 
 	send = received = NULL;
 
@@ -225,6 +226,14 @@ int aaa_authorize_sterman(struct sip_msg* _msg, dig_cred_t* _cred, str* _method,
 
 	/* Add SIP URI as a check item */
 	if (proto.avp_add(conn, send, &attrs[A_SIP_URI_USER], user.s,user.len,0)) {
+		LM_ERR("unable to add Sip-URI-User attribute\n");
+		goto err;
+	}
+
+	/* Add SIP source IP address as a check item */
+	ip.s = ip_addr2a(&_msg->rcv.src_ip);
+	ip.len = strlen(ip.s);
+	if (proto.avp_add(conn, send, &attrs[A_SIP_SOURCE_IP_ADDRESS], ip.s,ip.len,0)) {
 		LM_ERR("unable to add Sip-URI-User attribute\n");
 		goto err;
 	}


### PR DESCRIPTION
In some cases knowing login and password isn't enough. Sometimes we have to check SIP IP address as well (to implement whitelisted/blacklisted subnets or IPs).
