### PR TITLE
don't save ruri to Route in handle_sr if there is no next hop

### DIFF
--- a/modules/rr/loose.c
+++ b/modules/rr/loose.c
@@ -405,9 +405,11 @@ static inline int handle_sr(struct sip_msg* _m, struct hdr_field* _hdr, rr_t* _r
 	int rem_len;
 
 	/* Next hop is strict router, save R-URI here */
-	if (save_ruri(_m) < 0) {
-		LM_ERR("failed to save Request-URI\n");
-		return -1;
+	if (_r->next) {
+		if (save_ruri(_m) < 0) {
+			LM_ERR("failed to save Request-URI\n");
+			return -1;
+		}
 	}
 
 	/* Put the first Route in Request-URI */


### PR DESCRIPTION
In after_loose, behave much like in after_strict: don't insert the Route header with our own address if the next hop is the endpoint, and not a strict router.