### PR TITLE
Dispatcher module should honor db_default_url

### DIFF
--- a/modules/dispatcher/dispatcher.c
+++ b/modules/dispatcher/dispatcher.c
@@ -693,6 +693,8 @@ static int mod_init(void)
 
 	LM_DBG("initializing ...\n");
 
+	init_db_url( default_db_head.db_url , 0 /*can be null*/);
+
 	if (check_if_default_head_is_ok()) {
 		default_db_head.next = ds_db_heads;
 		ds_db_heads = &default_db_head;


### PR DESCRIPTION
Currently the dispatcher module won't start if only `db_default_url` is set and the `db_url` modparam for dispatcher is not. This fixes that.

```
Sep 23 13:43:55 [46257] DBG:dispatcher:mod_init: initializing ...
Sep 23 13:43:55 [46257] DBG:dispatcher:init_ds_bls: Initialising ds blacklists
Sep 23 13:43:55 [46257] ERROR:dispatcher:partition_init: [default] DB URL is not defined!
Sep 23 13:43:55 [46257] ERROR:core:init_mod: failed to initialize module dispatcher
Sep 23 13:43:55 [46257] ERROR:core:main: error while initializing modules
Sep 23 13:43:55 [46257] INFO:core:cleanup: cleanup
```