### PR TITLE
check for invalid parameter passed to _tr_parse_sparam #531

### DIFF
--- a/transformations.c
+++ b/transformations.c
@@ -2188,7 +2188,12 @@ error:
 
 #define _tr_parse_sparam(_p, _p0, _tp, _spec, _ps, _in, _s) \
 	while(is_in_str(_p, _in) && (*_p==' ' || *_p=='\t' || *_p=='\n')) _p++; \
-	if(*_p==PV_MARKER) \
+        if (*_p==TR_PARAM_MARKER) \
+        { \
+		LM_ERR("invalid spec in transformation: %.*s!\n",\
+			_in->len, _in->s); \
+		goto error; \
+	} else if(*_p==PV_MARKER) \
 	{ /* pseudo-variable */ \
 		_spec = (pv_spec_t*)pkg_malloc(sizeof(pv_spec_t)); \
 		if(_spec==NULL) \


### PR DESCRIPTION
My solution to #531 caused by _tr_parse_sparam attempting to parse an empty argument.  The 100% CPU is caused by an infinite loop in `static void trans_fill_right(pv_value_t *val, str pad, int len)` (transformations.c:129) since the while loop `while (len > 0)` depends on pad.len being decremented from len (`len -= pad.len;`) which never happens because pad.len = 0.

There are probably a couple different ways to incorporate this check, but this works.  Applying this pull request before my previous pull request, #530, will probably cause it to be invalid in case it is approved as well.

Here is the backtrace that led me to the above conclusion:

```
(gdb) bt
#0  trans_fill_right (len=1, val=<optimized out>, pad=...)
    at transformations.c:153
#1  tr_eval_string (msg=<optimized out>, tp=<optimized out>, 
    subtype=<optimized out>, val=<optimized out>) at transformations.c:707
#2  0x00000000004b97cd in run_transformations (msg=msg@entry=0x7fffffffdcf0, 
    tr=<optimized out>, val=val@entry=0x7fffffffd580) at transformations.c:78
#3  0x00000000004f5ae9 in pv_get_spec_value (msg=<optimized out>, 
    sp=0x7ffff745c3c8, value=0x7fffffffd580) at pvar.c:4122
#4  0x00000000004f75d0 in pv_printf (msg=msg@entry=0x7fffffffdcf0, 
    list=list@entry=0x7ffff745c3b8, buf=<optimized out>, 
    len=len@entry=0x7fffffffd5e4) at pvar.c:4194
#5  0x00000000004fce0c in pv_printf (msg=msg@entry=0x7fffffffdcf0, 
    list=list@entry=0x7ffff745c3b8, buf=<optimized out>, 
    len=len@entry=0x7fffffffd5e4) at pvar.c:4173
#6  0x0000000000484799 in xl_print_log (len=0x7fffffffd5e4, 
    list=0x7ffff745c3b8, msg=0x7fffffffdcf0) at xlog.c:65
#7  xlog_1 (msg=msg@entry=0x7fffffffdcf0, 
    frm=0x7ffff745c3b8 "p^B\367\377\177", str2=<optimized out>) at xlog.c:114
#8  0x0000000000459d46 in do_action (a=a@entry=0x7ffff7425f08, 
    msg=msg@entry=0x7fffffffdcf0) at action.c:1652
#9  0x000000000045dce1 in run_action_list (msg=<optimized out>, 
    a=<optimized out>) at action.c:169
#10 run_actions (msg=0x7fffffffdcf0, a=<optimized out>) at action.c:134
#11 run_top_route (a=<optimized out>, msg=msg@entry=0x7fffffffdcf0)
    at action.c:209
#12 0x00000000004a0732 in run_startup_route () at route.c:2381
#13 0x00000000005905ce in udp_start_nofork () at net/net_udp.c:363
#14 0x000000000041a75e in main_loop () at main.c:665
#15 main (argc=<optimized out>, argv=<optimized out>) at main.c:1248
```
