### PR TITLE
fix rpm build error on centos

### DIFF
--- a/packaging/rpm/opensips.spec.CentOS
+++ b/packaging/rpm/opensips.spec.CentOS
@@ -473,6 +473,7 @@ fi
 %doc %{_docdir}/opensips/README.pdt
 %doc %{_docdir}/opensips/README.permissions
 %doc %{_docdir}/opensips/README.pike
+%doc %{_docdir}/opensips/README.python
 %doc %{_docdir}/opensips/README.qos
 %doc %{_docdir}/opensips/README.ratelimit
 %doc %{_docdir}/opensips/README.registrar


### PR DESCRIPTION
README.python unpack  when build rpm package