### PR TITLE
New MI command dbt_reload - causes db_text module to reload cached tables from disk.

### DIFF
--- a/modules/db_text/README
+++ b/modules/db_text/README
@@ -44,6 +44,7 @@ Daniel-Constantin Mierla
         1.5. Exported MI Functions
 
               1.5.1. dbt_dump
+              1.5.2. dbt_reload
 
         1.6. Installation and Running
 
@@ -207,6 +208,32 @@ modparam("db_text", "db_mode", 1)
 
    MI FIFO Command Format:
 :dbt_dump:_reply_fifo_file_
+_empty_line_
+
+1.5.2. dbt_reload
+
+   Causes db_text module to reload cached tables from disk.
+   Depending on parameters it could be a whole cache or a specified
+   database or a single table.
+   If any table cannot be reloaded from disk - the old version
+   preserved and error reported.
+
+   Parameters:
+     * db_name (optional) - database name to reload.
+     * table_name (optional, but cannot be present without the
+       db_name parameter) - specific table to reload.
+
+   MI FIFO Command Format:
+:dbt_reload:_reply_fifo_file_
+_empty_line_
+
+:dbt_reload:_reply_fifo_file_
+/path/to/dbtext/database
+_empty_line_
+
+:dbt_reload:_reply_fifo_file_
+/path/to/dbtext/database
+table_name
 _empty_line_
 
 1.6. Installation and Running

--- a/modules/db_text/dbt_lib.c
+++ b/modules/db_text/dbt_lib.c
@@ -422,6 +422,116 @@ int dbt_cache_print(int _f)
 	return 0;
 }
 
+int dbt_cache_reload(const str *dbname, const str *name)
+{
+	dbt_cache_p _dc;
+	dbt_table_p _tbc, _tbc_new;
+	int hash, hashidx;
+	int i, res = 0;
+
+
+	if( !_dbt_cachesem || !_dbt_cachedb || !_dbt_cachetbl ) {
+		LM_ERR("dbtext cache is not initialized! Check if you loaded"
+			" dbtext before attempting to reload it\n");
+		return -2;
+	}
+	if( dbname && !(dbname->s && (dbname->len > 0)) ) {
+		LM_ERR("request to reload an invalid dbtext database.\n");
+		return -1;
+	}
+	if( name && !(name->s && (name->len > 0)) ) {
+		LM_ERR("request to reload an invalid dbtext table.\n");
+		return -1;
+	}
+
+
+	// lock to disable any cache modfifications while in reload
+	lock_get(_dbt_cachesem);
+
+	// resolve dbname in database cache if specified
+	_dc = NULL;
+	if( dbname ) {
+		_dc = *_dbt_cachedb;
+		while( _dc ) {
+			if( (_dc->name.len == dbname->len) && !strncasecmp(_dc->name.s, dbname->s, dbname->len) ) {
+				LM_DBG("resolved database [%.*s]\n", _dc->name.len, _dc->name.s);
+				break;
+			}
+			_dc = _dc->next;
+		}
+		if( !_dc ) {
+			LM_ERR("dbtext database [%.*s] not exists and cannot be reloaded!\n", dbname->len, dbname->s);
+			lock_release(_dbt_cachesem);
+			return -1;
+		}
+	}
+
+	// calculate hash & hashidx if dbname & name specified
+	hash = hashidx = -1;
+	if( _dc && name ) {
+		hash = core_hash(&_dc->name, name, DBT_CACHETBL_SIZE);
+		hashidx = hash % DBT_CACHETBL_SIZE;
+	}
+
+	for(i=0; i<DBT_CACHETBL_SIZE; i++) {
+		// iterate all table caches or only one if hashidx calculated
+		if( (hashidx < 0) || (hashidx == i) ) {
+			lock_get(&_dbt_cachetbl[i].sem);
+
+			_tbc = _dbt_cachetbl[i].dtp;
+			while( _tbc ) {
+				if(
+					// match hash if calcuated
+					((hashidx < 0) || (_tbc->hash == hash)) &&
+					// match table name if specified
+					(!name || ((_tbc->name.len == name->len) && !strncasecmp(_tbc->name.s, name->s, name->len))) &&
+					// match database name if specified
+					(!_dc || ((_tbc->dbname.len == _dc->name.len) && !strncasecmp(_tbc->dbname.s, _dc->name.s, _dc->name.len)))
+				) {
+					// load new version from disk
+					_tbc_new = dbt_load_file(&(_tbc->name), &(_tbc->dbname));
+					if( _tbc_new ) {
+						// inherit old version properties
+						_tbc_new->hash = _tbc->hash;
+						_tbc_new->prev = _tbc->prev;
+						_tbc_new->next = _tbc->next;
+
+						// update linked list links
+						if( _tbc_new->prev ) (_tbc_new->prev)->next = _tbc_new;
+						if( _tbc_new->next ) (_tbc_new->next)->prev = _tbc_new;
+						if( _dbt_cachetbl[i].dtp == _tbc ) _dbt_cachetbl[i].dtp = _tbc_new;
+
+						// delete old version and update iterator
+						dbt_table_free(_tbc);
+						_tbc = _tbc_new;
+
+						LM_INFO("dbtext table [%.*s]->[%.*s] successfully reloaded\n", _tbc->dbname.len, _tbc->dbname.s, _tbc->name.len, _tbc->name.s);
+					} else {
+						// report failure if any reload fails
+						res = -2;
+						LM_ERR("dbtext table [%.*s]->[%.*s] loading of a new version failed and old version preserved!\n", _tbc->dbname.len, _tbc->dbname.s, _tbc->name.len, _tbc->name.s);
+					}
+
+					// exit loop if name specified and in 'match only one' scenario
+					if( name ) break;
+				}
+				_tbc = _tbc->next;
+			}
+
+			lock_release(&_dbt_cachetbl[i].sem);
+
+			if( name && !_tbc ) {
+				LM_ERR("dbtext table [%.*s]->[%.*s] not exists and cannot be reloaded!\n", dbname->len, dbname->s, name->len, name->s);
+				lock_release(_dbt_cachesem);
+				return -1;
+			}
+		}
+	}
+
+	lock_release(_dbt_cachesem);
+	return res;
+}
+
 int dbt_is_neq_type(db_type_t _t0, db_type_t _t1)
 {
 	// LM_DBG("t0=%d t1=%d!\n", _t0, _t1);

--- a/modules/db_text/dbt_lib.h
+++ b/modules/db_text/dbt_lib.h
@@ -111,6 +111,7 @@ typedef struct _dbt_cache
 int dbt_init_cache();
 int dbt_cache_destroy();
 int dbt_cache_print(int);
+int dbt_cache_reload(const str *dbname, const str *name);
 
 dbt_cache_p dbt_cache_get_db(str*);
 int dbt_cache_check_db(str*);

--- a/modules/db_text/dbtext.c
+++ b/modules/db_text/dbtext.c
@@ -42,6 +42,7 @@ static int mod_init(void);
 static void destroy(void);
 
 static struct mi_root* mi_dbt_dump(struct mi_root* cmd, void* param);
+static struct mi_root* mi_dbt_reload(struct mi_root* cmd, void* param);
 
 /*
  * Module parameter variables
@@ -71,6 +72,7 @@ static param_export_t params[] = {
 /** MI commands */
 static mi_export_t mi_cmds[] = {
 	{"dbt_dump", 0, mi_dbt_dump, 0, 0, 0},
+	{"dbt_reload", 0, mi_dbt_reload, 0, 0, 0},
 	{0,          0,           0, 0, 0, 0}
 };
 
@@ -140,4 +142,31 @@ static struct mi_root* mi_dbt_dump(struct mi_root* cmd, void* param)
 	if (dbt_cache_print(0)!=0)
 		return NULL;
 	return rpl_tree;
+}
+
+static struct mi_root* mi_dbt_reload(struct mi_root* cmd, void* param)
+{
+	struct mi_node *node;
+	str *dbname, *name;
+	int res;
+
+	dbname = name = NULL;
+	if( (node = cmd->node.kids) ) {
+		dbname = &(node->value);
+
+		if( (node = node->next) ) {
+			name = &(node->value);
+
+			if( node->next )
+				return init_mi_tree(400, MI_SSTR(MI_MISSING_PARM_S));
+		}
+	}
+
+	if( (res = dbt_cache_reload(dbname, name)) >= 0 ) {
+		return init_mi_tree(200, MI_SSTR(MI_OK_S));
+	} else if( res == -1 ) {
+		return init_mi_tree(400, MI_SSTR(MI_BAD_PARM_S));
+	} else {
+		return init_mi_tree(500, MI_SSTR(MI_INTERNAL_ERR_S));
+	}
 }

--- a/modules/db_text/doc/db_text_admin.xml
+++ b/modules/db_text/doc/db_text_admin.xml
@@ -232,7 +232,7 @@ suser:supasswd:xxx:alpha.org:xxx
 	<title>Exported Parameters</title>
 		<para>
 			<emphasis>None</emphasis>.
-	   	</para>
+		</para>
 		<section>
 			<title><varname>db_mode</varname> (integer)</title>
 		<para>
@@ -260,7 +260,7 @@ modparam("db_text", "db_mode", 1)
 	<title>Exported Functions</title>
 		<para>
 			<emphasis>None</emphasis>.
-	   	</para>
+		</para>
 	</section>
 	<section>
 	<title>Exported MI Functions</title>
@@ -268,16 +268,57 @@ modparam("db_text", "db_mode", 1)
 		<title><varname>dbt_dump</varname></title>
 		<para>
 			Write back to hard drive modified tables.
-	   	</para>
+		</para>
 		<para>
 		Name: <emphasis>dbt_dump</emphasis>.
-	   	</para>
-	   	<para>Parameters: none</para>
-	   	<para>
-	   	MI FIFO Command Format:
-	   	</para>
-	   	<programlisting  format="linespecific">
+		</para>
+		<para>Parameters: none</para>
+		<para>
+		MI FIFO Command Format:
+		</para>
+		<programlisting  format="linespecific">
 :dbt_dump:_reply_fifo_file_
+_empty_line_
+		</programlisting>
+	</section>
+	<section>
+		<title><varname>dbt_reload</varname></title>
+		<para>
+			Causes db_text module to reload cached tables from disk.
+			Depending on parameters it could be a whole cache or a specified
+			database or a single table.
+			If any table cannot be reloaded from disk - the old version
+			preserved and error reported.
+		</para>
+		<para>
+		Name: <emphasis>dbt_reload</emphasis>.
+		</para>
+		<para>Parameters:</para>
+		<itemizedlist>
+			<listitem><para>
+				<emphasis>db_name</emphasis> (optional) - database name to reload.
+			</para></listitem>
+			<listitem><para>
+				<emphasis>table_name</emphasis> (optional, but cannot be present
+				without the db_name parameter) - specific table to reload.
+			</para></listitem>
+		</itemizedlist>
+		<para>
+		MI FIFO Command Format:
+		</para>
+		<programlisting  format="linespecific">
+:dbt_reload:_reply_fifo_file_
+_empty_line_
+		</programlisting>
+		<programlisting  format="linespecific">
+:dbt_reload:_reply_fifo_file_
+/path/to/dbtext/database
+_empty_line_
+		</programlisting>
+		<programlisting  format="linespecific">
+:dbt_reload:_reply_fifo_file_
+/path/to/dbtext/database
+table_name
 _empty_line_
 		</programlisting>
 	</section>


### PR DESCRIPTION
Depending on parameters it could be a whole cache or a specified database or a single table.
If any table cannot be reloaded from disk - the old version
preserved and error reported.