### PR TITLE
resolve inet6 records for hosts and prefer them if dns_try_ipv6 is set

### DIFF
--- a/resolve.c
+++ b/resolve.c
@@ -447,54 +447,58 @@ query:
 
 inline struct hostent* resolvehost(char* name, int no_ip_test)
 {
-	static struct hostent* he=0;
+        static struct hostent* he=0;
 #ifdef HAVE_GETIPNODEBYNAME
-	int err;
-	static struct hostent* he2=0;
+        int err;
+        static struct hostent* he2=0;
 #endif
-	struct ip_addr* ip;
-	str s;
+        struct ip_addr* ip;
+        str s;
 
-	if (!no_ip_test) {
-		s.s = (char*)name;
-		s.len = strlen(name);
+        if (!no_ip_test) {
+                s.s = (char*)name;
+                s.len = strlen(name);
 
-		/* check if it's an ip address */
-		if ( ((ip=str2ip(&s))!=0)
-			|| ((ip=str2ip6(&s))!=0)
-		){
-			/* we are lucky, this is an ip address */
-			return ip_addr2he(&s, ip);
-		}
-	}
+                /* check if it's an ip address */
+                if ( ((ip=str2ip(&s))!=0)
+                        || ((ip=str2ip6(&s))!=0)
+                ){
+                        /* we are lucky, this is an ip address */
+                        return ip_addr2he(&s, ip);
+                }
+        }
 
-	if (dnscache_fetch_func != NULL) {
-		he = own_gethostbyname2(name,AF_INET);
-	}
-	else {
-		he=gethostbyname(name);
-	}
-	if(he==0 && dns_try_ipv6){
-		/*try ipv6*/
-	#ifdef HAVE_GETHOSTBYNAME2
-		if (dnscache_fetch_func != NULL) {
-			he = own_gethostbyname2(name,AF_INET6);
-		}
-		else {
-			he=gethostbyname2(name, AF_INET6);
-		}
+        if(dns_try_ipv6){
+                /*try ipv6*/
+        #ifdef HAVE_GETHOSTBYNAME2
+                if (dnscache_fetch_func != NULL) {
+                        he = own_gethostbyname2(name,AF_INET6);
+                }
+                else {
+                        he=gethostbyname2(name, AF_INET6);
+                }
 
-	#elif defined HAVE_GETIPNODEBYNAME
-		/* on solaris 8 getipnodebyname has a memory leak,
-		 * after some time calls to it will fail with err=3
-		 * solution: patch your solaris 8 installation */
-		if (he2) freehostent(he2);
-		he=he2=getipnodebyname(name, AF_INET6, 0, &err);
-	#else
-		#error neither gethostbyname2 or getipnodebyname present
-	#endif
-	}
-	return he;
+        #elif defined HAVE_GETIPNODEBYNAME
+                /* on solaris 8 getipnodebyname has a memory leak,
+                 * after some time calls to it will fail with err=3
+                 * solution: patch your solaris 8 installation */
+                if (he2) freehostent(he2);
+                he=he2=getipnodebyname(name, AF_INET6, 0, &err);
+        #else
+                #error neither gethostbyname2 or getipnodebyname present
+        #endif
+                if (he != 0)
+                        /* return the inet6 result if exists */
+                        return he;
+        }
+
+        if (dnscache_fetch_func != NULL) {
+                he = own_gethostbyname2(name,AF_INET);
+        }
+        else {
+                he=gethostbyname(name);
+        }
+        return he;
 }
 
 struct hostent * own_gethostbyaddr(void *addr, socklen_t len, int af)


### PR DESCRIPTION
Previously, if `dns_try_ipv6` was set, resolvehost would only attempt to resolve the ipv6 address if the ipv4 lookup returned no results.  Now if `dns_try_ipv6` is true, both address families are attempted and ipv6 is preferred (this seems to be the logic of most software with ipv6 support enabled).

Also, now that both are resolved, I envision being able to override the default family from the script as well as enable failover should the ipv6 endpoint timeout.  This would follow with future pull requests.