### PR TITLE
Make rtpengine retry sending command on UDP fragmentation

### DIFF
--- a/modules/rtpengine/rtpengine.c
+++ b/modules/rtpengine/rtpengine.c
@@ -1524,7 +1524,7 @@ send_rtpe_command(struct rtpe_node *node, bencode_item_t *dict, int *outlen)
 		for (i = 0; i < rtpengine_retr; i++) {
 			do {
 				len = writev(rtpe_socks[node->idx], v, vcnt + 1);
-			} while (len == -1 && (errno == EINTR || errno == ENOBUFS));
+			} while (len == -1 && (errno == EINTR || errno == ENOBUFS || errno == EMSGSIZE));
 			if (len <= 0) {
 				LM_ERR("can't send command to a RTP proxy\n");
 				goto badproxy;


### PR DESCRIPTION
Title says it all.

With this error code check, rtpengine will try up to five times (default config further up) before failing out.