### PR TITLE
presence_dialoginfo: Fix memory leak in dlginfo_agg_nbody.

### DIFF
--- a/modules/presence_callinfo/add_events.c
+++ b/modules/presence_callinfo/add_events.c
@@ -82,7 +82,7 @@ static int callinfo_hdr_checker(struct sip_msg* msg, int* sent_reply)
 /*
  * event specific extra headers builder - for empty notifications
  */
-str* build_callinfo_dumy_header(str* pres_uri, str* extra_hdrs)
+str* build_callinfo_dummy_header(str* pres_uri, str* extra_hdrs)
 {
 	if (extra_hdrs->s == NULL)
 	{
@@ -425,7 +425,7 @@ int callinfo_add_events(void)
 	event.evs_publ_handl = callinfo_hdr_checker;
 
 	/* register the dummy Call-Info header builder */
-	event.build_empty_pres_info = build_callinfo_dumy_header;
+	event.build_empty_pres_info = build_callinfo_dummy_header;
 
 	if (pres.add_event(&event) < 0) {
 		LM_ERR("failed to add event \"call-info\"\n");


### PR DESCRIPTION
This commit fixes a couple of presence issues (introduced in 80c48e6):
- There was a memory leak in dlginfo_agg_nbody.
- Bounds checking in dlginfo_agg_nbody was off by 4 (potential stack
  corruption).
- There were 2 PKG allocs, straight after one another while no alloc
  was needed at all: reduced to 1 optional one.
- Replace "dumy" with "dummy" in the vicinity.
