### PR TITLE
Fix opensips-db_oracle library installation

### DIFF
--- a/packaging/rpm/opensips.spec.CentOS
+++ b/packaging/rpm/opensips.spec.CentOS
@@ -250,6 +250,7 @@ Summary:  opensips db_oracle implementation.
 Group:    System Environment/Daemons
 Requires: opensips = %ver
 BuildRequires:  oracle-instantclient11.2-devel
+AutoReqProv: no
 
 %description db_oracle
 This is a module which provides Oracle connectivity for OpenSIPS.


### PR DESCRIPTION
libclntsh.so.11.1() and libocci.so.11.1() not exported by oracle-instantclient
