### PR TITLE
xcap: make the 'doc' column a LONGBLOB on MySQL

### DIFF
--- a/db/schema/pr_xcap.xml
+++ b/db/schema/pr_xcap.xml
@@ -46,6 +46,7 @@
         <name>doc</name>
         <type>binary</type>
         <description>doc</description>
+        <type db="mysql">LONGBLOB</type>
     </column>
 
     <column id="doc_type">


### PR DESCRIPTION
A normal-sized XCAP document with external references easily exceedes
the default column size, leading to all sorts of problems.