### PR TITLE
A new flag for LB module lb_start() function to pick a rand()'om destinations with equal load

### DIFF
--- a/modules/load_balancer/README
+++ b/modules/load_balancer/README
@@ -278,6 +278,14 @@ modparam("load_balancer", "lb_define_blacklist", "blist2= 2,10,6")
             Absolute value is assumed - the effective available
             load ( maximum_load - current_load) is used in
             computing the load of each pear/resource.
+          + s - Pick a random destination if multiple destinations
+            with the same load are found, instead of always picking
+            first matched destination.
+            This could help to offload an excessive load from the
+            first destination and distribute load in situations
+            when failed calls always routed to first destination,
+            since they almost does not affect load counters of
+            destinations.
 
    Returns true if a new destination URI is set, pointing to the
    selected destination. NOTE that the RURI will not be changed by

--- a/modules/load_balancer/doc/load_balancer_admin.xml
+++ b/modules/load_balancer/doc/load_balancer_admin.xml
@@ -333,6 +333,16 @@ modparam("load_balancer", "lb_define_blacklist", "blist2= 2,10,6")
 				computing the load of each pear/resource.
 				</para>
 			</listitem>
+			<listitem>
+				<para><emphasis>s</emphasis> - Pick a random destination if
+				multiple destinations with the same load are found, instead
+				of always picking first matched destination.
+				This could help to offload an excessive load from the first
+				destination and distribute load in situations when failed
+				calls always routed to first destination, since they almost
+				does not affect load counters of destinations.
+				</para>
+			</listitem>
 			</itemizedlist>
 		</listitem>
 		</itemizedlist>

--- a/modules/load_balancer/lb_data.h
+++ b/modules/load_balancer/lb_data.h
@@ -37,6 +37,7 @@
 
 #define LB_FLAGS_RELATIVE (1<<0) /* do relative versus absolute estimation. default is absolute */
 #define LB_FLAGS_NEGATIVE (1<<1) /* do not skip negative loads. default to skip */
+#define LB_FLAGS_RANDOM   (1<<2) /* pick a random destination among all selected dsts with equal load */
 #define LB_FLAGS_DEFAULT  0
 
 #define LB_DST_PING_DSBL_FLAG   (1<<0)

--- a/modules/load_balancer/load_balancer.c
+++ b/modules/load_balancer/load_balancer.c
@@ -601,6 +601,10 @@ static int w_lb_start(struct sip_msg *req, char *grp, char *rl, char *fl)
 					flags |= LB_FLAGS_NEGATIVE;
 					LM_DBG("do not skip negative loads\n");
 					break;
+				case 's':
+					flags |= LB_FLAGS_RANDOM;
+					LM_DBG("pick a random destination among all selected dsts with equal load\n");
+					break;
 				default:
 					LM_DBG("skipping unknown flag: [%c]\n", *f);
 			}


### PR DESCRIPTION
...if multiple destinations selected.

This could help to offload an excessive load from first destination and distribute load in situations when calls duration is near to zero (like failed calls)
and counts in resources are almost always zero and does not reflect an actual calls flow.

Already discussed in PR: OpenSIPS/opensips#345