### PR TITLE
Update rtpproxy.c

### DIFF
--- a/modules/rtpproxy/rtpproxy.c
+++ b/modules/rtpproxy/rtpproxy.c
@@ -3755,6 +3755,8 @@ force_rtp_proxy_body(struct sip_msg* msg, struct force_rtpp_args *args, pv_spec_
 					LM_ERR("out of pkg memory\n");
 					goto error;
 				}
+				/* Accommodate new opts length */
+				v[1].iov_len++;
 			}
 			STR2IOVEC(newip, v[7]);
 			STR2IOVEC(oldport, v[9]);


### PR DESCRIPTION
When building I/O vector for command to rtpproxy in "force_rtp_proxy_body", after an IPv6 address is detected and the "6" option is added, increase the length component in the I/O vector so it is passed correctly.
