### PR TITLE
Remove generating error message on creating avp with null value

### DIFF
--- a/usr_avp.c
+++ b/usr_avp.c
@@ -131,7 +131,6 @@ struct usr_avp* new_avp(unsigned short flags, int id, int_str val)
 		memcpy( s->s, val.s.s , s->len);
 		s->s[s->len] = 0;
 	} else if (flags & AVP_VAL_NULL) {
-		LM_ERR("id: %d s- NULL VALUE!\n", id);
                 avp->data = NULL;
 	} else {
 		avp->data = (void *)(long)val.n;


### PR DESCRIPTION
#527 creating a null AVP should not generate an error since we are now supporting that type - AVP_VAL_NULL. 