### PR TITLE
Verify the dialog mi parameter is not null before passing to dlg_hash

### DIFF
--- a/modules/dialog/dlg_hash.c
+++ b/modules/dialog/dlg_hash.c
@@ -1337,6 +1337,9 @@ static inline struct mi_root* process_mi_params(struct mi_root *cmd_tree,
 
 	*idx = *cnt = 0;
 
+        if (!p1->s)
+                return init_mi_tree( 400, "Invalid Call-ID specified", 25);
+
 	h_entry = dlg_hash( p1/*callid*/ );
 
 	d_entry = &(d_table->entries[h_entry]);


### PR DESCRIPTION
Reported (and verified) by Satish Patel on the developers mailing list that issuing the following command crashes opensips:

opensipsctl fifo dlg_list to_uri::

The p1 value is never verified to not be NULL before calling dlg_hash which crashes the program.  Perhaps there is a better way to resolve this problem, but here is my pull request.

