### PR TITLE
added missing force-relay flag option for ICE

### DIFF
--- a/modules/rtpengine/rtpengine.c
+++ b/modules/rtpengine/rtpengine.c
@@ -996,7 +996,7 @@ static int parse_flags(struct ng_flags_parse *ng_flags, struct sip_msg *msg, enu
 					if (!val.s)
 						goto error;
 					err = "invalid value";
-					if (str_eq(&val, "force") || str_eq(&val, "remove"))
+					if (str_eq(&val, "force") || str_eq(&val, "force-relay") || str_eq(&val, "remove"))
 						bencode_dictionary_add_str(ng_flags->dict, "ICE", &val);
 					else
 						goto error;


### PR DESCRIPTION
The parse_flags method was missing the option to specify "force-relay" which is a valid ICE value in the rtpengine ng protocol.  Without the force-relay, ice candidates are all written in as host candidates.  This change has been tested against rtpengine and it does cause ICE relay candidates to be inserted into SDP.
