### PR TITLE
addition of rest_append_hf command

### DIFF
--- a/modules/rest_client/rest_cb.h
+++ b/modules/rest_client/rest_cb.h
@@ -35,6 +35,7 @@
 #define HTTP_HDR_CONTENT_TYPE    "Content-Type"
 #define CONTENT_TYPE_HDR_LEN     12
 #define MAX_CONTENT_TYPE_LEN     64
+#define MAX_HEADER_FIELD_LEN	 1024 /* arbitrary */
 
 size_t write_func(char *ptr, size_t size, size_t nmemb, void *userdata);
 size_t header_func(char *ptr, size_t size, size_t nmemb, void *userdata);

--- a/modules/rest_client/rest_client.c
+++ b/modules/rest_client/rest_client.c
@@ -76,6 +76,7 @@ static int w_async_rest_post(struct sip_msg *msg, async_resume_module **resume_f
 					 void **resume_param, char *gp_url, char *gp_body,
 					 char *gp_ctype, char *body_pv, char *ctype_pv, char *code_pv);
 
+static int w_rest_append_hf(struct sip_msg *msg, char *gp_hfv);
 
 static acmd_export_t acmds[] = {
 	{ "rest_get",  (acmd_function)w_async_rest_get,  2, fixup_rest_get },
@@ -108,6 +109,9 @@ static cmd_export_t cmds[] = {
 		ONREPLY_ROUTE|STARTUP_ROUTE|TIMER_ROUTE },
 	{ "rest_post",(cmd_function)w_rest_post, 6, fixup_rest_post, 0,
 		REQUEST_ROUTE|ONREPLY_ROUTE|FAILURE_ROUTE|BRANCH_ROUTE|
+		ONREPLY_ROUTE|STARTUP_ROUTE|TIMER_ROUTE },
+	{ "rest_append_hf",(cmd_function)w_rest_append_hf, 1, fixup_spve_null, 0,
+		REQUEST_ROUTE|FAILURE_ROUTE|BRANCH_ROUTE|
 		ONREPLY_ROUTE|STARTUP_ROUTE|TIMER_ROUTE },
 	{ 0, 0, 0, 0, 0, 0 }
 };
@@ -405,3 +409,14 @@ static int w_async_rest_post(struct sip_msg *msg, async_resume_module **resume_f
 	return 1;
 }
 
+static int w_rest_append_hf(struct sip_msg *msg, char *gp_hfv)
+{
+	str hfv;
+
+	if (fixup_get_svalue(msg, (gparam_p)gp_hfv, &hfv) != 0) {
+		LM_ERR("cannot retrieve header field value\n");
+		return -1;
+	}
+
+	return rest_append_hf_method(msg, &hfv);
+}

--- a/modules/rest_client/rest_methods.h
+++ b/modules/rest_client/rest_methods.h
@@ -66,5 +66,7 @@ int start_async_http_req(struct sip_msg *msg, enum rest_client_method method,
 					     CURL **out_handle, str *body, str *ctype);
 enum async_ret_code resume_async_http_req(int fd, struct sip_msg *msg, void *param);
 
+int rest_append_hf_method(struct sip_msg *msg, str *hfv);
+
 #endif /* _REST_METHODS_ */
 


### PR DESCRIPTION
This is an initial commit to address feature request #496.

I have tested this module with the following script excerpt:

### request route
```
  $json(test) := "{}";
  $json(test/id) = "1";
  route(TEST_POST);
  route(TEST_GET);
  route(TEST_ASYNC_POST);
```

### route definitions
```
route[TEST_GET] {
  rest_append_hf("Authorization: Bearer mF_9.B5f-4.1JqM");
  if (!rest_get("http://127.0.0.1:3000/",
                 "$var(reply)",
                 "$var(ct)",
                 "$var(rcode)"))
  {
    xlog("Error code $var(rcode) in HTTP GET!\n");
    send_reply("403", "GET Forbidden");
    exit;
  }
  xlog("Successful get - $var(ct) - $var(rcode)\n$var(reply)\n");
}

route[TEST_POST] {
  rest_append_hf("Authorization: Bearer mF_9.B5f-4.1JqM");
  if (!rest_post("http://127.0.0.1:3000/",
                 "$json(test)",
                 "application/json",
                 "$var(post_reply)",
                 "$var(post_ct)",
                 "$var(post_rcode)"))
  {
    xlog("Error code $var(post_rcode) in HTTP POST!\n");
    send_reply("403", "POST Forbidden");
    exit;
  }
  xlog("Successful post - $var(post_ct) - $var(rcode)\n$var(post_reply)\n");
}

route[TEST_ASYNC_POST] {
  rest_append_hf("Authorization: Bearer mF_9.B5f-4.1JqM");
  async(rest_post("http://127.0.0.1:3000/",
                  "$json(test)",
                  "application/json",
                  "$json(async_test_reply)",
                  "$var(async_ct)",
                  "$var(async_rcode)"),
        TEST_ASYNC_POST_REPLY);
}

route[TEST_ASYNC_POST_REPLY] {
  xlog("In TEST_ASYNC_POST_REPLY, reply received: $json(async_test_reply)\n");
}
```

### example log output
```
May  5 05:45:43 localhost opensips[919]: Successful post - application/json - <null>#012{"id": 1, "result": true}
May  5 05:45:43 localhost opensips[919]: Successful get - text/html - 200#012
May  5 05:45:43 localhost opensips[919]: In TEST_ASYNC_POST_REPLY, reply received: {"id": 1, "result": true}
```