### PR TITLE
opensipsctl is calling ds_relaod for dr instead of dr_reload

### DIFF
--- a/scripts/opensipsctl
+++ b/scripts/opensipsctl
@@ -1402,7 +1402,7 @@ dr() {
 				exit 1
 			fi
 
-			$CTLCMD ds_reload
+			$CTLCMD dr_reload
 			;;
 		rmgw)
 			shift
@@ -1452,7 +1452,7 @@ dr() {
 				exit 1
 			fi
 
-			$CTLCMD ds_reload
+			$CTLCMD dr_reload
 			;;
 		rmcr)
 			shift
@@ -1500,7 +1500,7 @@ dr() {
 				exit 1
 			fi
 
-			$CTLCMD ds_reload
+			$CTLCMD dr_reload
 			;;
 		rmgrp)
 			shift
@@ -1552,7 +1552,7 @@ dr() {
 				exit 1
 			fi
 
-			$CTLCMD ds_reload
+			$CTLCMD dr_reload
 			;;
 		rmgrule)
 			shift


### PR DESCRIPTION
Instead of reloading dynamic routes, script is trying to reload dispatcher gateways. Example command to reproduce problem:
`opensipsctl dr addgw "1" 10 "192.168.1.11" 0 "" "" 0 "main_gw"`
Returns: 500 command 'ds_reload' not available
