### PR TITLE
Update nathelper.c

### DIFF
--- a/modules/nathelper/nathelper.c
+++ b/modules/nathelper/nathelper.c
@@ -1073,9 +1073,9 @@ replace_sdp_ip(struct sip_msg* msg, str *org_body, char *line, str *ip)
 		body2.s = oldip.s + oldip.len;
 		body2.len = bodylimit - body2.s;
 		if (alter_mediaip(msg, &body1, &oldip, pf, &newip, pf,
-					! (get_field_flag(line[0])&skip_oldip) /*if flag set do not
-															 set oldmediaip field*/,
+					!(get_field_flag(line[0])&skip_oldip),
 					line[0]) == -1) {
+					/*if flag set do not set oldmediaip field*/
 			LM_ERR("can't alter '%s' IP\n",line);
 			return -1;
 		}


### PR DESCRIPTION
Multi-line comment in call to "alter_mediaip" is not allowing function to return normally (at least on Fedora). This can be seen by placing LM_INFO() lines below the call or before the return 0 statement.