### PR TITLE
fixed flex sub version check for isatty definition 

### DIFF
--- a/cfg.lex
+++ b/cfg.lex
@@ -119,7 +119,7 @@
 	} *oss_yy_fname_list = 0;
 
 	/* hack to solve the duplicate declaration of 'isatty' function */
-#if YY_FLEX_MAJOR_VERSION <= 2 && YY_FLEX_MINOR_VERSION <= 5 && YY_FLEX_SUBMINOR_VERSION <= 36
+#if YY_FLEX_MAJOR_VERSION <= 2 && YY_FLEX_MINOR_VERSION <= 5 && YY_FLEX_SUBMINOR_VERSION < 36
 	#define YY_NO_UNISTD_H
 #else
 	#include <unistd.h>

--- a/cfg.lex
+++ b/cfg.lex
@@ -119,7 +119,7 @@
 	} *oss_yy_fname_list = 0;
 
 	/* hack to solve the duplicate declaration of 'isatty' function */
-#if YY_FLEX_MAJOR_VERSION <= 2 && YY_FLEX_MINOR_VERSION <= 5 && YY_FLEX_SUBMINOR_VERSION <= 38
+#if YY_FLEX_MAJOR_VERSION <= 2 && YY_FLEX_MINOR_VERSION <= 5 && YY_FLEX_SUBMINOR_VERSION <= 36
 	#define YY_NO_UNISTD_H
 #else
 	#include <unistd.h>


### PR DESCRIPTION
It looks like the isatty definition was removed from flex in subversions >=36. This fixes #443 