### PR TITLE
makefile: detect target architecture using the compiler

### DIFF
--- a/Makefile.defs
+++ b/Makefile.defs
@@ -87,18 +87,18 @@ else
 	GETARCH=uname -m
 endif
 
-ARCH := $(shell $(GETARCH) |sed -e s/i.86/i386/ -e s/sun4u/sparc64/  \
+HOST_ARCH := $(shell $(GETARCH) |sed -e s/i.86/i386/ -e s/sun4u/sparc64/  \
 			-e s/armv4l/arm/ -e "s/Power Macintosh/ppc/" \
 			-e s/sun4v/sparc64/ -e "s/cobalt/mips2/" \
 			-e s/amd64/x86_64/ )
 
 # fix sparc -> sparc64
-ifeq ($(ARCH),sparc)
+ifeq ($(HOST_ARCH),sparc)
 	ifeq ($(shell uname -m),sun4u)
-		ARCH := sparc64
+		HOST_ARCH := sparc64
 	endif
 	ifeq ($(shell uname -m),sun4v)
-		ARCH := sparc64
+		HOST_ARCH := sparc64
 	endif
 endif
 
@@ -426,6 +426,85 @@ $(warning	Unknown compiler $(CC)\; supported compilers: \
 endif
 export CC_NAME
 
+# ARCH detection
+# predefined compiler macros for different architectures
+# (see http://predef.sourceforge.net/prearch.html for a more complete list)
+i386_macros= i386 __i386__ __i486__ __i586__ __i686__ \
+			__i386 _M_IX86 __X86__ _X86_
+x86_64_macros= __amd64__ __amd64 __x86_64__ __x86_64 _M_X64
+
+sparc_macros= __sparc__ __sparc __sparcv8
+sparc64_macros= __sparcv9 __sparc_v9__
+
+arm_macros= __arm__ __thumb__
+arm6_macros= __ARM_ARCH_6__
+
+ppc_macros= __powerpc __powerpc__ __POWERPC__ __ppc__ _ARCH_PPC
+ppc64_macros= __ppc64__ _ARCH_PPC64
+
+mips_macros= __mips__ __mips _MIPS_ARCH_MIPS1
+mips2_macros= _MIPS_ISA_MIPS2 _MIPS_ISA_MIPS3 _MIPS_ISA_MIPS4 \
+			_MIPS_ARCH_MIPS2 _MIPS_ARCH_MIPS3 _MIPS_ARCH_MIPS4
+mips64_macros= _MIPS_ISA_MIPS64 _MIPS_ARCH_MIPS64
+
+alpha_macros= __alpha__ __alpha _M_ALPHA_
+
+ifeq ($(CC_NAME),gcc)
+#if gcc use gcc arch
+predef_macros:=$(shell $(CC) -dM -E -x c $(CC_EXTRA_OPTS) $(extra_defs) \
+					$(CFLAGS) /dev/null)
+
+ifneq ($(strip $(filter $(i386_macros), $(predef_macros))),)
+CC_ARCH=i386
+else ifneq ($(strip $(filter $(x86_64_macros), $(predef_macros))),)
+CC_ARCH=x86_64
+else ifneq ($(strip $(filter $(sparc_macros), $(predef_macros))),)
+
+ifneq ($(strip $(filter $(sparc64_macros), $(predef_macros))),)
+CC_ARCH=sparc64
+else # sparc64_macros
+CC_ARCH=sparc
+endif # sparc64_macros
+
+else ifneq ($(strip $(filter $(arm_macros), $(predef_macros))),)
+
+ifneq ($(strip $(filter $(arm6_macros), $(predef_macros))),)
+CC_ARCH=arm6
+else # arm6_macros
+CC_ARCH=arm
+endif # arm6_macros
+
+else ifneq ($(strip $(filter $(ppc64_macros), $(predef_macros))),)
+CC_ARCH=ppc64
+else ifneq ($(strip $(filter $(ppc_macros), $(predef_macros))),)
+CC_ARCH=ppc
+else ifneq ($(strip $(filter $(mips_macros), $(predef_macros))),)
+
+ifneq ($(strip $(filter $(mips64_macros), $(predef_macros))),)
+CC_ARCH=mips64
+else ifneq ($(strip $(filter $(mips2_macros), $(predef_macros))),)
+CC_ARCH=mips2
+else # mips2_macros
+CC_ARCH=mips
+endif # mips64_macros
+
+else ifneq ($(strip $(filter $(alpha_macros), $(predef_macros))),)
+CC_ARCH=alpha
+else
+
+$(warn "Unknown target compiler architecture")
+
+endif # predefined macros tests (x86_macros, ...)
+
+endif # gcc
+
+ifdef CC_ARCH
+$(info "target architecture <$(CC_ARCH)>, host architecture <$(HOST_ARCH)>")
+ARCH:=$(CC_ARCH)
+else
+ARCH:=$(HOST_ARCH)
+endif
+
 
 # compile-time options
 #
@@ -651,8 +730,9 @@ ifeq	($(ARCH), i386)
 		# if gcc 
 ifeq		($(CC_NAME), gcc)
 				#common stuff
-				CFLAGS+=-O9 -funroll-loops  -Wcast-align $(PROFILE) \
-					-Wall 
+				CFLAGS+=-m32 -O9 -funroll-loops  -Wcast-align $(PROFILE) \
+					-Wall
+				LDFLAGS+=-m32
 			#if gcc 4.0+
 ifeq			($(CC_CLASS), 4.x)
 					ARCH_VER=$(shell $(GETARCH))


### PR DESCRIPTION
Fixes producing a 32bit build in a 64bit system.

Original patch by Andrei Pelinescu-Onciul:
https://github.com/kamailio/kamailio/commit/c46e79709216c4975abc83869fbce9fa696eac74