### PR TITLE
Fixed counter value when the key is not found.

### DIFF
--- a/modules/cachedb_sql/cachedb_sql.c
+++ b/modules/cachedb_sql/cachedb_sql.c
@@ -440,10 +440,12 @@ static int dbcache_fetch_counter(cachedb_con *con,str *attr,int *ret_val)
 	}
 
 	if (RES_ROW_N(db_res) <= 0 || RES_ROWS(db_res)[0].values[0].nul != 0) {
-		LM_DBG("no value found for keyI\n");
+		LM_DBG("no value found for counter key, assuming 0\n");
+		if (ret_val)
+			*ret_val = 0;
 		if (db_res != NULL && CACHEDBSQL_FUNC(con).free_result(CACHEDBSQL_CON(con), db_res) < 0)
 			LM_DBG("failed to free result of query\n");
-		return -2;
+		return 1;
 	}
 
 	switch(RES_ROWS(db_res)[0].values[0].type) {

--- a/modules/cachedb_sql/cachedb_sql.c
+++ b/modules/cachedb_sql/cachedb_sql.c
@@ -273,7 +273,7 @@ static int dbcache_get(cachedb_con *con, str* attr, str* res)
 	}
 
 	if (RES_ROW_N(db_res) <= 0 || RES_ROWS(db_res)[0].values[0].nul != 0) {
-		LM_DBG("no value found for keyI\n");
+		LM_DBG("no value found for key\n");
 		if (db_res != NULL && CACHEDBSQL_FUNC(con).free_result(CACHEDBSQL_CON(con),db_res) < 0)
 			LM_DBG("failed to free result of query\n");
 		return -2;


### PR DESCRIPTION
It can happen that a counter value is queried before it has been set. In
that case, we should assume a default value of 0.

A typical use case is the dialog module where we could call
get_dialog_profile for a specific key before set_dialog_profile has been
called for that key. There should be no error in that case and we should
simply return a value of 0.