### PR TITLE
support of rabbitmq's exchange and routing-key assignment

### DIFF
--- a/modules/event_rabbitmq/event_rabbitmq.c
+++ b/modules/event_rabbitmq/event_rabbitmq.c
@@ -23,13 +23,32 @@
  *  2011-05-xx  created (razvancrainea)
  */
 
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+
 #include "../../sr_module.h"
 #include "../../evi/evi_transport.h"
 #include "../../ut.h"
+#include "../../mod_fix.h"
+
 #include "event_rabbitmq.h"
 #include "rabbitmq_send.h"
-#include <string.h>
 
+#include "../../dprint.h"
+#include "../../mem/mem.h"
+#include "../../mod_fix.h"
+
+/*enhance functions*/
+
+
+static int set_routing_key_f(struct sip_msg* msg, char* _sp, rmq_params_t * rmqp);
+static int fallback_default_exchange_f(rmq_params_t * rmqp);
+static int fixup_routing_key_f(void** param, int param_no);
+
+static char* rk_avp_param = NULL;
+static unsigned short rk_avp_type = 0;
+static int rk_avp_name = -1;
 
 
 /* send buffer */
@@ -58,6 +77,16 @@ static proc_export_t procs[] = {
 	{"RabbitMQ sender",  0,  0, rmq_process, 1, 0},
 	{0,0,0,0,0,0}
 };
+
+/*
+ * Script commands: Exported Parameters.
+ */
+static param_export_t mod_params[] = {
+	{"routing-key_avp",     STR_PARAM, &rk_avp_param      },
+	{0, 0, 0}
+};
+
+
 /**
  * module exports
  */
@@ -66,7 +95,7 @@ struct module_exports exports= {
 	MODULE_VERSION,
 	DEFAULT_DLFLAGS,			/* dlopen flags */
 	0,							/* exported functions */
-	0,							/* exported parameters */
+	mod_params,					/* exported parameters */
 	0,							/* exported statistics */
 	0,							/* exported MI functions */
 	0,							/* exported pseudo-variables */
@@ -96,7 +125,7 @@ static evi_export_t trans_export_rmq = {
  */
 static int mod_init(void)
 {
-	LM_NOTICE("initializing module ...\n");
+	LM_NOTICE("initializing module ........\n");
 
 	if (register_event_mod(&trans_export_rmq)) {
 		LM_ERR("cannot register transport functions for RabbitMQ\n");
@@ -106,6 +135,36 @@ static int mod_init(void)
 	if (rmq_create_pipe() < 0) {
 		LM_ERR("cannot create communication pipe\n");
 		return -1;
+	}
+
+	pv_spec_t avp_spec;
+	str rk;
+
+	if (rk_avp_param && *rk_avp_param) {
+		rk.s = rk_avp_param; rk.len = strlen(rk.s);
+		if (pv_parse_spec(&rk, &avp_spec)==0 || avp_spec.type!=PVT_AVP) {
+			LM_ERR("Malformed RMQ AVP definition: %s\n", rk_avp_param);
+			return -1;
+		} else {
+			LM_DBG("Valid RMQ AVP definition - [%s] \n", rk_avp_param);
+		}
+
+		if(pv_get_avp_name(0, &avp_spec.pvp, &rk_avp_name, &rk_avp_type)!=0)
+		{
+			LM_ERR("Invalid RMQ AVP definition - [%s] \n", rk_avp_param);
+			return -1;
+		}
+	
+		if (fixup_routing_key_f(&rk_avp_param, 1) < 0) {
+			//how to release the rk_avp_param, might have leak??
+			rk_avp_param = NULL;
+			LM_ERR("RMQ AVP Processing Error - [%s] \n", rk_avp_param);
+			return -1;
+		}
+
+	} else {
+		rk_avp_name = -1;
+		rk_avp_type = 0;
 	}
 
 	return 0;
@@ -291,7 +350,6 @@ static evi_reply_sock* rmq_parse(str socket)
 				if (dupl_string(&sock->address, begin, socket.s + i) < 0)
 					goto err;
 				sock->flags |= EVI_ADDRESS;
-
 				if (dupl_string(&param->exchange, socket.s + i + 1, 
 							socket.s + len) < 0)
 					goto err;
@@ -310,7 +368,6 @@ static evi_reply_sock* rmq_parse(str socket)
 					goto err;
 				}
 				sock->flags |= EVI_PORT;
-
 				if (dupl_string(&param->exchange, socket.s + i + 1, 
 							socket.s + len) < 0)
 					goto err;
@@ -333,7 +390,6 @@ success:
 		param->user.len = param->pass.len = RMQ_DEFAULT_UP_LEN;
 		param->flags |= RMQ_PARAM_USER|RMQ_PARAM_PASS;
 	}
-
 	sock->params = param;
 	sock->flags |= EVI_PARAMS | RMQ_FLAG;
 
@@ -520,14 +576,107 @@ static int rmq_raise(struct sip_msg *msg, str* ev_name,
 		LM_ERR("no more shm memory\n");
 		return -1;
 	}
+
 	memcpy(rmqs->msg, rmq_buffer, len);
 	rmqs->sock = sock;
+
+	rmq_params_t * rmqp = (rmq_params_t *)rmqs->sock->params;
+
+	str rk;
+	// getting rabbitmq routing-key
+	if (rk_avp_param && *rk_avp_param) {
+		rk.s = rk_avp_param; rk.len = strlen(rk.s);
+		LM_DBG("modparam: routing-key_avp is set");
+		// modparam: routing-key_avp is set
+		if (set_routing_key_f(msg, rk_avp_param, rmqp)) {
+			LM_DBG("pvar value processing error\n");
+			//fallback to use default exchange
+			if (fallback_default_exchange_f(rmqp)) {
+				LM_DBG("fallback error");
+			} else {
+				LM_DBG("fallback success");
+			}
+		}
+	} else {
+		// modparam: routing-key_avp is not set
+		LM_DBG("modparam: routing-key_avp is not set");
+		//fallback to use default exchange
+		if (fallback_default_exchange_f(rmqp)) {
+			LM_DBG("fallback error");
+		} else {
+			LM_DBG("fallback success");
+		}
+	}
 
 	if (rmq_send(rmqs) < 0) {
 		LM_ERR("cannot send message\n");
 		shm_free(rmqs);
 		return -1;
 	}
+
+	return 0;
+}
+
+
+static int fixup_routing_key_f(void** param, int param_no) {
+	if (!rk_avp_param) {
+		LM_ERR("Configuration error: NO rk_avp_param\n");
+		return -1;
+	}
+	fixup_pvar_null(param, param_no);
+	return 0;
+}
+
+static int set_routing_key_f(struct sip_msg* msg, char* _sp, rmq_params_t * rmqp) {
+	pv_spec_t *sp;
+    pv_value_t pv_val;
+
+    sp = (pv_spec_t *)_sp;
+
+    if (sp && (pv_get_spec_value(msg, sp, &pv_val) == 0)) {
+		if (pv_val.flags & PV_VAL_STR) {
+	    	if (pv_val.rs.len == 0 || pv_val.rs.s == NULL) {
+				LM_DBG("pvar value is empty\n");
+				return -1;
+	    	}
+		} else {
+		    LM_DBG("pvar value is invalid\n");
+	    	return -1;
+		}
+    } else {
+		LM_DBG("cannot get the pvar spec\n");
+		return -1;
+    }
+	
+	int length = strlen(pv_val.rs.s);
+	char rk[length];
+	strncpy(rk, pv_val.rs.s, length);
+	rk[length]='\0';
+	char empty[] = "";
+	
+	if (dupl_string(&rmqp->routing_key, rk, empty)) {
+		return -1;
+	}
+
+	return 0;
+}
+
+static int fallback_default_exchange_f(rmq_params_t * rmqp) {
+
+	//fallback the routing-key as the exchange from the rabbitmq's URI
+	if (!rmqp->routing_key.s) {
+		int length = strlen(rmqp->exchange.s);
+		char rk[length];
+		strncpy(rk, rmqp->exchange.s, length);
+		rk[length]='\0';
+		char empty[] = "";
+		
+		if (dupl_string(&rmqp->routing_key, rk, empty)) {
+			return -1;
+		}
+	}
+
+	rmqp->exchange.s = "";
 
 	return 0;
 }

--- a/modules/event_rabbitmq/event_rabbitmq.h
+++ b/modules/event_rabbitmq/event_rabbitmq.h
@@ -62,6 +62,7 @@
 
 typedef struct _rmq_params {
 	str exchange;
+	str routing_key;
 	str user;
 	str pass;
 	amqp_connection_state_t conn;

--- a/modules/event_rabbitmq/rabbitmq_send.c
+++ b/modules/event_rabbitmq/rabbitmq_send.c
@@ -279,11 +279,14 @@ static int rmq_sendmsg(rmq_send_t *rmqs)
 {
 	rmq_params_t * rmqp = (rmq_params_t *)rmqs->sock->params;
 
+	LM_DBG("rmqp->exchange: %s\n", rmqp->exchange.s);
+	LM_DBG("rmqp->routing_key: %s\n", rmqp->routing_key.s);
+
 	/* all checks should be already done */
 	return amqp_basic_publish(rmqp->conn,
 			rmqp->channel,
-			AMQP_EMPTY_BYTES,
 			amqp_cstring_bytes(rmqp->exchange.s),
+			amqp_cstring_bytes(rmqp->routing_key.s),
 			0,
 			0,
 			0,


### PR DESCRIPTION
event-rabbitmq-ex-rk-assignment

Assigning exchange and routing-key against rabbitmq-server from opensips1.9

1.3. RabbitMQ socket syntax 'rabbitmq:' [user[':'password] '@' host [':' port] '/' exchange

Meanings:

'rabbitmq:' - informs the Event Interface that the events sent to this subscriber should be handled by the event_rabbitmq module.

user - username used for RabbitMQ server authentication. The default value is 'guest'.

password - password used for RabbitMQ server authentication. The default value is 'guest'.

host - host name of the RabbitMQ server.

port - port of the RabbitMQ server. The default value is '5672'.

exchange - exchange name used by the AMQP protocol. It is NOT used to identify the queue.

1.5. Exported Parameters 1.5.1. routing-key_avp (str)

This is for holding the name of the avp for assigning routing-key in the script. If the modparam is not used, the module will behave as before. The behavior is to use the default exchange of rabbitmq and the value of the "exchange" will be the routing-key of messages.

Example 1.17. Set the “routing-key_avp” parameter

 ...
 modparam("dispatcher", "routing-key_avp", "$avp(routing-key)")
 ...

1.8.1. OpenSIPS config file

startup_route {

```
if (!subscribe_event("E_SIP_MESSAGE", "rabbitmq:127.0.0.1/sipmsg")) {
    xlog("L_ERR","cannot the RabbitMQ server to the E_SIP_MESSAGE event\n");
}
```

}

route{

if (!mf_process_maxfwd_header("10")) {
    sl_send_reply("483","Too Many Hops");
    exit;
}

if (has_totag()) {
    if (loose_route()) {
        if (is_method("INVITE")) {
            record_route();
        }
        route(1);
    } else {
        if ( is_method("ACK") ) {
            if ( t_check_trans() ) {
                t_relay();
                exit;
            } else {
                exit;
            }
        }
        sl_send_reply("404","Not here");
    }
    exit;
}

if (is_method("CANCEL"))
{
    if (t_check_trans())
        t_relay();
    exit;
}

t_check_trans();

if (loose_route()) {
    xlog("L_ERR",
    "Attempt to route with preloaded Route's [$fu/$tu/$ru/$ci]");
    if (!is_method("ACK"))
        sl_send_reply("403","Preload Route denied");
    exit;
}

if (!is_method("REGISTER|MESSAGE"))
    record_route();

if (!uri==myself)
{
    append_hf("P-hint: outbound\r\n"); 
    route(1);
}

if (is_method("PUBLISH"))
{
    sl_send_reply("503", "Service Unavailable");
    exit;
}

if (is_method("REGISTER"))
{
    if (!save("location"))
        sl_reply_error();

```
exit;
```

}

if ($rU==NULL) {
    sl_send_reply("484","Address Incomplete");
    exit;
}

if (is_method("MESSAGE")) {
    $avp(attrs) = "user";
    $avp(vals) = $rU;
    $avp(attrs) = "msg";
    $avp(vals) = $rb;

/*
- This message will be sent to exchange sipmsg with routing-key of the value of $tU
- If the routing-key is not assigned, the message will be sent to the default exchange of the rabbitmq-server
- with the routing-key of the value of $tU. It means only the queue with the name of the value of $tU can get the
- message according to the amqp protocol. 
  */

$avp(routing-key) = $tU;
    if (!raise_event("E_SIP_MESSAGE", $avp(attrs), $avp(vals)))
        xlog("L_ERR", "cannot raise E_SIP_MESSAGE event\n");
}

if (!lookup("location","m")) {
    switch ($retcode) {
        case -1:
        case -3:
            t_newtran();
            t_reply("404", "Not Found");
            exit;
        case -2:
            sl_send_reply("405", "Method Not Allowed");
            exit;
    }
}

route(1);

}
