### PR TITLE
Add synchronous operation for raise functions for event_xmlrpc and event_rabbitmq

### DIFF
--- a/modules/event_rabbitmq/README
+++ b/modules/event_rabbitmq/README
@@ -26,6 +26,7 @@ Razvan Crainea
         1.5. Exported Parameters
 
               1.5.1. heartbeat (integer)
+              1.5.2. sync_mode (integer)
 
         1.6. Exported Functions
         1.7. Example
@@ -38,9 +39,10 @@ Razvan Crainea
    List of Examples
 
    1.1. Set heartbeat parameter
-   1.2. E_PIKE_BLOCKED event
-   1.3. RabbitMQ socket
-   1.4. OpenSIPS config script - sample event_rabbitmq usage
+   1.2. Set sync_mode parameter
+   1.3. E_PIKE_BLOCKED event
+   1.4. RabbitMQ socket
+   1.5. OpenSIPS config script - sample event_rabbitmq usage
    2.1. Event subscription
    2.2. Event subscription
 
@@ -130,6 +132,22 @@ Chapter 1. Admin Guide
 modparam("event_rabbitmq", "heartbeat", 3)
 ...
 
+1.5.2. sync_mode (integer)
+
+   Specifies whether an event raise operates synchronous or
+   asynchronous relative to the process where the raise is
+   triggered.In synchronous mode the process waits for the status
+   of the raise from the actual worker process.In asynchronous
+   mode the process continues its operation without receiving any
+   confirmation.
+
+   Default value is “0 (asynchronous)”.
+
+   Example 1.2. Set sync_mode parameter
+...
+modparam("event_rabbitmq", "sync_mode", 1)
+...
+
 1.6. Exported Functions
 
    No function exported to be used from configuration file.
@@ -139,13 +157,13 @@ modparam("event_rabbitmq", "heartbeat", 3)
    This is an example of an event raised by the pike module when
    it decides an ip should be blocked:
 
-   Example 1.2. E_PIKE_BLOCKED event
+   Example 1.3. E_PIKE_BLOCKED event
 
         E_PIKE_BLOCKED
         ip::192.168.2.11
 
 
-   Example 1.3. RabbitMQ socket
+   Example 1.4. RabbitMQ socket
 
         rabbitmq:guest:guest@127.0.0.1:5672/pike
 
@@ -163,7 +181,7 @@ modparam("event_rabbitmq", "heartbeat", 3)
    The parameters passed to the server are the R-URI username and
    the message body.
 
-   Example 1.4. OpenSIPS config script - sample event_rabbitmq
+   Example 1.5. OpenSIPS config script - sample event_rabbitmq
    usage
 ...
 loadmodule "signaling.so"

--- a/modules/event_rabbitmq/doc/event_rabbitmq_admin.xml
+++ b/modules/event_rabbitmq/doc/event_rabbitmq_admin.xml
@@ -157,6 +157,25 @@ modparam("event_rabbitmq", "heartbeat", 3)
 </programlisting>
 		</example>
 	</section>
+	<section>
+		<title><varname>sync_mode</varname> (integer)</title>
+		<para>
+			Specifies whether an event raise operates synchronous or asynchronous relative to the process where the raise is triggered.In synchronous mode the process waits for the status of the raise from the actual worker process.In asynchronous mode the process continues its operation without receiving any confirmation.
+		</para>
+		<para>
+		<emphasis>
+			Default value is <quote>0 (asynchronous)</quote>.
+		</emphasis>
+		</para>
+		<example>
+		<title>Set <varname>sync_mode</varname> parameter</title>
+		<programlisting format="linespecific">
+...
+modparam("event_rabbitmq", "sync_mode", 1)
+...
+</programlisting>
+		</example>
+	</section>
 	</section>
 
 	<section>

--- a/modules/event_rabbitmq/event_rabbitmq.c
+++ b/modules/event_rabbitmq/event_rabbitmq.c
@@ -47,6 +47,7 @@ static void destroy(void);
  * module parameters
  */
 static unsigned int heartbeat = 0;
+extern unsigned rmq_sync_mode;
 
 /**
  * exported functions
@@ -67,6 +68,7 @@ static proc_export_t procs[] = {
 /* module parameters */
 static param_export_t mod_params[] = {
 	{"heartbeat",					INT_PARAM, &heartbeat},
+	{"sync_mode",		INT_PARAM, &rmq_sync_mode},
 	{0,0,0}
 };
 
@@ -575,7 +577,6 @@ static int rmq_raise(struct sip_msg *msg, str* ev_name,
 
 	if (rmq_send(rmqs) < 0) {
 		LM_ERR("cannot send message\n");
-		shm_free(rmqs);
 		return -1;
 	}
 

--- a/modules/event_rabbitmq/rabbitmq_send.c
+++ b/modules/event_rabbitmq/rabbitmq_send.c
@@ -25,6 +25,7 @@
 
 #include "../../evi/evi_transport.h"
 #include "../../mem/shm_mem.h"
+#include "../../pt.h"
 #include "rabbitmq_send.h"
 #include <fcntl.h>
 #include <unistd.h>
@@ -41,8 +42,13 @@
         #define sched_yield()   sleep(0)
 #endif
 
+unsigned rmq_sync_mode = 0;
+static unsigned nr_procs = 0;
+
 /* used to communicate with the sending process */
 static int rmq_pipe[2];
+/* used to communicate the status of the send (success or fail) from the sending process back to the requesting ones */
+static int (*rmq_status_pipes)[2];
 
 /* creates communication pipe */
 int rmq_create_pipe(void)
@@ -59,6 +65,39 @@ int rmq_create_pipe(void)
 		LM_ERR("cannot create status pipe [%d:%s]\n", errno, strerror(errno));
 		return -1;
 	}
+
+	if (rmq_sync_mode && rmq_create_status_pipes() < 0) {
+		LM_ERR("cannot create communication status pipes\n");
+		return -1;
+	}
+
+	return 0;
+}
+
+/* creates status pipes */
+int rmq_create_status_pipes(void) {
+	int rc, i;
+
+	nr_procs = count_init_children(0) + 2;	/* + 2 timer processes */
+
+	rmq_status_pipes = shm_malloc(nr_procs * sizeof(rmq_pipe));
+
+	if (!rmq_status_pipes) {
+		LM_ERR("cannot allocate rmq_status_pipes\n");
+		return -1;
+	}
+
+	/* create pipes */
+	for (i = 0; i < nr_procs; i++) {
+		do {
+			rc = pipe(rmq_status_pipes[i]);
+		} while (rc < 0 && IS_ERR(EINTR));
+
+		if (rc < 0) {
+			LM_ERR("cannot create status pipe [%d:%s]\n", errno, strerror(errno));
+			return -1;
+		}
+	}
 	return 0;
 }
 
@@ -68,12 +107,30 @@ void rmq_destroy_pipe(void)
 		close(rmq_pipe[0]);
 	if (rmq_pipe[1] != -1)
 		close(rmq_pipe[1]);
+
+	if (rmq_sync_mode)
+		rmq_destroy_status_pipes();
+}
+
+void rmq_destroy_status_pipes(void)
+{
+	int i;
+
+	for(i = 0; i < nr_procs; i++) {
+		close(rmq_status_pipes[i][0]);
+		close(rmq_status_pipes[i][1]);
+	}
+
+	shm_free(rmq_status_pipes);
 }
 
 int rmq_send(rmq_send_t* rmqs)
 {
 	int rc;
 	int retries = RMQ_SEND_RETRY;
+	int send_status;
+
+	rmqs->process_idx = process_no;
 
 	do {
 		rc = write(rmq_pipe[1], &rmqs, RMQ_SIZE);
@@ -81,11 +138,27 @@ int rmq_send(rmq_send_t* rmqs)
 
 	if (rc < 0) {
 		LM_ERR("unable to send rmq send struct to worker\n");
-		return -1;
+		shm_free(rmqs);
+		return RMQ_SEND_FAIL;
 	}
 	/* give a change to the writer :) */
 	sched_yield();
-	return 0;
+
+	if (rmq_sync_mode) {
+		retries = RMQ_SEND_RETRY;
+
+		do {
+			rc = read(rmq_status_pipes[process_no][0], &send_status, sizeof(int));
+		} while (rc < 0 && (IS_ERR(EINTR) || retries-- > 0));
+
+		if (rc < 0) {
+			LM_ERR("cannot receive send status\n");
+			send_status = RMQ_SEND_FAIL;
+		}
+
+		return send_status;
+	} else
+		return RMQ_SEND_SUCCESS;
 }
 
 static rmq_send_t * rmq_receive(void)
@@ -117,6 +190,9 @@ int rmq_init_writer(void)
 		rmq_pipe[0] = -1;
 	}
 
+	if (rmq_sync_mode)
+		close(rmq_status_pipes[process_no][1]);
+
 	/* Turn non-blocking mode on for sending*/
 	flags = fcntl(rmq_pipe[1], F_GETFL);
 	if (flags == -1) {
@@ -137,10 +213,30 @@ error:
 
 static void rmq_init_reader(void)
 {
+	int i, flags;
+
 	if (rmq_pipe[1] != -1) {
 		close(rmq_pipe[1]);
 		rmq_pipe[1] = -1;
 	}
+
+	if (rmq_sync_mode)
+		for(i = 0; i < nr_procs; i++) {
+			close(rmq_status_pipes[i][0]);
+
+			/* Turn non-blocking mode on for sending*/
+			flags = fcntl(rmq_status_pipes[i][1], F_GETFL);
+			if (flags == -1) {
+				LM_ERR("fcntl failed: %s\n", strerror(errno));
+				close(rmq_status_pipes[i][1]);
+				return;
+			}
+			if (fcntl(rmq_status_pipes[i][1], F_SETFL, flags | O_NONBLOCK) == -1) {
+				LM_ERR("fcntl: set non-blocking failed: %s\n", strerror(errno));
+				close(rmq_status_pipes[i][1]);
+				return;
+			}
+		}
 }
 
 /* function that checks for error */
@@ -405,6 +501,9 @@ static int rmq_sendmsg(rmq_send_t *rmqs)
 
 void rmq_process(int rank)
 {
+	int retries, rc;
+	int send_status;
+
 	/* init blocking reader */
 	rmq_init_reader();
 	rmq_send_t * rmqs;
@@ -425,15 +524,31 @@ void rmq_process(int rank)
 		/* check if we should reconnect */
 		if (rmq_reconnect(rmqs->sock) < 0) {
 			LM_ERR("cannot reconnect socket\n");
-			goto end;
+			send_status = RMQ_SEND_FAIL;
+			goto send_status_reply;
 		}
 
 		/* send msg */
-		if (rmq_sendmsg(rmqs))
+		if (rmq_sendmsg(rmqs)) {
 			LM_ERR("cannot send message\n");
+			send_status = RMQ_SEND_FAIL;
+		} else {
+			send_status = RMQ_SEND_SUCCESS;
+		}
+
+send_status_reply:
+		if (rmq_sync_mode) {
+			retries = RMQ_SEND_RETRY;
+
+			do {
+				rc = write(rmq_status_pipes[rmqs->process_idx][1], &send_status, sizeof(int));
+			} while (rc < 0 && (IS_ERR(EINTR) || retries-- > 0));
+
+			if (rc < 0)
+				LM_ERR("cannot send status back to requesting process\n");
+		}
 end:
 		if (rmqs)
 			shm_free(rmqs);
 	}
 }
-

--- a/modules/event_rabbitmq/rabbitmq_send.h
+++ b/modules/event_rabbitmq/rabbitmq_send.h
@@ -30,19 +30,23 @@
 #include "event_rabbitmq.h"
 
 #define RMQ_SEND_RETRY 3
+#define RMQ_SEND_SUCCESS 0
+#define RMQ_SEND_FAIL -1
 
 typedef struct _rmq_send {
 	evi_reply_sock *sock;
 	char msg[0];
+	int process_idx;
 } rmq_send_t;
 
 void rmq_process(int rank);
 int rmq_create_pipe(void);
+int rmq_create_status_pipes(void);
 void rmq_destroy_pipe(void);
+void rmq_destroy_status_pipes(void);
 int rmq_init_writer(void);
 int rmq_send(rmq_send_t * rmqs);
 void rmq_free_param(rmq_params_t *rmqp);
 void rmq_destroy(evi_reply_sock *sock);
 
 #endif
-

--- a/modules/event_xmlrpc/README
+++ b/modules/event_xmlrpc/README
@@ -25,6 +25,7 @@ Razvan Crainea
         1.4. Exported Parameters
 
               1.4.1. use_struct_param (integer)
+              1.4.2. sync_mode (integer)
 
         1.5. Exported Functions
         1.6. Example
@@ -32,8 +33,9 @@ Razvan Crainea
    List of Examples
 
    1.1. Set use_struct_param parameter
-   1.2. E_PIKE_BLOCKED event
-   1.3. XMLRPC socket
+   1.2. Set sync_mode parameter
+   1.3. E_PIKE_BLOCKED event
+   1.4. XMLRPC socket
 
 Chapter 1. Admin Guide
 
@@ -97,6 +99,22 @@ Chapter 1. Admin Guide
 modparam("event_xmlrpc", "use_struct_param", 1)
 ...
 
+1.4.2. sync_mode (integer)
+
+   Specifies whether an event raise operates synchronous or
+   asynchronous relative to the process where the raise is
+   triggered.In synchronous mode the process waits for the status
+   of the raise from the actual worker process.In asynchronous
+   mode the process continues its operation without receiving any
+   confirmation.
+
+   Default value is “0 (asynchronous)”.
+
+   Example 1.2. Set sync_mode parameter
+...
+modparam("event_xmlrpc", "sync_mode", 1)
+...
+
 1.5. Exported Functions
 
    No function exported to be used from configuration file.
@@ -106,7 +124,7 @@ modparam("event_xmlrpc", "use_struct_param", 1)
    This is an example of an event raised by the pike module when
    it decides an ip should be blocked:
 
-   Example 1.2. E_PIKE_BLOCKED event
+   Example 1.3. E_PIKE_BLOCKED event
 
 
 POST /RPC2 HTTP/1.1.
@@ -131,7 +149,7 @@ Content-length: 240.
 </methodCall>
 
 
-   Example 1.3. XMLRPC socket
+   Example 1.4. XMLRPC socket
 
         # calls the 'block_ip' function
         xmlrpc:127.0.0.1:8080:block_ip

--- a/modules/event_xmlrpc/doc/event_xmlrpc_admin.xml
+++ b/modules/event_xmlrpc/doc/event_xmlrpc_admin.xml
@@ -111,6 +111,25 @@ modparam("event_xmlrpc", "use_struct_param", 1)
 </programlisting>
 		</example>
 	</section>
+	<section>
+		<title><varname>sync_mode</varname> (integer)</title>
+		<para>
+			Specifies whether an event raise operates synchronous or asynchronous relative to the process where the raise is triggered.In synchronous mode the process waits for the status of the raise from the actual worker process.In asynchronous mode the process continues its operation without receiving any confirmation.
+		</para>
+		<para>
+		<emphasis>
+			Default value is <quote>0 (asynchronous)</quote>.
+		</emphasis>
+		</para>
+		<example>
+		<title>Set <varname>sync_mode</varname> parameter</title>
+		<programlisting format="linespecific">
+...
+modparam("event_xmlrpc", "sync_mode", 1)
+...
+</programlisting>
+		</example>
+	</section>
 	</section>
 
 	<section>

--- a/modules/event_xmlrpc/xmlrpc_send.h
+++ b/modules/event_xmlrpc/xmlrpc_send.h
@@ -36,11 +36,14 @@ typedef struct _xmlrpc_send {
 	str method;
 	str host;
 	str event;
+	int process_idx;
 } xmlrpc_send_t;
 
 void xmlrpc_process(int rank);
 int xmlrpc_create_pipe(void);
+int xmlrpc_create_status_pipes(void);
 void xmlrpc_destroy_pipe(void);
+void xmlrpc_destroy_status_pipes(void);
 int xmlrpc_init_writer(void);
 int xmlrpc_init_buffers(void);
 int xmlrpc_send(xmlrpc_send_t * xmlrpcs);
@@ -52,10 +55,12 @@ int xmlrpc_build_buffer(str *,
 #define XMLRPC_DEFAULT_BUFFER_SIZE 8192
 #define XMLRPC_IOVEC_MAX_SIZE 32
 #define XMLRPC_DEFAULT_PORT 8080
+#define XMLRPC_SEND_SUCCESS 0
+#define XMLRPC_SEND_FAIL -1
 
 /* string macros */
 /* computes a macro len */
-#define LENOF(m)	(sizeof(m) - 1)
+#define LENOF(m)	(sizeof(m) - 1)	
 
 /* xmlrpc http header */
 #define XMLRPC_HTTP_CONST "POST /RPC2 HTTP/1.1\r\nHost: "


### PR DESCRIPTION
When an event is raised in synchronous mode (configurable through the "sync_mode" module parameter, asynchronous is default) the triggering process waits for the status of the operation from the actual worker process.