### PR TITLE
move init_shm before the script parsing

### DIFF
--- a/cfg.lex
+++ b/cfg.lex
@@ -326,8 +326,6 @@ SIP_WARNING sip_warning
 SERVER_SIGNATURE server_signature
 SERVER_HEADER server_header
 USER_AGENT_HEADER user_agent_header
-USER		"user"|"uid"
-GROUP		"group"|"gid"
 CHROOT		"chroot"
 WDIR		"workdir"|"wdir"
 MHOMED		mhomed
@@ -603,8 +601,6 @@ IMPORTFILE      "import_file"
 <INITIAL>{QUERYBUFFERSIZE}	{ count(); yylval.strval=yytext; return QUERYBUFFERSIZE; }
 <INITIAL>{QUERYFLUSHTIME}	{ count(); yylval.strval=yytext; return QUERYFLUSHTIME; }
 <INITIAL>{SIP_WARNING}	{ count(); yylval.strval=yytext; return SIP_WARNING; }
-<INITIAL>{USER}		{ count(); yylval.strval=yytext; return USER; }
-<INITIAL>{GROUP}	{ count(); yylval.strval=yytext; return GROUP; }
 <INITIAL>{CHROOT}	{ count(); yylval.strval=yytext; return CHROOT; }
 <INITIAL>{WDIR}	{ count(); yylval.strval=yytext; return WDIR; }
 <INITIAL>{MHOMED}	{ count(); yylval.strval=yytext; return MHOMED; }

--- a/cfg.y
+++ b/cfg.y
@@ -363,8 +363,6 @@ static struct multi_str *tmp_mod;
 %token MPATH
 %token MODPARAM
 %token MAXBUFFER
-%token USER
-%token GROUP
 %token CHROOT
 %token WDIR
 %token MHOMED
@@ -771,12 +769,6 @@ assign_stm: DEBUG EQUAL snumber {
 		| QUERYFLUSHTIME EQUAL error { yyerror("int value expected"); }
 		| SIP_WARNING EQUAL NUMBER { sip_warning=$3; }
 		| SIP_WARNING EQUAL error { yyerror("boolean value expected"); }
-		| USER EQUAL STRING     { user=$3; }
-		| USER EQUAL ID         { user=$3; }
-		| USER EQUAL error      { yyerror("string value expected"); }
-		| GROUP EQUAL STRING     { group=$3; }
-		| GROUP EQUAL ID         { group=$3; }
-		| GROUP EQUAL error      { yyerror("string value expected"); }
 		| CHROOT EQUAL STRING     { chroot_dir=$3; }
 		| CHROOT EQUAL ID         { chroot_dir=$3; }
 		| CHROOT EQUAL error      { yyerror("string value expected"); }


### PR DESCRIPTION
shared memory is now initialized before script parsing
removed uid and git script variables (can now be set only from commad line)
removed pending statistics list from statistics.c as dynamic statistics can now
be allocated directly in shared memory