### PR TITLE
digest+m_auth: Allow a domain in the digest username.

### DIFF
--- a/modules/auth/auth_mod.c
+++ b/modules/auth/auth_mod.c
@@ -366,11 +366,11 @@ static inline int auth_get_ha1(struct sip_msg *msg, struct username* _username,
 			pv_value_destroy(&sval);
 			return 1;
 		}
-		if(sval.rs.len!= _username->user.len
-				|| strncasecmp(sval.rs.s, _username->user.s, sval.rs.len))
+		if(sval.rs.len!= _username->whole.len
+				|| strncasecmp(sval.rs.s, _username->whole.s, sval.rs.len))
 		{
 			LM_DBG("username mismatch [%.*s] [%.*s]\n",
-				_username->user.len, _username->user.s, sval.rs.len, sval.rs.s);
+				_username->whole.len, _username->whole.s, sval.rs.len, sval.rs.s);
 			pv_value_destroy(&sval);
 			return 1;
 		}

--- a/parser/digest/digest.c
+++ b/parser/digest/digest.c
@@ -115,13 +115,6 @@ dig_err_t check_dig_cred(dig_cred_t* _c)
 	     /* Realm must be present */
 	if (_c->realm.s == 0)  res |= E_DIG_REALM;
 
-	     /* If Username has domain, it must equal to Realm */
-	if (_c->username.domain.s && 
-	    ((_c->username.domain.len != _c->realm.len) ||
-	     (strncmp(_c->username.domain.s, _c->realm.s,
-		      _c->realm.len) != 0)))
-	    res |= E_DIG_DOMAIN;
-
 	     /* Nonce that was used must be specified */
 	if (_c->nonce.s == 0) res |= E_DIG_NONCE;
 


### PR DESCRIPTION
Before this patch, a domain in the digest username was allowed:

```
Digest username="abc@domain", realm="domain"
```

but only if the domain is equal to the realm. This was introduced in
a92bf789 (Juha Heinanen, Mar. 29 2006).

The SIP spec. doesn't mention any such restriction.

This patch undoes that commit and makes sure the whole username is used
when authenticating through `pv_www_authorize` and `pv_proxy_authorize`.
That makes the following valid:

```
Digest username="abc@domain", realm="something different"
```
