### PR TITLE
mi_json documentation: corrected typo and XML translation problem

### DIFF
--- a/modules/mi_json/doc/mi_json.xml
+++ b/modules/mi_json/doc/mi_json.xml
@@ -17,12 +17,12 @@
 	<productname class="trade">&osipsname;</productname>
 	<authorgroup>
 	    <author>
-		<firstname>Stéphane</firstname>
+		<firstname>Stephane</firstname>
 		<surname>Alnet</surname>
 		<email>stephane@shimaore.net</email>
 	    </author>
 	    <editor>
-		<firstname>Stéphane</firstname>
+		<firstname>Stephane</firstname>
 		<surname>Alnet</surname>
 	    </editor>
 	</authorgroup>

--- a/modules/mi_json/doc/mi_json_admin.xml
+++ b/modules/mi_json/doc/mi_json_admin.xml
@@ -85,7 +85,7 @@ modparam("mi_xmlrpc_ng", "mi_json_root", "opensips_mi_json")
 		<title>JSON request</title>
 		<programlisting format="linespecific">
 <![CDATA[
-GET /json/get_statistics?params==net%3A%2Curi%3A HTTP/1.1
+GET /json/get_statistics?params=net%3A%2Curi%3A HTTP/1.1
 Accept: application/json
 Host: example.net
 


### PR DESCRIPTION
@vladpaiu thank you for merging #119 !
I noticed some typos / XML translation problems while reading over the `README` in 52405e6b56218f49063db878c3283d349dd02c7c and cleaned them up in the source.
