### PR TITLE
Updated log macro used for reporting event_rabbitmq heartbeat modparam

### DIFF
--- a/modules/event_rabbitmq/event_rabbitmq.c
+++ b/modules/event_rabbitmq/event_rabbitmq.c
@@ -127,7 +127,7 @@ static int mod_init(void)
 		LM_WARN("heartbeat is disabled according to the modparam configuration\n");
 		heartbeat = 0;
 	} else {
-		LM_WARN("heartbeat is enabled for [%d] seconds\n", heartbeat);
+		LM_NOTICE("heartbeat is enabled for [%d] seconds\n", heartbeat);
 	}
 
 	return 0;


### PR DESCRIPTION
This addresses issue #490 reported by @hydrosine by moving the heartbeat parameter setting notification to NOTICE log level for event_rabbitmq instead of WARNING.

The core dev can decide whether it's a non-issue or not.