### PR TITLE
Fix bug where a new publication does not extend the desired expire time.

### DIFF
--- a/modules/pua/send_publish.c
+++ b/modules/pua/send_publish.c
@@ -409,6 +409,7 @@ int send_publish_int(ua_pres_t* presentity, publ_info_t* publ, pua_event_t* ev,
 			memcpy(tuple_id.s, presentity->tuple_id.s, presentity->tuple_id.len);
 			tuple_id.len = presentity->tuple_id.len;
 		}
+               presentity->desired_expires= publ->expires + (int)time(NULL);
 
 		presentity->waiting_reply = 1;
 		presentity->cb_param = publ->cb_param;


### PR DESCRIPTION
The old code only updated the desired_expires value when handling
a completely new PUBLISH request. This was not done when there is
a new state publication reusing an existing "presentity".
