### PR TITLE
dialog: Update dlg lifetime whe re-evaluating the AVP after the callback...

### DIFF
--- a/modules/dialog/dlg_handlers.c
+++ b/modules/dialog/dlg_handlers.c
@@ -1231,6 +1231,7 @@ after_unlock5:
 		/* update timer during sequential request? */
 		timeout = get_dlg_timeout_update(req);
 		if (timeout != 0) {
+			dlg->lifetime = timeout;
 			if (update_dlg_timer( &dlg->tl, dlg->lifetime )==-1)
 				LM_ERR("failed to update dialog lifetime\n");
 		}


### PR DESCRIPTION
This completes the previous commit. Without this fix, when the SST module is activated and the routines are activated with the appropriate setflag, the calls will be interrupted after the sst timeout even when there is no sst support at all from both peers.