### PR TITLE
TLS: CRL+CA list refresh MI command added to tlsops

### DIFF
--- a/cfg.lex
+++ b/cfg.lex
@@ -357,6 +357,7 @@ TLS_CERTIFICATE	"tls_certificate"
 TLS_PRIVATE_KEY "tls_private_key"
 TLS_CA_LIST		"tls_ca_list"
 TLS_CA_DIR		"tls_ca_dir"
+TLS_CRL_DIR		"tls_crl_dir"
 TLS_DH_PARAMS		"tls_dh_params"
 TLS_EC_CURVE		"tls_ec_curve"
 TLS_CIPHERS_LIST	"tls_ciphers_list"
@@ -678,6 +679,8 @@ IMPORTFILE      "import_file"
 										return TLS_CA_LIST; }
 <INITIAL>{TLS_CA_DIR}  { count(); yylval.strval=yytext;
                                                                                 return TLS_CA_DIR; }
+<INITIAL>{TLS_CRL_DIR}  { count(); yylval.strval=yytext;
+                                                                                return TLS_CRL_DIR; }
 <INITIAL>{TLS_DH_PARAMS}  { count(); yylval.strval=yytext;
 										return TLS_DH_PARAMS; }
 <INITIAL>{TLS_EC_CURVE}  { count(); yylval.strval=yytext;

--- a/cfg.y
+++ b/cfg.y
@@ -412,7 +412,8 @@ extern char *finame;
 %token TLS_CERTIFICATE
 %token TLS_PRIVATE_KEY
 %token TLS_CA_LIST
-%token TLS_CA_DIR 
+%token TLS_CA_DIR
+%token TLS_CRL_DIR
 %token TLS_CIPHERS_LIST
 %token TLS_DH_PARAMS
 %token TLS_EC_CURVE
@@ -1172,7 +1173,18 @@ assign_stm: DEBUG EQUAL snumber {
                                                                         #endif
                                                                         }
                 | TLS_CA_DIR EQUAL error { yyerror("string value expected"); }
-		| TLS_CIPHERS_LIST EQUAL STRING { 
+ 	        | TLS_CRL_DIR EQUAL STRING {
+                                                                        #ifdef USE_TLS
+                                                                                tls_default_server_domain->crl_directory =
+                                                                                        $3;
+                                                                                tls_default_client_domain->crl_directory =
+                                                                                        $3;
+                                                                        #else
+                                                                                warn("tls support not compiled in");
+                                                                        #endif
+                                                                        }
+                | TLS_CRL_DIR EQUAL error { yyerror("string value expected"); }
+		| TLS_CIPHERS_LIST EQUAL STRING {
 									#ifdef USE_TLS
 										tls_default_server_domain->ciphers_list
 											= $3;
@@ -1652,6 +1664,14 @@ tls_server_var : TLS_METHOD EQUAL SSLv23 {
                                                 #endif
                                                                 }
         | TLS_CA_DIR EQUAL error { yyerror("string value expected"); }
+	| TLS_CRL_DIR EQUAL STRING {
+                                                #ifdef USE_TLS
+                                                                        tls_server_domains->crl_directory=$3;
+                                                #else
+                                                                        warn("tls support not compiled in");
+                                                #endif
+                                                                }
+        | TLS_CRL_DIR EQUAL error { yyerror("string value expected"); }
 	| TLS_CIPHERS_LIST EQUAL STRING { 
 						#ifdef USE_TLS
 									tls_server_domains->ciphers_list=$3;
@@ -1766,6 +1786,14 @@ tls_client_var : TLS_METHOD EQUAL SSLv23 {
                                                 #endif
                                                                 }
         | TLS_CA_DIR EQUAL error { yyerror("string value expected"); }
+	| TLS_CRL_DIR EQUAL STRING {
+                                                #ifdef USE_TLS
+                                                                        tls_client_domains->crl_directory=$3;
+                                                #else
+                                                                        warn("tls support not compiled in");
+                                                #endif
+                                                                }
+        | TLS_CRL_DIR EQUAL error { yyerror("string value expected"); }
 	| TLS_CIPHERS_LIST EQUAL STRING { 
 						#ifdef USE_TLS
 									tls_client_domains->ciphers_list=$3;

--- a/config.h
+++ b/config.h
@@ -48,6 +48,7 @@
 #define TLS_CERT_FILE CFG_DIR "tls/cert.pem"
 #define TLS_CA_FILE 0 		/*!< no CA list file by default */
 #define TLS_CA_DIRECTORY      "/etc/pki/CA/"
+#define TLS_CRL_DIRECTORY      NULL
 #define TLS_DH_PARAMS_FILE 0   /*!< no DH params file by default */
 
 #define MAX_LISTEN 16		/*!< maximum number of addresses on which we will listen */

--- a/tls/tls_config.c
+++ b/tls/tls_config.c
@@ -39,9 +39,11 @@ int             tls_method = TLS_USE_SSLv23;
 int             tls_verify_client_cert  = 1;
 int             tls_verify_server_cert  = 1;
 int             tls_require_client_cert = 1;
+int             crl_check_all = 0;
 /* default location of certificates */
 char           *tls_cert_file = TLS_CERT_FILE;
 char           *tls_pkey_file = TLS_PKEY_FILE;
+char           *tls_crl_directory = NULL;
 char           *tls_ca_file   = TLS_CA_FILE;
 char 	       *tls_ca_dir    = TLS_CA_DIRECTORY;
 char           *tls_tmp_dh_file        = TLS_DH_PARAMS_FILE;

--- a/tls/tls_config.h
+++ b/tls/tls_config.h
@@ -47,12 +47,14 @@ enum tls_method {
 
 extern int      tls_log;
 extern int      tls_method;
+extern int      crl_check_all;
 
 extern int      tls_verify_client_cert;
 extern int      tls_verify_server_cert;
 extern int      tls_require_client_cert;
 extern char    *tls_cert_file;
 extern char    *tls_pkey_file;
+extern char    *tls_crl_directory;
 extern char    *tls_ca_file;
 extern char    *tls_ca_dir;
 extern char    *tls_tmp_dh_file;

--- a/tls/tls_domain.c
+++ b/tls/tls_domain.c
@@ -185,6 +185,7 @@ struct tls_domain *tls_new_domain(int type)
 	memset( d, 0, sizeof(struct tls_domain));
 
 	d->type = type;
+	d->crl_check_all = crl_check_all;
 
 	if (type & TLS_DOMAIN_SRV) {
 		d->verify_cert         = tls_verify_client_cert;

--- a/tls/tls_domain.h
+++ b/tls/tls_domain.h
@@ -51,8 +51,10 @@ struct tls_domain {
 	SSL_CTX        *ctx;
 	int             verify_cert;
 	int             require_client_cert;
+	int             crl_check_all;
 	char           *cert_file;
 	char           *pkey_file;
+	char           *crl_directory;
 	char           *ca_file;
 	char           *tmp_dh_file;
 	char           *tls_ec_curve;

--- a/tls/tls_init.h
+++ b/tls/tls_init.h
@@ -56,4 +56,14 @@ int             init_tls(void);
  */
 int		init_tls_domains(struct tls_domain *d);
 
+/*
+ * reloads TLS configuration for given domain: CRL, CA list.
+ */
+int     reload_tls_domains_crl_ca(struct tls_domain *d);
+
+/*
+ * reloads TLS configuration for all domains: CRL, CA list.
+ */
+int     reload_tls_domains_crl_ca_all(void);
+
 #endif


### PR DESCRIPTION
TLS subsystem (TLS engine + tlsops module) was extended with functions to reload CA + CRL lists on-the-fly for all configured domains.  

TLSOPS module was extended to provide a new MI command "refresh_crl_ca", calling refresh of CRL and CA files. New connections will be validated with the newly loaded CA + CRLs.

Previously, OpenSIPS does not reload CA list when running. The same holds for CRL in 2.x branch. 

Reloading CRL is of high importance as OpenSIPS can be running several weeks/months without being restarted. If TLS with client certificates is used it is crucial to periodically refresh CRL files and to reload them by OpenSIPS without need to restart it.