### PR TITLE
enable rabbitmq heartbeat to solve processes hang by amqp socket

### DIFF
--- a/modules/event_rabbitmq/event_rabbitmq.h
+++ b/modules/event_rabbitmq/event_rabbitmq.h
@@ -68,6 +68,8 @@ typedef struct _rmq_params {
 	int sock;
 	int channel;
 	int flags;
+	int heartbeat;
 } rmq_params_t;
 
 #endif
+

--- a/modules/event_rabbitmq/rabbitmq_send.c
+++ b/modules/event_rabbitmq/rabbitmq_send.c
@@ -251,11 +251,25 @@ static int rmq_reconnect(evi_reply_sock *sock)
 		}
 		amqp_set_sockfd(rmqp->conn, rmqp->sock);
 
-		if (rmq_error("Logging in", amqp_login(rmqp->conn,
+/*
+librabbitmq-0.1-0.2 amqp.h
+RABBITMQ_EXPORT amqp_rpc_reply_t amqp_login(amqp_connection_state_t state,
+                                        char const *vhost,
+                                        int channel_max,
+                                        int frame_max,
+                                        int heartbeat,
+                                        amqp_sasl_method_enum sasl_method, ...);
+
+channel_max: the maximum number of channels per connection
+frame_max: maximum AMQP frame size for client
+*/
+
+		if (rmq_error("Logging in", amqp_login(
+				rmqp->conn,
 				RMQ_DEFAULT_VHOST,
 				0,
 				RMQ_DEFAULT_MAX,
-				0,
+				rmqp->heartbeat,
 				AMQP_SASL_METHOD_PLAIN,
 				rmqp->flags & RMQ_PARAM_USER ? rmqp->user.s : RMQ_DEFAULT_UP,
 				rmqp->flags & RMQ_PARAM_PASS ? rmqp->pass.s : RMQ_DEFAULT_UP)))
@@ -323,3 +337,4 @@ end:
 			shm_free(rmqs);
 	}
 }
+

--- a/modules/event_rabbitmq/rabbitmq_send.h
+++ b/modules/event_rabbitmq/rabbitmq_send.h
@@ -45,3 +45,4 @@ void rmq_free_param(rmq_params_t *rmqp);
 void rmq_destroy(evi_reply_sock *sock);
 
 #endif
+


### PR DESCRIPTION
This implementation enabled the rabbitmq's client side's heartbeat negotiation.

Issue:
Because of TCP's nature, it takes very long time for a TCP peer to make the decision of closing a local socket when the connection actually is broken. The event_rabbitmq module didn't handle the situation which causes the Opensips1.9 stop processing UDP packets until the O.S decides to close the local socket. One of the consequence is that UAC cannot register to the registrar during this time period.

Issue Reproduce:
1. Block an existing amqp connection from the rabbitmq-server that event_rabbitmq module connects to.
2. From the event_rabbitmq side, the UDP receive-buffer that Opensips uses should be full.

Solution:
If the module, even_rabbitmq/rabbitmq-client, doesn't get a heartbeat message from the rabbitmq-server within X seconds, the rabbitmq-client will kill the local socket connection actively.

Added a modparam:

modparam("event_rabbitmq", "heartbeat", [X seconds])
