### PR TITLE
verify pv_export_t parse_name function is set before calling

### DIFF
--- a/pvar.c
+++ b/pvar.c
@@ -3718,7 +3718,7 @@ done_inm:
 			goto error;
 		}
 		s.len = p - s.s;
-		if(pte->parse_name(e, &s)!=0)
+		if(pte->parse_name == NULL || pte->parse_name(e, &s)!=0)
 		{
 			LM_ERR("pvar \"%.*s\" has an invalid name param [%.*s]\n",
 					pvname.len, pvname.s, s.len, s.s);


### PR DESCRIPTION
A quick solution for #529 to verify the function being called is populated so it doesn't segfault.

### gdb output && bracktrace

```
Breakpoint 1, pv_parse_spec (in=in@entry=0x882e50 <tstr>, e=0x7ffff7425be0)
    at pvar.c:3720
3720			s.len = p - s.s;
(gdb) print pte
$5 = (pv_export_t *) 0x7ffff7420710
(gdb) print *pte
$6 = {name = {s = 0x7ffff6deed9d "T_fr_timeout", len = 12}, type = 1003, 
  getf = 0x7ffff6dbef92 <pv_get_tm_fr_timeout>, 
  setf = 0x7ffff6dbfc62 <pv_set_tm_fr_timeout>, parse_name = 0x0, 
  parse_index = 0x0, init_param = 0x0, iparam = 0}
(gdb) n
3721			if(pte->parse_name(e, &s)!=0)
(gdb) s

Program received signal SIGSEGV, Segmentation fault.
0x0000000000000000 in ?? ()
```
```
(gdb) bt
#0  0x0000000000000000 in ?? ()
#1  0x0000000000500ab9 in pv_parse_spec (in=in@entry=0x882e50 <tstr>, 
    e=0x7ffff7425be0) at pvar.c:3721
#2  0x00000000005b7b31 in yyparse () at cfg.y:1352
#3  0x00000000004193f1 in main (argc=<optimized out>, argv=0x7fffffffe6f8)
    at main.c:1022
```
