### PR TITLE
Always update the call ID when updating a contact in usrloc table

### DIFF
--- a/modules/usrloc/ucontact.c
+++ b/modules/usrloc/ucontact.c
@@ -258,8 +258,11 @@ int mem_update_ucontact(ucontact_t* _c, ucontact_info_t* _ci)
 
 	char* ptr;
 
-	/* No need to update Callid as it is constant
-	 * per ucontact (set at insert time)  -bogdan */
+	/* RFC 3261 states 'All registrations from a UAC SHOULD use
+	 * the same Call-ID header field value for registrations sent
+	 * to a particular registrar.', but it is not a 'MUST'. So
+	 * always update the call ID to be safe. */
+	update_str( &_c->callid, _ci->callid);
 
 	update_str( &_c->user_agent, _ci->user_agent);
 


### PR DESCRIPTION
RFC 3261 does not force UACs to use the same call ID for all registrations, only strongly suggests it. Some UAC implementations may not use the same call ID, causing the cseq check in `urecord.c` after a contact match to not occur in situations where an out of order request may be received.

Proposed change simply forces the call ID to be updated every time so that it is always accurate.
