### PR TITLE
Fixes bug where the pua db elements were deleted too early.

### DIFF
--- a/modules/pua/pua.c
+++ b/modules/pua/pua.c
@@ -900,13 +900,6 @@ static void db_update(unsigned int ticks,void *param)
 		return ;
 	}
 
-	db_vals[0].val.int_val= (int)time(NULL)- 10;
-	db_ops[0]= OP_LT;
-	if(pua_dbf.delete(pua_db, db_cols, db_ops, db_vals, 1) < 0)
-	{
-		LM_ERR("while deleting from db table pua\n");
-	}
-
 	for(i=0; i<HASH_SIZE; i++) 
 	{
 		if(!no_lock)
@@ -1019,6 +1012,13 @@ static void db_update(unsigned int ticks,void *param)
 		}
 		if(!no_lock)
 			lock_release(&HashT->p_records[i].lock);
+	}
+
+	db_vals[0].val.int_val= (int)time(NULL)- 10;
+	db_ops[0]= OP_LT;
+	if(pua_dbf.delete(pua_db, db_cols, db_ops, db_vals, 1) < 0)
+	{
+		LM_ERR("while deleting from db table pua\n");
 	}
 
 	return ;


### PR DESCRIPTION
The problem is that the update_db function was deleting elements
10 seconds before they are expired and before the expire time could
have been extended by the same function.

This patch fixes the order of update and delete operations:
1) Update the expired elements (and other changes)
2) Delete expired elements after the possible update

This allows only deleting elements that are really expired.
