### PR TITLE
Do not reset counter expiration on incr/decr

### DIFF
--- a/modules/cachedb_local/hash.c
+++ b/modules/cachedb_local/hash.c
@@ -242,6 +242,7 @@ int lcache_htable_add(cachedb_con *con,str *attr,int val,int expires,int *new_va
 			}
 
 			old_value+=val;
+			expires = it->expires;
 			new_value = sint2str(old_value,&new_len);
 			it = shm_realloc(it,sizeof(lcache_entry_t) + attr->len +new_len);
 			if (it == NULL) {
@@ -259,13 +260,10 @@ int lcache_htable_add(cachedb_con *con,str *attr,int val,int expires,int *new_va
 			
 			it->attr.s = (char*)(it + 1);
 			it->value.s =(char *)(it + 1) + attr->len;
-			
+			it->expires = expires;
+
 			memcpy(it->value.s,new_value,new_len);
 			it->value.len = new_len;
-			if( expires != 0) {
-				LM_DBG("key %.*s will expire in %d s\n",attr->len,attr->s,expires);
-				it->expires = get_ticks() + expires;
-			}
 			lock_release(&cache_htable[hash_code].lock);
 			if (new_val)
 				*new_val = old_value;


### PR DESCRIPTION
This patch makes it so that the localcache module does not reset the expiration of a key on an addition or subtraction. Instead the expiration is based off when the key was first inserted. For example, if you add 1 to a key every second and have it expire after 20 seconds, the counter will increase for 20 seconds and then be reset. The current behavior is that the counter will just continually increase and will not reset unless there is 20 seconds of inactivity on the key.

This behavior is more in-line with how other caches (such as memcache) treat these operations, and I believe should be the expected behavior. It also makes it much easier to use the localcache for things such as rate-limiting, loop detecting, etc without having to resort to interesting tricks in the keys (such as including the current second, minute, etc).
