### PR TITLE
set local variable memory to 0 to prevent core dump

### DIFF
--- a/modules/cachedb_cassandra/cachedb_cassandra.c
+++ b/modules/cachedb_cassandra/cachedb_cassandra.c
@@ -105,6 +105,8 @@ static int mod_init(void)
 	if (wr_consistency_level<1 || wr_consistency_level > 8)
 		wr_consistency_level=1;
 
+	memset(&cde, 0, sizeof(cachedb_engine));
+
 	cde.name = cache_mod_name;
 
 	cde.cdb_func.init = cassandra_init;


### PR DESCRIPTION
I didn't read the docs to find out cachedb_cassandra wasn't supported with db_cachedb so when I enabled it opensips was seg faulting.  This would probably need to be added to the declaration for other engines.

The cachedb_engine variable `cde` in `mod_init` (cachedb_cassandra.c:100) doesn't explicitly set the translation functions of the stack variable to NULL so the check in `db_cachedb_query` (db_cachedb/dbase.c:132) is passed and the db_query_trans tries to execute which faults:

## Before
```
Breakpoint 1, db_cachedb_query (_h=0x7ffff74221a8, _k=0x7fffffffe140, _op=0x0, 
    _v=0x7fffffffe1a0, _c=0x7fffffffe150, _n=1, _nc=1, _o=0x0, 
    _r=0x7fffffffe160) at dbase.c:129
warning: Source file is more recent than executable.
129	{
(gdb) n
130		struct db_cachedb_con* ptr = (struct db_cachedb_con *)_h->tail;
(gdb) n
132		if (ptr->cdbf.db_query_trans == NULL) {
(gdb) n
137		return ptr->cdbf.db_query_trans(ptr->cdbc,_h->table,_k,_op,_v,_c,_n,_nc,_o,_r);
(gdb) print *ptr->cdbf.db_query_trans
$1 = {int (cachedb_con *, const str *, const db_key_t *, const db_op_t *, 
    const db_val_t *, const db_key_t *, const int, const int, const db_key_t, 
    db_res_t **)} 0x7ffff7420aa8
(gdb) n

Program received signal SIGSEGV, Segmentation fault.
0x00007ffff7420aa8 in ?? ()
```

## After
```
Breakpoint 1, db_cachedb_query (_h=0x7ffff74221a8, _k=0x7fffffffe140, _op=0x0, 
    _v=0x7fffffffe1a0, _c=0x7fffffffe150, _n=1, _nc=1, _o=0x0, 
    _r=0x7fffffffe160) at dbase.c:129
warning: Source file is more recent than executable.
129	{
(gdb) n
130		struct db_cachedb_con* ptr = (struct db_cachedb_con *)_h->tail;
(gdb) n
132		if (ptr->cdbf.db_query_trans == NULL) {
(gdb) n
133			LM_ERR("The selected NoSQL driver cannot convert select queries\n");
(gdb) n
134			return -1;
```
