### PR TITLE
TLS: Client authentication with client certificate CN 

### DIFF
--- a/modules/tls_mgm/README
+++ b/modules/tls_mgm/README
@@ -58,6 +58,8 @@ Marius Cristian Eseanu
         1.5. Exported Functions
 
               1.5.1. is_peer_verified
+              1.5.2. tls_check_to
+              1.5.3. tls_check_from
 
         1.6. Exported MI Functions
 
@@ -199,6 +201,8 @@ Marius Cristian Eseanu
    1.32. Example of $tls_[peer|my]_[subject|issuer]
    1.33. Script with TLS support
    1.34. Example of TLS logging
+   1.35. Example of tls_check_to
+   1.36. Example of tls_check_from
 
 Chapter 1. Admin Guide
 
@@ -269,6 +273,44 @@ if (is_peer_verified()) {
         xlog("L_INFO","request from verified TLS peer\n");
 } else {
         xlog("L_INFO","request not verified\n");
+}
+...
+
+1.5.2.  tls_check_to
+
+   Check To username against peer certificate CN.
+   Returns 1 on success, negative on failure.
+
+   This function can be used from REQUEST_ROUTE.
+
+   Example 1.35. tls_check_to usage
+...
+# Authenticate for REGISTER
+if (proto==TLS && is_peer_verified()){
+    if (!tls_check_to()){
+        xlog("L_NOTICE","[$pr:$fU@$si:$sp]: Processing '$rm' auth TO check failed\n");
+        sl_send_reply("403","Forbidden auth ID");
+        exit;
+    }
+}
+...
+
+1.5.3.  tls_check_from
+
+   Check From username against peer certificate CN.
+   Returns 1 on success, negative on failure.
+
+   This function can be used from REQUEST_ROUTE.
+
+   Example 1.35. is_peer_verified usage
+...
+# Authenticate for MESSAGE / INVITE
+if (proto==TLS && tls_check_from()){
+    if (!tls_check_from()){
+        xlog("L_NOTICE","[$pr:$fU@$si:$sp]: Processing '$rm' auth FROM check failed\n");
+        sl_send_reply("403","Forbidden auth ID");
+        exit;
+    }
 }
 ...
 

--- a/modules/tls_mgm/doc/tls_mgm_admin.xml
+++ b/modules/tls_mgm/doc/tls_mgm_admin.xml
@@ -114,6 +114,60 @@ if (is_peer_verified()) {
 </programlisting>
 		</example>
 	</section>
+		<section>
+			<title>
+				<function moreinfo="none">tls_check_to</function>
+			</title>
+			<para>
+				Check To username against peer certificate CN.
+				Returns 1 on success, negative on failure.
+			</para>
+			<para>
+				This function can be used from REQUEST_ROUTE.
+			</para>
+			<example>
+				<title><function>tls_check_to</function> usage</title>
+				<programlisting format="linespecific">
+...
+# Authenticate for REGISTER
+if (proto==TLS && is_peer_verified()){
+	if (!tls_check_to()){
+		xlog("L_NOTICE","[$pr:$fU@$si:$sp]: Processing '$rm' auth TO check failed\n");
+		sl_send_reply("403","Forbidden auth ID");
+		exit;
+	}
+}
+...
+				</programlisting>
+			</example>
+		</section>
+	<section>
+		<title>
+		<function moreinfo="none">tls_check_from</function>
+		</title>
+		<para>
+			Check From username against peer certificate CN.
+			Returns 1 on success, negative on failure.
+		</para>
+		<para>
+		This function can be used from REQUEST_ROUTE.
+		</para>
+		<example>
+		<title><function>tls_check_from</function> usage</title>
+		<programlisting format="linespecific">
+...
+# Authenticate for MESSAGE / INVITE
+if (proto==TLS && tls_check_from()){
+	if (!tls_check_from()){
+		xlog("L_NOTICE","[$pr:$fU@$si:$sp]: Processing '$rm' auth FROM check failed\n");
+		sl_send_reply("403","Forbidden auth ID");
+		exit;
+	}
+}
+...
+</programlisting>
+		</example>
+	</section>
 	</section>
 
         <section>

--- a/modules/tls_mgm/tls_select.c
+++ b/modules/tls_mgm/tls_select.c
@@ -414,6 +414,55 @@ int tlsops_sn(struct sip_msg *msg, pv_param_t *param,
 	return 0;
 }
 
+int tlsops_get_peer_cn(struct sip_msg *msg, str *res, char * buff, size_t buff_size)
+{
+	X509* cert;
+	struct tcp_connection* c;
+	X509_NAME* name;
+	X509_NAME_ENTRY* e;
+	ASN1_STRING* asn1;
+	int index;
+	str text;
+
+	res->s = 0;
+	res->len = 0;
+	text.s = 0;
+	if (get_cert(&cert, &c, msg, 0) < 0) {
+		return -1;
+	}
+
+	name = X509_get_subject_name(cert);
+	if (!name) {
+		LM_ERR("cannot extract subject or issuer name from peer"
+					   " certificate\n");
+		goto err;
+	}
+
+	index = X509_NAME_get_index_by_NID(name, NID_commonName, -1);
+	e = X509_NAME_get_entry(name, index);
+	asn1 = X509_NAME_ENTRY_get_data(e);
+	text.len = ASN1_STRING_to_UTF8((unsigned char**)(void*)&text.s, asn1);
+	if (text.len < 0 || text.len >= buff_size) {
+		LM_ERR("failed to convert ASN1 string\n");
+		goto err;
+	}
+	memcpy(buff, text.s, text.len >= buff_size ? buff_size : (size_t)text.len);
+	res->s = buff;
+	res->len = text.len;
+
+	OPENSSL_free(text.s);
+
+	X509_free(cert);
+	tcp_conn_release(c,0);
+	return 0;
+
+err:
+	if (text.s) OPENSSL_free(text.s);
+	X509_free(cert);
+	tcp_conn_release(c,0);
+	return -2;
+}
+
 int tlsops_comp(struct sip_msg *msg, pv_param_t *param,
 		pv_value_t *res)
 {

--- a/modules/tls_mgm/tls_select.h
+++ b/modules/tls_mgm/tls_select.h
@@ -97,6 +97,9 @@ int tlsops_validity(struct sip_msg *msg, pv_param_t *param,
 int tlsops_sn(struct sip_msg *msg, pv_param_t *param,
 		pv_value_t *res);
 
+int tlsops_get_peer_cn(struct sip_msg *msg, str *res, char * buff,
+		size_t buff_size);
+
 int tlsops_comp(struct sip_msg *msg, pv_param_t *param,
 		pv_value_t *res);
 


### PR DESCRIPTION
TLSOPS module was extended to add support for checking correspondence between FROM/TO URIs and CN of the client certificate used for TLS connection = client authentication via client certificates.

For clients using TLS client certificates this patch can save bandwidth and messages up to 50% for REGISTER, MESSAGE and INVITE requests compared to traditional www_authorize authentication. This improvement is especially important for clients connected via mobile networks (higher packet loss / latency). 

Example configuration for TLS client authentication:
```
# authenticate the REGISTER requests 
if (proto==TLS && is_peer_verified()){
    xlog("L_NOTICE","[$pr:$fU@$si:$sp]: Processing '$rm' auth trusted cert '$tls_peer_subject_cn'\n");

    # Doing pretty serious stuff here, check if to matches CN.
    if (!tls_check_to())
    {
        xlog("L_NOTICE","[$pr:$fU@$si:$sp]: Processing '$rm' auth TO check failed\n");
        sl_send_reply("403","Forbidden auth ID");
        exit;
    }
}
else {
    # TLS validation could not be applied - use challenge response
    $var(auth_code) = www_authorize("", "subscriber");
    xlog("L_NOTICE","[$pr:$fU@$si:$sp]: Processing '$rm' auth: '$var(auth_code)'\n");

    if ( $var(auth_code) == -1 || $var(auth_code) == -2 ) {
        xlog("L_NOTICE","Auth error for $fU@$fd from $si cause $var(auth_code)");
    }
    if ( $var(auth_code) < 0 ) {
        www_challenge("", "0");
        exit;
    }
    if (!db_check_to())
    {
        sl_send_reply("403","Forbidden auth ID");
        exit;
    }
}
```