### PR TITLE
Prevent crash in `fm_remove_free`.

### DIFF
--- a/mem/f_malloc.c
+++ b/mem/f_malloc.c
@@ -332,7 +332,7 @@ void* fm_malloc(struct fm_block* qm, unsigned long size)
 	for(hash=GET_HASH(size);hash<F_HASH_SIZE;hash++){
 		frag=qm->free_hash[hash].first;
 		for( ; frag; frag = frag->u.nxt_free )
-			if ( frag->size >= size ) goto found;
+			if ( frag->size >= size && frag->prev ) goto found;
 		/* try in a bigger bucket */
 	}
 	/* not found, bad! */


### PR DESCRIPTION
This is a workaround for #721 
This doesn't address the base question (why would a fragement have `->prev` set to NULL), so this isn't a fix, but it should prevent crashes for this case.