### PR TITLE
Changes to stop keepalives on unregisters

### DIFF
--- a/modules/nat_traversal/nat_traversal.c
+++ b/modules/nat_traversal/nat_traversal.c
@@ -373,11 +373,9 @@ SIP_Dialog_end(SIP_Dialog *dialog)
 static INLINE void
 SIP_Registration_update(NAT_Contact *contact, time_t expire)
 {
-    if (expire > contact->registration_expire) {
-        if (contact->registration_expire == 0)
-            update_stat(registered_endpoints, 1);
-        contact->registration_expire = expire;
-    }
+    if (contact->registration_expire == 0)
+        update_stat(registered_endpoints, 1);
+    contact->registration_expire = expire;
 }
 
 static INLINE void
@@ -891,10 +889,10 @@ get_register_expire(struct sip_msg *request, struct sip_msg *reply)
         return 0;
     }
 
-    if (!reply->contact)
-        return 0;
-
     now = time(NULL);
+
+    if (!reply->contact)
+        return now;
 
     // request may be R/O (if we are called from the TM callback),
     // thus we copy the hdr_field structures before parsing them
@@ -943,7 +941,11 @@ get_register_expire(struct sip_msg *request, struct sip_msg *reply)
 
     LM_DBG("maximum expire for all contacts: %u\n", (unsigned)expire);
 
-    return (expire ? expire + now : 0);
+    // If no contacts were found in the reply which match the contact
+    // address being registered, then it was an unregister. As such,
+    // we return 'now' as the expiration time, to stop keepalives
+
+    return (expire ? expire + now : now);
 }
 
 


### PR DESCRIPTION
Observed cases where keepalives from `nat_traversal` continued after unregister were traced back to a few lines of code which prevented stopping keepalives on unregister events.

There are three main changes here:
1. Allow `SIP_Registration_update` to decrease a keepalive time
2. If a successful register reply has no contact field assume no remaining contacts exist and stop keepalives
3. If a successful register reply has no contacts which match the request then it was an unregister and stop keepalives

These changes have been in use in a high traffic production environment for two years now with no known ill effect. Logic should still be double checked to ensure the changes are general enough to incorporate back into OpenSIPS.
