### PR TITLE
OpenSIPS: Fixed possible crash in cachedb module.

### DIFF
--- a/modules/cachedb_sql/cachedb_sql.c
+++ b/modules/cachedb_sql/cachedb_sql.c
@@ -476,9 +476,6 @@ static int mod_init(void)
 		return -1;
 	}
 
-	cdb_dbf.close(cdb_db_handle);
-	cdb_db_handle = 0;
-
 	if(cache_clean_period <= 0) {
 			LM_ERR("wrong parameter cache_clean_period - need a postive value\n");
 			return -1;
@@ -511,12 +508,6 @@ static int mod_init(void)
  */
 static int child_init(int rank)
 {
-	cdb_db_handle = cdb_dbf.init(&db_url);
-	if (cdb_db_handle == 0) {
-			LM_ERR("unable to connect to the database\n");
-			return -1;
-	}
-
 	return 0;
 }
 


### PR DESCRIPTION
This is due to the dialog module mod_init method using the cachedb
module methods before child_init has been called.

In that case, the SQL handled is still set to NULL.

Fixes issue #197.
