### PR TITLE
CacheDB_SQL: Removed harmless ERROR log.

### DIFF
--- a/modules/cachedb_sql/cachedb_sql.c
+++ b/modules/cachedb_sql/cachedb_sql.c
@@ -273,7 +273,7 @@ static int dbcache_get(cachedb_con *con, str* attr, str* res)
 	}
 
 	if (RES_ROW_N(db_res) <= 0 || RES_ROWS(db_res)[0].values[0].nul != 0) {
-		LM_DBG("no value found for keyI\n");
+		LM_DBG("no value found for keyIn");
 		if (db_res != NULL && CACHEDBSQL_FUNC(con).free_result(CACHEDBSQL_CON(con),db_res) < 0)
 			LM_DBG("failed to free result of query\n");
 		return -2;
@@ -440,7 +440,9 @@ static int dbcache_fetch_counter(cachedb_con *con,str *attr,int *ret_val)
 	}
 
 	if (RES_ROW_N(db_res) <= 0 || RES_ROWS(db_res)[0].values[0].nul != 0) {
-		LM_DBG("no value found for keyI\n");
+		LM_DBG("no counter value found for key, assuming 0\n");
+		if (ret_val)
+			*ret_val = 0;
 		if (db_res != NULL && CACHEDBSQL_FUNC(con).free_result(CACHEDBSQL_CON(con), db_res) < 0)
 			LM_DBG("failed to free result of query\n");
 		return -2;


### PR DESCRIPTION
It is possible that set_dlg_profile has not been called yet when
get_dlg_profile is called for a specific key.

In that case, the counter value should be set to 0 and we should not
report an error because it is perfectly valid.