### PR TITLE
append '\0' null character to the end of db_url in macro init_db_url

### DIFF
--- a/db/db.h
+++ b/db/db.h
@@ -454,6 +454,7 @@ int estimate_available_rows( int payload_size, int column_count);
 		} else {\
 			_db_url.len = strlen(_db_url.s); \
 		} \
+		_db_url.s[_db_url.len+1] = '\0'; \
 	}while(0)
 
 


### PR DESCRIPTION
I guess most of the time this doesn't matter since other libraries also ask for the length along with the `db_url` string, but libsqlite3 is unfortunately not one of those libraries.  This resolved issue #471 for me, but it changes a macro used everywhere else.