### PR TITLE
rtpproxy: patch: has_sdp() does not exist

### DIFF
--- a/modules/rtpproxy/README
+++ b/modules/rtpproxy/README
@@ -499,14 +499,14 @@ sock_pvar]]]])
 route {
 ...
     if (is_method("INVITE")) {
-        if (has_sdp()) {
+        if (has_body("application/sdp")) {
             if (rtpproxy_offer())
                 t_on_reply("1");
         } else {
             t_on_reply("2");
         }
     }
-    if (is_method("ACK") && has_sdp())
+    if (is_method("ACK") && has_body("application/sdp"))
         rtpproxy_answer();
 ...
 }
@@ -514,7 +514,7 @@ route {
 onreply_route[1]
 {
 ...
-    if (has_sdp())
+    if (has_body("application/sdp"))
         rtpproxy_answer();
 ...
 }
@@ -522,7 +522,7 @@ onreply_route[1]
 onreply_route[2]
 {
 ...
-    if (has_sdp())
+    if (has_body("application/sdp"))
         rtpproxy_offer();
 ...
 }

--- a/modules/rtpproxy/doc/rtpproxy_admin.xml
+++ b/modules/rtpproxy/doc/rtpproxy_admin.xml
@@ -602,14 +602,14 @@ if (is_method("INVITE") &amp;&amp; has_totag()) {
 route {
 ...
     if (is_method("INVITE")) {
-        if (has_sdp()) {
+        if (has_body("application/sdp")) {
             if (rtpproxy_offer())
                 t_on_reply("1");
         } else {
             t_on_reply("2");
         }
     }
-    if (is_method("ACK") &amp;&amp; has_sdp())
+    if (is_method("ACK") &amp;&amp; has_body("application/sdp"))
         rtpproxy_answer();
 ...
 }
@@ -617,7 +617,7 @@ route {
 onreply_route[1]
 {
 ...
-    if (has_sdp())
+    if (has_body("application/sdp"))
         rtpproxy_answer();
 ...
 }
@@ -625,7 +625,7 @@ onreply_route[1]
 onreply_route[2]
 {
 ...
-    if (has_sdp())
+    if (has_body("application/sdp"))
         rtpproxy_offer();
 ...
 }


### PR DESCRIPTION
Not sure how this slipped through, but we don't have a function called has_sdp.