### PR TITLE
store registration problem

### DIFF
--- a/scripts/dbtext/opensips/location
+++ b/scripts/dbtext/opensips/location
@@ -1,1 +1,1 @@
-id(int,auto) username(string) domain(string) contact(string) received(string,null) path(string,null) expires(int) q(double) callid(string) cseq(int) last_modified(int) flags(int) cflags(int) user_agent(string) socket(string,null) methods(int,null) sip_instance(string,null) 
+id(int,auto) username(string) domain(string,null) contact(string) received(string,null) path(string,null) expires(int) q(double) callid(string) cseq(int) last_modified(int) flags(int) cflags(int) user_agent(string) socket(string,null) methods(int,null) sip_instance(string,null) 


### PR DESCRIPTION
when a registration arrives:
 ERROR:usrloc:wb_timer: inserting contact into database failed
 ERROR:db_text:dbt_table_check_row: null value not allowed - field 2
