### PR TITLE
Silently disable GLIBC-specific features if we are not on Linux (unbrear modules on FreeBSD)

### DIFF
--- a/modules/cfgutils/cfgutils.c
+++ b/modules/cfgutils/cfgutils.c
@@ -39,7 +39,9 @@
  *
  */
 #include <stdlib.h>
+#ifdef __OS_linux
 #include <features.h>     /* for GLIBC version testing */
+#endif
 
 #include "../../sr_module.h"
 #include "../../error.h"
@@ -61,7 +63,9 @@
 	#include <sys/timerfd.h>  /* for timer FD */
 	#define HAVE_TIMER_FD 1
 #else
+#ifdef __OS_linux
 	#warning Your GLIB is too old, disabling async sleep functions!!!
+#endif
 #endif
 
 /* FIFO action protocol names */


### PR DESCRIPTION
Please wrap GLIBC-specific stuff into proper ifdefs. This just breaks modules build on the FreeBSD currently. Thanks!