### PR TITLE
TLS: Client authentication with client certificate CN

### DIFF
--- a/cfg.lex
+++ b/cfg.lex
@@ -357,6 +357,7 @@ TLS_CERTIFICATE	"tls_certificate"
 TLS_PRIVATE_KEY "tls_private_key"
 TLS_CA_LIST		"tls_ca_list"
 TLS_CA_DIR		"tls_ca_dir"
+TLS_CRL_DIR		"tls_crl_dir"
 TLS_DH_PARAMS		"tls_dh_params"
 TLS_EC_CURVE		"tls_ec_curve"
 TLS_CIPHERS_LIST	"tls_ciphers_list"
@@ -678,6 +679,8 @@ IMPORTFILE      "import_file"
 										return TLS_CA_LIST; }
 <INITIAL>{TLS_CA_DIR}  { count(); yylval.strval=yytext;
                                                                                 return TLS_CA_DIR; }
+<INITIAL>{TLS_CRL_DIR}  { count(); yylval.strval=yytext;
+                                                                                return TLS_CRL_DIR; }
 <INITIAL>{TLS_DH_PARAMS}  { count(); yylval.strval=yytext;
 										return TLS_DH_PARAMS; }
 <INITIAL>{TLS_EC_CURVE}  { count(); yylval.strval=yytext;

--- a/cfg.y
+++ b/cfg.y
@@ -412,7 +412,8 @@ extern char *finame;
 %token TLS_CERTIFICATE
 %token TLS_PRIVATE_KEY
 %token TLS_CA_LIST
-%token TLS_CA_DIR 
+%token TLS_CA_DIR
+%token TLS_CRL_DIR
 %token TLS_CIPHERS_LIST
 %token TLS_DH_PARAMS
 %token TLS_EC_CURVE
@@ -1172,7 +1173,18 @@ assign_stm: DEBUG EQUAL snumber {
                                                                         #endif
                                                                         }
                 | TLS_CA_DIR EQUAL error { yyerror("string value expected"); }
-		| TLS_CIPHERS_LIST EQUAL STRING { 
+ 	        | TLS_CRL_DIR EQUAL STRING {
+                                                                        #ifdef USE_TLS
+                                                                                tls_default_server_domain->crl_directory =
+                                                                                        $3;
+                                                                                tls_default_client_domain->crl_directory =
+                                                                                        $3;
+                                                                        #else
+                                                                                warn("tls support not compiled in");
+                                                                        #endif
+                                                                        }
+                | TLS_CRL_DIR EQUAL error { yyerror("string value expected"); }
+		| TLS_CIPHERS_LIST EQUAL STRING {
 									#ifdef USE_TLS
 										tls_default_server_domain->ciphers_list
 											= $3;
@@ -1652,6 +1664,14 @@ tls_server_var : TLS_METHOD EQUAL SSLv23 {
                                                 #endif
                                                                 }
         | TLS_CA_DIR EQUAL error { yyerror("string value expected"); }
+	| TLS_CRL_DIR EQUAL STRING {
+                                                #ifdef USE_TLS
+                                                                        tls_server_domains->crl_directory=$3;
+                                                #else
+                                                                        warn("tls support not compiled in");
+                                                #endif
+                                                                }
+        | TLS_CRL_DIR EQUAL error { yyerror("string value expected"); }
 	| TLS_CIPHERS_LIST EQUAL STRING { 
 						#ifdef USE_TLS
 									tls_server_domains->ciphers_list=$3;
@@ -1766,6 +1786,14 @@ tls_client_var : TLS_METHOD EQUAL SSLv23 {
                                                 #endif
                                                                 }
         | TLS_CA_DIR EQUAL error { yyerror("string value expected"); }
+	| TLS_CRL_DIR EQUAL STRING {
+                                                #ifdef USE_TLS
+                                                                        tls_client_domains->crl_directory=$3;
+                                                #else
+                                                                        warn("tls support not compiled in");
+                                                #endif
+                                                                }
+        | TLS_CRL_DIR EQUAL error { yyerror("string value expected"); }
 	| TLS_CIPHERS_LIST EQUAL STRING { 
 						#ifdef USE_TLS
 									tls_client_domains->ciphers_list=$3;

--- a/config.h
+++ b/config.h
@@ -48,6 +48,7 @@
 #define TLS_CERT_FILE CFG_DIR "tls/cert.pem"
 #define TLS_CA_FILE 0 		/*!< no CA list file by default */
 #define TLS_CA_DIRECTORY      "/etc/pki/CA/"
+#define TLS_CRL_DIRECTORY      NULL
 #define TLS_DH_PARAMS_FILE 0   /*!< no DH params file by default */
 
 #define MAX_LISTEN 16		/*!< maximum number of addresses on which we will listen */

--- a/modules/tlsops/tls_select.c
+++ b/modules/tlsops/tls_select.c
@@ -432,7 +432,7 @@ int tlsops_get_peer_cn(struct sip_msg *msg, str *res, char * buff, size_t buff_s
 	e = X509_NAME_get_entry(name, index);
 	asn1 = X509_NAME_ENTRY_get_data(e);
 	text.len = ASN1_STRING_to_UTF8((unsigned char**)(void*)&text.s, asn1);
-	if (text.len < 0 || text.len >= 1024) {
+	if (text.len < 0 || text.len >= buff_size) {
 		LM_ERR("failed to convert ASN1 string\n");
 		goto err;
 	}

--- a/modules/tlsops/tls_select.c
+++ b/modules/tlsops/tls_select.c
@@ -404,6 +404,55 @@ int tlsops_sn(struct sip_msg *msg, pv_param_t *param,
 	return 0;
 }
 
+int tlsops_get_peer_cn(struct sip_msg *msg, str *res, char * buff, size_t buff_size)
+{
+	X509* cert;
+	struct tcp_connection* c;
+	X509_NAME* name;
+	X509_NAME_ENTRY* e;
+	ASN1_STRING* asn1;
+	int index, my = 0;
+	str text;
+
+	res->s = 0;
+	res->len = 0;
+	text.s = 0;
+	if (get_cert(&cert, &c, msg, my) < 0) {
+		return -1;
+	}
+
+	name = X509_get_subject_name(cert);
+	if (!name) {
+		LM_ERR("cannot extract subject or issuer name from peer"
+					   " certificate\n");
+		goto err;
+	}
+
+	index = X509_NAME_get_index_by_NID(name, NID_commonName, -1);
+	e = X509_NAME_get_entry(name, index);
+	asn1 = X509_NAME_ENTRY_get_data(e);
+	text.len = ASN1_STRING_to_UTF8((unsigned char**)(void*)&text.s, asn1);
+	if (text.len < 0 || text.len >= 1024) {
+		LM_ERR("failed to convert ASN1 string\n");
+		goto err;
+	}
+	memcpy(buff, text.s, text.len >= buff_size ? buff_size : (size_t)text.len);
+	res->s = buff;
+	res->len = text.len;
+
+	OPENSSL_free(text.s);
+
+	if (!my) X509_free(cert);
+	tcpconn_put(c);
+	return 0;
+
+err:
+	if (text.s) OPENSSL_free(text.s);
+	if (!my) X509_free(cert);
+	tcpconn_put(c);
+	return -2;
+}
+
 int tlsops_comp(struct sip_msg *msg, pv_param_t *param,
 		pv_value_t *res)
 {
@@ -451,6 +500,7 @@ int tlsops_comp(struct sip_msg *msg, pv_param_t *param,
 		case COMP_C:  nid = NID_countryName;            break;
 		case COMP_ST: nid = NID_stateOrProvinceName;    break;
 		case COMP_L:  nid = NID_localityName;           break;
+		case COMP_SUBJECT_SERIAL: nid = NID_serialNumber;break;
 		default:      nid = NID_undef;
 	}
 
@@ -478,6 +528,7 @@ int tlsops_comp(struct sip_msg *msg, pv_param_t *param,
 			case COMP_C:  elem = "CountryName";             break;
 			case COMP_ST: elem = "StateOrProvinceName";     break;
 			case COMP_L:  elem = "LocalityName";            break;
+			case COMP_SUBJECT_SERIAL:  elem = "SubjectSerialNumber";break;
 			default:      elem = "Unknown";                 break;
 			}
 			LM_DBG("element %s not found in "

--- a/modules/tlsops/tls_select.h
+++ b/modules/tlsops/tls_select.h
@@ -51,7 +51,8 @@ enum {
 	COMP_HOST = 1<<16,        /* hostname from subject/alternative */
 	COMP_URI  = 1<<17,        /* URI from subject/alternative */
 	COMP_E    = 1<<18,        /* Email address */
-	COMP_IP   = 1<<19         /* IP from subject/alternative */
+	COMP_IP   = 1<<19,         /* IP from subject/alternative */
+	COMP_SUBJECT_SERIAL = 1<<20    /*Serial name from Subject*/
 };
 
 
@@ -91,4 +92,6 @@ int tlsops_comp(struct sip_msg *msg, pv_param_t *param,
 int tlsops_alt(struct sip_msg *msg, pv_param_t *param,
 		pv_value_t *res);
 
+int tlsops_get_peer_cn(struct sip_msg *msg, str *res,
+		char * buff, size_t buff_size);
 #endif

--- a/modules/tlsops/tlsops.c
+++ b/modules/tlsops/tlsops.c
@@ -44,6 +44,8 @@
 #include "../../sr_module.h"
 #include "../../pvar.h"
 #include "../../tls/tls_init.h"
+#include "../../parser/parse_from.h"
+#include "../../parser/digest/digest.h"
 
 
 int tcp_con_lifetime=DEFAULT_TCP_CONNECTION_LIFETIME;
@@ -51,12 +53,37 @@ int tcp_con_lifetime=DEFAULT_TCP_CONNECTION_LIFETIME;
 /* definition of exported functions */
 static int is_peer_verified(struct sip_msg*, char*, char*);
 
+/*
+ * Check if To header field contains the same username
+ * as digest credentials
+ */
+int tls_check_to(struct sip_msg* _msg, char* _str1, char* _str2);
+
+/*
+ * Check if From header field contains the same username
+ * as digest credentials
+ */
+int tls_check_from(struct sip_msg* _msg, char* _str1, char* _str2);
+
 /* MI function to refresh all TLS CRL & CA configuration */
 static struct mi_root* mi_refresh_crl_ca(struct mi_root* cmd, void* param);
 
 /* definition of internal functions */
 static int mod_init(void);
 static void mod_destroy(void);
+
+/* Return codes reference */
+#define OK 		 	 1		/* success */
+#define ERR_INTERNAL		-1		/* Internal Error */
+#define ERR_CREDENTIALS 	-2		/* No credentials error */
+#define ERR_DBUSE  		-3		/* Data Base Use error */
+#define ERR_USERNOTFOUND  	-4		/* No found username error */
+#define ERR_DBEMTPYRES		-5		/* Emtpy Query Result */
+
+#define ERR_DBACCESS	   	-7     		/* Data Base Access Error */
+#define ERR_DBQUERY	  	-8		/* Data Base Query Error */
+#define ERR_SPOOFEDUSER   	-9		/* Spoofed User Error */
+#define ERR_NOMATCH	    	-10		/* No match Error */
 
 /*
  * Module parameter variables
@@ -67,6 +94,10 @@ static void mod_destroy(void);
  */
 static cmd_export_t cmds[]={
 	{"is_peer_verified", (cmd_function)is_peer_verified,   0, 0, 0,
+			REQUEST_ROUTE},
+	{"tls_check_to", (cmd_function)tls_check_to, 0, 0, 0,
+			REQUEST_ROUTE},
+	{"tls_check_from", (cmd_function)tls_check_from, 0, 0, 0,
 			REQUEST_ROUTE},
 	{0,0,0,0,0,0}
 };
@@ -192,6 +223,12 @@ static pv_export_t mod_items[] = {
 	{{"tls_peer_subject_unit", sizeof("tls_peer_subject_unit")-1},
 		850, tlsops_comp, 0,
 		0, 0, pv_init_iname, CERT_PEER  | CERT_SUBJECT | COMP_OU },
+	{{"tls_my_subject_serial", sizeof("tls_my_subject_serial")-1},
+			850, tlsops_comp, 0,
+			0, 0, pv_init_iname, CERT_LOCAL | CERT_SUBJECT | COMP_SUBJECT_SERIAL },
+	{{"tls_peer_subject_serial", sizeof("tls_peer_subject_serial")-1},
+			850, tlsops_comp, 0,
+			0, 0, pv_init_iname, CERT_PEER | CERT_SUBJECT | COMP_SUBJECT_SERIAL },
 	{{"tls_peer_issuer_unit", sizeof("tls_peer_issuer_unit")-1},
 		850, tlsops_comp, 0,
 		0, 0, pv_init_iname, CERT_PEER  | CERT_ISSUER  | COMP_OU },
@@ -357,4 +394,99 @@ static struct mi_root* mi_refresh_crl_ca(struct mi_root* cmd, void* param)
 	reload_tls_domains_crl_ca_all();
 
 	return init_mi_tree(200, MI_OK_S, MI_OK_LEN);
+}
+
+/*
+ * Check if a header field contains the same username
+ * as TLS CN
+ */
+static inline int check_username(struct sip_msg* _m, struct sip_uri *_uri) {
+#define CN_BUFF_SIZE 256
+	str cn = {0,0};
+	str usr = {0,0};
+	char cn_buff[CN_BUFF_SIZE];
+	char usr_buff[CN_BUFF_SIZE];
+
+	if (_uri == NULL) {
+		LM_ERR("Bad parameter\n");
+		return ERR_INTERNAL;
+	}
+
+	/* Parse To/From URI */
+	/* Make sure that the URI contains username */
+	if (_uri->user.len == 0 || _uri->host.len == 0) {
+		LM_ERR("Username not found in URI\n");
+		return ERR_USERNOTFOUND;
+	}
+
+	/* make CN like identifier */
+	if ((_uri->user.len + _uri->host.len + 4) >= CN_BUFF_SIZE){
+		LM_ERR("Username buffer too short\n");
+		return ERR_INTERNAL;
+	}
+
+	snprintf(usr_buff, CN_BUFF_SIZE, "%.*s@%.*s",
+			 _uri->user.len, _uri->user.s,
+			 _uri->host.len, _uri->host.s);
+	usr.s = usr_buff;
+	usr.len = _uri->user.len + _uri->host.len + 1;
+
+	/* Get CN from the peer certificate */
+	if (tlsops_get_peer_cn(_m, &cn, cn_buff, CN_BUFF_SIZE) != 0) {
+		LM_ERR("Could not extract CN\n");
+		return ERR_INTERNAL;
+	}
+
+	/* Check URI match to the CN match */
+	if (usr.len == cn.len) {
+		if (!strncasecmp(usr.s, cn.s,
+						 usr.len)) {
+			LM_DBG("Digest username and URI username match\n");
+			return OK;
+		} else {
+			LM_INFO("Spoofed user '%.*s' should be '%.*s' as in CN\n",
+					usr.len, usr.s,
+					cn.len, cn.s);
+			return ERR_SPOOFEDUSER;
+		}
+	}
+
+	LM_INFO("Digest username and URI username do NOT match, '%.*s' should be '%.*s' as in CN\n",
+			usr.len, usr.s,
+			cn.len, cn.s);
+	return ERR_NOMATCH;
+}
+
+/*
+ * Check username part in To header field
+ */
+int tls_check_to(struct sip_msg* _m, char* _s1, char* _s2)
+{
+	if (!_m->to && ((parse_headers(_m, HDR_TO_F, 0) == -1) || (!_m->to))) {
+		LM_ERR("Error while parsing To header field\n");
+		return ERR_INTERNAL;
+	}
+	if(parse_to_uri(_m)==NULL) {
+		LM_ERR("Error while parsing To header URI\n");
+		return ERR_INTERNAL;
+	}
+
+	return check_username(_m, &get_to(_m)->parsed_uri);
+}
+
+/*
+ * Check username part in From header field
+ */
+int tls_check_from(struct sip_msg* _m, char* _s1, char* _s2)
+{
+	if (parse_from_header(_m) < 0) {
+		LM_ERR("Error while parsing From header field\n");
+		return ERR_INTERNAL;
+	}
+	if(parse_from_uri(_m)==NULL) {
+		LM_ERR("Error while parsing From header URI\n");
+		return ERR_INTERNAL;
+	}
+
+	return check_username(_m, &get_from(_m)->parsed_uri);
 }

--- a/tls/tls_config.c
+++ b/tls/tls_config.c
@@ -39,9 +39,11 @@ int             tls_method = TLS_USE_SSLv23;
 int             tls_verify_client_cert  = 1;
 int             tls_verify_server_cert  = 1;
 int             tls_require_client_cert = 1;
+int             crl_check_all = 0;
 /* default location of certificates */
 char           *tls_cert_file = TLS_CERT_FILE;
 char           *tls_pkey_file = TLS_PKEY_FILE;
+char           *tls_crl_directory = NULL;
 char           *tls_ca_file   = TLS_CA_FILE;
 char 	       *tls_ca_dir    = TLS_CA_DIRECTORY;
 char           *tls_tmp_dh_file        = TLS_DH_PARAMS_FILE;

--- a/tls/tls_config.h
+++ b/tls/tls_config.h
@@ -47,12 +47,14 @@ enum tls_method {
 
 extern int      tls_log;
 extern int      tls_method;
+extern int      crl_check_all;
 
 extern int      tls_verify_client_cert;
 extern int      tls_verify_server_cert;
 extern int      tls_require_client_cert;
 extern char    *tls_cert_file;
 extern char    *tls_pkey_file;
+extern char    *tls_crl_directory;
 extern char    *tls_ca_file;
 extern char    *tls_ca_dir;
 extern char    *tls_tmp_dh_file;

--- a/tls/tls_domain.c
+++ b/tls/tls_domain.c
@@ -185,6 +185,7 @@ struct tls_domain *tls_new_domain(int type)
 	memset( d, 0, sizeof(struct tls_domain));
 
 	d->type = type;
+	d->crl_check_all = crl_check_all;
 
 	if (type & TLS_DOMAIN_SRV) {
 		d->verify_cert         = tls_verify_client_cert;

--- a/tls/tls_domain.h
+++ b/tls/tls_domain.h
@@ -51,8 +51,10 @@ struct tls_domain {
 	SSL_CTX        *ctx;
 	int             verify_cert;
 	int             require_client_cert;
+	int             crl_check_all;
 	char           *cert_file;
 	char           *pkey_file;
+	char           *crl_directory;
 	char           *ca_file;
 	char           *tmp_dh_file;
 	char           *tls_ec_curve;

--- a/tls/tls_init.h
+++ b/tls/tls_init.h
@@ -56,4 +56,14 @@ int             init_tls(void);
  */
 int		init_tls_domains(struct tls_domain *d);
 
+/*
+ * reloads TLS configuration for given domain: CRL, CA list.
+ */
+int     reload_tls_domains_crl_ca(struct tls_domain *d);
+
+/*
+ * reloads TLS configuration for all domains: CRL, CA list.
+ */
+int     reload_tls_domains_crl_ca_all(void);
+
 #endif


### PR DESCRIPTION
TLSOPS module was extended to add support for checking correspondence between FROM/TO URIs and CN of the client certificate used for TLS connection = client authentication via client certificates.

For clients using TLS client certificates this patch can save bandwidth and messages up to 50% for REGISTER, MESSAGE and INVITE requests compared to traditional www_authorize authentication. This improvement is especially important for clients connected via mobile networks (higher packet loss / latency). 

Example configuration for TLS client authentication:
```
# authenticate the REGISTER requests 
if (proto==TLS && is_peer_verified()){
    xlog("L_NOTICE","[$pr:$fU@$si:$sp]: Processing '$rm' auth trusted cert '$tls_peer_subject_cn'\n");

    # Doing pretty serious stuff here, check if to matches CN.
    if (!tls_check_to())
    {
        xlog("L_NOTICE","[$pr:$fU@$si:$sp]: Processing '$rm' auth TO check failed\n");
        sl_send_reply("403","Forbidden auth ID");
        exit;
    }
}
else {
    # TLS validation could not be applied - use challenge response
    $var(auth_code) = www_authorize("", "subscriber");
    xlog("L_NOTICE","[$pr:$fU@$si:$sp]: Processing '$rm' auth: '$var(auth_code)'\n");

    if ( $var(auth_code) == -1 || $var(auth_code) == -2 ) {
        xlog("L_NOTICE","Auth error for $fU@$fd from $si cause $var(auth_code)");
    }
    if ( $var(auth_code) < 0 ) {
        www_challenge("", "0");
        exit;
    }
    if (!db_check_to())
    {
        sl_send_reply("403","Forbidden auth ID");
        exit;
    }
}
```