### PR TITLE
Shmem rework

### DIFF
--- a/blacklists.c
+++ b/blacklists.c
@@ -57,25 +57,6 @@ static mi_export_t mi_bl_cmds[] = {
 	{ 0, 0, 0, 0, 0, 0}
 };
 
-
-
-int preinit_black_lists(void)
-{
-	blst_heads = (struct bl_head*)shm_malloc(max_heads*sizeof(struct bl_head));
-	if (blst_heads==NULL) {
-		LM_ERR("no more shared memory!\n");
-		return -1;
-	}
-	memset( blst_heads, 0, max_heads*sizeof(struct bl_head));
-
-	used_heads = 0;
-
-	/* black lists were successfully allocated */
-	return 0;
-}
-
-
-
 int init_black_lists(void)
 {
 	/* register timer routine  */
@@ -101,6 +82,14 @@ struct bl_head *create_bl_head(int owner, int flags, struct bl_rule *head,
 {
 	unsigned int i;
 
+	if(!blst_heads) {
+		blst_heads = (struct bl_head*)shm_malloc(max_heads*sizeof(struct bl_head));
+		if (blst_heads==NULL) {
+			LM_ERR("no more shared memory!\n");
+			return NULL;
+		}
+		memset( blst_heads, 0, max_heads*sizeof(struct bl_head));
+	}
 	i = used_heads;
 	if (i==max_heads) {
 		LM_ERR("too many lists\n");
@@ -181,7 +170,8 @@ void destroy_black_lists(void)
 		blst_heads[i].first = blst_heads[i].last = NULL;
 	}
 
-	shm_free(blst_heads);
+	if(blst_heads)
+		shm_free(blst_heads);
 }
 
 

--- a/blacklists.h
+++ b/blacklists.h
@@ -62,9 +62,6 @@ struct bl_head{
 
 #define BL_CORE_ID        13
 
-
-int preinit_black_lists();
-
 int init_black_lists();
 
 void destroy_black_lists();

--- a/main.c
+++ b/main.c
@@ -986,11 +986,6 @@ try_again:
 	/*register builtin  modules*/
 	register_builtin_modules();
 
-	if (preinit_black_lists()!=0) {
-		LM_CRIT("failed to alloc black list's anchor\n");
-		goto error00;
-	}
-
 	/* init avps */
 	if (init_global_avps() != 0) {
 		LM_ERR("error while initializing avps\n");
@@ -1038,6 +1033,11 @@ try_again:
 	if (init_stats_collector() < 0) {
 		LM_ERR("failed to initialize statistics\n");
 		goto error;
+	}
+
+	if (preinit_black_lists()!=0) {
+		LM_CRIT("failed to alloc black list's anchor\n");
+		goto error00;
 	}
 
 	/* parse the config file, prior to this only default values

--- a/main.c
+++ b/main.c
@@ -1035,11 +1035,6 @@ try_again:
 		goto error;
 	}
 
-	if (preinit_black_lists()!=0) {
-		LM_CRIT("failed to alloc black list's anchor\n");
-		goto error00;
-	}
-
 	/* parse the config file, prior to this only default values
 	   e.g. for debugging settings will be used */
 	yyin=cfg_stream;

--- a/modules/cfgutils/cfgutils.c
+++ b/modules/cfgutils/cfgutils.c
@@ -703,12 +703,6 @@ static int mod_init(void)
 		return -1;
 	}
 
-	if(init_shvars()<0)
-	{
-		LM_ERR("init shvars failed\n");
-		shm_free(probability);
-		return -1;
-	}
 	LM_INFO("module initialized, pid [%d]\n", getpid());
 
 	return 0;

--- a/modules/cfgutils/shvar.c
+++ b/modules/cfgutils/shvar.c
@@ -35,9 +35,6 @@ int shvar_locks_no=16;
 gen_lock_set_t* shvar_locks=0;
 
 static sh_var_t *sh_vars = 0;
-static script_var_t *sh_local_vars = 0;
-static pv_spec_list_t *sh_pv_list = 0;
-static int shvar_initialized = 0;
 
 /*
  * Initialize locks
@@ -67,7 +64,6 @@ int shvar_init_locks(void)
 		}
 	} while (1);
 }
-
 
 void shvar_unlock_locks(void)
 {
@@ -140,6 +136,13 @@ sh_var_t* add_shvar(str *name)
 {
 	sh_var_t *sit;
 
+	if(!shvar_locks){
+		if(shvar_init_locks()){
+			LM_ERR("init shvars locks failed\n");
+			return 0;
+		}
+	}
+
 	if(name==0 || name->s==0 || name->len<=0)
 		return 0;
 
@@ -184,131 +187,6 @@ sh_var_t* add_shvar(str *name)
 	sh_vars = sit;
 
 	return sit;
-}
-
-script_var_t* add_local_shvar(str *name)
-{
-	script_var_t *it;
-
-	if(name==0 || name->s==0 || name->len<=0)
-		return 0;
-
-	for(it=sh_local_vars; it; it=it->next)
-	{
-		if(it->name.len==name->len
-				&& strncmp(name->s, it->name.s, name->len)==0)
-			return it;
-	}
-	it = (script_var_t*)pkg_malloc(sizeof(script_var_t));
-	if(it==0)
-	{
-		LM_ERR("out of pkg mem\n");
-		return 0;
-	}
-	memset(it, 0, sizeof(script_var_t));
-	it->name.s = (char*)pkg_malloc((name->len+1)*sizeof(char));
-
-	if(it->name.s==0)
-	{
-		LM_ERR("out of pkg mem!\n");
-		return 0;
-	}
-	it->name.len = name->len;
-	strncpy(it->name.s, name->s, name->len);
-	it->name.s[it->name.len] = '\0';
-
-	it->next = sh_local_vars;
-
-	sh_local_vars = it;
-
-	return it;
-}
-
-
-int init_shvars(void)
-{
-	script_var_t *lit = 0;
-	sh_var_t *sit = 0;
-	pv_spec_list_t *pvi = 0;
-	pv_spec_list_t *pvi0 = 0;
-
-	if(shvar_init_locks()!=0)
-		return -1;
-
-	LM_DBG("moving shvars in share memory\n");
-	for(lit=sh_local_vars; lit; lit=lit->next)
-	{
-		sit = (sh_var_t*)shm_malloc(sizeof(sh_var_t));
-		if(sit==0)
-		{
-			LM_ERR("out of sh mem\n");
-			return -1;
-		}
-		memset(sit, 0, sizeof(sh_var_t));
-		sit->name.s = (char*)shm_malloc((lit->name.len+1)*sizeof(char));
-
-		if(sit->name.s==0)
-		{
-			LM_ERR("out of pkg mem!\n");
-			shm_free(sit);
-			return -1;
-		}
-		sit->name.len = lit->name.len;
-		strncpy(sit->name.s, lit->name.s, lit->name.len);
-		sit->name.s[sit->name.len] = '\0';
-
-		if(sh_vars!=0)
-			sit->n = sh_vars->n + 1;
-		else
-			sit->n = 1;
-
-#ifdef GEN_LOCK_T_PREFERED
-		sit->lock = &shvar_locks->locks[sit->n%shvar_locks_no];
-#else
-		sit->lockidx = sit->n%shvar_locks_no;
-#endif
-
-		if(set_shvar_value(sit, &lit->v.value, lit->v.flags)==NULL)
-		{
-			shm_free(sit->name.s);
-			shm_free(sit);
-			return -1;
-		}
-
-		pvi0 = 0;
-		pvi = sh_pv_list;
-		while(pvi!=NULL)
-		{
-			if(pvi->spec->pvp.pvn.u.dname == lit)
-			{
-				pvi->spec->pvp.pvn.u.dname = (void*)sit;
-				if(pvi0!=NULL)
-				{
-					pvi0->next = pvi->next;
-					pkg_free(pvi);
-					pvi = pvi0->next;
-				} else {
-					sh_pv_list = pvi->next;
-					pkg_free(pvi);
-					pvi = sh_pv_list;
-				}
-			} else {
-				pvi0 = pvi;
-				pvi = pvi->next;
-			}
-		}
-
-		sit->next = sh_vars;
-		sh_vars = sit;
-	}
-	destroy_vars_list(sh_local_vars);
-	if(sh_pv_list != NULL)
-	{
-		LM_ERR("sh_pv_list not null!\n");
-		return -1;
-	}
-	shvar_initialized = 1;
-	return 0;
 }
 
 /* call it with lock set */
@@ -429,34 +307,15 @@ void destroy_shvars(void)
 /********* PV functions *********/
 int pv_parse_shvar_name(pv_spec_p sp, str *in)
 {
-	pv_spec_list_t *pvi = 0;
-
 	if(in==NULL || in->s==NULL || sp==NULL)
 		return -1;
 
 	sp->pvp.pvn.type = PV_NAME_PVAR;
-	if(shvar_initialized)
-		sp->pvp.pvn.u.dname = (void*)add_shvar(in);
-	else
-		sp->pvp.pvn.u.dname = (void*)add_local_shvar(in);
+	sp->pvp.pvn.u.dname = (void*)add_shvar(in);
 	if(sp->pvp.pvn.u.dname==NULL)
 	{
-		LM_ERR("cannot register shvar [%.*s] (%d)\n", in->len, in->s,
-				shvar_initialized);
+		LM_ERR("cannot register shvar [%.*s]\n", in->len, in->s);
 		return -1;
-	}
-
-	if(shvar_initialized==0)
-	{
-		pvi = (pv_spec_list_t*)pkg_malloc(sizeof(pv_spec_list_t));
-		if(pvi == NULL)
-		{
-			LM_ERR("cannot index shvar [%.*s]\n", in->len, in->s);
-			return -1;
-		}
-		pvi->spec = sp;
-		pvi->next = sh_pv_list;
-		sh_pv_list = pvi;
 	}
 
 	return 0;
@@ -747,9 +606,7 @@ int param_set_xvar( modparam_t type, void* val, int mode)
 	int flags;
 	int ival;
 	script_var_t *sv;
-
-	if(shvar_initialized!=0)
-		goto error;
+	sh_var_t *shared_sv;
 
 	s.s = (char*)val;
 	if(s.s == NULL || s.s[0] == '\0')
@@ -782,14 +639,20 @@ int param_set_xvar( modparam_t type, void* val, int mode)
 			goto error;
 		isv.n = ival;
 	}
-	if(mode==0)
+	if(mode==0){
 		sv = add_var(&s);
-	else
-		sv = add_local_shvar(&s);
-	if(sv==NULL)
-		goto error;
-	if(set_var_value(sv, &isv, flags)==NULL)
-		goto error;
+		if(sv==NULL)
+			goto error;
+		if(set_var_value(sv, &isv, flags)==NULL)
+			goto error;
+	}
+	else {
+		shared_sv = add_shvar(&s);
+		if(shared_sv == NULL)
+			goto error;
+		if(set_shvar_value(shared_sv, &isv, flags) == NULL)
+			goto error;
+	}
 
 	return 0;
 error:


### PR DESCRIPTION
blacklists are now initialized directly in shared memory
$shv pseudo-variable initialisation (from cfgutils module) is done completely in shared memory 