### PR TITLE
xlog support for multiple lines

### DIFF
--- a/cfg.y
+++ b/cfg.y
@@ -2561,6 +2561,30 @@ cmd:	 FORWARD LPAREN STRING RPAREN	{ mk_action2( $$, FORWARD_T,
 				mk_action1($$, XLOG_T, STR_ST, $3); }
 		| XLOG LPAREN STRING COMMA STRING RPAREN {
 				mk_action2($$, XLOG_T, STR_ST, STR_ST, $3, $5); }
+		| XLOG LPAREN STRING COMMA STRING COMMA STRING RPAREN {
+				mk_action3($$, XLOG_T, STR_ST, STR_ST, STR_ST, $3, $5, $7); }
+		| XLOG LPAREN STRING COMMA STRING COMMA STRING COMMA STRING RPAREN {
+				elems[0].type = STR_ST;
+				elems[0].u.data = $3;
+				elems[1].type = STR_ST;
+				elems[1].u.data = $5;
+				elems[2].type = STR_ST;
+				elems[2].u.data = $7;
+				elems[3].type = STR_ST;
+				elems[3].u.data = $9;
+				mk_action_($$, XLOG_T, 4, elems); }
+		| XLOG LPAREN STRING COMMA STRING COMMA STRING COMMA STRING COMMA STRING RPAREN {
+				elems[0].type = STR_ST;
+				elems[0].u.data = $3;
+				elems[1].type = STR_ST;
+				elems[1].u.data = $5;
+				elems[2].type = STR_ST;
+				elems[2].u.data = $7;
+				elems[3].type = STR_ST;
+				elems[3].u.data = $9;
+				elems[4].type = STR_ST;
+				elems[4].u.data = $11;
+				mk_action_($$, XLOG_T, 5, elems); }
 		| RAISE_EVENT LPAREN STRING RPAREN {
 				mk_action1($$, RAISE_EVENT_T, STR_ST, $3); }
 		| RAISE_EVENT LPAREN STRING COMMA script_var RPAREN {

--- a/cfg.y
+++ b/cfg.y
@@ -2561,29 +2561,29 @@ cmd:	 FORWARD LPAREN STRING RPAREN	{ mk_action2( $$, FORWARD_T,
 				mk_action1($$, XLOG_T, STR_ST, $3); }
 		| XLOG LPAREN STRING COMMA STRING RPAREN {
 				mk_action2($$, XLOG_T, STR_ST, STR_ST, $3, $5); }
-		| XLOG LPAREN STRING COMMA STRING COMMA STRING RPAREN {
-				mk_action3($$, XLOG_T, STR_ST, STR_ST, STR_ST, $3, $5, $7); }
-		| XLOG LPAREN STRING COMMA STRING COMMA STRING COMMA STRING RPAREN {
+		| XLOG LPAREN STRING COMMA STRING STRING RPAREN {
+				mk_action3($$, XLOG_T, STR_ST, STR_ST, STR_ST, $3, $5, $6); }
+		| XLOG LPAREN STRING COMMA STRING STRING STRING RPAREN {
 				elems[0].type = STR_ST;
 				elems[0].u.data = $3;
 				elems[1].type = STR_ST;
 				elems[1].u.data = $5;
 				elems[2].type = STR_ST;
-				elems[2].u.data = $7;
+				elems[2].u.data = $6;
 				elems[3].type = STR_ST;
-				elems[3].u.data = $9;
+				elems[3].u.data = $7;
 				mk_action_($$, XLOG_T, 4, elems); }
-		| XLOG LPAREN STRING COMMA STRING COMMA STRING COMMA STRING COMMA STRING RPAREN {
+		| XLOG LPAREN STRING COMMA STRING STRING STRING STRING RPAREN {
 				elems[0].type = STR_ST;
 				elems[0].u.data = $3;
 				elems[1].type = STR_ST;
 				elems[1].u.data = $5;
 				elems[2].type = STR_ST;
-				elems[2].u.data = $7;
+				elems[2].u.data = $6;
 				elems[3].type = STR_ST;
-				elems[3].u.data = $9;
+				elems[3].u.data = $7;
 				elems[4].type = STR_ST;
-				elems[4].u.data = $11;
+				elems[4].u.data = $8;
 				mk_action_($$, XLOG_T, 5, elems); }
 		| RAISE_EVENT LPAREN STRING RPAREN {
 				mk_action1($$, RAISE_EVENT_T, STR_ST, $3); }

--- a/route.c
+++ b/route.c
@@ -772,15 +772,15 @@ static int fix_actions(struct action* a)
 					t->elem[i].u.data = model;
 					t->elem[i].type = SCRIPTVAR_ELEM_ST;
 
-					/* set pointer to primary element */
-					ep0 = t->elem[1].u.data;
-
-					if (i > 1) {
-						ep1 = t->elem[i].u.data;
+					if (i == 1) {
+						/* set pointer to primary element */
+						ep0 = t->elem[1].u.data;
 
 						/* seek to the end of the ll */
 						while (ep0->next != NULL)
 							ep0 = ep0->next;
+					} else {
+						ep1 = t->elem[i].u.data;
 
 						/* append additional elements to primary structure */
 						while (ep1 != NULL) {


### PR DESCRIPTION
The only thing lacking in producing well formatted scripts (< 80 columns) has been xlog multiline support.  This PR works by collapsing the multiple elements into the single element by further populating the linked list.  

### script example
```
startup_route {
    $var(prefix) = "test   :";
    xlog("===============< BEGIN TEST >======================\n");
    xlog("L_INFO","single no pvar\n");
    xlog("L_INFO","double no pvar : line 1, ",
                  "line 2\n");
    xlog("L_INFO","$var(prefix) single line\n");
    xlog("L_INFO","$var(prefix) double : line 1, ",
                  "line 2\n");
    xlog("L_INFO", "$var(prefix) double pvar : line 1, ",
                   "line 2 with pvar $var(prefix)\n");
    xlog("L_INFO", "$var(prefix) triple pvar : line 1, ",
                   "line 2, ",
                   "line 3 with pvar $var(prefix)\n");
    xlog("L_INFO", "$var(prefix) quadruple : line 1, ",
                   "line 2, ",
                   "line 3, ",
                   "line 4 - LONGEST_ACTION_SIZE\n");
    xlog("===============< END TEST >======================\n\n");
}
```
### log output
```
Jun  2 09:01:41 opensandra opensips: ===============< BEGIN TEST >======================
Jun  2 09:01:41 opensandra opensips: single no pvar
Jun  2 09:01:41 opensandra opensips: double no pvar : line 1, line 2
Jun  2 09:01:41 opensandra opensips: test   : single line
Jun  2 09:01:41 opensandra opensips: test   : double : line 1, line 2
Jun  2 09:01:41 opensandra opensips: test   : double pvar : line 1, line 2 with pvar test   :
Jun  2 09:01:41 opensandra opensips: test   : triple : line 1, line 2, line 3 with pvar test   :
Jun  2 09:01:41 opensandra opensips: test   : quadruple : line 1, line 2, line 3, line 4 - LONGEST_ACTION_SIZE
Jun  2 09:01:41 opensandra opensips: ===============< END TEST >======================
```