### PR TITLE
packaging/debian: change MI_XMLRPC to MI_XMLRPC_NG in packaging

### DIFF
--- a/packaging/debian/control
+++ b/packaging/debian/control
@@ -10,7 +10,7 @@ Homepage: http://www.opensips.org/
 Package: opensips
 Architecture: any
 Depends: ${shlibs:Depends}, ${misc:Depends}, adduser
-Suggests: opensips-mysql-module, opensips-postgres-module, opensips-unixodbc-module, opensips-jabber-module, opensips-cpl-module, opensips-radius-modules, opensips-presence-modules, opensips-xmlrpc-module, opensips-perl-modules, opensips-snmpstats-module, opensips-xmpp-module, opensips-carrierroute-module, opensips-berkeley-module, opensips-ldap-modules, opensips-geoip-module, opensips-regex-module, opensips-identity-module, opensips-b2bua-module, opensips-dbhttp-module, opensips-dialplan-module, opensips-memcached-module, opensips-json-module, opensips-console, opensips-redis-module, opensips-rabbitmq-module, opensips-lua-module, opensips-http-modules
+Suggests: opensips-mysql-module, opensips-postgres-module, opensips-unixodbc-module, opensips-jabber-module, opensips-cpl-module, opensips-radius-modules, opensips-presence-modules, opensips-xmlrpcng-module, opensips-perl-modules, opensips-snmpstats-module, opensips-xmpp-module, opensips-carrierroute-module, opensips-berkeley-module, opensips-ldap-modules, opensips-geoip-module, opensips-regex-module, opensips-identity-module, opensips-b2bua-module, opensips-dbhttp-module, opensips-dialplan-module, opensips-memcached-module, opensips-json-module, opensips-console, opensips-redis-module, opensips-rabbitmq-module, opensips-lua-module, opensips-http-modules
 Description: very fast and configurable SIP server
  OpenSIPS is a very fast and flexible SIP (RFC3261)
  server. Written entirely in C, OpenSIPS can handle thousands calls
@@ -115,7 +115,7 @@ Description: SIMPLE presence modules for OpenSIPS
  server and presence user agent for RICH presence, registrar-based presence,
  external triggered presence and XCAP support.
 
-Package: opensips-xmlrpc-module
+Package: opensips-xmlrpcng-module
 Architecture: any
 Depends: ${shlibs:Depends}, opensips (= ${binary:Version})
 Description: XMLRPC support for OpenSIPS's Management Interface
@@ -284,7 +284,7 @@ Description: Support for JSON handling in OpenSIPS script
 Package: opensips-console
 Architecture: any
 Depends: opensips (= ${binary:Version}), libfrontier-rpc-perl, libnet-ip-perl, libberkeleydb-perl, libterm-readline-perl-perl
-Suggests: opensips-mysql-module, opensips-postgres-module, opensips-unixodbc-module, opensips-xmlrpc-module, opensips-berkeley-module 
+Suggests: opensips-mysql-module, opensips-postgres-module, opensips-unixodbc-module, opensips-xmlrpcng-module, opensips-berkeley-module 
 Description: Generic tool for OpenSIPS provisioning
  OpenSIPS is a very fast and flexible SIP (RFC3261)
  server. Written entirely in C, OpenSIPS can handle thousands calls

--- a/packaging/debian/rules
+++ b/packaging/debian/rules
@@ -35,7 +35,7 @@ TLS=
 # Used to index the make variable below, which has details about each package
 ALL_MODPKG_LIST := \
 	MYSQL POSTGRES UNIXODBC JABBER CPL RADIUS \
-	PRESENCE XMLRPC PERL SNMPSTATS XMPP CROUTE BERKELEY LDAP \
+	PRESENCE XMLRPCNG PERL SNMPSTATS XMPP CROUTE BERKELEY LDAP \
 	GEOIP REGEX IDENTITY B2BUA DBHTTP DIALPLAN MEMCACHED JSON \
 	REDIS RABBITMQ HTTP REST_CLIENT
 
@@ -71,9 +71,9 @@ RADIUS_MOD_PATH=$(addprefix modules/, $(RADIUS_MODULES))
 PRESENCE_PKGNAME = opensips-presence-modules 
 PRESENCE_MODULES = presence presence_callinfo presence_dialoginfo presence_xml presence_mwi presence_xcapdiff pua pua_bla pua_dialoginfo pua_mi pua_usrloc pua_xmpp rls xcap xcap_client
 PRESENCE_MOD_PATH=$(addprefix modules/, $(PRESENCE_MODULES))
-XMLRPC_PKGNAME = opensips-xmlrpc-module
-XMLRPC_MODULES = mi_xmlrpc
-XMLRPC_MOD_PATH=$(addprefix modules/, $(XMLRPC_MODULES))
+XMLRPCNG_PKGNAME = opensips-xmlrpcng-module
+XMLRPCNG_MODULES = mi_xmlrpc_ng
+XMLRPCNG_MOD_PATH=$(addprefix modules/, $(XMLRPCNG_MODULES))
 PERL_PKGNAME = opensips-perl-modules
 PERL_MODULES = perl db_perlvdb
 PERL_MOD_PATH=$(addprefix modules/, $(PERL_MODULES))


### PR DESCRIPTION
mi_xmlrpc has some problems with multithreading and has been
superseeded by mi_xmlrpc_ng module. Aditionaly needs a very old
version of libxmlrpc-c3 that is not present in debian wheezy or
jessie

This commit change updates Debian packaging files