### PR TITLE
This patch fixes the entity URI in XML documents to contain "sip:".

### DIFF
--- a/modules/presence_dialoginfo/notify_body.c
+++ b/modules/presence_dialoginfo/notify_body.c
@@ -175,10 +175,11 @@ str* agregate_xmls(str* pres_user, str* pres_domain, str** body_array, int n, in
         LM_ERR("entity URI too long, maximum=%d\n", MAX_URI_SIZE);
         return NULL;
     }
-    memcpy(buf, pres_user->s, pres_user->len);
-    buf[pres_user->len] = '@';
-    memcpy(buf + pres_user->len + 1, pres_domain->s, pres_domain->len);
-    buf[pres_user->len + 1 + pres_domain->len]= '\0';
+	memcpy(buf, "sip:", 4);
+	memcpy(buf+4, pres_user->s, pres_user->len);
+	buf[pres_user->len+4] = '@';
+	memcpy(buf + pres_user->len + 5, pres_domain->s, pres_domain->len);
+	buf[pres_user->len + 5 + pres_domain->len]= '\0';
 
     doc = xmlNewDoc(BAD_CAST "1.0");
     if(doc==0)


### PR DESCRIPTION
Without it, Polycom phones do not reset the state correctly
when receiving full state notifications.

Polycom phones indeed require the entity to be formatted exactly the same
way for all notifications it receives. From their point of view, sip:a@b
and a@b are different URIs.

This can be safely merged into all active branches.
