### PR TITLE
mem/module_info: adapt code to shared memory initialisation change

### DIFF
--- a/Makefile.conf.template
+++ b/Makefile.conf.template
@@ -88,5 +88,6 @@ DEFS+= -DDBG_MALLOC #Enables debugging for memory allocators
 #DEFS+= -DNOSMP #Do not use SMP sompliant locking. Faster but won't work on SMP machines
 #DEFS+= -DEXTRA_DEBUG #Compiles in some extra debugging code
 #DEFS+= -DORACLE_USRLOC #Uses Oracle compatible queries for USRLOC
+#DEFS+= -DSHM_EXTRA_STATS #Needed when using the mem-group core parameter
 
 PREFIX ?= /usr/local/

--- a/cfg.y
+++ b/cfg.y
@@ -938,7 +938,12 @@ assign_stm: DEBUG EQUAL snumber
 									YYABORT;
 								}
 							}
-							mem_free_idx++;
+
+							mem_free_idx++;	
+
+							if(alloc_group_stat()){
+								YYABORT;
+							}
 							#endif
 						}
 		| MEMGROUP EQUAL STRING COLON error { yyerror("invalid or no module specified"); }

--- a/mem/module_info.c
+++ b/mem/module_info.c
@@ -70,75 +70,100 @@ int set_mem_idx(char* mod_name, int  mem_free_idx){
 	return 0;
 }
 
-inline void update_module_stats(long mem_used, long real_used, int frags, int group_idx){
+int init_new_stat(stat_var* stat) {
+#ifndef DBG_MALLOC
+	#define MALLOC_UNSAFE(_size)  MY_MALLOC_UNSAFE(shm_block, _size)
+#else
+	#define MALLOC_UNSAFE(_size)  MY_MALLOC_UNSAFE(shm_block, _size, __FILE__, __FUNCTION__, __LINE__ )
+#endif
+
+	stat->u.val = MALLOC_UNSAFE(sizeof(stat_val));
+
+	if(!stat->u.val) {
+		LM_ERR("no more shm memory\n");
+		return -1;
+	}
+
+#ifdef NO_ATOMIC_OPS
+		*(stat->u.val) = 0;
+#else
+		atomic_set(stat->u.val,0);
+#endif
+
+	return 0;
+
+#undef MALLOC_UNSAFE
+}
+
+inline void update_module_stats(long mem_used, long real_used, int frags, int group_idx) {
 #ifdef SHM_SHOW_DEFAULT_GROUP
 	if(!memory_mods_stats)
 		return;
-	update_stat(memory_mods_stats[group_idx].fragments, frags);
-	update_stat(memory_mods_stats[group_idx].memory_used, mem_used);
-	update_stat(memory_mods_stats[group_idx].real_used, real_used);
+	update_stat(&memory_mods_stats[group_idx].fragments, frags);
+	update_stat(&memory_mods_stats[group_idx].memory_used, mem_used);
+	update_stat(&memory_mods_stats[group_idx].real_used, real_used);
 #else
 	if(group_idx == 0)
 		return;
-	update_stat(memory_mods_stats[group_idx - 1].fragments, frags);
-	update_stat(memory_mods_stats[group_idx - 1].memory_used, mem_used);
-	update_stat(memory_mods_stats[group_idx - 1].real_used, real_used);
+	update_stat(&memory_mods_stats[group_idx - 1].fragments, frags);
+	update_stat(&memory_mods_stats[group_idx - 1].memory_used, mem_used);
+	update_stat(&memory_mods_stats[group_idx - 1].real_used, real_used);
 #endif
 }
 
 int alloc_group_stat(void) {
-	int size_prealoc, j, one_full_entry, groups;
-	char *start;
-	struct module_info* new_stats_vec;
+	int size_prealoc, groups;
+
 #ifndef SHM_SHOW_DEFAULT_GROUP
 	groups = mem_free_idx - 1;
 #else
 	groups = mem_free_idx;
+
 #endif
 
-	one_full_entry = 3 * (sizeof(stat_var) + sizeof(stat_val));
-	size_prealoc = groups * sizeof(struct module_info) + groups * one_full_entry;
+	size_prealoc = groups * sizeof(struct module_info);
 
 #ifndef DBG_MALLOC
-	new_stats_vec = MY_MALLOC_UNSAFE(shm_block, size_prealoc);
+	memory_mods_stats = MY_REALLOC_UNSAFE(shm_block, (void*)memory_mods_stats, size_prealoc);
 #else
-	new_stats_vec = MY_MALLOC_UNSAFE(shm_block, size_prealoc, __FILE__, __FUNCTION__, __LINE__ );
+	memory_mods_stats = MY_REALLOC_UNSAFE(shm_block, (void*)memory_mods_stats, size_prealoc, __FILE__, __FUNCTION__, __LINE__ );
 #endif
 
-	if(!new_stats_vec){
+	if(!memory_mods_stats){
 		LM_CRIT("could not alloc shared memory");
 		return -1;
 	}
-	memset( (void*)new_stats_vec, 0, size_prealoc);
-	start = (char*)new_stats_vec + groups * sizeof(struct module_info);
-	for(j = 0; j < groups; j++){
-		new_stats_vec[j].fragments = (stat_var *)(start + j * one_full_entry);
-		new_stats_vec[j].memory_used = (stat_var *)(start + j * one_full_entry + sizeof(stat_var));
-		new_stats_vec[j].real_used = (stat_var *)(start + j * one_full_entry + 2 * sizeof(stat_var));
+	//initialize the new created group
+	memset((void*)&memory_mods_stats[groups - 1], 0, sizeof(struct module_info));
+	if (init_new_stat((stat_var *)&memory_mods_stats[groups - 1].fragments) < 0)
+		return -1;
 
-		new_stats_vec[j].fragments->u.val = (stat_val*)(start + j * one_full_entry + 3 * sizeof(stat_var));
-		new_stats_vec[j].memory_used->u.val = (stat_val*)(start + j * one_full_entry + 3 * sizeof(stat_var) + sizeof(stat_val));
-		new_stats_vec[j].real_used->u.val = (stat_val*)(start + j * one_full_entry + 3 * sizeof(stat_var) + 2 * sizeof(stat_val));
-	}
-#ifndef SHM_SHOW_DEFAULT_GROUP
-	if(core_index != 0) {
-		update_stat(new_stats_vec[core_index - 1].fragments, 1);
-		update_stat(new_stats_vec[core_index - 1].memory_used, size_prealoc);
-		update_stat(new_stats_vec[core_index - 1].real_used, size_prealoc + FRAG_OVERHEAD);
-	}
-#else
-	update_stat(new_stats_vec[0].fragments, get_stat_val(memory_mods_stats[0].fragments));
-	update_stat(new_stats_vec[0].memory_used, one_full_entry + get_stat_val(memory_mods_stats[0].memory_used));
-	update_stat(new_stats_vec[0].real_used, one_full_entry + get_stat_val(memory_mods_stats[0].real_used));
+	if (init_new_stat((stat_var *)&memory_mods_stats[groups - 1].memory_used) < 0)
+		return -1;
+
+	if (init_new_stat((stat_var *)&memory_mods_stats[groups - 1].real_used) < 0)
+		return -1;
+
+	if(core_index) {
+		if(mem_free_idx - 1 == core_index) {
+			update_module_stats(size_prealoc + groups * sizeof(stat_val) * 3, size_prealoc +
+							groups * sizeof(stat_val) * 3 + FRAG_OVERHEAD * (groups * 3 + 1), groups * 3 + 1, core_index);
+			update_module_stats(-((groups - 1) * sizeof(struct module_info) + (groups - 1) * sizeof(stat_val) * 3),
+			-((groups - 1) * sizeof(struct module_info) + (groups - 1) * sizeof(stat_val) * 3 + FRAG_OVERHEAD * ((groups - 1) * 3 + 1)),
+			  -((groups - 1) * 3 + 1), 0);
+		} else {
+			update_module_stats(sizeof(stat_val) * 3 + sizeof(struct module_info), sizeof(stat_val) * 3 + sizeof(struct module_info) 
+							+ 3 * FRAG_OVERHEAD, 3, core_index);
+		}
+	} else {
+#ifdef SHM_SHOW_DEFAULT_GROUP
+	update_stat(&memory_mods_stats[0].fragments, 3);
+	update_stat(&memory_mods_stats[0].memory_used, sizeof(stat_val) * 3 + sizeof(struct module_info));
+	update_stat(&memory_mods_stats[0].real_used, sizeof(stat_val) * 3 + sizeof(struct module_info)
+							+ 3 * FRAG_OVERHEAD);
 #endif
-
-	if(memory_mods_stats){
-	#ifndef DBG_MALLOC
-		MY_FREE_UNSAFE(shm_block, (void*)memory_mods_stats);
-	#else
-		MY_FREE_UNSAFE(shm_block, (void*)memory_mods_stats, __FILE__, __FUNCTION__, __LINE__ );
-	#endif
 	}
-	memory_mods_stats = new_stats_vec;
+
+
 	return 0;
 }

--- a/mem/module_info.c
+++ b/mem/module_info.c
@@ -99,7 +99,7 @@ int alloc_group_stat(void) {
 	one_full_entry = 3 * (sizeof(stat_var) + sizeof(stat_val));
 	size_prealoc = groups * sizeof(struct module_info) + groups * one_full_entry;
 
-#ifndef DBG_QM_MALLOC
+#ifndef DBG_MALLOC
 	new_stats_vec = MY_MALLOC_UNSAFE(shm_block, size_prealoc);
 #else
 	new_stats_vec = MY_MALLOC_UNSAFE(shm_block, size_prealoc, __FILE__, __FUNCTION__, __LINE__ );
@@ -133,7 +133,7 @@ int alloc_group_stat(void) {
 #endif
 
 	if(memory_mods_stats){
-	#ifndef DBG_QM_MALLOC
+	#ifndef DBG_MALLOC
 		MY_FREE_UNSAFE(shm_block, (void*)memory_mods_stats);
 	#else
 		MY_FREE_UNSAFE(shm_block, (void*)memory_mods_stats, __FILE__, __FUNCTION__, __LINE__ );

--- a/mem/module_info.h
+++ b/mem/module_info.h
@@ -38,9 +38,9 @@ extern volatile struct module_info* memory_mods_stats;
 extern int core_index;
 
 struct module_info{
-	stat_var* fragments;
-	stat_var* memory_used;
-	stat_var* real_used;
+	stat_var fragments;
+	stat_var memory_used;
+	stat_var real_used;
 };
 
 struct multi_str{
@@ -53,4 +53,6 @@ int set_mem_idx(char* mod_name, int  mem_free_idx);
 void update_module_stats(long mem_used, long real_used, int frags, int group_idx);
 
 int alloc_group_stat(void);
+
+int init_new_stat(stat_var *);
 #endif

--- a/mem/module_info.h
+++ b/mem/module_info.h
@@ -51,4 +51,6 @@ struct multi_str{
 int set_mem_idx(char* mod_name, int  mem_free_idx);
 
 void update_module_stats(long mem_used, long real_used, int frags, int group_idx);
+
+int alloc_group_stat(void);
 #endif

--- a/mem/shm_mem.c
+++ b/mem/shm_mem.c
@@ -309,35 +309,32 @@ int shm_mem_init_mallocs(void* mempool, unsigned long pool_size)
 
 #if defined(SHM_EXTRA_STATS) && defined(SHM_SHOW_DEFAULT_GROUP)
 	/* we create the the default group statistic where memory alocated untill groups are defined is indexed */
-	int size_prealoc;
-	char *start;
-
-	size_prealoc = sizeof(struct module_info) + 3 * (sizeof(stat_var) + sizeof(stat_val));
 
 	#ifndef DBG_MALLOC
-		memory_mods_stats = MY_MALLOC_UNSAFE(shm_block, size_prealoc);
+	memory_mods_stats = MY_MALLOC_UNSAFE(shm_block, sizeof(struct module_info));
 	#else
-		memory_mods_stats = MY_MALLOC_UNSAFE(shm_block, size_prealoc, __FILE__, __FUNCTION__, __LINE__ );
+	memory_mods_stats = MY_MALLOC_UNSAFE(shm_block, sizeof(struct module_info), __FILE__, __FUNCTION__, __LINE__ );
 	#endif
 
 	if(!memory_mods_stats){
 		LM_CRIT("could not alloc shared memory");
 		return -1;
 	}
-	memset( (void*)memory_mods_stats, 0, size_prealoc);
-	start = (char*)memory_mods_stats + sizeof(struct module_info);
+	//initialize the new created groups
+	memset((void*)&memory_mods_stats[0], 0, sizeof(struct module_info));
+	if (init_new_stat((stat_var*)&memory_mods_stats[0].fragments) < 0)
+		return -1;
 	
-	memory_mods_stats->fragments = (stat_var *)(start );
-	memory_mods_stats->memory_used = (stat_var *)(start + sizeof(stat_var));
-	memory_mods_stats->real_used = (stat_var *)(start + 2 * sizeof(stat_var));
+	if (init_new_stat((stat_var*)&memory_mods_stats[0].memory_used) < 0)
+		return -1;
 	
-	memory_mods_stats->fragments->u.val = (stat_val*)(start + 3 * sizeof(stat_var));
-	memory_mods_stats->memory_used->u.val = (stat_val*)(start + 3 * sizeof(stat_var) + sizeof(stat_val));
-	memory_mods_stats->real_used->u.val = (stat_val*)(start + 3 * sizeof(stat_var) + 2 * sizeof(stat_val));
-			
-	update_stat(memory_mods_stats[0].fragments, 1);
-	update_stat(memory_mods_stats[0].memory_used, size_prealoc);
-	update_stat(memory_mods_stats[0].real_used, size_prealoc + FRAG_OVERHEAD);
+	if (init_new_stat((stat_var*)&memory_mods_stats[0].real_used) < 0)
+		return -1;
+
+	update_stat((stat_var*)&memory_mods_stats[0].fragments, 4);
+	update_stat((stat_var*)&memory_mods_stats[0].memory_used, sizeof(stat_val) * 3 + sizeof(struct module_info));
+	update_stat((stat_var*)&memory_mods_stats[0].real_used, sizeof(stat_val) * 3 + sizeof(struct module_info) 
+					+ 4 * FRAG_OVERHEAD);
 #endif
 
 
@@ -454,21 +451,24 @@ void init_shm_statistics(void)
 	struct multi_str *mod_name;
 	int i, len;
 	char *full_name = NULL;
+	stat_var *p;
 
 	if(mem_free_idx != 1){
 
 #ifdef SHM_SHOW_DEFAULT_GROUP
-		if (register_stat("shmem_group_default", "fragments", (stat_var **)&memory_mods_stats[0].fragments, STAT_NO_RESET|STAT_ONLY_REGISTER)!=0 ) {
+		p = (stat_var *)&memory_mods_stats[0].fragments;
+		if (register_stat("shmem_group_default", "fragments", &p, STAT_NO_RESET|STAT_ONLY_REGISTER)!=0 ) {
+			LM_CRIT("can't add stat variable");
+			return;
+		}
+		p = (stat_var *)&memory_mods_stats[0].memory_used;
+		if (register_stat("shmem_group_default", "memory_used", &p, STAT_NO_RESET|STAT_ONLY_REGISTER)!=0 ) {
 			LM_CRIT("can't add stat variable");
 			return;
 		}
 
-		if (register_stat("shmem_group_default", "memory_used", (stat_var **)&memory_mods_stats[0].memory_used, STAT_NO_RESET|STAT_ONLY_REGISTER)!=0 ) {
-			LM_CRIT("can't add stat variable");
-			return;
-		}
-
-		if (register_stat("shmem_group_default", "real_used", (stat_var **)&memory_mods_stats[0].real_used, STAT_NO_RESET|STAT_ONLY_REGISTER)!=0 ) {
+		p = (stat_var *)&memory_mods_stats[0].real_used;
+		if (register_stat("shmem_group_default", "real_used", &p, STAT_NO_RESET|STAT_ONLY_REGISTER)!=0 ) {
 			LM_CRIT("can't add stat variable");
 			return;
 		}
@@ -484,17 +484,20 @@ void init_shm_statistics(void)
 
 			strcpy(full_name, STAT_PREFIX);
 			strcat(full_name, mod_name->s);
-			if (register_stat(full_name, "fragments", (stat_var **)&memory_mods_stats[i].fragments, STAT_NO_RESET|STAT_ONLY_REGISTER)!=0 ) {
+			p = (stat_var *)&memory_mods_stats[i].fragments;
+			if (register_stat(full_name, "fragments", &p, STAT_NO_RESET|STAT_ONLY_REGISTER)!=0 ) {
 				LM_CRIT("can't add stat variable");
 				return;
 			}
 
-			if (register_stat(full_name, "memory_used", (stat_var **)&memory_mods_stats[i].memory_used, STAT_NO_RESET|STAT_ONLY_REGISTER)!=0 ) {
+			p = (stat_var *)&memory_mods_stats[i].memory_used;
+			if (register_stat(full_name, "memory_used", &p, STAT_NO_RESET|STAT_ONLY_REGISTER)!=0 ) {
 				LM_CRIT("can't add stat variable");
 				return;
 			}
 
-			if (register_stat(full_name, "real_used", (stat_var **)&memory_mods_stats[i].real_used, STAT_NO_RESET|STAT_ONLY_REGISTER)!=0 ) {
+			p = (stat_var *) &memory_mods_stats[i].real_used;
+			if (register_stat(full_name, "real_used", &p, STAT_NO_RESET|STAT_ONLY_REGISTER)!=0 ) {
 				LM_CRIT("can't add stat variable");
 				return;
 			}

--- a/mem/shm_mem.c
+++ b/mem/shm_mem.c
@@ -306,18 +306,13 @@ int shm_mem_init_mallocs(void* mempool, unsigned long pool_size)
 		shm_mem_destroy();
 		return -1;
 	}
-#ifdef SHM_EXTRA_STATS
-	int size_prealoc, j, one_full_entry, groups;
-	char *start;
-	if(mem_free_idx != 1){
-	#ifndef SHM_SHOW_DEFAULT_GROUP
-		groups = mem_free_idx - 1;
-	#else
-		groups = mem_free_idx;
-	#endif
 
-		one_full_entry = 3 * (sizeof(stat_var) + sizeof(stat_val));
-		size_prealoc = groups * sizeof(struct module_info) + groups * one_full_entry;
+#if defined(SHM_EXTRA_STATS) && defined(SHM_SHOW_DEFAULT_GROUP)
+	/* we create the the default group statistic where memory alocated untill groups are defined is indexed */
+	int size_prealoc;
+	char *start;
+
+	size_prealoc = sizeof(struct module_info) + 3 * (sizeof(stat_var) + sizeof(stat_val));
 
 	#ifndef DBG_MALLOC
 		memory_mods_stats = MY_MALLOC_UNSAFE(shm_block, size_prealoc);
@@ -325,34 +320,26 @@ int shm_mem_init_mallocs(void* mempool, unsigned long pool_size)
 		memory_mods_stats = MY_MALLOC_UNSAFE(shm_block, size_prealoc, __FILE__, __FUNCTION__, __LINE__ );
 	#endif
 
-		if(!memory_mods_stats){
-			LM_CRIT("could not alloc shared memory");
-			return -1;
-		}
-		memset( (void*)memory_mods_stats, 0, size_prealoc);
-		start = (char*)memory_mods_stats + groups * sizeof(struct module_info);
-		for(j = 0; j < groups; j++){
-			memory_mods_stats[j].fragments = (stat_var *)(start + j * one_full_entry);
-			memory_mods_stats[j].memory_used = (stat_var *)(start + j * one_full_entry + sizeof(stat_var));
-			memory_mods_stats[j].real_used = (stat_var *)(start + j * one_full_entry + 2 * sizeof(stat_var));
-
-			memory_mods_stats[j].fragments->u.val = (stat_val*)(start + j * one_full_entry + 3 * sizeof(stat_var));
-			memory_mods_stats[j].memory_used->u.val = (stat_val*)(start + j * one_full_entry + 3 * sizeof(stat_var) + sizeof(stat_val));
-			memory_mods_stats[j].real_used->u.val = (stat_val*)(start + j * one_full_entry + 3 * sizeof(stat_var) + 2 * sizeof(stat_val));
-		}
-	#ifndef SHM_SHOW_DEFAULT_GROUP
-		if(core_index != 0){
-			update_stat(memory_mods_stats[core_index - 1].fragments, 1);
-			update_stat(memory_mods_stats[core_index - 1].memory_used, size_prealoc);
-			update_stat(memory_mods_stats[core_index - 1].real_used, size_prealoc + FRAG_OVERHEAD);
-		}
-	#else
-		update_stat(memory_mods_stats[core_index].fragments, 1);
-		update_stat(memory_mods_stats[core_index].memory_used, size_prealoc);
-		update_stat(memory_mods_stats[core_index].real_used, size_prealoc + FRAG_OVERHEAD);
-	#endif
+	if(!memory_mods_stats){
+		LM_CRIT("could not alloc shared memory");
+		return -1;
 	}
+	memset( (void*)memory_mods_stats, 0, size_prealoc);
+	start = (char*)memory_mods_stats + sizeof(struct module_info);
+	
+	memory_mods_stats->fragments = (stat_var *)(start );
+	memory_mods_stats->memory_used = (stat_var *)(start + sizeof(stat_var));
+	memory_mods_stats->real_used = (stat_var *)(start + 2 * sizeof(stat_var));
+	
+	memory_mods_stats->fragments->u.val = (stat_val*)(start + 3 * sizeof(stat_var));
+	memory_mods_stats->memory_used->u.val = (stat_val*)(start + 3 * sizeof(stat_var) + sizeof(stat_val));
+	memory_mods_stats->real_used->u.val = (stat_val*)(start + 3 * sizeof(stat_var) + 2 * sizeof(stat_val));
+			
+	update_stat(memory_mods_stats[0].fragments, 1);
+	update_stat(memory_mods_stats[0].memory_used, size_prealoc);
+	update_stat(memory_mods_stats[0].real_used, size_prealoc + FRAG_OVERHEAD);
 #endif
+
 
 #ifdef HP_MALLOC
 	/* lock_alloc cannot be used yet! */


### PR DESCRIPTION
the statistics vector is exteded as more memory groups are declared
if SHM_SHOW_DEFAULT_GROUP is defined allocations done util grups are
defined are added to the default group
