### PR TITLE
Added pvar to expose CSeq method

### DIFF
--- a/pvar.c
+++ b/pvar.c
@@ -966,6 +966,22 @@ static int pv_get_cseq(struct sip_msg *msg, pv_param_t *param,
 	return pv_get_strval(msg, param, res, &(get_cseq(msg)->number));
 }
 
+static int pv_get_cseq_method(struct sip_msg *msg, pv_param_t *param,
+		pv_value_t *res)
+{
+	if(msg==NULL)
+		return -1;
+
+	if(msg->cseq==NULL && ((parse_headers(msg, HDR_CSEQ_F, 0)==-1)
+				|| (msg->cseq==NULL)) )
+	{
+		LM_ERR("cannot parse CSEQ header\n");
+		return pv_get_null(msg, param, res);
+	}
+	return pv_get_strval(msg, param, res, &(get_cseq(msg)->method));
+}
+
+
 static int pv_get_msg_buf(struct sip_msg *msg, pv_param_t *param,
 		pv_value_t *res)
 {
@@ -3260,6 +3276,9 @@ static pv_export_t _pv_names_table[] = {
 		0, 0, 0, 0},
 	{{"cs", (sizeof("cs")-1)}, /* */
 		PVT_CSEQ, pv_get_cseq, 0,
+		0, 0, 0, 0},
+	{{"cm", (sizeof("cm")-1)}, /* */
+		PVT_CSEQ_METHOD, pv_get_cseq_method, 0,
 		0, 0, 0, 0},
 	{{"ct", (sizeof("ct")-1)}, /* */
 		PVT_CONTACT, pv_get_contact_body, 0,

--- a/pvar.h
+++ b/pvar.h
@@ -108,7 +108,7 @@ enum _pv_type {
 	PVT_HDRCNT,           PVT_AUTH_NONCE_COUNT,  PVT_AUTH_QOP,
 	PVT_AUTH_ALGORITHM,   PVT_AUTH_OPAQUE,       PVT_AUTH_CNONCE,
 	PVT_RU_Q,             PVT_ROUTE_PARAM,       PVT_ROUTE_TYPE,
-	PVT_EXTRA /* keep it last */
+	PVT_CSEQ_METHOD,      PVT_EXTRA /* keep it last */
 };
 
 typedef enum _pv_type pv_type_t;


### PR DESCRIPTION
Eric mentioned the usefulness of having the CSeq method exposed from the script in replies in addition to the number: $cm = get_cseq(msg)->method