### PR TITLE
added more rtp transports to match those available in rtpengine

### DIFF
--- a/modules/rtpengine/rtpengine.c
+++ b/modules/rtpengine/rtpengine.c
@@ -960,6 +960,9 @@ static const char *transports[] = {
 	[0x01]	= "RTP/SAVP",
 	[0x02]	= "RTP/AVPF",
 	[0x03]	= "RTP/SAVPF",
+	[0x04]  = "UDP/TLS/RTP/SAVP",
+	[0x05]  = "UDP/TLS/RTP/SAVPF"
+
 };
 
 static int parse_flags(struct ng_flags_parse *ng_flags, struct sip_msg *msg, enum rtpe_operation *op,
@@ -1170,6 +1173,20 @@ static int parse_flags(struct ng_flags_parse *ng_flags, struct sip_msg *msg, enu
 					goto error;
 				break;
 
+			case 16:
+				if (str_eq(&key, "UDP/TLS/RTP/SAVP"))
+					ng_flags->transport = 0x104;
+				else
+					goto error;
+				break;
+
+			case 17:
+				if (str_eq(&key, "UDP/TLS/RTP/SAVPF"))
+					ng_flags->transport = 0x105;
+				else
+					goto error;
+				break;
+
 			case 26:
 				if (str_eq(&key, "replace-session-connection"))
 					bencode_list_add_string(ng_flags->replace, "session-connection");
@@ -1257,7 +1274,7 @@ static bencode_item_t *rtpe_function_call(bencode_buffer_t *bencbuf, struct sip_
 		bencode_dictionary_add(ng_flags.dict, "replace", ng_flags.replace);
 	if ((ng_flags.transport & 0x100))
 		bencode_dictionary_add_string(ng_flags.dict, "transport-protocol",
-				transports[ng_flags.transport & 0x003]);
+				transports[ng_flags.transport & 0x005]);
 	if (ng_flags.rtcp_mux && ng_flags.rtcp_mux->child)
 		bencode_dictionary_add(ng_flags.dict, "rtcp-mux", ng_flags.rtcp_mux);
 


### PR DESCRIPTION
rtpengine has updated the available rtp transports to match what browsers are expecting/supporting.  This patch adds transports to match what is available in rtpengine.
