### PR TITLE
fixes for Debian packaging

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,13 @@
 #
 
 #FREERADIUS=1
+# freeradius libs check (must be done in toplevel makefile)
+ifneq ("$(wildcard /usr/include/freeradius-client.h)","")
+FREERADIUS=1
+else
+#FREERADIUS=0
+endif
+
 #SQLITE_BIND=1
 NICER?=1
 auto_gen=lex.yy.c cfg.tab.c   #lexx, yacc etc
@@ -52,6 +59,13 @@ tls_overwrite_certs?=
 makefile_defs=0
 DEFS:=
 DEBUG_PARSER?=
+
+# json libs check
+ifneq ("$(wildcard /usr/include/json-c/json.h)","")
+DEFS += -I/usr/include/json-c
+else
+DEFS += -I/usr/include/json
+endif
 
 # create the template only if the file is not yet created
 ifeq (,$(wildcard Makefile.conf))

--- a/packaging/debian/changelog
+++ b/packaging/debian/changelog
@@ -1,3 +1,10 @@
+opensips (2.1.0) stable; urgency=low
+
+  * Major Public Release.
+
+ -- Bogdan-Andrei Iancu <bogdan@opensips.org>  Tue, 07 May 2015 19:22:57 +0200
+
+
 opensips (2.1-rc1) unstable; urgency=low
 
   * Major Public Release.

--- a/packaging/debian/control
+++ b/packaging/debian/control
@@ -3,8 +3,8 @@ Section: net
 Priority: optional
 Maintainer: Bogdan Iancu <bogdan@opensips.org>
 Uploaders: Bogdan Iancu <bogdan@opensips.org>
-Build-Depends: debhelper (>= 5), dpatch, libmysqlclient-dev, libexpat1-dev, libxml2-dev, libpq-dev, libradiusclient-ng-dev, flex, bison, zlib1g-dev, unixodbc-dev, libxmlrpc-c3-dev, libperl-dev, libsnmp-dev, dpkg-dev (>= 1.13.19), libdb-dev (>= 4.6.19), xsltproc, libconfuse-dev, libldap2-dev, libcurl4-gnutls-dev, libgeoip-dev (>= 1.4.4), libpcre3-dev, libmemcached-dev, libjson0-dev, libmicrohttpd-dev, libhiredis-dev, librabbitmq-dev, liblua5.1-dev, libncurses5-dev, libmemcache-dev
-Standards-Version: 3.9.1
+Build-Depends: debhelper (>= 9), libmysqlclient-dev, libexpat1-dev, libxml2-dev, libpq-dev, flex, bison, zlib1g-dev, unixodbc-dev, libxmlrpc-core-c3-dev, libperl-dev, libsnmp-dev, dpkg-dev (>= 1.16.1.1), libdb-dev (>= 4.6.19), xsltproc, libconfuse-dev, libldap2-dev, libcurl4-gnutls-dev, libgeoip-dev (>= 1.4.4), libpcre3-dev, libmemcached-dev, libjson0-dev, libmicrohttpd-dev, libhiredis-dev, librabbitmq-dev, liblua5.1-dev, libncurses5-dev, libfreeradius-client-dev | libradiusclient-ng-dev, libjson0-dev, libsctp-dev
+Standards-Version: 3.9.5
 Homepage: http://www.opensips.org/
 
 Package: opensips

--- a/packaging/debian/rules
+++ b/packaging/debian/rules
@@ -26,10 +26,6 @@ URL := http://opensips.org/pub/opensips/$(UPVERSION)/src/opensips-$(UPVERSION)-t
 # Uncomment this to turn on verbose mode.
 # export DH_VERBOSE=1
 
-# Include dpatch rules
-include /usr/share/dpatch/dpatch.make
-
-
 # Do we want the TLS version ?
 # Disabled by default due to license issues, set to non-void to enable
 TLS=
@@ -41,7 +37,7 @@ ALL_MODPKG_LIST := \
 	MYSQL POSTGRES UNIXODBC JABBER CPL RADIUS \
 	PRESENCE XMLRPC PERL SNMPSTATS XMPP CROUTE BERKELEY LDAP \
 	GEOIP REGEX IDENTITY B2BUA DBHTTP DIALPLAN MEMCACHED JSON \
-	REDIS RABBITMQ LUA HTTP COMPRESSION EMERGENCY \
+	REDIS RABBITMQ HTTP COMPRESSION EMERGENCY \
 	PROTO_SCTP PROTO_TLS
 
 ifeq ($(BUILD_MODPKG_LIST),NONE)
@@ -197,7 +193,7 @@ configure-stamp:
 
 
 build: build-stamp
-build-stamp: patch-stamp configure-stamp 
+build-stamp: configure-stamp 
 	dh_testdir
 
 	# Add here commands to compile the package.


### PR DESCRIPTION
* Check for freeradius libs in Makefile
* Check for json lib include paths in Makefile
* Update debian/changelog to reflect 2.1.0 stable
* Update debian/control with new dependency names and standards
* Update debian/rules to remove deprecated dpatch