### PR TITLE
Fixes bug where a refreshed PUBLISH request triggers an error message.

### DIFF
--- a/modules/pua_mi/mi_func.c
+++ b/modules/pua_mi/mi_func.c
@@ -264,9 +264,14 @@ int mi_publ_rpl_cback( ua_pres_t* hentity, struct sip_msg* reply)
 	str etag;
 	str reason= {0, 0};
 
-	if(reply== NULL || hentity== NULL || hentity->cb_param== NULL)
+	if(reply== NULL || hentity== NULL)
 	{
 		LM_ERR("NULL parameter\n");
+		return -1;
+	}
+	if(hentity->cb_param== NULL)
+	{
+		LM_DBG("NULL callback parameter, probably a refresh\n");
 		return -1;
 	}
 	if(reply== FAKED_REPLY)


### PR DESCRIPTION
A missing callback argument should be turned into a debug message
because it only happens when refreshing a PUBLISH and executing
a callback does not make sense in that specific case for mi module.
