### PR TITLE
dr_state_flusher() might be called before the data structures are initialized

### DIFF
--- a/modules/drouting/drouting.c
+++ b/modules/drouting/drouting.c
@@ -432,6 +432,9 @@ static void dr_state_flusher(void)
 	db_key_t key_set;
 	db_val_t val_set;
 
+	if (!dr_persistent_state || !db_hdl || !rdata || !(*rdata)) {
+		return;
+	}
 
 	val_cmp.type = DB_INT;
 	val_cmp.nul  = 0;
@@ -811,8 +814,7 @@ static int dr_child_init(int rank)
 
 static int dr_exit(void)
 {
-	if (dr_persistent_state && db_hdl)
-		dr_state_flusher();
+	dr_state_flusher();
 
 	/* close DB connection */
 	if (db_hdl) {


### PR DESCRIPTION
This was causing opensips to crash at startup when using the `drouting` module in 1.11.
