### PR TITLE
load_balancer module enhancements

### DIFF
--- a/modules/load_balancer/lb_data.c
+++ b/modules/load_balancer/lb_data.c
@@ -951,7 +951,7 @@ int lb_is_dst(struct lb_data *data, struct sip_msg *_m,
 
 
 int lb_count_call(struct lb_data *data, struct sip_msg *req,
-			struct ip_addr *ip, int port, int grp, struct lb_res_str_list *rl)
+			struct ip_addr *ip, int port, int grp, struct lb_res_str_list *rl, int mode)
 {
 	static struct lb_resource **call_res = NULL;
 	static unsigned int call_res_no = 0;
@@ -1014,9 +1014,16 @@ end_search:
 
 	/* add to the profiles */
 	for( i=0 ; i<rl->n ; i++) {
-		if (lb_dlg_binds.set_profile( req, &dst->profile_id,
-		call_res[i]->profile, 0)!=0)
-			LM_ERR("failed to add to profile\n");
+		if( !mode ) {
+			if (lb_dlg_binds.set_profile( req, &dst->profile_id,
+			call_res[i]->profile, 0)!=0)
+				LM_ERR("failed to add to profile\n");
+		}
+		else {
+			if (lb_dlg_binds.unset_profile( req, &dst->profile_id,
+			call_res[i]->profile)!=1)
+				LM_ERR("failed to remove from profile\n");
+		}
 	}
 
 	/* unlock the resources*/

--- a/modules/load_balancer/lb_data.c
+++ b/modules/load_balancer/lb_data.c
@@ -470,7 +470,7 @@ int lb_route(struct sip_msg *req, int group, struct lb_res_str_list *rl, unsigne
 		for( it_r=data->resources,i=0 ; it_r ; it_r=it_r->next ) {
 			if( search_resource_str(rl, &it_r->name) ) {
 				res_new[i++] = it_r;
-				/*LM_DBG*/LM_ERR("initial call of LB - found requested %d/%d resource [%.*s]\n", i, res_new_n, it_r->name.len, it_r->name.s);
+				LM_DBG("initial call of LB - found requested %d/%d resource [%.*s]\n", i, res_new_n, it_r->name.len, it_r->name.s);
 			}
 		}
 		if( i != res_new_n ) {
@@ -500,7 +500,7 @@ int lb_route(struct sip_msg *req, int group, struct lb_res_str_list *rl, unsigne
 		for( it_d=data->dsts ; it_d ; it_d=it_d->next ) {
 			if( it_d->id == id_val.n ) {
 				last_dst = it_d;
-				/*LM_DBG*/LM_ERR("%s call of LB - found previous dst %d [%.*s]\n", (reuse ? "sequential" : "initial"), last_dst->id, last_dst->profile_id.len, last_dst->profile_id.s);
+				LM_DBG("%s call of LB - found previous dst %d [%.*s]\n", (reuse ? "sequential" : "initial"), last_dst->id, last_dst->profile_id.len, last_dst->profile_id.s);
 				break;
 			}
 		}
@@ -528,7 +528,7 @@ int lb_route(struct sip_msg *req, int group, struct lb_res_str_list *rl, unsigne
 				/* fill buffer only if buffer size not exeeded */
 				if( res_prev_n < res_prev_size ) {
 					res_prev[res_prev_n] = it_r;
-					/*LM_DBG*/LM_ERR("%s call of LB - found previous resource [%.*s]\n", (reuse ? "sequential" : "initial"), it_r->name.len, it_r->name.s);
+					LM_DBG("%s call of LB - found previous resource [%.*s]\n", (reuse ? "sequential" : "initial"), it_r->name.len, it_r->name.s);
 				}
 				res_prev_n++;
 			}
@@ -571,7 +571,7 @@ int lb_route(struct sip_msg *req, int group, struct lb_res_str_list *rl, unsigne
 		else
 			flags = LB_FLAGS_DEFAULT;
 
-		/*LM_DBG*/LM_ERR("sequential call of LB - found previous group %d and flags 0x%x\n", group, flags);
+		LM_DBG("sequential call of LB - found previous group %d and flags 0x%x\n", group, flags);
 	}
 
 
@@ -674,7 +674,7 @@ int lb_route(struct sip_msg *req, int group, struct lb_res_str_list *rl, unsigne
 						dst = it_d;
 						cond = 1;
 					}
-					/*LM_DBG*/LM_ERR("%s call of LB - destination %d <%.*s> selected for LB set with free=%d\n",
+					LM_DBG("%s call of LB - destination %d <%.*s> selected for LB set with free=%d\n",
 						(reuse ? "sequential" : "initial"),
 						it_d->id, it_d->uri.len, it_d->uri.s, it_l
 					);
@@ -687,7 +687,7 @@ int lb_route(struct sip_msg *req, int group, struct lb_res_str_list *rl, unsigne
 				}
 			}
 			else {
-				/*LM_DBG*/LM_ERR("%s call of LB - skipping destination %d <%.*s> (filtered=%d , disabled=%d)\n",
+				LM_DBG("%s call of LB - skipping destination %d <%.*s> (filtered=%d , disabled=%d)\n",
 					(reuse ? "sequential" : "initial"),
 					it_d->id, it_d->uri.len, it_d->uri.s,
 					((dst_bitmap_cur[i] & (1 << j)) ? 0 : 1), ((it_d->flags & LB_DST_STAT_DSBL_FLAG) ? 1 : 0)
@@ -699,7 +699,7 @@ int lb_route(struct sip_msg *req, int group, struct lb_res_str_list *rl, unsigne
 
 
 	if( dst != NULL ) {
-		/*LM_DBG*/LM_ERR("%s call of LB - winning destination %d <%.*s> selected for LB set with free=%d\n",
+		LM_DBG("%s call of LB - winning destination %d <%.*s> selected for LB set with free=%d\n",
 			(reuse ? "sequential" : "initial"),
 			dst->id, dst->uri.len, dst->uri.s, load
 		);
@@ -720,7 +720,7 @@ int lb_route(struct sip_msg *req, int group, struct lb_res_str_list *rl, unsigne
 		}
 	}
 	else {
-		/*LM_DBG*/LM_ERR("%s call of LB - no destination found\n", (reuse ? "sequential" : "initial"));
+		LM_DBG("%s call of LB - no destination found\n", (reuse ? "sequential" : "initial"));
 	}
 
 
@@ -729,7 +729,7 @@ int lb_route(struct sip_msg *req, int group, struct lb_res_str_list *rl, unsigne
 		lock_release(res_cur[i]->lock);
 
 
-	/* we're done with load-ballancing from here, now save state */
+	/* we're done with load-balancing, now save state */
 
 
 	/* save state - group */
@@ -742,7 +742,7 @@ int lb_route(struct sip_msg *req, int group, struct lb_res_str_list *rl, unsigne
 	else if( group_val.n != group ) {
 		group_avp->data = (void *)(long)group;
 	}
-	/* save state - flags, only if they are set */
+	/* save state - flags, save only if they are set */
 	if( flags_avp == NULL ) {
 		if( flags != LB_FLAGS_DEFAULT ) {
 			flags_val.n = flags;
@@ -766,7 +766,7 @@ int lb_route(struct sip_msg *req, int group, struct lb_res_str_list *rl, unsigne
 			LM_ERR("failed to add MASK AVP\n");
 		}
 	}
-	/* save state - dst, only save if we have one */
+	/* save state - dst, save only if we have one */
 	if( id_avp == NULL ) {
 		if( dst != NULL ) {
 			id_val.n = dst->id;
@@ -832,12 +832,12 @@ int lb_route(struct sip_msg *req, int group, struct lb_res_str_list *rl, unsigne
 
 int do_lb_start(struct sip_msg *req, int group, struct lb_res_str_list *rl, unsigned int flags, struct lb_data *data)
 {
-	return lb_route(req, group, rl, flags, data, 0/* should NOT reuse previous data */);
+	return lb_route(req, group, rl, flags, data, 0/*should NOT reuse previous data*/);
 }
 
 int do_lb_next(struct sip_msg *req, struct lb_data *data)
 {
-	return lb_route(req, -1, NULL, 0, data, 1/* reuse previous data */);
+	return lb_route(req, -1, NULL, 0, data, 1/*reuse previous data*/);
 }
 
 
@@ -864,7 +864,7 @@ int do_lb_reset(struct sip_msg *req, struct lb_data *data)
 		for( it_d=data->dsts ; it_d ; it_d=it_d->next ) {
 			if( it_d->id == id_val.n ) {
 				last_dst = it_d;
-				/*LM_DBG*/LM_ERR("reset LB - found previous dst %d [%.*s]\n", last_dst->id, last_dst->profile_id.len, last_dst->profile_id.s);
+				LM_DBG("reset LB - found previous dst %d [%.*s]\n", last_dst->id, last_dst->profile_id.len, last_dst->profile_id.s);
 				break;
 			}
 		}
@@ -883,7 +883,7 @@ int do_lb_reset(struct sip_msg *req, struct lb_data *data)
 		if( (last_dst != NULL) && (is_avp_str_val(res_avp) != 0) ) {
 			for( it_r=data->resources ; it_r ; it_r=it_r->next ) {
 				if( (it_r->name.len == res_val.s.len) && (memcmp(it_r->name.s, res_val.s.s, res_val.s.len) == 0) ) {
-					/*LM_DBG*/LM_ERR("reset LB - found previous resource [%.*s]\n", it_r->name.len, it_r->name.s);
+					LM_DBG("reset LB - found previous resource [%.*s]\n", it_r->name.len, it_r->name.s);
 					break;
 				}
 			}

--- a/modules/load_balancer/lb_data.h
+++ b/modules/load_balancer/lb_data.h
@@ -101,7 +101,7 @@ int lb_is_dst(struct lb_data *data, struct sip_msg *_m,
 		pv_spec_t *pv_ip, pv_spec_t *pv_port, int grp, int active);
 
 int lb_count_call(struct lb_data *data, struct sip_msg *req,
-		struct ip_addr *ip, int port, int grp, struct lb_res_str_list *rl);
+		struct ip_addr *ip, int port, int grp, struct lb_res_str_list *rl, int mode);
 
 int lb_init_event(void);
 void lb_raise_event(struct lb_dst *dst);

--- a/modules/load_balancer/lb_data.h
+++ b/modules/load_balancer/lb_data.h
@@ -36,8 +36,10 @@
 #include "../dialog/dlg_load.h"
 #include "lb_parser.h"
 
-#define LB_ABSOLUTE_LOAD_ALG    0
-#define LB_RELATIVE_LOAD_ALG    1
+#define LB_ALG_ABS              0
+#define LB_ALG_REL              1
+#define LB_ALG_ABS_NEG          2
+#define LB_ALG_REL_NEG          3
 
 #define LB_DST_PING_DSBL_FLAG   (1<<0)
 #define LB_DST_PING_PERM_FLAG   (1<<1)

--- a/modules/load_balancer/lb_data.h
+++ b/modules/load_balancer/lb_data.h
@@ -95,6 +95,8 @@ int do_load_balance(struct sip_msg *req, int grp, struct lb_res_str_list *rl,
 
 int do_lb_disable(struct sip_msg *req, struct lb_data *data);
 
+int do_lb_reset(struct sip_msg *req, struct lb_data *data);
+
 int lb_is_dst(struct lb_data *data, struct sip_msg *_m,
 		pv_spec_t *pv_ip, pv_spec_t *pv_port, int grp, int active);
 

--- a/modules/load_balancer/lb_data.h
+++ b/modules/load_balancer/lb_data.h
@@ -108,4 +108,5 @@ void lb_raise_event(struct lb_dst *dst);
 extern int grp_avp_name;
 extern int mask_avp_name;
 extern int id_avp_name;
+extern int prfs_avp_name;
 #endif

--- a/modules/load_balancer/lb_data.h
+++ b/modules/load_balancer/lb_data.h
@@ -101,7 +101,7 @@ int do_lb_reset(struct sip_msg *req, struct lb_data *data);
 
 int do_lb_is_started(struct sip_msg *req);
 
-int do_lb_disable_dst(struct sip_msg *req, struct lb_data *data);
+int do_lb_disable_dst(struct sip_msg *req, struct lb_data *data, unsigned int verbose);
 
 int lb_is_dst(struct lb_data *data, struct sip_msg *_m,
 		pv_spec_t *pv_ip, pv_spec_t *pv_port, int group, int active);

--- a/modules/load_balancer/lb_data.h
+++ b/modules/load_balancer/lb_data.h
@@ -30,16 +30,16 @@
 
 #ifndef LB_LB_DATA_H_
 #define LB_LB_DATA_H_
+
 #include "../../str.h"
 #include "../../locking.h"
 #include "../../parser/msg_parser.h"
 #include "../dialog/dlg_load.h"
 #include "lb_parser.h"
 
-#define LB_ALG_ABS              0
-#define LB_ALG_REL              1
-#define LB_ALG_ABS_NEG          2
-#define LB_ALG_REL_NEG          3
+#define LB_FLAGS_RELATIVE (1<<0) /* do relative versus absolute estimation. default is absolute */
+#define LB_FLAGS_NEGATIVE (1<<1) /* do not skip negative loads. default to skip */
+#define LB_FLAGS_DEFAULT  0
 
 #define LB_DST_PING_DSBL_FLAG   (1<<0)
 #define LB_DST_PING_PERM_FLAG   (1<<1)
@@ -92,25 +92,30 @@ int add_lb_dsturi( struct lb_data *data, int id, int group, char *uri,
 
 void free_lb_data(struct lb_data *data);
 
-int do_load_balance(struct sip_msg *req, int grp, struct lb_res_str_list *rl,
-		unsigned int alg, struct lb_data *data);
+int do_lb_start(struct sip_msg *req, int group, struct lb_res_str_list *rl,
+		unsigned int flags, struct lb_data *data);
 
-int do_lb_disable(struct sip_msg *req, struct lb_data *data);
+int do_lb_next(struct sip_msg *req, struct lb_data *data);
 
 int do_lb_reset(struct sip_msg *req, struct lb_data *data);
 
+int do_lb_is_started(struct sip_msg *req);
+
+int do_lb_disable_dst(struct sip_msg *req, struct lb_data *data);
+
 int lb_is_dst(struct lb_data *data, struct sip_msg *_m,
-		pv_spec_t *pv_ip, pv_spec_t *pv_port, int grp, int active);
+		pv_spec_t *pv_ip, pv_spec_t *pv_port, int group, int active);
 
 int lb_count_call(struct lb_data *data, struct sip_msg *req,
-		struct ip_addr *ip, int port, int grp, struct lb_res_str_list *rl, int mode);
+		struct ip_addr *ip, int port, int group, struct lb_res_str_list *rl, int dir);
 
 int lb_init_event(void);
 void lb_raise_event(struct lb_dst *dst);
 
 /* failover stuff */
-extern int grp_avp_name;
+extern int group_avp_name;
+extern int flags_avp_name;
 extern int mask_avp_name;
 extern int id_avp_name;
-extern int prfs_avp_name;
+extern int res_avp_name;
 #endif

--- a/modules/load_balancer/load_balancer.c
+++ b/modules/load_balancer/load_balancer.c
@@ -667,7 +667,7 @@ static int w_lb_disable_dst(struct sip_msg *req)
 	lock_start_read(ref_lock);
 
 	/* do lb */
-	ret = do_lb_disable_dst(req, *curr_data);
+	ret = do_lb_disable_dst(req, *curr_data, lb_prob_verbose);
 
 	lock_stop_read(ref_lock);
 

--- a/modules/load_balancer/load_balancer.c
+++ b/modules/load_balancer/load_balancer.c
@@ -94,6 +94,7 @@ static int fixup_cnt_call(void** param, int param_no);
 
 static int w_load_balance(struct sip_msg *req, char *grp, char *rl, char* al);
 static int w_lb_disable(struct sip_msg *req);
+static int w_lb_reset(struct sip_msg *req);
 static int w_lb_is_dst2(struct sip_msg *msg, char *ip, char *port);
 static int w_lb_is_dst3(struct sip_msg *msg, char *ip, char *port, char *grp);
 static int w_lb_is_dst4(struct sip_msg *msg, char *ip, char *port, char *grp,
@@ -113,6 +114,8 @@ static cmd_export_t cmds[]={
 	{"load_balance",     (cmd_function)w_load_balance,   3, fixup_resources,
 		0, REQUEST_ROUTE|BRANCH_ROUTE|FAILURE_ROUTE},
 	{"lb_disable",       (cmd_function)w_lb_disable,     0,               0,
+		0, REQUEST_ROUTE|FAILURE_ROUTE},
+	{"lb_reset",         (cmd_function)w_lb_reset,       0,               0,
 		0, REQUEST_ROUTE|FAILURE_ROUTE},
 	{"lb_is_destination",(cmd_function)w_lb_is_dst2,     2,    fixup_is_dst,
 		0, REQUEST_ROUTE|FAILURE_ROUTE|ONREPLY_ROUTE|BRANCH_ROUTE|LOCAL_ROUTE},
@@ -559,6 +562,23 @@ static int w_lb_disable(struct sip_msg *req)
 
 	/* do lb */
 	ret = do_lb_disable( req , *curr_data);
+
+	lock_stop_read( ref_lock );
+
+	if (ret<0)
+		return ret;
+	return 1;
+}
+
+
+static int w_lb_reset(struct sip_msg *req)
+{
+	int ret;
+
+	lock_start_read( ref_lock );
+
+	/* do lb */
+	ret = do_lb_reset( req , *curr_data);
 
 	lock_stop_read( ref_lock );
 

--- a/modules/load_balancer/load_balancer.c
+++ b/modules/load_balancer/load_balancer.c
@@ -75,9 +75,11 @@ static int mi_child_init();
 static str grp_avp_name_s = str_init("lb_grp");
 static str mask_avp_name_s = str_init("lb_mask");
 static str id_avp_name_s = str_init("lb_id");
+static str prfs_avp_name_s = str_init("lb_prfs");
 int grp_avp_name;
 int mask_avp_name;
 int id_avp_name;
+int prfs_avp_name;
 
 
 
@@ -90,7 +92,7 @@ static int fixup_resources(void** param, int param_no);
 static int fixup_is_dst(void** param, int param_no);
 static int fixup_cnt_call(void** param, int param_no);
 
-static int w_load_balance(struct sip_msg *req, char *grp,  char *rl, char* al);
+static int w_load_balance(struct sip_msg *req, char *grp, char *rl, char* al);
 static int w_lb_disable(struct sip_msg *req);
 static int w_lb_is_dst2(struct sip_msg *msg, char *ip, char *port);
 static int w_lb_is_dst3(struct sip_msg *msg, char *ip, char *port, char *grp);
@@ -442,6 +444,10 @@ static int mod_init(void)
 
 	if (lb_init_event() < 0) {
 		LM_ERR("cannot init event\n");
+		return -1;
+	}
+	if (parse_avp_spec(&prfs_avp_name_s, &prfs_avp_name)) {
+		LM_ERR("cannot parse resources avp\n");
 		return -1;
 	}
 


### PR DESCRIPTION
Apparently, in its current implementation load_balancer module could be used in the only one way:

load balance on static destinations group and static resources list.
first - because do_load_balance() ignores new group.
second - because do_load_balance() - clean up dialog profiles according to new resources string. not a previous one.

I tried to enhance this module to be able to use it in the following ways (this is just a sample to cover all possible cases):

route[LB1] {
      if( load_balancer("ID_1", "res1;res2") ) {
           t_on_failure("LB2_RETRY");
           route(RELAY);
       }
       route(LB2);
}
route[LB2] {
      if( load_balancer("ID_1", "res3") ) {
           t_on_failure("LB2_RETRY");
           route(RELAY);
       }
       route(LB3);
}
failure_route[LB2_RETRY] {
       route(LB2);
}
route[LB3] {
      if( load_balancer("ID_2", "res4") ) {
           t_on_failure("LB3_RETRY");
           route(RELAY);
       }
       route(FAILURE);
}
failure_route[LB3_RETRY] {
        route(LB3);
}

I also need to implement a scenario where I load-balance some amount of calls and reject excessive load, but some high-priority calls have to be handled at all cost. so I still want to load-balance them to select less busiest node, but ignore the fact that the amount of traffic on this node might exceed configured limits.

Also, if i register call as a 'load' using lb_count_call() function, I want to be able undo it.

