### PR TITLE
Add DBPORT parameter with comment to opensipsctlrc

### DIFF
--- a/scripts/opensipsctlrc
+++ b/scripts/opensipsctlrc
@@ -18,6 +18,9 @@
 # this parameter.
 # DBENGINE=MYSQL
 
+## database port (PostgreSQL=5432 mandatory; MYSQL=3306 default)
+# DBPORT=3306
+
 ## database host
 # DBHOST=localhost
 


### PR DESCRIPTION
Added DBPORT parameter with comments similar to osipsconsolerc to alleviate confusion when using PostgreSQL.  References issue #485