### PR TITLE
dialog: Document that unset_dlg_profile can be used from request_route.

### DIFF
--- a/modules/dialog/README
+++ b/modules/dialog/README
@@ -1212,8 +1212,8 @@ set_dlg_profile("caller","$fu");
        the dialog to the profile - note that the profile must
        support values. Pseudo-variables are supported.
 
-   This function can be used from BRANCH_ROUTE, REPLY_ROUTE and
-   FAILURE_ROUTE.
+   This function can be used from REQUEST_ROUTE, BRANCH_ROUTE,
+   REPLY_ROUTE and FAILURE_ROUTE.
 
    Example 1.60. unset_dlg_profile usage
 ...

--- a/modules/dialog/doc/dialog_admin.xml
+++ b/modules/dialog/doc/dialog_admin.xml
@@ -1642,7 +1642,7 @@ set_dlg_profile("caller","$fu");
 		</listitem>
 		</itemizedlist>
 		<para>
-		This function can be used from BRANCH_ROUTE,
+		This function can be used from REQUEST_ROUTE, BRANCH_ROUTE,
 			REPLY_ROUTE and FAILURE_ROUTE.
 		</para>
 		<example>


### PR DESCRIPTION
This has been possible since 23f2322d in 1.8 and higher.