### PR TITLE
add ability to support raw query translation in cachedb modules

### DIFF
--- a/cachedb/cachedb.h
+++ b/cachedb/cachedb.h
@@ -74,6 +74,7 @@ typedef int(cachedb_free_trans_f)(cachedb_con* con, db_res_t* _r);
 typedef int(cachedb_insert_trans_f)(cachedb_con *con,const str *table,const db_key_t* _k, const db_val_t* _v,const int _n);
 typedef int(cachedb_delete_trans_f)(cachedb_con *con,const str *table,const db_key_t* _k,const db_op_t *_o, const db_val_t* _v,const int _n);
 typedef int (cachedb_update_trans_f)(cachedb_con *con,const str *table,const db_key_t* _k,const db_op_t *_o, const db_val_t* _v,const db_key_t* _uk, const db_val_t* _uv, const int _n,const int _un);
+typedef int(cachedb_raw_trans_f)(cachedb_con* con, const str *_s, db_res_t** _r);
 
 typedef struct cachedb_funcs_t {
 	cachedb_init_f			*init;
@@ -90,6 +91,7 @@ typedef struct cachedb_funcs_t {
 	cachedb_insert_trans_f	*db_insert_trans;
 	cachedb_delete_trans_f	*db_delete_trans;
 	cachedb_update_trans_f	*db_update_trans;
+        cachedb_raw_trans_f     *db_raw_trans;
 	int capability;
 } cachedb_funcs;
 

--- a/modules/cachedb_mongodb/cachedb_mongodb.c
+++ b/modules/cachedb_mongodb/cachedb_mongodb.c
@@ -137,7 +137,7 @@ static int mod_init(void)
 	}
 
 	if (register_cachedb(&cde) < 0) {
-		LM_ERR("failed to initialize cachedb_redis\n");
+		LM_ERR("failed to initialize cachedb_mongo\n");
 		return -1;
 	}
 

--- a/modules/db_cachedb/dbase.c
+++ b/modules/db_cachedb/dbase.c
@@ -189,7 +189,11 @@ int db_cachedb_use_table(db_con_t* _h, const str* _t)
 
 int db_cachedb_raw_query(const db_con_t* _h, const str* _s, db_res_t** _r)
 {
-	/* This will most likely never be supported :( */
-	LM_ERR("RAW query not support by db_cachedb \n");
-	return -1;
+        struct db_cachedb_con* ptr = (struct db_cachedb_con *)_h->tail;
+
+        if (ptr->cdbf.db_raw_trans == NULL) {
+                LM_ERR("The selected NoSQL driver cannot convert raw queries\n");
+                return -1;
+        }
+        return ptr->cdbf.db_raw_trans(ptr->cdbc, _s, _r);
 }


### PR DESCRIPTION
I understand the reasoning behind globally rejecting the notion of supporting raw queries in a cachedb engine, but I think the mechanism should at least be enabled (it will default to not supported) and let a module developer decide if they want to implement.

Also includes a simply typo correct in cachedb_mongo