### PR TITLE
Use DB_STR instead of DB_STRING for string value (and as default value)

### DIFF
--- a/modules/db_postgres/res.c
+++ b/modules/db_postgres/res.c
@@ -151,8 +151,8 @@ int db_postgres_get_columns(const db_con_t* _h, db_res_t* _r)
 			case VARCHAROID:
 			case BPCHAROID:
 			case TEXTOID:
-				LM_DBG("use DB_STRING result type\n");
-				RES_TYPES(_r)[col] = DB_STRING;
+				LM_DBG("use DB_STR result type\n");
+				RES_TYPES(_r)[col] = DB_STR;
 			break;
 
 			case BYTEAOID:
@@ -170,7 +170,7 @@ int db_postgres_get_columns(const db_con_t* _h, db_res_t* _r)
 				LM_WARN("unhandled data type column (%.*s) type id (%d), "
 						"use DB_STRING as default\n", RES_NAMES(_r)[col]->len,
 						RES_NAMES(_r)[col]->s, datatype);
-				RES_TYPES(_r)[col] = DB_STRING;
+				RES_TYPES(_r)[col] = DB_STR;
 			break;
 		}
 	}


### PR DESCRIPTION
There is currently a bug with dialog persistency using postgres database. If OpenSIPS is restarted, all dialogs variables are lost (not read from database at start-up).
The bug comes from this block of code (line 1616 in dlg_db_handler.c)
                    if (!VAL_NULL(values+18))
                        read_dialog_vars( VAL_STR(values+18).s,
                            VAL_STR(values+18).len, known_dlg);
As the DB type for string in db_postgres module is DB_STRING (NULL terminated string),  VAL_STR(values+18).len is always 0 (or undefined), hence dialog variables are never read from database.

This bug could be fix by replacing  VAL_STR(values+18).len by strlen(VAL_STR(values+18)). However, I think it's better to change DB type for string to DB_STR to avoid this kind of bug in the future.
