### PR TITLE
Removed default DBPORT from opensipsdbctl.base 

### DIFF
--- a/scripts/opensipsctlrc
+++ b/scripts/opensipsctlrc
@@ -18,7 +18,7 @@
 # this parameter.
 # DBENGINE=MYSQL
 
-## database port (PostgreSQL=5432 mandatory; MYSQL=3306 default)
+## database port (PostgreSQL=5432 default; MYSQL=3306 default)
 # DBPORT=3306
 
 ## database host

--- a/scripts/opensipsdbctl.base
+++ b/scripts/opensipsdbctl.base
@@ -9,7 +9,7 @@ DBNAME=${DBNAME:-opensips}
 DBHOST=${DBHOST:-localhost}
 
 # port of database server
-DBPORT=${DBPORT:-3306}
+DBPORT=${DBPORT}
 
 # user with full privileges over DBNAME database
 DBRWUSER=${DBRWUSER:-opensips}


### PR DESCRIPTION
After speaking with @razvancrainea, the real solution is to remove the default value for DBPORT from the opensipsdbctl.base.  DBPORT is used by mysql and pgsql and both have this consideration:

```
if ! [ -z "$DBPORT" ]; then                                                     
        PORT_OPT="-p$DBPORT"                                                    
else                                                                            
        PORT_OPT=                                                               
fi  
```

By removing the default DBPORT, the command line client that is called by the scripts will choose the appropriate default port since it will be omitted as a command line argument.