### PR TITLE
add missing space in debian/opensips.init

### DIFF
--- a/packaging/debian/opensips.init
+++ b/packaging/debian/opensips.init
@@ -30,7 +30,7 @@ DEFAULTS=/etc/default/opensips
 RUN_OPENSIPS=no
 
 
-[-e "/lib/lsb/init-functions" ] && . /lib/lsb/init-functions
+[ -e "/lib/lsb/init-functions" ] && . /lib/lsb/init-functions
 test -f $DAEMON || exit 0
 
 # Load startup options if available


### PR DESCRIPTION
This fixes a very small typo that causes the debian/ubuntu init script to throw the following error:

```
/etc/init.d/opensips: 31: /etc/init.d/opensips: [-e: not found
```