### PR TITLE
Do not append colon if uri password is NULL

### DIFF
--- a/action.c
+++ b/action.c
@@ -1029,7 +1029,7 @@ int do_action(struct action* a, struct sip_msg* msg)
 			/* passwd */
 			tmp = uri.passwd.s;
 			len = uri.passwd.len;
-			if (user || tmp) {
+			if (tmp) {
 				if (crt+len+1>end) goto error_uri;
 				*crt++=':';
 				memcpy(crt, tmp, len);


### PR DESCRIPTION
I agree with @brettnem's assessment of the problem with #593.  As @liviuchircu pointed out, this pull requests addresses the problem in `do_action.c:1032` where a colon is blindly added if the user exists without consideration for the presence of an actual password... it attempts a memcpy on a NULL pointer no less (albeit with a length of 0).

I think if `parse_uri(tmp, len, &uri)<0)` finds an actual semi colon after the user and the password IS indeed blank, uri.password.s should be initialized to an empty string `""` instead of NULL so that `do_action.c:1032` check passes and the current "problematic" behavior will occur.  But otherwise, if the password is NULL, the colon should not be appended.

This should satisfy the userinfo requirements as well as fix the issue presented.

Thoughts?
