### PR TITLE
Maintain database result integrity by supporting null column values

### DIFF
--- a/modules/avpops/avpops_db.c
+++ b/modules/avpops/avpops_db.c
@@ -477,9 +477,6 @@ int db_query_avp_print_results(struct sip_msg *msg, const db_res_t *db_res,
 		crt = dest;
 		for(j = 0; j < RES_COL_N(db_res); j++)
 		{
-			if(RES_ROWS(db_res)[i].values[j].nul)
-                                LM_DBG("column [%d] value is null\n", j);
-                                //goto next_avp;
 			avp_type = 0;
 			if(crt==NULL)
 			{

--- a/modules/avpops/avpops_db.c
+++ b/modules/avpops/avpops_db.c
@@ -478,7 +478,8 @@ int db_query_avp_print_results(struct sip_msg *msg, const db_res_t *db_res,
 		for(j = 0; j < RES_COL_N(db_res); j++)
 		{
 			if(RES_ROWS(db_res)[i].values[j].nul)
-				goto next_avp;
+                                LM_DBG("column [%d] value is null\n", j);
+                                //goto next_avp;
 			avp_type = 0;
 			if(crt==NULL)
 			{
@@ -525,8 +526,13 @@ int db_query_avp_print_results(struct sip_msg *msg, const db_res_t *db_res,
 						goto next_avp;
 				break;
 				case DB_INT:
-					avp_val.n
-						= (int)RES_ROWS(db_res)[i].values[j].val.int_val;
+                                        if (RES_ROWS(db_res)[i].values[j].nul)
+						// DB_INT is the default type so process NULL values here
+						// so we keep the integrity of the db results in tact.
+						avp_type |= AVP_VAL_NULL;
+                                        else
+						avp_val.n
+							= (int)RES_ROWS(db_res)[i].values[j].val.int_val;
 				break;
 				case DB_DATETIME:
 					avp_val.n


### PR DESCRIPTION
The avp population of column values from avp_db_query equaling NULL are skipped, sacrificing the integrity of the actual database result.

Basically, the old method checked if the column value structure's nul member was 1 and skipped to the next avp:

```
if (RES_ROWS(db_res)[i].values[j].nul)
        goto next_avp;
```

I moved this check to column values of type DB_INT, since that is the default type, and instead of skipping the avp, assign the value type to AVP_VAL_NULL:

```
avp_type |= AVP_VAL_NULL;
```