### PR TITLE
Registrar: Add contact-based aliasing when the remote UA supports it.

### DIFF
--- a/modules/registrar/save.c
+++ b/modules/registrar/save.c
@@ -458,6 +458,13 @@ static inline int insert_contacts(struct sip_msg* _m, contact_t* _c,
 				} else {
 					e_max = e;
 				}
+				if (_m->flags&tcp_persistent_flag && _m->via1->alias && tcp_accept_aliases) {
+
+					if (tcpconn_add_alias(_m->rcv.proto_reserved1, uri.port_no ? uri.port_no : SIP_PORT, uri.proto))
+						LM_ERR("tcp alias failed\n");
+					else
+						LM_DBG("tcp alias contact port %d\n", uri.port_no ? uri.port_no : SIP_PORT);
+				}
 			}
 		}
 #endif
@@ -668,6 +675,12 @@ static inline int update_contacts(struct sip_msg* _m, urecord_t* _r,
 					LM_WARN("multiple TCP contacts on single REGISTER\n");
 				}
 				if (e>e_max) e_max = e;
+				if (_m->flags&tcp_persistent_flag && _m->via1->alias && tcp_accept_aliases) {
+					if (tcpconn_add_alias(_m->rcv.proto_reserved1, uri.port_no ? uri.port_no : SIP_PORT, uri.proto))
+						LM_ERR("tcp alias failed\n");
+					else
+						LM_DBG("tcp alias contact port %d\n", uri.port_no ? uri.port_no : SIP_PORT);
+				}
 			}
 		}
 #endif


### PR DESCRIPTION
If an endpoint supporting TCP connection reuse registers to OpenSIPS, we
now create TCP connections aliases for all IP/ports announced by the UA.

From my point of view, it is more a fix than a new feature.

Without this patch, OpenSIPS will only reuse connections targetted at the IP / ports in the Via, which correspond to the actual currently active connection. But most of the time, the proxy will not use those IP/ports when communicating with the UA. It will instead use the registered IP/ports. We should automatically reuse the active connection for all communications with those IP/ports instead of creating new connections, especially in 1.8 where it is a blocking operation.

If the connection can not be reused, then OpenSIPS will create a new one.