### PR TITLE
other fixes on db value interpretation in dialog module

### DIFF
--- a/modules/dialog/dlg_db_handler.c
+++ b/modules/dialog/dlg_db_handler.c
@@ -573,7 +573,7 @@ static int load_dialog_info_from_db(int dlg_hash_size)
 			/* script variables */
 			if (!VAL_NULL(values+18))
 				read_dialog_vars( VAL_STR(values+18).s,
-					VAL_STR(values+18).len, dlg);
+					strlen(VAL_STR(values+18)), dlg);
 
 			/* profiles */
 			if (!VAL_NULL(values+19))
@@ -1378,7 +1378,7 @@ static int sync_dlg_db_mem(void)
 				/* script variables */
 				if (!VAL_NULL(values+18))
 					read_dialog_vars( VAL_STR(values+18).s,
-						VAL_STR(values+18).len, dlg);
+						strlen(VAL_STR(values+18)), dlg);
 
 				/* profiles */
 				if (!VAL_NULL(values+19))
@@ -1536,7 +1536,7 @@ static int sync_dlg_db_mem(void)
 					 * and replace with new one */
 					if (!VAL_NULL(values+18))
 						read_dialog_vars( VAL_STR(values+18).s,
-							VAL_STR(values+18).len, known_dlg);
+							strlen(VAL_STR(values+18)), known_dlg);
 
 					/* skip flags - keep what we have - anyway can't tell which is new */
 


### PR DESCRIPTION
@bogdan-iancu : There are other places in dlg_db_handler.c where VAL_STR().len is used. This one fix them all.