### PR TITLE
Reset prepared statement between query lists on shutdown

### DIFF
--- a/db/db_insertq.c
+++ b/db/db_insertq.c
@@ -125,6 +125,10 @@ void flush_query_list(void)
 			}
 
 			it->dbf.use_table(it->conn,&it->table);
+
+			//Reset prepared statement between query lists/connections
+			my_ps = NULL;
+
 			CON_PS_REFERENCE(it->conn) = &my_ps;
 
 			/* and let's insert the rows */


### PR DESCRIPTION
Failing to do so results in a segfault when multiple database flushes are required at shutdown.
