### PR TITLE
Replace odd -j in modules-submake with ability for proper parallelism.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -208,6 +208,7 @@ _modules: $(modules)
 
 .PHONY: $(modules)
 $(modules):
+	@if ! echo $(MAKEFLAGS) | grep -q -- --jobserver; then echo; echo; fi  # extra LF if not using -j
 	$(MAKE) -C $@
 
 .PHONY: modules


### PR DESCRIPTION
Recently `-j` was added to the list of flags passed to the modules
$(MAKE) command. That's bad practise for two reasons: (1) the caller
should decide on how much -j is required, not the programmer, and (2)
just -j without any numeric argument is "use all resources you can
get", which can be too much.

We order the Makefile around so the supermake (the user invocation)
can dispatch individual submakes in a parallel fashion. This is done
by (a) making the module directories phony targets and (b) replacing
the sequential for-loop over the modules with a simple dependency.

And, to top it off, I ran a quick and dirty non-scientific test (*) and came up with these tests results:

Before patch, make modules -j3:

real    1m23.744s
user    2m24.796s
sys 0m7.252s

After patch, make modules -j3:

real    1m2.799s
user    2m51.112s
sys 0m7.400s

That's quite a bit of speedup too. Even though that wasn't the goal.

(*) I ran the test twice to rule out caching issues in favor of either one of them and came up with pretty much the same numbers both times.
