### PR TITLE
opensipsctl compatibility

### DIFF
--- a/scripts/dbtext/opensips/subscriber
+++ b/scripts/dbtext/opensips/subscriber
@@ -1,1 +1,1 @@
-id(int,auto) username(string) domain(string) password(string) email_address(string) ha1(string) ha1b(string) rpid(string,null) 
+id(int,auto) username(string) domain(string) password(string) email_address(string,null) ha1(string) ha1b(string) rpid(string,null) 


### PR DESCRIPTION
this change allows to insert empty email field.
 This change allows to insert new user with opensipsctl script
