### PR TITLE
[siptrace] all types of tracing are done using sip_trace function

### DIFF
--- a/db/schema/sip_trace.xml
+++ b/db/schema/sip_trace.xml
@@ -9,7 +9,7 @@
 
 <table id="sip_trace" xmlns:db="http://docbook.org/ns/docbook">
     <name>sip_trace</name>
-    <version>4</version>
+    <version>5</version>
     <type db="mysql">&MYSQL_TABLE_TYPE;</type>
     <description>
         <db:para>This table is used to store incoming/outgoing SIP messages in database. More informations can be found in the siptrace module documentation at: &OPENSIPS_MOD_DOC;siptrace.html.
@@ -43,8 +43,8 @@
         <natural/>
     </column>
 
-    <column id="traced_user">
-        <name>traced_user</name>
+    <column id="trace_attrs">
+        <name>trace_attrs</name>
         <type>string</type>
         <size>&uri_len;</size>
         <null/>
@@ -136,8 +136,8 @@
     </column>
 
     <index>
-        <name>traced_user_idx</name>
-        <colref linkend="traced_user"/>
+        <name>trace_attrs_idx</name>
+        <colref linkend="trace_attrs"/>
     </index>
 
     <index>

--- a/modules/siptrace/README
+++ b/modules/siptrace/README
@@ -27,46 +27,27 @@ Daniel-Constantin Mierla
 
         1.3. Exported Parameters
 
-              1.3.1. db_url (str)
-              1.3.2. trace_flag (string/integer)
-              1.3.3. trace_on (integer)
-              1.3.4. enable_ack_trace (integer)
-              1.3.5. traced_user_avp (str)
-              1.3.6. trace_table_avp (str)
-              1.3.7. duplicate_uri (str)
-              1.3.8. trace_local_ip (str)
-              1.3.9. table (str)
+              1.3.1. trace_on (integer)
+              1.3.2. trace_local_ip (str)
+              1.3.3. trace_id (str)
 
         1.4. Exported Functions
 
-              1.4.1. sip_trace()
-              1.4.2. trace_dialog()
-              1.4.3. trace_to_database (integer)
-              1.4.4. duplicate_with_hep (integer)
+              1.4.1. sip_trace(trace_id, [type, [trace_attrs]])
 
         1.5. Exported MI Functions
 
               1.5.1. sip_trace
-              1.5.2. trace_to_database
 
         1.6. Database setup
         1.7. Known issues
 
    List of Examples
 
-   1.1. Set db_url parameter
-   1.2. Set trace_flag parameter
-   1.3. Set trace_on parameter
-   1.4. Set enable_ack_trace parameter
-   1.5. Set traced_user_avp parameter
-   1.6. Set trace_table_avp parameter
-   1.7. Set duplicate_uri parameter
-   1.8. Set trace_local_ip parameter
-   1.9. Set sip_trace parameter
-   1.10. sip_trace() usage
-   1.11. trace_dialog() usage
-   1.12. Set trace_to_databaseparameter
-   1.13. Set duplicate_with_hep parameter
+   1.1. Set trace_on parameter
+   1.2. Set trace_local_ip parameter
+   1.3. Set trace_id parameter
+   1.4. sip_trace() usage
 
 Chapter 1. Admin Guide
 
@@ -77,21 +58,27 @@ Chapter 1. Admin Guide
    loaded in order to duplicate with hep. All hep parameters moved
    inside proto_hep.
 
-   There are two ways of storing information.
-     * by calling explicitely the sip_trace() method in OpenSIPS
-       configuration file. In this case the original message is
-       processed.
-     * by setting the flag equal with the value of 'trace_flag'
-       (e.g., setflag(TRACE_FLAG)) parameter of the module. In
-       this case, the\ message sent forward is processed. The
-       logging mechanism is based on TM/SL callbacks, so only
-       messages processed with TM/SL are logged.
+   The 2.2 version of OpenSIPS came with a major improvement in
+   siptrace module. Now all you have to do is call sip_trace()
+   function with the proper parameters and it will do the job for
+   you. Now you can trace messages, transactions and dialogs with
+   the same function. Also, you can trace to multiple databases,
+   multiple hep destinations and sip destinations using only one
+   parameter. All you need now is defining trace_id parameters in
+   modparam section and switch between them in siptrace function.
+   Also you cand turn tracing on and off using trace_on either
+   globally(for all trace_ids) or for a certain trace_id.
 
-   The tracing can be turned on/off using fifo commad.
+   IMPORTANT: In 2.2 version support for stateless trace has been
+   removed.
 
-   opensipsctl fifo sip_trace on
+   The tracing tracing can be turned on/off using fifo command.
 
-   opensipsctl fifo sip_trace off
+   opensipsctl fifo sip_trace on opensipsctl fifo sip_trace
+   [some_trace_id] on
+
+   opensipsctl fifo sip_trace off opensipsctl fifo sip_trace
+   [some_trace_id] off
 
 1.2. Dependencies
 
@@ -99,8 +86,11 @@ Chapter 1. Admin Guide
 
    The following modules must be loaded before this module:
      * database module - mysql, postrgress, dbtext, unixodbc...
-     * tm and sl modules - optional, only if you want to trace
-       messages forwarded by these modules.
+       only if you are using a database type trace id
+     * dialog - only if you want to trace dialogs.
+     * tm - only if you want to trace dialogs/transactions.
+     * proto_hep - only if you want to replicate messages over
+       hep.
 
 1.2.2. External Libraries or Applications
 
@@ -110,99 +100,18 @@ Chapter 1. Admin Guide
 
 1.3. Exported Parameters
 
-1.3.1. db_url (str)
-
-   Database URL.
-
-   Default value is "".
-
-   Example 1.1. Set db_url parameter
-...
-modparam("siptrace", "db_url", "mysql://user:passwd@host/dbname")
-...
-
-1.3.2. trace_flag (string/integer)
-
-   Which flag is used to mark messages to trace
-
-   WARNING: Setting INT flags is deprecated! Use quoted strings
-   instead!
-
-   Default value is "NULL" (not set).
-
-   Example 1.2. Set trace_flag parameter
-...
-modparam("siptrace", "trace_flag", "TRACE_FLAG")
-...
-
-1.3.3. trace_on (integer)
+1.3.1. trace_on (integer)
 
    Parameter to enable/disable trace (on(1)/off(0))
 
    Default value is "0".
 
-   Example 1.3. Set trace_on parameter
+   Example 1.1. Set trace_on parameter
 ...
 modparam("siptrace", "trace_on", 1)
 ...
 
-1.3.4. enable_ack_trace (integer)
-
-   Parameter to enable/disable tracing of statelessly received
-   ACKs (on(1)/off(0))
-
-   Default value is "0".
-
-   Example 1.4. Set enable_ack_trace parameter
-...
-modparam("siptrace", "enable_ack_trace", 1)
-...
-
-1.3.5. traced_user_avp (str)
-
-   The name of the AVP storing the SIP URI of the traced user. If
-   the AVP is set, messages are stored in database table and
-   'traced_user' column is filled with AVP's value. You can store
-   the message many times for many users by having multiple values
-   for this AVP.
-
-   Default value is "NULL" (feature disabled).
-
-   Example 1.5. Set traced_user_avp parameter
-...
-modparam("siptrace", "traced_user_avp", "$avp(123)")
-modparam("siptrace", "traced_user_avp", "$avp(user)")
-...
-
-1.3.6. trace_table_avp (str)
-
-   The name of the AVP storing the name of the table where to
-   store the SIP messages. If it is not set, the value of 'table'
-   parameter is used. In this way one can select dynamically where
-   to store the traced messages. The table must exist, and must
-   have the same structure as 'sip_trace' table.
-
-   Default value is "NULL" (feature disabled).
-
-   Example 1.6. Set trace_table_avp parameter
-...
-modparam("siptrace", "trace_table_avp", "$avp(345)")
-modparam("siptrace", "trace_table_avp", "$avp(siptrace_table)")
-...
-
-1.3.7. duplicate_uri (str)
-
-   The address in form of SIP uri where to send a duplicate of
-   traced message. It uses UDP all the time.
-
-   Default value is "NULL".
-
-   Example 1.7. Set duplicate_uri parameter
-...
-modparam("siptrace", "duplicate_uri", "sip:10.1.1.1:5888")
-...
-
-1.3.8. trace_local_ip (str)
+1.3.2. trace_local_ip (str)
 
    The address to be used in the fields that specify the source
    address (protocol, ip and port) for locally generated messages.
@@ -213,7 +122,7 @@ modparam("siptrace", "duplicate_uri", "sip:10.1.1.1:5888")
 
    Default value is "NULL".
 
-   Example 1.8. Set trace_local_ip parameter
+   Example 1.2. Set trace_local_ip parameter
 ...
 #Resulting address: udp:10.1.1.1:5064
 modparam("siptrace", "trace_local_ip", "10.1.1.1:5064")
@@ -234,77 +143,131 @@ modparam("siptrace", "trace_local_ip", "tcp:10.1.1.1:5064")
 modparam("siptrace", "trace_local_ip", "10.1.1.1")
 ...
 
-1.3.9. table (str)
+1.3.3. trace_id (str)
 
-   Name of the table where to store the SIP messages.
+   Specify a destination for the trace. This can be a hep uri, sip
+   uri or a database url and a table. All parameters inside
+   trace_id must be separated by ;. The parameters are given in
+   key-value format, the possible keys being uri for HEP and SIP
+   IDs and uri and table for databases. The format is
+   [id_name]key1=value1;key2=value2;. HEP uris must be specified
+   as hep:host:port.
 
-   Default value is "sip_trace".
+   One can declare multiple types of tracing under the same trace
+   id, being identified by their name. So if you define two
+   database url, one hep uri and one sip uri with the same name,
+   when calling sip_trace() with this name tracing shall be done
+   to all the destinations.
 
-   Example 1.9. Set sip_trace parameter
+   All the old parameter such as db_url, table and duplicate_uri
+   will form the trace id with the name "default".
+
+   No default value. If not set the module will be useless.
+
+   Example 1.3. Set trace_id parameter
 ...
-modparam("siptrace", "table", "strace")
+/*DB trace id*/
+modparam("siptrace", "trace_id",
+"[tid]
+uri=mysql://xxxx:xxxx@10.10.10.10/opensips;
+table=new_sip_trace;")
+/*hep trace id*/
+modparam("siptrace", "trace_id",
+"[tid]uri=hep:10.10.10.10:6161;")
+/*sip trace id*/
+modparam("siptrace", "trace_id",
+"[tid]uri=sip:10.10.10.11:5060;")
+/* notice that they all have the same name
+ * meaning that calling sip_trace("tid",...)
+ * will do sql, sip and hep tracing */
+
 ...
 
 1.4. Exported Functions
 
-1.4.1.  sip_trace()
+1.4.1.  sip_trace(trace_id, [type, [trace_attrs]])
 
-   Store current processed SIP message in database. It is stored
-   in the form prior applying chages made to it.
+   Store or replocate current processed SIP message,transaction or
+   dialogin database. It is stored in the form prior applying
+   chages made to it. The traced_user_avp parameter is now an
+   argument to sip_trace() function. Since version 2.2,
+   sip_trace() also catches internally generated replies in
+   stateless mode(sl_send_reply(...)).
 
    This function can be used from REQUEST_ROUTE, FAILURE_ROUTE,
    ONREPLY_ROUTE, BRANCH_ROUTE.
 
-   Example 1.10. sip_trace() usage
+   Meaning of the parameters is as follows:
+     * trace_id (string, pvar) the name of the trace_id specifying
+       where to do the tracing.
+     * type (string) what do you want to trace: dialog,
+       transaction or only the message. If not specified, will try
+       the topmost trace that can be done: if dialog module loaded
+       will trace dialogs, else if tm module loaded will trace
+       transaction and if none of these loaded will trace
+       messages.
+       Types can be the following:
+          + 'm'/'M' trace messages. Is the only one you should use
+            in stateless mode.
+          + 't'/'T' trace transactions. If tm module not loaded,
+            it will be in stateless transaction aware mode meaning
+            that will catch selected requests both in and out and
+            internally generated replies.
+          + 'd'/'D' trace dialog
+     * trace_attrs (string,pvar) this parameter replaces the
+       traced_user_avp from the old version. To avoid duplicating
+       an entry only for this parameter, whatever you put
+       here(string/pvar) shall be stored in the trace_attrs column
+       in the sip_trace table.
+
+   Example 1.4. sip_trace() usage
 ...
-sip_trace();
+/* see declaration of tid in trace_id section */
+        $var(trace_id) = "tid";
+        $var(user) = "osip_user@opensips.org";
+
 ...
-
-1.4.2.  trace_dialog()
-
-   The function triggers the tracing of all messages belonging to
-   a dialog. The function must be called for the initial request
-   (that starts the dialog) and it will automatically take care of
-   tracing evertyhing related to that dialog.
-
-   When using this function, you do not have to explicity set any
-   tracing flag or to explicitly call anothe trace function.
-
-   This function can be used from REQUEST_ROUTE.
-
-   Example 1.11. trace_dialog() usage
+/* Example 1: how to trace a dialog  */
+        if (has_totag()) {
+                match_dialog();
+        } else {
+                if (is_method("INVITE") {
+                        sip_trace("$var(trace_id)", "d", "$var(user)");
+                }
+        }
 ...
-if(is_method("INVITE") && !has_totag())
-        trace_dialog();
+/* Example 2: how to trace initial INVITE and BYE */
+        if (has_totag()) {
+                if (is_method("BYE")) {
+                        sip_trace("$var(trace_id)", "m", "$var(user)")
+                }
+        } else {
+                if (is_method("INVITE")) {
+                        sip_trace("$var(trace_id)", "m", "$var(user)")
+                }
+        }
+
 ...
-
-1.4.3. trace_to_database (integer)
-
-   Parameter to enable/disable inserts to the Database from this
-   OpenSIPS.
-
-   In case we only want to send the SIP-Messages to the
-   duplicate_uri and not store the information to the local
-   database we can set this to "0".
-
-   Default value is "1".
-
-   Example 1.12. Set trace_to_databaseparameter
+/* Example 3: trace initial INVITE transaction */
+        if (!has_totag()) {
+                if (is_method("INVITE")) {
+                        sip_trace("$var(trace_id)", "t", "$var(user)");
+                }
+        }
 ...
-modparam("siptrace", "trace_to_database", 0)
-...
+/* Example 4: stateless transaction aware mode!*/
+/* tm module must not be loaded */
+        if (is_method("REGISTER")) {
+                sip_trace("$var(trace_id)", "t", "$var(user)");
+                if (!www_authorize("", "subscriber")) {
+                        /* siptrace will also catch the 401 generated by
+ www_challenge() */
+                        www_challenge("", "1");
+                }
+        }
 
-1.4.4. duplicate_with_hep (integer)
 
-   Parameter to enable/disable homer encapsulate mode
-   (on(1)/off(0))
 
-   Default value is "0".
-
-   Example 1.13. Set duplicate_with_hep parameter
-...
-modparam("siptrace", "duplicate_with_hep", 1)
-...
 
 1.5. Exported MI Functions
 
@@ -313,37 +276,30 @@ modparam("siptrace", "duplicate_with_hep", 1)
    Name: sip_trace
 
    Parameters:
-     * trace_mode : turns on/off SIP message tracing. Possible
-       values are:
+     * trace_id/trace_mode : if it is a trace_id name it dumps
+       info about that trace id if the second parameter is not set
+       to on/off or it turns tracing on/off for a certain trace id
+       if it is set, else if it's on/off it turns on/off tracing
+       for all the trace ids. If you turn global trace on but some
+       of the trace ids had trace to off, then they shall not do
+       tracing. In order to do that you have to set the trace_on
+       parameter for each trace_id. Possible values are:
           + on
           + off
+          + trace_id name
        The parameter is optional - if missing, the command will
        return the status of the SIP message tracing (as string
-       “on” or “off” ) without changing anything.
+       “on” or “off”) marked with global and the status for each
+       trace id without changing anything.
+     * trace_mode : this parameter has the same meaning as the
+       trace_mode in the first parameter, but this time it
+       enables/disables tracing for a certain trace id given in
+       the first parameter.
 
    MI FIFO Command Format:
                 :sip_trace:_reply_fifo_file_
+                trace_id/trace_mode
                 trace_mode
-                _empty_line_
-
-1.5.2.  trace_to_database
-
-   Name: trace_to_database
-
-   Parameters:
-     * trace_to_db_mode : turns on/off SIP message tracing into
-       DB. Possible values are:
-          + on
-          + off
-       The parameter is optional - if missing, the command will
-       return the status of the SIP message tracing (as string
-       “on” or “off” ) without changing anything. The parameter
-       can be switched from off to on, if db connection was before
-       inizialized
-
-   MI FIFO Command Format:
-                :trace_to_database:_reply_fifo_file_
-                trace_to_db_mode
                 _empty_line_
 
 1.6. Database setup
@@ -359,5 +315,8 @@ modparam("siptrace", "duplicate_with_hep", 1)
 
 1.7. Known issues
 
-   Stateless forwarded messages (forward()) are not logged if you
-   set the flag, use sip_trace().
+   ACKs related to a transaction that are leaving OpenSIPS are not
+   traced since they are handled statelessly using forward_request
+   function. Fixing it would mean to register a fwdcb callback
+   that would be called for all the messages but would be used
+   only by ACKs, which would be highly ineffective.

--- a/modules/siptrace/doc/siptrace_admin.xml
+++ b/modules/siptrace/doc/siptrace_admin.xml
@@ -12,33 +12,32 @@
 		with hep. All hep parameters moved inside proto_hep.
 	</para>
 	<para>
-	There are two ways of storing information.
-		<itemizedlist>
-		<listitem>
-		<para>
-		by calling explicitely the sip_trace() method in OpenSIPS configuration
-		file. In this case the original message is processed.
-		</para>
-		</listitem>
-		<listitem>
-		<para>
-		by setting the flag equal with the value of 'trace_flag' (e.g.,
-		setflag(TRACE_FLAG)) parameter of the module. In this case, the\
-		message sent forward is processed. The logging mechanism is based on
-		TM/SL callbacks, so only messages processed with TM/SL are logged.
-		</para>
-		</listitem>
-		</itemizedlist>
+		The 2.2 version of &osips; came with a major improvement in siptrace module.
+		Now all you have to do is call <emphasis>sip_trace()</emphasis> function
+		with the proper parameters and it will do the job for you. Now you can trace
+		messages, transactions and dialogs with the same function. Also, you can trace
+		to multiple databases, multiple hep destinations and sip destinations using
+		only one parameter. All you need now is defining <emphasis>trace_id</emphasis>
+		parameters in modparam section and switch between them in
+		siptrace function. Also you cand turn tracing  on
+		and off using <emphasis>trace_on</emphasis> either globally(for all trace_ids)
+		or for a certain trace_id.
 	</para>
 
 	<para>
-	The tracing can be turned on/off using fifo commad.
+		IMPORTANT: In 2.2 version support for stateless trace has been removed.
+	</para>
+
+	<para>
+	The tracing tracing can be turned on/off using fifo command.
 	</para>
 	<para>
 	opensipsctl fifo sip_trace on
+	opensipsctl fifo sip_trace [some_trace_id] on
 	</para>
 	<para>
 	opensipsctl fifo sip_trace off
+	opensipsctl fifo sip_trace [some_trace_id] off
 	</para>
 	</section>
 	<section>
@@ -51,13 +50,23 @@
 			<listitem>
 			<para>
 				<emphasis>database module</emphasis> - mysql, postrgress,
-				dbtext, unixodbc...
+				dbtext, unixodbc... only if you are using a database type
+				trace id
 			</para>
 			</listitem>
 			<listitem>
 			<para>
-				<emphasis>tm and sl modules</emphasis> - optional, only if
-				you want to trace messages forwarded by these modules.
+				<emphasis>dialog</emphasis> - only if you want to trace dialogs.
+			</para>
+			</listitem>
+			<listitem>
+			<para>
+				<emphasis>tm</emphasis> - only if you want to trace dialogs/transactions.
+			</para>
+			</listitem>
+			<listitem>
+			<para>
+				<emphasis>proto_hep</emphasis> - only if you want to replicate messages over hep.
 			</para>
 			</listitem>
 			</itemizedlist>
@@ -80,49 +89,7 @@
 	</section>
 	<section>
 	<title>Exported Parameters</title>
-	<section>
-		<title><varname>db_url</varname> (str)</title>
-		<para>
-		Database URL.
-		</para>
-		<para>
-		<emphasis>
-			Default value is "".
-		</emphasis>
-		</para>
-		<example>
-		<title>Set <varname>db_url</varname> parameter</title>
-		<programlisting format="linespecific">
-...
-modparam("siptrace", "db_url", "mysql://user:passwd@host/dbname")
-...
-</programlisting>
-		</example>
-	</section>
-	<section>
-		<title><varname>trace_flag</varname> (string/integer)</title>
-		<para>
-		Which flag is used to mark messages to trace
-		</para>
-		<para>
-		<emphasis>WARNING: </emphasis>Setting INT flags is deprecated!
-		Use quoted strings instead!
-		</para>
-		<para>
-		<emphasis>
-			Default value is "NULL" (not set).
-		</emphasis>
-		</para>
-		<example>
-		<title>Set <varname>trace_flag</varname> parameter</title>
-		<programlisting format="linespecific">
-...
-modparam("siptrace", "trace_flag", "TRACE_FLAG")
-...
-</programlisting>
-		</example>
-	</section>
-	<section>
+		<section>
 		<title><varname>trace_on</varname> (integer)</title>
 		<para>
 		Parameter to enable/disable trace (on(1)/off(0))
@@ -141,95 +108,7 @@ modparam("siptrace", "trace_on", 1)
 </programlisting>
 		</example>
 	</section>
-	<section>
-		<title><varname>enable_ack_trace</varname> (integer)</title>
-		<para>
-		Parameter to enable/disable tracing of statelessly received ACKs
-		(on(1)/off(0))
-		</para>
-		<para>
-		<emphasis>
-			Default value is "0".
-		</emphasis>
-		</para>
-		<example>
-		<title>Set <varname>enable_ack_trace</varname> parameter</title>
-		<programlisting format="linespecific">
-...
-modparam("siptrace", "enable_ack_trace", 1)
-...
-</programlisting>
-		</example>
-	</section>
-	<section>
-		<title><varname>traced_user_avp</varname> (str)</title>
-		<para>
-		The name of the AVP storing the SIP URI of the traced user. If
-		the AVP is set, messages are stored in database table and
-		'traced_user' column is filled with AVP's value. You can store
-		the message many times for many users by having multiple values
-		for this AVP.
-		</para>
-		<para>
-		<emphasis>
-			Default value is "NULL" (feature disabled).
-		</emphasis>
-		</para>
-		<example>
-		<title>Set <varname>traced_user_avp</varname> parameter</title>
-		<programlisting format="linespecific">
-...
-modparam("siptrace", "traced_user_avp", "$avp(123)")
-modparam("siptrace", "traced_user_avp", "$avp(user)")
-...
-</programlisting>
-		</example>
-	</section>
-	<section>
-		<title><varname>trace_table_avp</varname> (str)</title>
-		<para>
-		The name of the AVP storing the name of the table where to
-		store the SIP messages. If it is not set, the value of
-		'table' parameter is used. In this way one can select
-		dynamically where to store the traced messages. The table
-		must exist, and must have the same structure as 'sip_trace'
-		table.
-		</para>
-		<para>
-		<emphasis>
-			Default value is "NULL" (feature disabled).
-		</emphasis>
-		</para>
-		<example>
-		<title>Set <varname>trace_table_avp</varname> parameter</title>
-		<programlisting format="linespecific">
-...
-modparam("siptrace", "trace_table_avp", "$avp(345)")
-modparam("siptrace", "trace_table_avp", "$avp(siptrace_table)")
-...
-</programlisting>
-		</example>
-	</section>
-	<section>
-		<title><varname>duplicate_uri</varname> (str)</title>
-		<para>
-		The address in form of SIP uri where to send a duplicate
-		of traced message. It uses UDP all the time.
-		</para>
-		<para>
-		<emphasis>
-			Default value is "NULL".
-		</emphasis>
-		</para>
-		<example>
-		<title>Set <varname>duplicate_uri</varname> parameter</title>
-		<programlisting format="linespecific">
-...
-modparam("siptrace", "duplicate_uri", "sip:10.1.1.1:5888")
-...
-</programlisting>
-		</example>
-	</section>
+
 	<section>
 		<title><varname>trace_local_ip</varname> (str)</title>
 		<para>
@@ -269,125 +148,172 @@ modparam("siptrace", "trace_local_ip", "10.1.1.1")
 </programlisting>
 		</example>
 	</section>
+
 	<section>
-		<title><varname>table</varname> (str)</title>
+		<title><varname>trace_id</varname> (str)</title>
 		<para>
-		Name of the table where to store the SIP messages.
+			Specify a destination for the trace. This can be a hep uri,
+			sip uri or a database url and a table. All parameters inside
+			<emphasis>trace_id</emphasis> must be separated by
+			<emphasis>;</emphasis>. The parameters are given in key-value
+			format, the possible keys being <emphasis>uri</emphasis>
+			for HEP and SIP IDs and <emphasis>uri</emphasis> and
+			<emphasis>table</emphasis> for databases. The format is
+			<emphasis>[id_name]key1=value1;key2=value2;</emphasis>. HEP
+			uris must be specified as <emphasis>hep:host:port</emphasis>.
+		</para>
+		<para>
+			One can declare multiple types of tracing under the same trace
+			id, being identified by their name. So if you define two
+			database url, one hep uri and one sip uri with the same name,
+			when calling sip_trace() with this name tracing shall be done
+			to all the destinations.
+		</para>
+		<para>
+			All the old parameter such as db_url, table and duplicate_uri
+			will form the trace id with the name "default".
 		</para>
 		<para>
 		<emphasis>
-			Default value is "sip_trace".
+			No default value. If not set the module will be useless.
 		</emphasis>
 		</para>
 		<example>
-		<title>Set <varname>sip_trace</varname> parameter</title>
+		<title>Set <varname>trace_id</varname> parameter</title>
 		<programlisting format="linespecific">
 ...
-modparam("siptrace", "table", "strace")
+/*DB trace id*/
+modparam("siptrace", "trace_id",
+"[tid]
+uri=mysql://xxxx:xxxx@10.10.10.10/opensips;
+table=new_sip_trace;")
+/*hep trace id*/
+modparam("siptrace", "trace_id",
+"[tid]uri=hep:10.10.10.10:6161;")
+/*sip trace id*/
+modparam("siptrace", "trace_id",
+"[tid]uri=sip:10.10.10.11:5060;")
+/* notice that they all have the same name
+ * meaning that calling sip_trace("tid",...)
+ * will do sql, sip and hep tracing */
+
 ...
 </programlisting>
 		</example>
 	</section>
+
 	</section>
 
 	<section>
 	<title>Exported Functions</title>
 	<section>
 		<title>
-		<function moreinfo="none">sip_trace()</function>
+		<function moreinfo="none">sip_trace(trace_id, [type, [trace_attrs]])</function>
 		</title>
 		<para>
-		Store current processed SIP message in database. It is stored in the
-		form prior applying chages made to it.
+			Store or replocate current processed SIP message,transaction or dialogin database.
+			It is stored in the form prior applying chages made to it. The traced_user_avp
+			parameter is now an argument to sip_trace() function. Since version 2.2, sip_trace()
+			also catches internally generated replies in stateless mode(sl_send_reply(...)).
 		</para>
 		<para>
 		This function can be used from REQUEST_ROUTE, FAILURE_ROUTE, ONREPLY_ROUTE, BRANCH_ROUTE.
 		</para>
+		<para>Meaning of the parameters is as follows:</para>
+		<itemizedlist>
+		<listitem>
+			<para><emphasis>trace_id (string, pvar)</emphasis>
+			the name of the <emphasis>trace_id</emphasis> specifying where to do
+			the tracing.
+			</para>
+		</listitem>
+		<listitem>
+			<para><emphasis>type (string)</emphasis> what do you want to trace:
+		dialog, transaction or only the message. If not specified, will try
+		the topmost trace that can be done: if dialog module loaded will trace
+		dialogs, else if tm module loaded will trace transaction and if none
+		of these loaded will trace messages.</para>
+			<para>Types can be the following:</para>
+			<itemizedlist>
+			<listitem>
+				<para><emphasis>'m'/'M'</emphasis> trace messages. Is the only
+				one you should use in stateless mode.</para>
+			</listitem>
+			<listitem>
+				<para><emphasis>'t'/'T'</emphasis> trace transactions. If tm
+					module not loaded, it will be in stateless transaction aware
+					mode meaning that will catch selected requests both in and out
+				and internally generated replies.</para>
+			</listitem>
+			<listitem>
+				<para><emphasis>'d'/'D'</emphasis> trace dialog</para>
+			</listitem>
+			</itemizedlist>
+		</listitem>
+		<listitem>
+			<para><emphasis>trace_attrs (string,pvar)</emphasis> this parameter
+			replaces the traced_user_avp from the old version. To avoid duplicating
+			an entry only for this parameter, whatever you put here(string/pvar)
+			shall be stored in the trace_attrs column in the sip_trace table.
+			</para>
+		</listitem>
+
+		</itemizedlist>
 		<example>
 		<title><function>sip_trace()</function> usage</title>
 		<programlisting format="linespecific">
 ...
-sip_trace();
+/* see declaration of tid in trace_id section */
+	$var(trace_id) = "tid";
+	$var(user) = "osip_user@opensips.org";
+
 ...
+/* Example 1: how to trace a dialog  */
+	if (has_totag()) {
+		match_dialog();
+	} else {
+		if (is_method("INVITE") {
+			sip_trace("$var(trace_id)", "d", "$var(user)");
+		}
+	}
+...
+/* Example 2: how to trace initial INVITE and BYE */
+	if (has_totag()) {
+		if (is_method("BYE")) {
+			sip_trace("$var(trace_id)", "m", "$var(user)")
+		}
+	} else {
+		if (is_method("INVITE")) {
+			sip_trace("$var(trace_id)", "m", "$var(user)")
+		}
+	}
+
+...
+/* Example 3: trace initial INVITE transaction */
+	if (!has_totag()) {
+		if (is_method("INVITE")) {
+			sip_trace("$var(trace_id)", "t", "$var(user)");
+		}
+	}
+...
+/* Example 4: stateless transaction aware mode!*/
+/* tm module must not be loaded */
+	if (is_method("REGISTER")) {
+		sip_trace("$var(trace_id)", "t", "$var(user)");
+		if (!www_authorize("", "subscriber")) {
+			/* siptrace will also catch the 401 generated by www_challenge() */
+			www_challenge("", "1");
+		}
+	}
+
+
+
 </programlisting>
 		</example>
 	</section>
-	<section>
-		<title>
-		<function moreinfo="none">trace_dialog()</function>
-		</title>
-		<para>
-		The function triggers the tracing of all messages belonging to a
-		dialog. The function must be called for the initial request (that
-		starts the dialog) and it will automatically take care of tracing
-		evertyhing related to that dialog.
-		</para>
-		<para>
-		When using this function, you do not have to explicity set any tracing
-		flag or to explicitly call anothe trace function.
-		</para>
-		<para>
-		This function can be used from REQUEST_ROUTE.
-		</para>
-		<example>
-		<title><function>trace_dialog()</function> usage</title>
-		<programlisting format="linespecific">
-...
-if(is_method("INVITE") &amp;&amp; !has_totag())
-	trace_dialog();
-...
-</programlisting>
-		</example>
-	</section>
-	<section>
-                <title><varname>trace_to_database</varname> (integer)</title>
-                <para>
-                Parameter to enable/disable inserts to the Database from this
-                OpenSIPS.
-                </para>
-                <para>
-                In case we only want to send the SIP-Messages to the
-                duplicate_uri and not store the information to the local
-                database we can set this to "0".
-                </para>
-                <para>
-                <emphasis>
-                        Default value is "1".
-                </emphasis>
-                </para>
-                <example>
-                <title>Set <varname>trace_to_database</varname>parameter</title>
-                <programlisting format="linespecific">
-...
-modparam("siptrace", "trace_to_database", 0)
-...
-</programlisting>
-                </example>
-        </section>
-
-	<section>
-                <title><varname>duplicate_with_hep</varname> (integer)</title>
-                <para>
-                Parameter to enable/disable homer encapsulate mode
-                (on(1)/off(0))
-                </para>
-                <para>
-                <emphasis>
-                        Default value is "0".
-                </emphasis>
-                </para>
-                <example>
-                <title>Set <varname>duplicate_with_hep</varname> parameter</title>
-                <programlisting format="linespecific">
-...
-modparam("siptrace", "duplicate_with_hep", 1)
-...
-</programlisting>
-                </example>
-        </section>
 	</section>
 
-    <section>
+   <section>
 	<title>Exported MI Functions</title>
 	<section>
 		<title>
@@ -401,16 +327,30 @@ modparam("siptrace", "duplicate_with_hep", 1)
 		</para>
 		<para>Parameters: </para>
 		<itemizedlist>
-			<listitem><para>trace_mode : turns on/off SIP message tracing.
+			<listitem><para>trace_id/trace_mode : if it is a trace_id name
+			it dumps info about that trace id if the second parameter is
+			not set to on/off or it turns tracing on/off for a certain
+			trace id if it is set, else if it's on/off
+			it turns on/off tracing for all the trace ids. If you turn
+			global trace on but some of the trace ids had trace to off,
+			then they shall not do tracing. In order to do that you
+			have to set the trace_on parameter for each trace_id.
 			Possible values are:</para>
 			<itemizedlist>
 				<listitem><para> on </para></listitem>
 				<listitem><para> off </para></listitem>
+				<listitem><para> trace_id name </para></listitem>
 			</itemizedlist>
 			<para>The parameter is optional - if missing, the command will
 			return the status of the SIP message tracing (as string
-			<quote>on</quote> or <quote>off</quote> ) without changing
-			anything.</para>
+			<quote>on</quote> or <quote>off</quote>) marked with
+			<emphasis>global</emphasis> and the status for each trace id
+			without changing anything.</para>
+			</listitem>
+			<listitem><para>trace_mode : this parameter has the same
+			meaning as the trace_mode in the first parameter, but this time
+			it enables/disables tracing for a certain trace id given in the
+			first parameter.</para>
 			</listitem>
 		</itemizedlist>
 
@@ -419,46 +359,11 @@ modparam("siptrace", "duplicate_with_hep", 1)
 		</para>
 		<programlisting  format="linespecific">
 		:sip_trace:_reply_fifo_file_
+		trace_id/trace_mode
 		trace_mode
 		_empty_line_
 		</programlisting>
 	</section>
-	<section>
-		<title>
-		<function moreinfo="none">trace_to_database</function>
-		</title>
-		<para>
-
-		</para>
-		<para>
-		Name: <emphasis>trace_to_database</emphasis>
-		</para>
-		<para>Parameters: </para>
-		<itemizedlist>
-			<listitem><para>trace_to_db_mode : turns on/off SIP message tracing into DB.
-			Possible values are:</para>
-			<itemizedlist>
-				<listitem><para> on </para></listitem>
-				<listitem><para> off </para></listitem>
-			</itemizedlist>
-			<para>The parameter is optional - if missing, the command will
-			return the status of the SIP message tracing (as string
-			<quote>on</quote> or <quote>off</quote> ) without changing
-			anything. The parameter can be switched from off to on,
-			if db connection was before inizialized</para>
-			</listitem>
-		</itemizedlist>
-
-		<para>
-		MI FIFO Command Format:
-		</para>
-		<programlisting  format="linespecific">
-		:trace_to_database:_reply_fifo_file_
-		trace_to_db_mode
-		_empty_line_
-		</programlisting>
-	</section>
-
 
 	</section>
 
@@ -477,11 +382,14 @@ modparam("siptrace", "duplicate_with_hep", 1)
 	</section>
 
 	<section>
-	<title>Known issues</title>
-	<para>
-	Stateless forwarded messages (forward()) are not logged if you set the
-	flag, use sip_trace().
-	</para>
+		<title>Known issues</title>
+		<para>
+			ACKs related to a transaction that are leaving &osips; are not
+			traced since they are handled statelessly using forward_request function.
+			Fixing it would mean to register a fwdcb callback that would be called
+			for all the messages but would be used only by ACKs, which would be
+			highly ineffective.
+		</para>
 	</section>
 
 </chapter>

--- a/modules/siptrace/siptrace.c
+++ b/modules/siptrace/siptrace.c
@@ -45,17 +45,8 @@
 #include "../dialog/dlg_load.h"
 #include "../proto_hep/hep.h"
 #include "../proto_hep/hep_cb.h"
-
-#define NR_KEYS 14
-#define SIPTRACE_TABLE_VERSION 4
-
-/* trace is completly disabled */
-#define trace_is_off() \
-	(trace_on_flag==NULL || *trace_on_flag==0)
-
-/* flag-based tracing ise set */
-#define flag_trace_is_set(_msg) \
-	(((_msg)->flags&trace_flag)!=0)
+#include "../../mod_fix.h"
+#include "siptrace.h"
 
 
 /* DB structures used for all queries */
@@ -63,7 +54,8 @@ db_key_t db_keys[NR_KEYS];
 db_val_t db_vals[NR_KEYS];
 
 static db_ps_t siptrace_ps = NULL;
-static query_list_t *ins_list = NULL;
+//static query_list_t *ins_list = NULL;
+
 
 struct tm_binds tmb;
 struct dlg_binds dlgb;
@@ -76,43 +68,10 @@ static int mod_init(void);
 static int child_init(int rank);
 static void destroy(void);
 
-static int fixup_trace_dialog(void** param, int param_no);
-
-static int sip_trace(struct sip_msg*);
-static int sip_trace_w(struct sip_msg*);
-static int trace_dialog(struct sip_msg*);
-
-static int trace_send_duplicate(char *buf, int len);
-
-static void trace_onreq_in(struct cell* t, int type, struct tmcb_params *ps);
-static void trace_onreq_out(struct cell* t, int type, struct tmcb_params *ps);
-static void trace_onreply_in(struct cell* t, int type, struct tmcb_params *ps);
-static void trace_onreply_out(struct cell* t, int type, struct tmcb_params *ps);
-static void trace_sl_onreply_out(struct sip_msg* req, str *buffer,int rpl_code,
-		union sockaddr_union *dst, struct socket_info *sock, int proto);
-static void trace_sl_ack_in(struct sip_msg* req, str *buffer,int rpl_code,
-		union sockaddr_union *dst, struct socket_info *sock, int proto);
-static void trace_msg_out_w(struct sip_msg* req, str *buffer,int rpl_code,
-		union sockaddr_union *dst, struct socket_info *sock, int proto);
-
-static void trace_msg_out(struct sip_msg* msg, str  *sbuf,
-		struct socket_info* send_sock, int proto, union sockaddr_union *to);
-
-static struct mi_root* sip_trace_mi(struct mi_root* cmd, void* param );
-static struct mi_root* trace_to_database_mi(struct mi_root* cmd, void* param );
-
-static int trace_send_hep_duplicate(str *body, str *fromproto, str *fromip,
-		unsigned short fromport, str *toproto, str *toip, unsigned short toport);
-static int pipport2su (str *sproto, str *ip, unsigned short port,
-			union sockaddr_union *tmp_su, unsigned int *proto);
-
-static void siptrace_dlg_cancel(struct cell* t, int type, struct tmcb_params *param);
-
-static str db_url             = {NULL, 0};
 static str siptrace_table     = str_init("sip_trace");
 static str date_column        = str_init("time_stamp");  /* 00 */
 static str callid_column      = str_init("callid");      /* 01 */
-static str traced_user_column = str_init("traced_user"); /* 02 */
+static str trace_attrs_column = str_init("trace_attrs"); /* 02 */
 static str msg_column         = str_init("msg");         /* 03 */
 static str method_column      = str_init("method");      /* 04 */
 static str status_column      = str_init("status");      /* 05 */
@@ -125,47 +84,28 @@ static str toport_column      = str_init("to_port");     /* 11 */
 static str fromtag_column     = str_init("fromtag");     /* 12 */
 static str direction_column   = str_init("direction");   /* 13 */
 
-static str st_flag_val = str_init("_st_XX_flag_43");
-
-static char *trace_flag_str = 0;
-int trace_flag = -1;
-int trace_on   = 0;
-int trace_to_database = 1;
-int duplicate_with_hep = 0;
-
-str    dup_uri_str      = {0, 0};
-struct sip_uri *dup_uri = 0;
+int trace_on   = 1;
+static int callbacks_registered=0;
 
 int *trace_on_flag = NULL;
-int *trace_to_database_flag = NULL;
-
-static unsigned short traced_user_avp_type = 0;
-static int traced_user_avp;
-static str traced_user_avp_str = {NULL, 0};
-
-static unsigned short trace_table_avp_type = 0;
-static int trace_table_avp;
-static str trace_table_avp_str = {NULL, 0};
 
 static str trace_local_proto = {NULL, 0};
 static str trace_local_ip = {NULL, 0};
 static unsigned short trace_local_port = 0;
+static int sl_ctx_idx=-1;
 
-static unsigned int enable_ack_trace = 0;
-
-/** database connection */
-db_con_t *db_con = NULL;
-db_func_t db_funcs;      /* Database functions */
-
+tlist_elem_p trace_list=NULL;
 
 /*
  * Exported functions
  */
 static cmd_export_t cmds[] = {
-	{"sip_trace", (cmd_function)sip_trace_w, 0, 0, 0,
+	{"sip_trace", (cmd_function)sip_trace_w, 1, sip_trace_fixup, 0,
 		REQUEST_ROUTE|FAILURE_ROUTE|ONREPLY_ROUTE|BRANCH_ROUTE|LOCAL_ROUTE},
-	{"trace_dialog", (cmd_function)trace_dialog, 0, fixup_trace_dialog, 0,
-		REQUEST_ROUTE},
+	{"sip_trace", (cmd_function)sip_trace_w, 2, sip_trace_fixup, 0,
+		REQUEST_ROUTE|FAILURE_ROUTE|ONREPLY_ROUTE|BRANCH_ROUTE|LOCAL_ROUTE},
+	{"sip_trace", (cmd_function)sip_trace_w, 3, sip_trace_fixup, 0,
+		REQUEST_ROUTE|FAILURE_ROUTE|ONREPLY_ROUTE|BRANCH_ROUTE|LOCAL_ROUTE},
 	{0, 0, 0, 0, 0, 0}
 };
 
@@ -174,11 +114,10 @@ static cmd_export_t cmds[] = {
  * Exported parameters
  */
 static param_export_t params[] = {
-	{"db_url",             STR_PARAM, &db_url.s             },
-	{"table",              STR_PARAM, &siptrace_table.s     },
+	{"trace_id",           STR_PARAM|USE_FUNC_PARAM, parse_trace_id},
 	{"date_column",        STR_PARAM, &date_column.s        },
 	{"callid_column",      STR_PARAM, &callid_column.s      },
-	{"traced_user_column", STR_PARAM, &traced_user_column.s },
+	{"trace_attrs_column", STR_PARAM,&trace_attrs_column.s},
 	{"msg_column",         STR_PARAM, &msg_column.s         },
 	{"method_column",      STR_PARAM, &method_column.s      },
 	{"status_column",      STR_PARAM, &status_column.s      },
@@ -190,22 +129,13 @@ static param_export_t params[] = {
 	{"toport_column",      STR_PARAM, &toport_column.s      },
 	{"fromtag_column",     STR_PARAM, &fromtag_column.s     },
 	{"direction_column",   STR_PARAM, &direction_column.s   },
-	{"trace_flag",         STR_PARAM, &trace_flag_str       },
-	{"trace_flag",         INT_PARAM, &trace_flag           },
 	{"trace_on",           INT_PARAM, &trace_on             },
-	{"traced_user_avp",    STR_PARAM, &traced_user_avp_str.s},
-	{"trace_table_avp",    STR_PARAM, &trace_table_avp_str.s},
-	{"duplicate_uri",      STR_PARAM, &dup_uri_str.s        },
 	{"trace_local_ip",     STR_PARAM, &trace_local_ip.s     },
-	{"enable_ack_trace",   INT_PARAM, &enable_ack_trace     },
-	{"trace_to_database",  INT_PARAM, &trace_to_database 	},
-	{"duplicate_with_hep", INT_PARAM, &duplicate_with_hep   },
 	{0, 0, 0}
 };
 
 static mi_export_t mi_cmds[] = {
 	{ "sip_trace", 0, sip_trace_mi,   0,  0,  0 },
-	{ "trace_to_database", 0, trace_to_database_mi,   0,  0,  0 },
 	{ 0, 0, 0, 0, 0, 0}
 };
 
@@ -225,24 +155,24 @@ static stat_export_t siptrace_stats[] = {
 
 static module_dependency_t *get_deps_hep(param_export_t *param)
 {
-	int hep_on = *(int *)param->param_pointer;
+	tlist_elem_p it;
 
-	if (hep_on == 0)
-		return NULL;
+	for (it=trace_list;it;it=it->next)
+		if (it->type==TYPE_HEP)
+			return alloc_module_dep(MOD_TYPE_DEFAULT, "proto_hep", DEP_ABORT);
+		else if (it->type==TYPE_DB)
+			return alloc_module_dep(MOD_TYPE_SQLDB, NULL, DEP_ABORT);
 
-	return alloc_module_dep(MOD_TYPE_DEFAULT, "proto_hep", DEP_ABORT);
+	return NULL;
 }
 
 
 static dep_export_t deps = {
 	{ /* OpenSIPS module dependencies */
-		{ MOD_TYPE_DEFAULT, "tm", DEP_ABORT },
-		{ MOD_TYPE_DEFAULT, "sl", DEP_ABORT },
-		{ MOD_TYPE_SQLDB, NULL,   DEP_ABORT },
 		{ MOD_TYPE_NULL, NULL, 0 },
 	},
 	{ /* modparam dependencies */
-		{"duplicate_with_hep", get_deps_hep},
+		{"trace_id", get_deps_hep},
 		{ NULL, NULL },
 	},
 };
@@ -272,17 +202,360 @@ struct module_exports exports = {
 };
 
 
-static int fixup_trace_dialog(void** param, int param_no)
+static int
+get_db_struct(str *url, str *tb_name, st_db_struct_t **st_db)
 {
-	/* register callback to dialog */
-	if (load_dlg_api(&dlgb)!=0) {
-		LM_ERR("can't load dialog api\n");
+	st_db_struct_t *dbs;
+	dbs = pkg_malloc(sizeof(st_db_struct_t));
+
+	if (st_db == NULL) {
+		LM_ERR("invalid output parameter!\n");
+		return -1;
+	}
+
+	if (url == NULL || url->s == NULL || url->len == 0) {
+		LM_ERR("invalid URL!\n");
+		return -1;
+	}
+
+	/* if not set populated with 'siptrace_table' in parse_siptrace_id() */
+	dbs->table = *tb_name;
+
+	if (db_bind_mod(url, &dbs->funcs)) {
+		LM_ERR("unable to bind database module\n");
+		return -1;
+	}
+
+	if (!DB_CAPABILITY(dbs->funcs, DB_CAP_INSERT)) {
+		LM_ERR("database modules does not provide all functions needed by module\n");
+		return -1;
+	}
+
+	if ((dbs->con=dbs->funcs.init(url)) == 0) {
+		LM_CRIT("Cannot connect to DB\n");
+		return -1;
+	}
+
+	if (db_check_table_version(&dbs->funcs, dbs->con,
+						&dbs->table, SIPTRACE_TABLE_VERSION) < 0) {
+		LM_ERR("error during table version check.\n");
+		return -1;
+	}
+
+	dbs->url = *url;
+	dbs->funcs.close(dbs->con);
+	dbs->con = 0;
+
+	*st_db = dbs;
+
+	return 0;
+
+}
+
+static int
+parse_siptrace_uri(const str *token, str *uri, str *table/* only for dbs */)
+{
+	enum states {ST_TOK_NAME, ST_TOK_VALUE, ST_TOK_END};
+	enum states state = ST_TOK_NAME;
+
+	unsigned int p;
+	unsigned int last_equal=0;
+
+	int _word_start=-1, _word_end=-1;
+
+	#define HAVE_URI   (1<<0)
+	#define HAVE_TABLE (1<<1)
+	#define HAVE_AVP   (1<<2)
+	#define HAVE_USER_AVP (1<<3)
+
+	unsigned char found_bitmask=0;
+
+
+	str uri_str={"uri", sizeof("uri")-1};
+	str tb_name_str={"table", sizeof("table")-1};
+
+	str name={NULL, 0}, value={NULL, 0};
+
+	if (!token) {
+		LM_ERR("bad input parameter!\n");
+		return -1;
+	}
+
+	if (!uri || !table) {
+		LM_ERR("bad output parameter!\n");
+		return -1;
+	}
+
+	for (p=0; p<token->len; p++) {
+		switch (token->s[p]){
+		case '=':
+			_word_end = _word_end == -1 ? p : _word_end;
+
+			if (state==ST_TOK_VALUE) {
+				LM_ERR("bad value declaration!parsed until <%.*s>!\n",
+						token->len-p, token->s+p);
+				return -1;
+			}
+
+			name.s = token->s + _word_start;
+			name.len = _word_end - _word_start;
+			last_equal = p;
+
+			state=ST_TOK_VALUE;
+			_word_start=_word_end=-1;
+			break;
+		case ';':
+			if (state==ST_TOK_NAME || last_equal == 0) {
+				LM_ERR("bad name declaration!parsed until <%.*s>!\n",
+						token->len-p, token->s+p);
+				return -1;
+			}
+
+			_word_end = _word_end == -1 ? p : _word_end;
+			value.s = token->s + _word_start;;
+			value.len = _word_end - _word_start;
+
+			/* most probably will be found first; will do strcmp only once */
+			if (!(found_bitmask&HAVE_URI) && !str_strcasecmp(&uri_str, &name)) {
+				found_bitmask |= HAVE_URI;
+				*uri = value;
+			}
+
+			if (!(found_bitmask&HAVE_TABLE)
+					&& !str_strcasecmp(&tb_name_str, &name)) {
+				found_bitmask |= HAVE_TABLE;
+				*table = value;
+			}
+
+			state=ST_TOK_END;
+			_word_start=_word_end=-1;
+
+			break;
+		case '\n':
+		case '\r':
+		case '\t':
+		case ' ':
+			if (_word_start > 0) {
+				LM_ERR("invalid definition! parsed until <%.*s>\n",
+						token->len-p, &token->s[p]);
+				return -1;
+			}
+		case '(':
+		case ')':
+		case '/':
+		case ':':
+		case '@':
+		case '.':
+		case '_':
+			break;
+		default:
+			if (_word_start==-1 && (isalpha(token->s[p])||token->s[p]=='$')) {
+				_word_start = p;
+			} else if (_word_start==-1 && isdigit(token->s[p])) {
+				LM_ERR("trace id can't start with digit!\n");
+				return -1;
+			}
+
+			if (_word_end == -1 && !isalnum(token->s[p]))
+				_word_end = p;
+
+			if (state==ST_TOK_END)
+				state = ST_TOK_NAME;
+			break;
+		}
+	}
+
+	if (state != ST_TOK_END)
+		return -1;
+
+	if (!(found_bitmask&HAVE_URI)) {
+		LM_ERR("URL is MANDATORY!\n");
 		return -1;
 	}
 
 	return 0;
 }
 
+static int parse_siptrace_id(str *suri)
+{
+	#define LIST_SEARCH(__start, __type, __hash)                        \
+		do {                                                            \
+			tlist_elem_p __el;                                          \
+			for (__el=__start; __el; __el=__el->next) {                 \
+				if (__el->type==__type  &&__el->hash==__hash)           \
+					return 0;                                           \
+			}                                                           \
+		} while (0);
+
+	#define ALLOC_EL(__list_el, __lel_size)                             \
+		do {                                                            \
+			__list_el = pkg_malloc(__lel_size);                         \
+			if (__list_el == NULL) {                                    \
+				LM_ERR("no more pkg memmory!\n");                       \
+				return -1;                                              \
+			}                                                           \
+			memset(__list_el, 0, __lel_size);                           \
+		} while (0);
+
+	#define ADD2LIST(__list__, __list_type__,  __el__)                  \
+		do {                                                            \
+			if (__list__ == NULL) {                                     \
+				__list__ = __el__;                                      \
+				break;                                                  \
+			}                                                           \
+			__list_type__ __it = __list__;                              \
+			while (__it->next) __it = __it->next;                       \
+			__it->next = __el__;                                        \
+		} while(0);
+
+	#define PARSE_NAME(__uri, __name)                                   \
+		do {                                                            \
+			while (__uri->s[0]==' ')                                    \
+				(__uri->s++, __uri->len--);                             \
+			__name.s = __uri->s;                                        \
+			while (__uri->len                                           \
+					&& (__uri->s[0] != ']' && __uri->s[0] != ' '))      \
+				(__uri->s++, __uri->len--, __name.len++);               \
+                                                                        \
+			if (*(__uri->s-1) != ']')                                   \
+				while (__uri->len && __uri->s[0] != ']')                \
+					(__uri->s++, __uri->len--);                         \
+			                                                            \
+			if (!__uri->len || __uri->s[0] != ']') {                    \
+				LM_ERR("bad name [%.*s]!\n", __uri->len, __uri->s);     \
+				return -1;                                              \
+			}                                                           \
+			(__uri->s++, __uri->len--);                                 \
+		} while(0);
+
+	#define IS_HEP_URI(__url__) ((__url__.len > 3/*O_o*/ \
+				&& (__url__.s[0]|0x20) == 'h' && (__url__.s[1]|0x20) == 'e' \
+					&& (__url__.s[2]|0x20) == 'p'))
+
+	#define IS_SIP_URI(__url__) ((__url__.len > 3/*O_o*/ \
+				&& (__url__.s[0]|0x20) == 's' && (__url__.s[1]|0x20) == 'i' \
+					&& (__url__.s[2]|0x20) == 'p'))
+
+
+
+	unsigned int hash, url_table_hash;
+
+	char *new_url;
+
+	str name={NULL, 0};
+	str trace_uri, db_table={NULL, 0};
+	tlist_elem_p    elem;
+	enum types uri_type;
+
+
+	if (suri == NULL) {
+		LM_ERR("bad input parameters!\n");
+		return  -1;
+	}
+
+	/*format: [<proto>]uri; it should never have
+	 * less than 5 */
+	if (suri->len < 5) {
+		LM_ERR("suri too short!\n");
+		return -1;
+	}
+
+	/* we consider the str trimmed before the function */
+	if (suri->s[0] != '[') {
+		LM_ERR("bad format for uri {%.*s}\n", suri->len, suri->s);
+		return -1;
+	} else {
+		(suri->s++, suri->len--);                                 \
+	}
+
+	PARSE_NAME(suri, name); /*parse '[<name>]'*/
+
+	if (parse_siptrace_uri(suri, &trace_uri, &db_table) < 0) {
+		LM_ERR("invalid uri <%.*s>\n", suri->len, suri->s);
+		return -1;
+	}
+
+	hash = core_hash(&name, &trace_uri, 0);
+
+	 if (IS_HEP_URI(trace_uri)) {
+		uri_type = TYPE_HEP;
+	} else if (IS_SIP_URI(trace_uri)) {
+		uri_type = TYPE_SIP;
+	} else {
+		/* need to take the table into account */
+		if (db_table.s == NULL || db_table.len == 0)
+			db_table = siptrace_table;
+
+		url_table_hash = core_hash(&trace_uri, &db_table, 0);
+		hash ^= (url_table_hash>>3);
+		uri_type = TYPE_DB;
+	}
+
+	LIST_SEARCH(trace_list, uri_type, hash);
+
+	if (uri_type == TYPE_HEP) {
+		new_url = pkg_malloc(trace_uri.len);
+		if (new_url == NULL) {
+			LM_ERR("no more pkg mem!\n");
+			return -1;
+		}
+		memcpy(new_url, "sip", 3);
+		memcpy(new_url+3, trace_uri.s+3, trace_uri.len-3);
+		trace_uri.s = new_url;
+	}
+
+	ALLOC_EL(elem, sizeof(tlist_elem_t));
+
+	elem->type = uri_type;
+	elem->hash = hash;
+	elem->name = name;
+
+	/* did memset in ALLOC_EL but just to be sure */
+	elem->next = NULL;
+
+	if (uri_type == TYPE_DB) {
+		if (get_db_struct(&trace_uri, &db_table, &elem->el.db) < 0) {
+			LM_ERR("Invalid parameters extracted!url <%.*s>! table name <%.*s>!\n",
+					trace_uri.len, trace_uri.s, db_table.len, db_table.s);
+			return -1;
+		}
+	} else {
+		if (parse_uri(trace_uri.s, trace_uri.len, &elem->el.uri) < 0) {
+			LM_ERR("failed to parse the URI!\n");
+			return -1;
+		}
+	}
+
+	ADD2LIST(trace_list, tlist_elem_p, elem);
+
+	return 0;
+
+	#undef LIST_SEARCH
+	#undef ALLOC_EL
+	#undef ADD2LIST
+	#undef PARSE_NAME
+	#undef IS_HEP_URI
+	#undef IS_SIP_URI
+}
+
+
+int parse_trace_id(unsigned int type, void *val)
+{
+	str suri;
+
+	suri.s   = (char*)val;
+	suri.len = strlen(suri.s);
+
+	str_trim_spaces_lr(suri);
+
+	if (parse_siptrace_id(&suri) < 0) {
+		LM_ERR("failed to parse siptrace uri [%.*s]\n", suri.len, suri.s);
+		return -1;
+	}
+
+	return 0;
+
+}
 
 static int parse_trace_local_ip(void){
 	/* We tokenize the trace_local_ip from proto:ip:port to three fields */
@@ -367,16 +640,77 @@ static int parse_trace_local_ip(void){
 	return 0;
 }
 
+/*
+ * no fancy stuff just bubble sort; the list will be quite small
+ */
+static void do_sort(tlist_elem_p *list_p)
+{
+	int done=1;
+	tlist_elem_p it, prev, tmp;
+
+	/* 0 or 1 elems already sorted */
+	if (*list_p==NULL || (*list_p)->next==NULL)
+		return;
+
+	do {
+		done=1;
+		prev=NULL;
+		it=*list_p;
+		do {
+			if (it->hash > it->next->hash) {
+				/* need to modify start of the list */
+				if (!prev) {
+					tmp=it->next;
+					it->next=tmp->next;
+					tmp->next=it;
+					*list_p=tmp;
+				} else {
+					tmp=it->next;
+					prev->next=tmp;
+					it->next=tmp->next;
+					tmp->next=it;
+				}
+				done=0;
+			}
+			prev=it;
+			it=it->next;
+		} while (it && it->next);
+	} while (!done);
+}
+
+static void init_db_cols(void)
+{
+	#define COL_INIT(_col, _index, _type)                  \
+		do {                                               \
+			db_keys[_index] = &_col##_column;              \
+			db_vals[_index].type = DB_##_type;             \
+			db_vals[_index].nul  = 0;                      \
+		} while(0);
+
+
+	COL_INIT(msg, 0, BLOB);
+	COL_INIT(callid, 1, STR);
+	COL_INIT(method, 2, STR);
+	COL_INIT(status, 3, STR);
+	COL_INIT(fromproto, 4, STR);
+	COL_INIT(fromip, 5, STR);
+	COL_INIT(fromport, 6, INT);
+	COL_INIT(toproto, 7, STR);
+	COL_INIT(toip, 8, STR);
+	COL_INIT(toport, 9, INT);
+	COL_INIT(date, 10, DATETIME);
+	COL_INIT(direction, 11, STRING);
+	COL_INIT(fromtag, 12, STR);
+	COL_INIT(trace_attrs, 13, STR);
+}
+
 static int mod_init(void)
 {
-	pv_spec_t avp_spec;
-	int i;
+	tlist_elem_p it;
 
-	init_db_url( db_url , 0 /*cannot be null*/);
-	siptrace_table.len = strlen(siptrace_table.s);
 	date_column.len = strlen(date_column.s);
 	callid_column.len = strlen(callid_column.s);
-	traced_user_column.len = strlen(traced_user_column.s);
+	trace_attrs_column.len = strlen(trace_attrs_column.s);
 	msg_column.len = strlen(msg_column.s);
 	method_column.len = strlen(method_column.s);
 	status_column.len = strlen(status_column.s);
@@ -388,60 +722,11 @@ static int mod_init(void)
 	toport_column.len = strlen(toport_column.s);
 	fromtag_column.len = strlen(fromtag_column.s);
 	direction_column.len = strlen(direction_column.s);
-	if (traced_user_avp_str.s)
-		traced_user_avp_str.len = strlen(traced_user_avp_str.s);
-	if (trace_table_avp_str.s)
-		trace_table_avp_str.len = strlen(trace_table_avp_str.s);
-	if (dup_uri_str.s)
-		dup_uri_str.len = strlen(dup_uri_str.s);
 
 	if (trace_local_ip.s)
 		parse_trace_local_ip();
 
 	LM_INFO("initializing...\n");
-
-	fix_flag_name(trace_flag_str, trace_flag);
-
-	trace_flag = get_flag_id_by_name(FLAG_TYPE_MSG, trace_flag_str);
-
-	if (flag_idx2mask(&trace_flag)<0)
-		return -1;
-
-	trace_to_database_flag = (int*)shm_malloc(sizeof(int));
-        if(trace_to_database_flag==NULL) {
-                LM_ERR("no more shm memory left\n");
-                return -1;
-        }
-
-	*trace_to_database_flag = trace_to_database;
-
-	if(trace_to_database_flag!=NULL && *trace_to_database_flag!=0) {
-		/* Find a database module */
-		if (db_bind_mod(&db_url, &db_funcs))
-		{
-			LM_ERR("unable to bind database module\n");
-			return -1;
-		}
-		if (trace_to_database_flag && !DB_CAPABILITY(db_funcs, DB_CAP_INSERT))
-		{
-			LM_ERR("database modules does not provide all functions needed by module\n");
-			return -1;
-		}
-
-		if ((db_con = db_funcs.init(&db_url)) == 0) {
-			LM_CRIT("Cannot connect to DB\n");
-			return -1;
-		}
-
-		if(db_check_table_version(&db_funcs, db_con,
-				&siptrace_table, SIPTRACE_TABLE_VERSION) < 0) {
-			LM_ERR("error during table version check.\n");
-			return -1;
-		}
-
-		db_funcs.close(db_con);
-		db_con = 0;
-	}
 
 	trace_on_flag = (int*)shm_malloc(sizeof(int));
 	if(trace_on_flag==NULL)
@@ -452,94 +737,12 @@ static int mod_init(void)
 
 	*trace_on_flag = trace_on;
 
+	/* initialize hep api */
+	for (it=trace_list;it;it=it->next) {
+		if (it->type!=TYPE_HEP)
+			continue;
 
-
-	/* register callbacks to TM */
-	if (load_tm_api(&tmb)!=0)
-	{
-		LM_ERR("can't load tm api\n");
-		return -1;
-	}
-
-	if(tmb.register_tmcb( 0, 0, TMCB_REQUEST_IN, trace_onreq_in, 0, 0) <=0)
-	{
-		LM_ERR("can't register trace_onreq_in\n");
-		return -1;
-	}
-
-	/* register sl callback */
-	if(register_slcb( SLCB_REPLY_OUT, 0, trace_sl_onreply_out)!=0)
-	{
-		LM_ERR("can't register callback for stateless generated replies\n");
-		return -1;
-	}
-	if(register_slcb( SLCB_REQUEST_OUT, 0, trace_msg_out_w)!=0)
-	{
-		LM_ERR("can't register callback for stateless request forwarding\n");
-		return -1;
-	}
-	if(enable_ack_trace&&register_slcb( SLCB_ACK_IN, 0, trace_sl_ack_in)!=0)
-	{
-		LM_ERR("can't register callback for incoming stateless ACK\n");
-		return -1;
-	}
-
-	if(dup_uri_str.s!=0) {
-		dup_uri_str.len = strlen(dup_uri_str.s);
-		dup_uri = (struct sip_uri *)pkg_malloc(sizeof(struct sip_uri));
-		if(dup_uri==0) {
-			LM_ERR("no more pkg memory left\n");
-			return -1;
-		}
-		memset(dup_uri, 0, sizeof(struct sip_uri));
-		if(parse_uri(dup_uri_str.s, dup_uri_str.len, dup_uri)<0) {
-			LM_ERR("bad dup uri\n");
-			return -1;
-		}
-	}
-
-	if(traced_user_avp_str.s && traced_user_avp_str.len > 0)
-	{
-		if (pv_parse_spec(&traced_user_avp_str, &avp_spec)==0
-				|| avp_spec.type!=PVT_AVP) {
-			LM_ERR("malformed or non AVP %.*s AVP definition\n",
-				traced_user_avp_str.len, traced_user_avp_str.s);
-			return -1;
-		}
-
-		if(pv_get_avp_name(0, &avp_spec.pvp, &traced_user_avp,
-					&traced_user_avp_type)!=0)
-		{
-			LM_ERR("[%.*s] - invalid AVP definition\n",
-				traced_user_avp_str.len, traced_user_avp_str.s);
-			return -1;
-		}
-	} else {
-		traced_user_avp = -1;
-		traced_user_avp_type = 0;
-	}
-	if(trace_table_avp_str.s && trace_table_avp_str.len > 0)
-	{
-		if (pv_parse_spec(&trace_table_avp_str, &avp_spec)==0
-				|| avp_spec.type!=PVT_AVP) {
-			LM_ERR("malformed or non AVP %.*s AVP definition\n",
-				trace_table_avp_str.len, trace_table_avp_str.s);
-			return -1;
-		}
-
-		if(pv_get_avp_name(0, &avp_spec.pvp, &trace_table_avp,
-					&trace_table_avp_type)!=0)
-		{
-			LM_ERR("[%.*s] - invalid AVP definition\n"
-				, trace_table_avp_str.len, trace_table_avp_str.s);
-			return -1;
-		}
-	} else {
-		trace_table_avp = -1;
-		trace_table_avp_type = 0;
-	}
-
-	if (duplicate_with_hep) {
+		LM_DBG("Loading hep api!\n");
 		load_hep = (load_hep_f)find_export("load_hep", 1, 0);
 		if (!load_hep) {
 			LM_ERR("Can't bind proto hep!\n");
@@ -550,174 +753,49 @@ static int mod_init(void)
 			LM_ERR("can't bind proto hep\n");
 			return -1;
 		}
+
+		break;
 	}
 
+	/* set db_keys/vals info */
+	init_db_cols();
 
-
-	/* init the DB keys for future queries */
-	db_keys[0] = &msg_column;
-	db_keys[1] = &callid_column;
-	db_keys[2] = &method_column;
-	db_keys[3] = &status_column;
-	db_keys[4] = &fromproto_column;
-	db_keys[5] = &fromip_column;
-	db_keys[6] = &fromport_column;
-	db_keys[7] = &toproto_column;
-	db_keys[8] = &toip_column;
-	db_keys[9] = &toport_column;
-	db_keys[10] = &date_column;
-	db_keys[11] = &direction_column;
-	db_keys[12] = &fromtag_column;
-	db_keys[13] = &traced_user_column;
-
-	/* init DB values info which is constant ( type, null ) */
-	db_vals[0].type = DB_BLOB;
-	db_vals[1].type = DB_STR;
-	db_vals[2].type = DB_STR;
-	db_vals[3].type = DB_STR;
-	db_vals[4].type = DB_STR;
-	db_vals[5].type = DB_STR;
-	db_vals[6].type = DB_INT;
-	db_vals[7].type = DB_STR;
-	db_vals[8].type = DB_STR;
-	db_vals[9].type = DB_INT;
-	db_vals[10].type = DB_DATETIME;
-	db_vals[11].type = DB_STRING;
-	db_vals[12].type = DB_STR;
-	db_vals[13].type = DB_STR;
-	/* no field can be null */
-	for (i=0;i<NR_KEYS;i++)
-		db_vals[i].nul = 0;
-
-	return 0;
-}
-
-static inline int insert_siptrace_flag(struct sip_msg *msg,
-		db_key_t *keys,db_val_t *vals)
-{
-	db_vals[13].val.str_val.s   = "";
-	db_vals[13].val.str_val.len = 0;
-
-	LM_DBG("storing info 1...\n");
-	if (con_set_inslist(&db_funcs,db_con,&ins_list,keys,NR_KEYS) < 0 )
-		CON_RESET_INSLIST(db_con);
-	CON_PS_REFERENCE(db_con) = &siptrace_ps;
-	if(db_funcs.insert(db_con, keys, vals, NR_KEYS) < 0)
-	{
-			LM_ERR("error storing trace\n");
-		return -1;
-	}
-
-	return 0;
-}
-
-static inline int insert_siptrace_avp(struct usr_avp *avp,
-		int_str *first_val,db_key_t *keys,db_val_t *vals)
-{
-	int_str        avp_value;
-
-	if (avp == 0)
-		return 0;
-
-	if (!is_avp_str_val(avp)) {
-		avp_value.s.s=int2str(first_val->n,&avp_value.s.len);
-		LM_DBG("int val [%.*s]\n",avp_value.s.len,avp_value.s.s);
-	} else {
-		avp_value = *first_val;
-		LM_DBG("str val [%.*s]\n",avp_value.s.len,avp_value.s.s);
-	}
-	db_vals[13].val.str_val.s = avp_value.s.s;
-	db_vals[13].val.str_val.len = avp_value.s.len;
-
-	LM_DBG("storing info 14...\n");
-	CON_PS_REFERENCE(db_con) = &siptrace_ps;
-	if (con_set_inslist(&db_funcs,db_con,&ins_list,keys,NR_KEYS) < 0 )
-		CON_RESET_INSLIST(db_con);
-	if(db_funcs.insert(db_con, keys, vals, NR_KEYS) < 0) {
-		LM_ERR("error storing trace\n");
-		return -1;
-	}
-
-	avp = search_next_avp( avp, &avp_value);
-	while(avp!=NULL)
-	{
-		if (!is_avp_str_val(avp))
-			avp_value.s.s=int2str(avp_value.n,&avp_value.s.len);
-		db_vals[13].val.str_val.s = avp_value.s.s;
-		db_vals[13].val.str_val.len = avp_value.s.len;
-
-		LM_DBG("### - storing info 14 \n");
-		CON_PS_REFERENCE(db_con) = &siptrace_ps;
-		if (con_set_inslist(&db_funcs,db_con,&ins_list,keys,NR_KEYS) < 0 )
-			CON_RESET_INSLIST(db_con);
-		if(db_funcs.insert(db_con, keys, vals, NR_KEYS) < 0)
-		{
-			LM_ERR("error storing trace\n");
+	/* this will allow using HEP, SIP and DB that
+	 * are declared  under the same name in the same
+	 * sip_trace() call */
+	for (it=trace_list; it; it=it->next) {
+		it->hash = core_hash(&it->name, NULL, 0);
+		it->traceable=shm_malloc(sizeof(unsigned char));
+		if (it->traceable==NULL) {
+			LM_ERR("no mre shmem!\n");
 			return -1;
 		}
-		avp = search_next_avp( avp, &avp_value);
+		*it->traceable = trace_on;
+	}
+
+	/* sort the list */
+	do_sort(&trace_list);
+	if (trace_list==NULL) {
+		LM_WARN("No trace id defined! The module is useless!\n");
 	}
 
 	return 0;
 }
-
-static inline str* siptrace_get_table(void)
-{
-	static int_str         avp_value;
-	struct usr_avp *avp;
-
-	if(trace_table_avp < 0)
-		return &siptrace_table;
-
-	avp=search_first_avp(trace_table_avp_type, trace_table_avp,
-			&avp_value, 0);
-
-	if(avp==NULL || !is_avp_str_val(avp) || avp_value.s.len<=0)
-		return &siptrace_table;
-
-	return &avp_value.s;
-}
-
-static int save_siptrace(struct sip_msg *msg,struct usr_avp *avp,
-		int_str *first_val,db_key_t *keys,db_val_t *vals)
-{
-
-	if (duplicate_with_hep)
-		trace_send_hep_duplicate(&db_vals[0].val.blob_val, &db_vals[4].val.str_val,
-				&db_vals[5].val.str_val, db_vals[6].val.int_val, &db_vals[7].val.str_val,
-				&db_vals[8].val.str_val, db_vals[9].val.int_val);
-	else
-		trace_send_duplicate(db_vals[0].val.blob_val.s,
-			db_vals[0].val.blob_val.len);
-
-
-	if(trace_to_database_flag!=NULL && *trace_to_database_flag!=0) {
-		LM_DBG("saving siptrace\n");
-		db_funcs.use_table(db_con, siptrace_get_table());
-
-		if (flag_trace_is_set(msg) && insert_siptrace_flag(msg,keys,vals) < 0)
-			return -1;
-
-		if (avp==NULL)
-			return 0;
-
-		if (insert_siptrace_avp(avp,first_val,keys,vals) < 0)
-			return -1;
-	}
-
-	return 0;
-}
-
 
 static int child_init(int rank)
 {
+	tlist_elem_p it;
 
-	if(trace_to_database_flag!=NULL && *trace_to_database_flag!=0) {
-		db_con = db_funcs.init(&db_url);
-		if (!db_con)
-		{
-			LM_ERR("unable to connect database\n");
-			return -1;
+	for (it=trace_list; it; it=it->next) {
+		if (it->type == TYPE_DB) {
+			LM_DBG("Initializing trace id [%.*s]\n",
+					it->name.len, it->name.s);
+			it->el.db->con = it->el.db->funcs.init(&it->el.db->url);
+			if (!it->el.db->con) {
+				LM_ERR("Unable to connect to database with url [%.*s]\n",
+						it->el.db->url.len, it->el.db->url.s);
+				return -1;
+			}
 		}
 	}
 
@@ -727,210 +805,633 @@ static int child_init(int rank)
 
 static void destroy(void)
 {
-	if(trace_to_database_flag!=NULL && *trace_to_database_flag!=0) {
-		if (db_con!=NULL)
-			db_funcs.close(db_con);
-		if (trace_on_flag)
-			shm_free(trace_on_flag);
-	}
-}
+	tlist_elem_p el, last=NULL;
 
-
-static str* generate_val_name(unsigned char n)
-{
-	#define SIPTRACE_VAL_NAME "trace_xxx"
-	static str v_name = {NULL,0};
-
-	if (v_name.s==NULL) {
-		v_name.len = sizeof(SIPTRACE_VAL_NAME)-1;
-		v_name.s = pkg_malloc(v_name.len);
-		if (v_name.s==NULL) {
-			LM_ERR("failed to get pkg mem\n");
-			return NULL;
+	el=trace_list;
+	while (el) {
+		if (last) {
+			shm_free(last->traceable);
+			pkg_free(last);
 		}
-		memcpy(v_name.s, SIPTRACE_VAL_NAME, v_name.len);
-	}
-	v_name.s[v_name.len-2] = '0' + n/10;
-	v_name.s[v_name.len-1] = '0' + n%10;
 
-	return &v_name;
+		if (el->type == TYPE_DB) {
+			if (el->el.db->con) {
+				el->el.db->funcs.close(el->el.db->con);
+			}
+		}
+		last=el;
+		el=el->next;
+	}
+
+	if (last)
+		pkg_free(last);
+
+	if (trace_on_flag)
+		shm_free(trace_on_flag);
 }
 
 
-static void trace_transaction(struct dlg_cell* dlg, int type,
+
+static inline int insert_siptrace(st_db_struct_t *st_db,
+		db_key_t *keys,db_val_t *vals, str *trace_attrs)
+{
+	if (trace_attrs) {
+		db_vals[13].val.str_val = *trace_attrs;
+
+		LM_DBG("storing info 14...\n");
+	} else {
+		db_vals[13].val.str_val.s   = "";
+		db_vals[13].val.str_val.len = 0;
+	}
+
+	CON_PS_REFERENCE(st_db->con) = &siptrace_ps;
+	if (con_set_inslist(&st_db->funcs,st_db->con,
+						&st_db->ins_list,keys,NR_KEYS) < 0 )
+		CON_RESET_INSLIST(st_db->con);
+	if(st_db->funcs.insert(st_db->con, keys, vals, NR_KEYS) < 0) {
+		LM_ERR("error storing trace\n");
+		return -1;
+	}
+
+
+	return 0;
+}
+
+
+static int save_siptrace(struct sip_msg *msg, db_key_t *keys, db_val_t *vals,
+				trace_info_p info)
+{
+	unsigned int hash;
+
+	tlist_elem_p it;
+
+	if (!info || !info->trace_list) {
+		LM_ERR("invalid trace info!\n");
+		return -1;
+	}
+
+	if (!(*trace_on_flag)) {
+		LM_DBG("trace is off!\n");
+		return 0;
+	}
+
+	hash = info->trace_list->hash;
+	/* check where the hash matches and take the proper action */
+	for (it=info->trace_list; it && (it->hash == hash); it=it->next) {
+		if (!(*it->traceable))
+			continue;
+
+		switch (it->type) {
+		case TYPE_HEP:
+			if (trace_send_hep_duplicate(&db_vals[0].val.blob_val,
+					&db_vals[4].val.str_val, &db_vals[5].val.str_val,
+					db_vals[6].val.int_val, &db_vals[7].val.str_val,
+					&db_vals[8].val.str_val, db_vals[9].val.int_val,
+					&it->el.uri) < 0) {
+				LM_ERR("Failed to duplicate with hep to <%.*s:%.*s>\n",
+						it->el.uri.host.len, it->el.uri.host.s,
+						it->el.uri.port.len, it->el.uri.port.s);
+				continue;
+			}
+
+			break;
+		case TYPE_SIP:
+			if (trace_send_duplicate(db_vals[0].val.blob_val.s,
+					db_vals[0].val.blob_val.len, &it->el.uri) < 0) {
+				LM_ERR("Faield to duplicate with sip to <%.*s:%.*s>\n",
+						it->el.uri.host.len, it->el.uri.host.s,
+						it->el.uri.port.len, it->el.uri.port.s);
+				continue;
+			}
+
+			break;
+		case TYPE_DB:
+			it->el.db->funcs.use_table(it->el.db->con,
+										&it->el.db->table);
+
+			if (insert_siptrace(it->el.db, keys, vals, info->trace_attrs) < 0) {
+				LM_ERR("failed to insert in DB!\n");
+				return -1;
+			}
+
+			break;
+		default:
+			LM_ERR("invalid type!\n");
+			return -1;
+		}
+	}
+
+	return 0;
+}
+
+static void trace_transaction_dlgcb(struct dlg_cell* dlg, int type,
 		struct dlg_cb_params * params)
 {
-	unsigned char n;
-	static int_str avp_value;
-	str *name;
+	trace_info_p info;
 
-	if (params->msg==NULL)
-		return;
+	info=*params->param;
 
-	/* restore the AVPs from the dialog values */
-	n = 0;
-	do {
-		name = generate_val_name(n);
-		if (dlgb.fetch_dlg_value( dlg, name, &avp_value.s, 0)!=0)
-			break;
-		add_avp( traced_user_avp_type|AVP_VAL_STR, traced_user_avp, avp_value);
-		n++;
-	}while(1);
-
-	/* set the flag */
-	if ( dlgb.fetch_dlg_value( dlg, &st_flag_val, &avp_value.s, 0)==0 )
-		params->msg->flags |= trace_flag;
-	params->msg->msg_flags |= FL_USE_SIPTRACE;
-	/* trace current request */
-	sip_trace(params->msg);
-
-	if(tmb.register_tmcb( params->msg, 0, TMCB_REQUEST_BUILT, trace_onreq_out, 0, 0) <=0)
-	{
-		LM_ERR("can't register trace_onreq_out\n");
+	if (trace_transaction(params->msg, info, 1)<0) {
+		LM_ERR("trace transaction failed!\n");
 		return;
 	}
 
-	/* doesn't make sense to register the reply callbacks for ACK or PRACK */
-	if (params->msg->REQ_METHOD & (METHOD_ACK | METHOD_PRACK))
-		return;
-
-	if(tmb.register_tmcb( params->msg, 0, TMCB_RESPONSE_IN, trace_onreply_in, 0, 0) <=0)
-	{
-		LM_ERR("can't register trace_onreply_in\n");
-		return;
-	}
-
-	if(tmb.register_tmcb( params->msg, 0, TMCB_RESPONSE_OUT, trace_onreply_out, 0, 0) <=0)
-	{
-		LM_ERR("can't register trace_onreply_out\n");
-		return;
-	}
-
+	sip_trace(params->msg, info);
 }
 
-
-static int trace_dialog(struct sip_msg *msg)
+void free_trace_info_pkg(void *param)
 {
-	unsigned char n;
+	pkg_free((trace_info_p)param);
+}
+
+void free_trace_info_shm(void *param)
+{
+	shm_free((trace_info_p)param);
+}
+
+static int trace_transaction(struct sip_msg* msg, trace_info_p info,
+								char dlg_tran)
+{
+	if (msg==NULL)
+		return 0;
+
+	if(tmb.register_tmcb( msg, 0, TMCB_REQUEST_BUILT, trace_onreq_out, info, 0) <=0)
+	{
+		LM_ERR("can't register trace_onreq_out\n");
+		return -1;
+	}
+
+	/* allows catching statelessly forwarded ACK in stateful transactions
+	 * and stateless replies */
+	msg->msg_flags |= FL_USE_SIPTRACE;
+
+	/* doesn't make sense to register the reply callbacks for ACK or PRACK */
+	if (msg->REQ_METHOD & (METHOD_ACK | METHOD_PRACK))
+		return 0;
+
+	if(tmb.register_tmcb( msg, 0, TMCB_RESPONSE_IN, trace_onreply_in, info, 0) <=0)
+	{
+		LM_ERR("can't register trace_onreply_in\n");
+		return -1;
+	}
+
+	if(tmb.register_tmcb( msg, 0, TMCB_RESPONSE_OUT, trace_onreply_out,
+									info, dlg_tran?0:free_trace_info_shm) <=0)
+	{
+		LM_ERR("can't register trace_onreply_out\n");
+		return -1;
+	}
+
+	return 0;
+}
+
+static int trace_dialog(struct sip_msg *msg, trace_info_p info)
+{
 	struct dlg_cell* dlg;
-	struct usr_avp *avp;
-	static int_str avp_value;
-	str *name;
 
-	if (!msg) {
-		LM_ERR("no msg specified\n");
+	if (!dlgb.create_dlg || ! dlgb.get_dlg) {
+		LM_ERR("Can't trace dialog!Api not loaded!\n");
 		return -1;
 	}
 
-	if (trace_is_off()) {
-		LM_DBG("Trace if off...\n");
+	if (dlgb.create_dlg(msg, 0)<1) {
+		LM_ERR("faield to create dialog!\n");
 		return -1;
 	}
 
-	/* any need to do tracing here ? check the triggers */
-	avp = traced_user_avp<0 ? NULL : search_first_avp(traced_user_avp_type,
-			traced_user_avp, &avp_value, 0);
-	if (avp==NULL && (msg->flags&trace_flag)==0) {
-		LM_DBG("Nothing to trace here\n");
-		return -1;
-	}
-
-	if (dlgb.create_dlg(msg,0)<1) {
-		LM_ERR("failed to create dialog\n");
-		return -1;
-	}
-
-	dlg = dlgb.get_dlg();
+	dlg=dlgb.get_dlg();
 	if (dlg==NULL) {
 		LM_CRIT("BUG: no dialog found after create dialog\n");
 		return -1;
 	}
 
-	if(dlgb.register_dlgcb(dlg, DLGCB_REQ_WITHIN|DLGCB_TERMINATED,
-	trace_transaction,0,0)!=0) {
+	/* dialog callbacks */
+	if(dlgb.register_dlgcb(dlg, DLGCB_REQ_WITHIN,
+							trace_transaction_dlgcb,info,0)!=0) {
 		LM_ERR("failed to register dialog callback\n");
 		return -1;
 	}
 
-	/* store in dialog the user avps for tracing ; we will restore
-	 them for each transactin from the dialog */
-	if(traced_user_avp>=0) {
-		n = 0;
-		while(avp!=NULL) {
-			/* generate a name */
-			name = generate_val_name(n);
-			if (!is_avp_str_val(avp))
-				avp_value.s.s=int2str(avp_value.n,
-						&avp_value.s.len);
-			/* add the avp value as dialog var */
-			dlgb.store_dlg_value( dlg, name, &avp_value.s);
-			/* next avp */
-			avp = search_next_avp( avp, &avp_value);
-			n++;
-		}
+	/* here also free trace info param because we are sure that
+	 * this callback is ran only once - when dialog gets for
+	 * the first time in DELETED state */
+	if(dlgb.register_dlgcb(dlg,DLGCB_TERMINATED,
+				trace_transaction_dlgcb,info,free_trace_info_shm)!=0) {
+		LM_ERR("failed to register dialog callback\n");
+		return -1;
 	}
 
-	/* set the flag to trace the rest of the transaction */
-	if (msg->flags&trace_flag) {
-		avp_value.s.s = "1";
-		avp_value.s.len = 1;
-		dlgb.store_dlg_value( dlg, &st_flag_val, &avp_value.s);
+	/* also trace this transaction */
+	if (trace_transaction(msg, info, 1) < 0) {
+		LM_ERR("failed to trace initial INVITE transaction!\n");
+		return -1;
 	}
 
-	/* trace current request */
-	sip_trace(msg);
-
-	/* we also want to catch the incoming cancel */
 	if ( tmb.register_tmcb( msg, NULL,TMCB_TRANS_CANCELLED,
-				siptrace_dlg_cancel, NULL, NULL)<0 ) {
+				siptrace_dlg_cancel, info, NULL)<0 ) {
 		LM_ERR("failed to register trans cancelled TMCB\n");
+		return -1;
 	}
 
-	return 1;
+	return 0;
 }
+
 
 
 static void siptrace_dlg_cancel(struct cell* t, int type, struct tmcb_params *param)
 {
-	int_str avp_value;
 	struct sip_msg *req;
 	req = param->req;
 
 	LM_DBG("Tracing incoming cancel due to trace_dialog() \n");
 
-	/* set the flag */
-	if ( dlgb.fetch_dlg_value( (struct dlg_cell*)t->dialog_ctx, &st_flag_val, &avp_value.s, 0)==0 )
-		req->flags |= trace_flag;
-	req->msg_flags |= FL_USE_SIPTRACE;
 	/* trace current request */
-	sip_trace(req);
+	sip_trace(req, (trace_info_p)(*param->param));
+	shm_free((trace_info_p)(*param->param));
 }
 
 
-static inline int siptrace_copy_proto(int proto, char *buf)
+/*
+* the topmost flag shall be kept: if both dialog and transaction
+* flags are set, dialog capture shall be done
+*/
+static int st_parse_flags(str *sflags)
 {
-	if(buf==0)
-		return -1;
-	if(proto==PROTO_TCP) {
-		strcpy(buf, "tcp:");
-	} else if(proto==PROTO_TLS) {
-		strcpy(buf, "tls:");
-	} else if(proto==PROTO_SCTP) {
-		strcpy(buf, "sctp:");
-	} else {
-		strcpy(buf, "udp:");
+	int p;
+	int flags=0;
+
+	for (p=0; p<sflags->len; p++) {
+		switch(sflags->s[p]) {
+			case 'm':
+			case 'M':
+				if (flags)
+					continue;
+
+				flags = TRACE_MESSAGE;
+				break;
+			case 't':
+			case 'T':
+				if (flags == TRACE_DIALOG)
+					continue;
+
+				flags = TRACE_TRANSACTION;
+				break;
+			case 'd':
+			case 'D':
+				flags = TRACE_DIALOG;
+				break;
+			case ' ':
+				continue;
+			default:
+				LM_ERR("invalid character <%c> in"
+						" sip_trace() flags definition", sflags->s[p]);
+				return -1;
+		}
 	}
+
+	return flags;
+
+}
+
+
+static tlist_elem_p get_list_start(str *name)
+{
+	unsigned int hash;
+	tlist_elem_p it;
+
+	if (name==NULL)
+		return NULL;
+
+	hash = core_hash(name, NULL, 0);
+	for (it=trace_list; it; it=it->next)
+		if (hash==it->hash)
+			return it;
+
+	return NULL;
+}
+
+/*
+ * build a list with only those elements that belong to this
+ * id
+ */
+static int sip_trace_fixup(void **param, int param_no)
+{
+	int _flags;
+
+	str _sflags;
+	str _trace_attrs;
+
+	gparam_p gp;
+	pv_elem_p el;
+	tid_param_p tparam;
+
+	if (param_no < 1 || param_no > 3) {
+		LM_ERR("bad param number!\n");
+		return -1;
+	}
+
+	switch (param_no) {
+	case 1:
+		if (fixup_spve(param) < 0) {
+			LM_ERR("trace id fixup failed!\n");
+			return -1;
+		}
+
+		tparam=pkg_malloc(sizeof(tid_param_t));
+		if (!tparam) {
+			LM_ERR("no more pkg mem!\n");
+			return -1;
+		}
+
+		gp=*param;
+		if (gp->type==GPARAM_TYPE_STR) {
+			tparam->type = TYPE_LIST;
+			if ((tparam->u.lst=get_list_start(&gp->v.sval))==NULL) {
+				LM_ERR("Trace id <%.*s> not defined!\n",
+						gp->v.sval.len, gp->v.sval.s);
+				return -1;
+			}
+		} else {
+			tparam->type = TYPE_PVAR;
+			tparam->u.el = gp->v.pve;
+		}
+
+		pkg_free(gp);
+		*param = tparam;
+
+		break;
+	case 2:
+		_sflags.s   = (char *)*param;
+		_sflags.len = strlen(_sflags.s);
+
+		if ((_flags=st_parse_flags(&_sflags)) < 0) {
+			LM_ERR("flag parsing failed!\n");
+			return -1;
+		}
+
+		if (_flags==TRACE_DIALOG) {
+			if (load_dlg_api(&dlgb)!=0) {
+				LM_ERR("Requested dialog trace but dialog module not loaded!\n");
+				return -1;
+			}
+		}
+
+		if (_flags==TRACE_TRANSACTION||_flags==TRACE_DIALOG) {
+			if (load_tm_api(&tmb)!=0) {
+				if (_flags==TRACE_DIALOG) {
+					LM_ERR("Requested dialog trace "
+						"but dialog module not loaded!\n");
+					return -1;
+				} else {
+					LM_INFO("Will do stateless transaction aware tracing!\n");
+					LM_INFO("Siptrace will catch internally generated replies"
+							" and forwarded requests!\n");
+					_flags = TRACE_SL_TRANSACTION;
+				}
+			}
+		}
+
+		/* register callbacks for forwarded messages and internally generated replies  */
+		if (!callbacks_registered && _flags != TRACE_MESSAGE) {
+			/* statelessly forwarded request callback  and its context index */
+			if (register_slcb(SLCB_REQUEST_OUT, FL_USE_SIPTRACE, trace_slreq_out) != 0) {
+				LM_ERR("can't register callback for statelessly forwarded request\n");
+				return -1;
+			}
+
+			if (register_slcb(SLCB_REPLY_OUT, FL_USE_SIPTRACE, trace_slreply_out) != 0) {
+				LM_ERR("can't register callback for statelessly forwarded request\n");
+				return -1;
+			}
+
+
+		/* FIXME find a way to pass the flags and the trace_info_p parameter
+		 * if there's any*/
+		#if 0
+			if (register_slcb(SLCB_ACK_IN, 0, trace_slack_in) != 0) {
+				LM_ERR("can't register callback for statelessly forwarded request\n");
+				return -1;
+			}
+		#endif
+
+			/* register the free function only in stateless mode
+			 * else tm/dialog will free the structure */
+			sl_ctx_idx=context_register_ptr(CONTEXT_GLOBAL,
+					_flags==TRACE_SL_TRANSACTION?free_trace_info_pkg:0);
+
+
+			/* avoid registering the callbacks mutliple times */
+			callbacks_registered=1;
+		}
+
+		*param = (void *)((unsigned long)_flags);
+
+		break;
+	case 3:
+		_trace_attrs.s = (char *)*param;
+		_trace_attrs.len = strlen(_trace_attrs.s);
+
+		if (pv_parse_format(&_trace_attrs, &el) < 0) {
+			LM_ERR("Parsing trace attrs param failed!\n");
+			return -1;
+		}
+
+		*param = el;
+		break;
+	}
+
 	return 0;
 }
 
-/* siptrace wrapper that verifies if the trace is on */
-static int sip_trace_w(struct sip_msg *msg)
+int trace_has_totag(struct sip_msg* _m)
 {
-	if( trace_is_off() ) {
-		LM_DBG("trace off...\n");
+	str tag;
+
+	if (!_m->to && parse_headers(_m, HDR_TO_F,0)==-1) {
+		LM_ERR("To parsing failed\n");
+		return 0;
+	}
+	if (!_m->to) {
+		LM_ERR("no To\n");
+		return 0;
+	}
+	tag=get_to(_m)->tag_value;
+	if (tag.s==0 || tag.len==0) {
+		LM_DBG("no totag\n");
+		return 0;
+	}
+	LM_DBG("totag found\n");
+	return 1;
+}
+
+
+
+/* siptrace wrapper that verifies if the trace is on */
+static int sip_trace_w(struct sip_msg *msg, char *param1,
+									char *param2, char *param3)
+{
+
+	int extra_len=0;
+	int trace_flags;
+
+	str tid_name;
+	str trace_attrs={NULL, 0};
+
+	tlist_elem_p list;
+	tid_param_p tparam;
+
+	trace_info_p info=NULL;
+	trace_info_t stack_info;
+
+	if(msg==NULL)
+	{
+		LM_DBG("no uas request, local transaction\n");
 		return -1;
 	}
-	return sip_trace(msg);
+
+	/* NULL trace id; not allowed */
+	if (param1==NULL) {
+		LM_ERR("Null trace id! This is a mandatory parameter!\n");
+		return -1;
+	}
+
+	if ((tparam=(tid_param_p)param1)->type == TYPE_LIST) {
+		list=tparam->u.lst;
+	} else {
+		if (pv_printf_s(msg, tparam->u.el, &tid_name) < 0) {
+			LM_ERR("cannot print trace id PV-formated string\n");
+			return -1;
+		}
+
+		if ((list=get_list_start(&tid_name))==NULL) {
+			LM_ERR("Trace id <%.*s> not defined!\n", tid_name.len, tid_name.s);
+			return -1;
+		}
+	}
+
+	if (param2 != NULL) {
+		trace_flags = (int)((unsigned long)param2);
+	} else {
+		/* we use the topmost flag; if dialogs available trace dialog etc. */
+		/* for dialogs check for dialog api and whether it is an initial
+		 * INVITE; else we degrade the flag */
+		if (dlgb.get_dlg && msg->first_line.type == SIP_REQUEST &&
+				msg->REQ_METHOD == METHOD_INVITE ) {
+			trace_flags=TRACE_DIALOG;
+		} else if (tmb.t_gett) {
+			trace_flags=TRACE_TRANSACTION;
+		} else {
+			trace_flags=TRACE_SL_TRANSACTION;
+		}
+	}
+
+	if (trace_flags == TRACE_DIALOG &&
+			dlgb.get_dlg && msg->first_line.type == SIP_REQUEST &&
+			msg->REQ_METHOD == METHOD_INVITE && !trace_has_totag(msg)) {
+		LM_DBG("tracing dialog!\n");
+	} else if (trace_flags == TRACE_DIALOG) {
+		LM_DBG("can't trace dialog! Will try to trace transaction\n");
+		trace_flags = TRACE_TRANSACTION;
+	}
+
+	if (trace_flags == TRACE_TRANSACTION &&
+		tmb.t_gett && msg->first_line.type == SIP_REQUEST &&
+		(msg->REQ_METHOD != METHOD_ACK)) {
+		LM_DBG("tracing transaction!\n");
+	} else if (trace_flags == TRACE_TRANSACTION) {
+		LM_DBG("can't trace transaction! Will trace only this message!\n");
+		trace_flags = TRACE_MESSAGE;
+	}
+
+	if (trace_flags == TRACE_SL_TRANSACTION &&
+			msg->first_line.type == SIP_REQUEST &&
+				(msg->REQ_METHOD != METHOD_ACK)) {
+		LM_DBG("tracing stateless transaction!\n");
+	} else if (trace_flags == TRACE_SL_TRANSACTION) {
+		LM_DBG("can't trace stateless transaction! "
+					"Will trace only this message!\n");
+		trace_flags = TRACE_MESSAGE;
+	}
+
+	if (param3 != NULL) {
+		if (pv_printf_s(msg, (pv_elem_p)param3, &trace_attrs) < 0) {
+			LM_ERR("failed to get trace_attrs param!\n");
+			return -1;
+		}
+		extra_len = sizeof(str) + trace_attrs.len;
+	}
+
+
+	if (trace_flags == TRACE_MESSAGE) {
+		/* we don't need to allocate this structure since it will only be
+		 * used in this function's context */
+		info = &stack_info;
+
+		memset(info, 0, sizeof(trace_info_t));
+		if (extra_len) {
+			info->trace_attrs = &trace_attrs;
+		}
+	/* for stateful transactions or dialogs
+	 * we need the structure in the shared memory */
+	} else if(trace_flags == TRACE_DIALOG || trace_flags == TRACE_TRANSACTION) {
+		info=shm_malloc(sizeof(trace_info_t) + extra_len);
+		if (info==NULL) {
+			LM_ERR("no more shm!\n");
+			return -1;
+		}
+
+		memset(info, 0, sizeof(trace_info_t) + extra_len);
+
+		if (extra_len) {
+			info->trace_attrs = (str*)(info+1);
+			info->trace_attrs->s = (char*)(info->trace_attrs+1);
+
+			memcpy(info->trace_attrs->s, trace_attrs.s, trace_attrs.len);
+			info->trace_attrs->len = trace_attrs.len;
+		}
+	} else if (trace_flags == TRACE_SL_TRANSACTION) {
+		/* we need this structure in pkg for stateless replies
+		 * and request out callback */
+		info=pkg_malloc(sizeof(trace_info_t));
+		if (info==NULL) {
+			LM_ERR("no more pkg!\n");
+			return -1;
+		}
+
+		memset(info, 0, sizeof(trace_info_t));
+		if (extra_len)
+			info->trace_attrs = &trace_attrs;
+	}
+
+	info->trace_list=list;
+
+	if (trace_flags != TRACE_MESSAGE) {
+		context_put_ptr(CONTEXT_GLOBAL, current_processing_ctx,
+					sl_ctx_idx, info);
+		/* this flag here will help catching
+		 * stateless replies(sl_send_reply(...))*/
+		msg->msg_flags |= FL_USE_SIPTRACE;
+	}
+
+
+	if (trace_flags==TRACE_DIALOG) {
+		if (trace_dialog(msg, info) < 0) {
+			LM_ERR("trace dialog failed!\n");
+			return -1;
+		}
+	} else if (trace_flags==TRACE_TRANSACTION) {
+		if (trace_transaction(msg, info, 0) < 0) {
+			LM_ERR("trace transaction failed!\n");
+			return -1;
+		}
+	}
+
+	if (sip_trace(msg, info) < 0) {
+		LM_ERR("sip trace failed!\n");
+		return -1;
+	}
+
+	return 1;
 }
 
 #define set_sock_columns( _col_proto, _col_ip, _col_port, _buff, _ip, _port, _proto) \
@@ -945,7 +1446,7 @@ static int sip_trace_w(struct sip_msg *msg)
 	} while (0)
 
 #define set_columns_to_any( _col_proto, _col_ip, _col_port) \
-	do { \
+do { \
 		_col_proto.val.str_val.s = "any"; \
 		_col_proto.val.str_val.len = sizeof("any") - 1; \
 		_col_ip.val.str_val.s = "255.255.255.255"; \
@@ -960,29 +1461,10 @@ static int sip_trace_w(struct sip_msg *msg)
 		db_vals[6].val.int_val = trace_local_port; \
 	} while (0)
 
-static int sip_trace(struct sip_msg *msg)
+static int sip_trace(struct sip_msg *msg, trace_info_p info)
 {
 	static char toip_buff[IP_ADDR_MAX_STR_SIZE+6];
 	static char fromip_buff[IP_ADDR_MAX_STR_SIZE+6];
-	int_str         avp_value;
-	struct usr_avp *avp;
-
-	if(msg==NULL)
-	{
-		LM_DBG("no uas request, local transaction\n");
-		return -1;
-	}
-
-	avp = NULL;
-	if(traced_user_avp>=0)
-		avp=search_first_avp(traced_user_avp_type, traced_user_avp,
-				&avp_value, 0);
-
-	if ( (avp==NULL) && !flag_trace_is_set(msg) )
-	{
-		LM_DBG("nothing to trace...\n");
-		return -1;
-	}
 
 	if(parse_from_header(msg)==-1 || msg->from==NULL || get_from(msg)==NULL)
 	{
@@ -990,12 +1472,12 @@ static int sip_trace(struct sip_msg *msg)
 		goto error;
 	}
 
-	if(parse_headers(msg, HDR_CALLID_F, 0)!=0 || msg->callid==NULL
-			|| msg->callid->body.s==NULL)
+	if(parse_headers(msg, HDR_CALLID_F, 0)!=0)
 	{
 		LM_ERR("cannot parse call-id\n");
 		goto error;
 	}
+
 
 	LM_DBG("sip_trace called \n");
 	db_vals[0].val.blob_val.s = msg->buf;
@@ -1035,7 +1517,7 @@ static int sip_trace(struct sip_msg *msg)
 	db_vals[12].val.str_val.s = get_from(msg)->tag_value.s;
 	db_vals[12].val.str_val.len = get_from(msg)->tag_value.len;
 
-	if (save_siptrace(msg,avp,&avp_value,db_keys,db_vals) < 0) {
+	if (save_siptrace(msg, db_keys,db_vals, info) < 0) {
 		LM_ERR("failed to save siptrace\n");
 		goto error;
 	}
@@ -1052,84 +1534,14 @@ error:
 	return -1;
 }
 
-static void trace_onreq_in(struct cell* t, int type, struct tmcb_params *ps)
-{
-	struct sip_msg* msg;
-	int_str         avp_value;
-	struct usr_avp* avp;
-
-	if(t==NULL || ps==NULL)
-	{
-		LM_DBG("no uas request, local transaction\n");
-		return;
-	}
-
-	msg = ps->req;
-	if(msg==NULL)
-	{
-		LM_DBG("no uas request, local transaction\n");
-		return;
-	}
-
-	if( trace_is_off() )
-	{
-		LM_DBG("trace off...\n");
-		return;
-	}
-
-	if (msg->msg_flags & FL_USE_SIPTRACE) {
-		return;
-	}
-	LM_DBG("trace on req in \n");
-
-	avp = NULL;
-	if(traced_user_avp>=0)
-		avp=search_first_avp(traced_user_avp_type, traced_user_avp,
-				&avp_value, 0);
-
-	if( (avp==NULL) && !flag_trace_is_set(msg))
-	{
-		LM_DBG("nothing to trace...\n");
-		return;
-	}
-
-	if(parse_from_header(msg)==-1 || msg->from==NULL || get_from(msg)==NULL)
-	{
-		LM_ERR("cannot parse FROM header\n");
-		return;
-	}
-
-	if(parse_headers(msg, HDR_CALLID_F, 0)!=0)
-	{
-		LM_ERR("cannot parse call-id\n");
-		return;
-	}
-
-	if(tmb.register_tmcb( 0, t, TMCB_REQUEST_BUILT, trace_onreq_out, 0, 0) <=0)
-	{
-		LM_ERR("can't register trace_onreq_out\n");
-		return;
-	}
-
-	if(tmb.register_tmcb( 0, t, TMCB_RESPONSE_IN, trace_onreply_in, 0, 0) <=0)
-	{
-		LM_ERR("can't register trace_onreply_in\n");
-		return;
-	}
-
-	if(tmb.register_tmcb( 0, t, TMCB_RESPONSE_OUT, trace_onreply_out, 0, 0) <=0)
-	{
-		LM_ERR("can't register trace_onreply_out\n");
-		return;
-	}
-}
-
 static void trace_onreq_out(struct cell* t, int type, struct tmcb_params *ps)
 {
+
 	if(t==NULL || ps==NULL) {
 		LM_DBG("no uas request, local transaction\n");
 		return;
 	}
+
 	if(ps->req==NULL) {
 		LM_DBG("no uas msg, local transaction\n");
 		return;
@@ -1141,43 +1553,129 @@ static void trace_onreq_out(struct cell* t, int type, struct tmcb_params *ps)
 		trace_msg_out( ps->req, (str*)ps->extra1,
 			((struct dest_info*)ps->extra2)->send_sock,
 			((struct dest_info*)ps->extra2)->proto,
-			&((struct dest_info*)ps->extra2)->to);
+			&((struct dest_info*)ps->extra2)->to,
+			(trace_info_p)(*ps->param));
 	else
 		trace_msg_out( ps->req, (str*)ps->extra1,
-			NULL, PROTO_NONE, NULL);
+			NULL, PROTO_NONE, NULL, (trace_info_p)(*ps->param));
 
 }
 
-static void trace_msg_out_w(struct sip_msg* msg, str *sbuf,int rpl_code,
-			union sockaddr_union *to, struct socket_info *send_sock, int proto)
+static void trace_slreq_out(struct sip_msg* req, str *buffer,int rpl_code,
+				union sockaddr_union *to, struct socket_info *sock, int proto)
 {
-	if( trace_is_off() )
-	{
-		LM_DBG("trace off...\n");
-		return;
-	}
-	return trace_msg_out(msg, sbuf, send_sock, proto, to);
+	trace_info_p info;
+
+	info = context_get_ptr(CONTEXT_GLOBAL,
+				current_processing_ctx, sl_ctx_idx);
+
+	trace_msg_out(req, buffer, sock, proto, to, info);
 }
 
-static void trace_msg_out(struct sip_msg* msg, str  *sbuf,
-			struct socket_info* send_sock, int proto, union sockaddr_union *to)
+static void trace_slreply_out(struct sip_msg* req, str *buffer,int rpl_code,
+				union sockaddr_union *dst, struct socket_info *sock, int proto)
 {
 	static char fromip_buff[IP_ADDR_MAX_STR_SIZE+12];
 	static char toip_buff[IP_ADDR_MAX_STR_SIZE+12];
-	int_str        avp_value;
-	struct usr_avp *avp;
+
 	struct ip_addr to_ip;
+	int len;
+	char statusbuf[INT2STR_MAX_LEN];
 
-	avp = NULL;
-	if(traced_user_avp>=0)
-		avp=search_first_avp(traced_user_avp_type, traced_user_avp,
-				&avp_value, 0);
+	trace_info_p info;
 
-	if ( (avp==NULL) && !flag_trace_is_set(msg) )
-	{
-		LM_DBG("trace off...\n");
+	info = context_get_ptr(CONTEXT_GLOBAL, current_processing_ctx, sl_ctx_idx);
+	if (info == NULL) {
+		LM_BUG("null trace info!something is wrong here \n");
 		return;
 	}
+
+	if(parse_from_header(req)==-1 || req->from==NULL || get_from(req)==NULL)
+	{
+		LM_ERR("cannot parse FROM header\n");
+		goto error;
+	}
+
+	if(parse_headers(req, HDR_CALLID_F, 0)!=0)
+	{
+		LM_ERR("cannot parse call-id\n");
+		return;
+	}
+
+	db_vals[0].val.blob_val.s   = (buffer)?buffer->s:"";
+	db_vals[0].val.blob_val.len = (buffer)?buffer->len:0;
+
+	/* check Call-ID header */
+	if(req->callid==NULL || req->callid->body.s==NULL)
+	{
+		LM_ERR("cannot find Call-ID header!\n");
+		goto error;
+	}
+
+	db_vals[1].val.str_val.s = req->callid->body.s;
+	db_vals[1].val.str_val.len = req->callid->body.len;
+
+	db_vals[2].val.str_val.s = req->first_line.u.request.method.s;
+	db_vals[2].val.str_val.len = req->first_line.u.request.method.len;
+
+	if(trace_local_ip.s && trace_local_ip.len > 0){
+		set_columns_to_trace_local_ip( db_vals[4], db_vals[5], db_vals[6]);
+	} else {
+		set_sock_columns( db_vals[4], db_vals[5], db_vals[6], fromip_buff,
+		&req->rcv.dst_ip, req->rcv.dst_port, req->rcv.proto);
+	}
+
+	char * str_code = int2str(rpl_code, &len);
+	statusbuf[INT2STR_MAX_LEN-1]=0;
+	strncpy(statusbuf, str_code, len >= INT2STR_MAX_LEN ? INT2STR_MAX_LEN-1 : len);
+	db_vals[3].val.str_val.s = statusbuf;
+	db_vals[3].val.str_val.len = len;
+	memset(&to_ip, 0, sizeof(struct ip_addr));
+	if(dst==0)
+	{
+		set_columns_to_any(db_vals[7], db_vals[8], db_vals[9]);
+	} else {
+		su2ip_addr(&to_ip, dst);
+		set_sock_columns( db_vals[7], db_vals[8],db_vals[9], toip_buff, &to_ip,
+		(unsigned short)su_getport(dst), req->rcv.proto);
+	}
+
+	db_vals[10].val.time_val = time(NULL);
+
+	db_vals[11].val.string_val = "out";
+
+	db_vals[12].val.str_val.s = get_from(req)->tag_value.s;
+	db_vals[12].val.str_val.len = get_from(req)->tag_value.len;
+
+	if (save_siptrace(req,db_keys,db_vals, info) < 0) {
+		LM_ERR("failed to save siptrace\n");
+		goto error;
+	}
+#ifdef STATISTICS
+	update_stat(siptrace_rpl, 1);
+#endif
+	return;
+error:
+	return;
+}
+
+/* FIXME can't get the trace info here */
+#if 0
+static void trace_slack_in(struct sip_msg* req, str *buffer,int rpl_code,
+				union sockaddr_union *dst, struct socket_info *sock, int proto)
+{
+	/* FIXME How can we pass the trace info structure here ???? */
+	// sip_trace(req, NULL);
+}
+#endif
+
+static void trace_msg_out(struct sip_msg* msg, str  *sbuf,
+		struct socket_info* send_sock, int proto, union sockaddr_union *to,
+		trace_info_p info)
+{
+	static char fromip_buff[IP_ADDR_MAX_STR_SIZE+12];
+	static char toip_buff[IP_ADDR_MAX_STR_SIZE+12];
+	struct ip_addr to_ip;
 
 	if(parse_from_header(msg)==-1 || msg->from==NULL || get_from(msg)==NULL)
 	{
@@ -1258,7 +1756,7 @@ static void trace_msg_out(struct sip_msg* msg, str  *sbuf,
 	db_vals[12].val.str_val.s = get_from(msg)->tag_value.s;
 	db_vals[12].val.str_val.len = get_from(msg)->tag_value.len;
 
-	if (save_siptrace(msg,avp,&avp_value,db_keys,db_vals) < 0) {
+	if (save_siptrace(msg, db_keys,db_vals, info) < 0) {
 		LM_ERR("failed to save siptrace\n");
 		goto error;
 	}
@@ -1278,8 +1776,6 @@ static void trace_onreply_in(struct cell* t, int type, struct tmcb_params *ps)
 	static char toip_buff[IP_ADDR_MAX_STR_SIZE+12];
 	struct sip_msg* msg;
 	struct sip_msg* req;
-	int_str        avp_value;
-	struct usr_avp *avp;
 	char statusbuf[INT2STR_MAX_LEN];
 	int len;
 
@@ -1291,6 +1787,7 @@ static void trace_onreply_in(struct cell* t, int type, struct tmcb_params *ps)
 
 	req = ps->req;
 	msg = ps->rpl;
+
 	if(msg==NULL || req==NULL)
 	{
 		LM_DBG("no reply\n");
@@ -1298,11 +1795,6 @@ static void trace_onreply_in(struct cell* t, int type, struct tmcb_params *ps)
 	}
 
 	LM_DBG("trace onreply in \n");
-
-	avp = NULL;
-	if(traced_user_avp>=0)
-		avp=search_first_avp(traced_user_avp_type, traced_user_avp,
-				&avp_value, 0);
 
 	if(parse_from_header(msg)==-1 || msg->from==NULL || get_from(msg)==NULL)
 	{
@@ -1361,7 +1853,7 @@ static void trace_onreply_in(struct cell* t, int type, struct tmcb_params *ps)
 	db_vals[12].val.str_val.s = get_from(msg)->tag_value.s;
 	db_vals[12].val.str_val.len = get_from(msg)->tag_value.len;
 
-	if (save_siptrace(req,avp,&avp_value,db_keys,db_vals) < 0) {
+	if (save_siptrace(msg, db_keys,db_vals, (trace_info_p)(*ps->param)) < 0) {
 		LM_ERR("failed to save siptrace\n");
 		goto error;
 	}
@@ -1380,9 +1872,6 @@ static void trace_onreply_out(struct cell* t, int type, struct tmcb_params *ps)
 	static char fromip_buff[IP_ADDR_MAX_STR_SIZE+12];
 	static char toip_buff[IP_ADDR_MAX_STR_SIZE+12];
 	struct sip_msg* msg;
-	struct sip_msg* req;
-	int_str        avp_value;
-	struct usr_avp *avp;
 	struct ip_addr to_ip;
 	int len;
 	char statusbuf[8];
@@ -1397,13 +1886,8 @@ static void trace_onreply_out(struct cell* t, int type, struct tmcb_params *ps)
 
 	LM_DBG("trace onreply out \n");
 
-	avp = NULL;
-	if(traced_user_avp>=0)
-		avp=search_first_avp(traced_user_avp_type, traced_user_avp,
-				&avp_value, 0);
-
-	req = ps->req;
 	msg = ps->rpl;
+
 	if(msg==NULL || msg==FAKED_REPLY)
 	{
 		msg = t->uas.request;
@@ -1495,119 +1979,7 @@ static void trace_onreply_out(struct cell* t, int type, struct tmcb_params *ps)
 	db_vals[12].val.str_val.s = get_from(msg)->tag_value.s;
 	db_vals[12].val.str_val.len = get_from(msg)->tag_value.len;
 
-	if (save_siptrace(req,avp,&avp_value,db_keys,db_vals) < 0) {
-		LM_ERR("failed to save siptrace\n");
-		goto error;
-	}
-
-#ifdef STATISTICS
-	update_stat(siptrace_rpl, 1);
-#endif
-	return;
-error:
-	return;
-}
-
-static void trace_sl_ack_in(struct sip_msg* req, str *buffer,int rpl_code,
-				union sockaddr_union *dst, struct socket_info *sock, int proto)
-{
-	LM_DBG("storing ack...\n");
-	sip_trace_w(req);
-}
-
-static void trace_sl_onreply_out(struct sip_msg* req, str *buffer,int rpl_code,
-				union sockaddr_union *dst, struct socket_info *sock, int proto)
-{
-	static char fromip_buff[IP_ADDR_MAX_STR_SIZE+12];
-	static char toip_buff[IP_ADDR_MAX_STR_SIZE+12];
-	struct sip_msg* msg;
-	int_str        avp_value;
-	struct usr_avp *avp;
-	struct ip_addr to_ip;
-	int len;
-	char statusbuf[INT2STR_MAX_LEN];
-
-	if( trace_is_off() )
-	{
-		LM_DBG("trace off...\n");
-		return;
-	}
-
-	LM_DBG("trace slonreply out \n");
-
-	avp = NULL;
-	if(traced_user_avp >= 0)
-		avp=search_first_avp(traced_user_avp_type, traced_user_avp,
-				&avp_value, 0);
-
-	if((avp==NULL) && !flag_trace_is_set(req))
-	{
-		LM_DBG("nothing to trace...\n");
-		return;
-	}
-
-	msg = req;
-
-	if(parse_from_header(msg)==-1 || msg->from==NULL || get_from(msg)==NULL)
-	{
-		LM_ERR("cannot parse FROM header\n");
-		goto error;
-	}
-
-	if(parse_headers(msg, HDR_CALLID_F, 0)!=0)
-	{
-		LM_ERR("cannot parse call-id\n");
-		return;
-	}
-
-	db_vals[0].val.blob_val.s   = (buffer)?buffer->s:"";
-	db_vals[0].val.blob_val.len = (buffer)?buffer->len:0;
-
-	/* check Call-ID header */
-	if(msg->callid==NULL || msg->callid->body.s==NULL)
-	{
-		LM_ERR("cannot find Call-ID header!\n");
-		goto error;
-	}
-
-	db_vals[1].val.str_val.s = msg->callid->body.s;
-	db_vals[1].val.str_val.len = msg->callid->body.len;
-
-	db_vals[2].val.str_val.s = msg->first_line.u.request.method.s;
-	db_vals[2].val.str_val.len = msg->first_line.u.request.method.len;
-
-	if(trace_local_ip.s && trace_local_ip.len > 0){
-		set_columns_to_trace_local_ip( db_vals[4], db_vals[5], db_vals[6]);
-	}
-	else {
-		set_sock_columns( db_vals[4], db_vals[5], db_vals[6], fromip_buff,
-			&msg->rcv.dst_ip, msg->rcv.dst_port, msg->rcv.proto);
-	}
-
-	char * str_code = int2str(rpl_code, &len);
-	statusbuf[INT2STR_MAX_LEN-1]=0;
-	strncpy(statusbuf, str_code, len >= INT2STR_MAX_LEN ? INT2STR_MAX_LEN-1 : len);
-	db_vals[3].val.str_val.s = statusbuf;
-	db_vals[3].val.str_val.len = len;
-
-	memset(&to_ip, 0, sizeof(struct ip_addr));
-	if(dst==0)
-	{
-		set_columns_to_any(db_vals[7], db_vals[8], db_vals[9]);
-	} else {
-		su2ip_addr(&to_ip, dst);
-		set_sock_columns( db_vals[7], db_vals[8],db_vals[9], toip_buff, &to_ip,
-			(unsigned short)su_getport(dst), req->rcv.proto);
-	}
-
-	db_vals[10].val.time_val = time(NULL);
-
-	db_vals[11].val.string_val = "out";
-
-	db_vals[12].val.str_val.s = get_from(msg)->tag_value.s;
-	db_vals[12].val.str_val.len = get_from(msg)->tag_value.len;
-
-	if (save_siptrace(msg,avp,&avp_value,db_keys,db_vals) < 0) {
+	if (save_siptrace(msg, db_keys,db_vals, (trace_info_p)(*ps->param)) < 0) {
 		LM_ERR("failed to save siptrace\n");
 		goto error;
 	}
@@ -1628,101 +2000,135 @@ error:
  */
 static struct mi_root* sip_trace_mi(struct mi_root* cmd_tree, void* param )
 {
+	#define TID_INFO(_tid_el, _node, _rpl)                                          \
+		do {                                                                        \
+			char uri[256];                                                          \
+			_node=add_mi_node_child(_rpl, 0, _tid_el->name.s,                       \
+					_tid_el->name.len, 0, 0);                                       \
+			if (_tid_el->type==TYPE_HEP)                                            \
+				add_mi_attr(_node, 0, MI_SSTR("\n\ttype"), MI_SSTR("HEP"));         \
+			else if (_tid_el->type==TYPE_SIP)                                       \
+				add_mi_attr(_node, 0, MI_SSTR("\n\ttype"), MI_SSTR("SIP"));         \
+			else if (_tid_el->type==TYPE_DB)                                        \
+				add_mi_attr(_node, 0, MI_SSTR("\n\ttype"), MI_SSTR("Database"));    \
+                                                                                    \
+			if (_tid_el->type==TYPE_HEP||_tid_el->type==TYPE_SIP) {                 \
+				memcpy(uri, _tid_el->el.uri.host.s, _tid_el->el.uri.host.len);      \
+				uri[_tid_el->el.uri.host.len] = ':';                                \
+				memcpy(uri+_tid_el->el.uri.host.len+1,                              \
+						_tid_el->el.uri.port.s, _tid_el->el.uri.port.len);          \
+                                                                                    \
+				add_mi_attr(_node, 0, MI_SSTR("\n\turi"), uri,                      \
+						_tid_el->el.uri.host.len + 1 + _tid_el->el.uri.port.len);   \
+			} else {                                                                \
+				/* TYPE_DB */                                                       \
+				add_mi_attr(_node, 0, MI_SSTR("\n\turi"), _tid_el->el.db->url.s,    \
+						_tid_el->el.db->url.len);                                   \
+			}                                                                       \
+                                                                                    \
+			if (*_tid_el->traceable)                                                \
+				add_mi_attr(_node, 0, MI_SSTR("\n\tstate"), MI_SSTR("on"));         \
+			else                                                                    \
+				add_mi_attr(_node, 0, MI_SSTR("\n\tstate"), MI_SSTR("off"));        \
+		} while(0);
+
 	struct mi_node* node;
 
 	struct mi_node *rpl;
 	struct mi_root *rpl_tree ;
 
+	tlist_elem_p it;
+
+	unsigned int hash;
+	unsigned int tid_trace_flag=1;
+
 	node = cmd_tree->node.kids;
 	if(node == NULL) {
+		/* display name, type and state for all ids */
 		rpl_tree = init_mi_tree( 200, MI_SSTR(MI_OK));
 		if (rpl_tree == 0)
 			return 0;
 		rpl = &rpl_tree->node;
 
 		if (*trace_on_flag == 0 ) {
-			node = add_mi_node_child(rpl,0,0,0,MI_SSTR("off"));
+			node = add_mi_node_child(rpl,0,MI_SSTR("global"),MI_SSTR("off"));
 		} else if (*trace_on_flag == 1) {
-			node = add_mi_node_child(rpl,0,0,0,MI_SSTR("on"));
+			node = add_mi_node_child(rpl,0,MI_SSTR("global"),MI_SSTR("on"));
 		}
+
+		for (it=trace_list;it;it=it->next)
+			TID_INFO(it, node, rpl);
+
+
 		return rpl_tree ;
-	}
+	} else {
 	if(trace_on_flag==NULL)
 		return init_mi_tree( 500, MI_SSTR(MI_INTERNAL_ERR));
 
-	if ( node->value.len==2 &&
-	(node->value.s[0]=='o'|| node->value.s[0]=='O') &&
-	(node->value.s[1]=='n'|| node->value.s[1]=='N'))
-	{
-		*trace_on_flag = 1;
-		return init_mi_tree( 200, MI_SSTR(MI_OK));
-	} else if ( node->value.len==3 &&
-	(node->value.s[0]=='o'|| node->value.s[0]=='O') &&
-	(node->value.s[1]=='f'|| node->value.s[1]=='F') &&
-	(node->value.s[2]=='f'|| node->value.s[2]=='F'))
-	{
-		*trace_on_flag = 0;
-		return init_mi_tree( 200, MI_SSTR(MI_OK));
-	} else {
-		return init_mi_tree( 400, MI_SSTR(MI_BAD_PARM));
-	}
-}
+		/* <on/off> global or trace_id name */
+		if (node && !node->next) {
+			/* if on/off set global accordingly
+			 * else display trace_id info */
+			if ( node->value.len==2 &&
+			(node->value.s[0]=='o'|| node->value.s[0]=='O') &&
+			(node->value.s[1]=='n'|| node->value.s[1]=='N'))
+			{
+				*trace_on_flag = 1;
+				return init_mi_tree( 200, MI_SSTR(MI_OK));
+			} else if ( node->value.len==3 &&
+			(node->value.s[0]=='o'|| node->value.s[0]=='O') &&
+			(node->value.s[1]=='f'|| node->value.s[1]=='F') &&
+			(node->value.s[2]=='f'|| node->value.s[2]=='F'))
+			{
+				*trace_on_flag = 0;
+				return init_mi_tree( 200, MI_SSTR(MI_OK));
+			}
 
-/**
- * MI command format:
- * name: trace_to_database
- * attribute: name=none, value=[on|off]
- */
-static struct mi_root* trace_to_database_mi (struct mi_root* cmd_tree, void* param )
-{
-	struct mi_node* node;
+			/* display trace id content here */
+			rpl_tree = init_mi_tree( 200, MI_SSTR(MI_OK));
+			if (rpl_tree == 0)
+				return 0;
+			rpl = &rpl_tree->node;
 
-	struct mi_node *rpl;
-	struct mi_root *rpl_tree ;
+			it=get_list_start(&node->value);
+			hash=it->hash;
+			for (;it&&it->hash==hash;it=it->next)
+				TID_INFO(it, node, rpl);
 
-	node = cmd_tree->node.kids;
-	if(node == NULL) {
-		rpl_tree = init_mi_tree( 200, MI_SSTR(MI_OK));
-		if (rpl_tree == 0)
-			return 0;
-		rpl = &rpl_tree->node;
+			return rpl_tree;
+		} else if (node && node->next && !node->next->next) {
+			/* trace on off for an id */
+			if ( node->next->value.len==2 &&
+			(node->next->value.s[0]=='o'|| node->next->value.s[0]=='O') &&
+			(node->next->value.s[1]=='n'|| node->next->value.s[1]=='N'))
+			{
+				tid_trace_flag=1;
+			} else if ( node->next->value.len==3 &&
+			(node->next->value.s[0]=='o'|| node->next->value.s[0]=='O') &&
+			(node->next->value.s[1]=='f'|| node->next->value.s[1]=='F') &&
+			(node->next->value.s[2]=='f'|| node->next->value.s[2]=='F'))
+			{
+				tid_trace_flag=0;
+			} else {
+				return init_mi_tree( 400, MI_SSTR(MI_BAD_PARM));
+			}
 
-		if (*trace_to_database_flag == 0 ) {
-			node = add_mi_node_child(rpl,0,0,0,MI_SSTR("off"));
-		} else if (*trace_to_database_flag == 1) {
-			node = add_mi_node_child(rpl,0,0,0,MI_SSTR("on"));
+			it=get_list_start(&node->value);
+			hash=it->hash;
+
+			for (;it&&it->hash==hash;it=it->next)
+				*it->traceable=tid_trace_flag;
+
+			return init_mi_tree(200, MI_SSTR(MI_OK));
 		}
-		return rpl_tree ;
-	}
-	if(trace_to_database_flag==NULL)
-		return init_mi_tree( 500, MI_SSTR(MI_INTERNAL_ERR));
-
-	if ( node->value.len==2 &&
-	(node->value.s[0]=='o'|| node->value.s[0]=='O') &&
-	(node->value.s[1]=='n'|| node->value.s[1]=='N'))
-	{
-                if (db_con!=NULL) {
-        		*trace_to_database_flag = 1;
-	        	return init_mi_tree( 200, MI_SSTR(MI_OK));
-                }
-                else {
-                        return init_mi_tree( 501, MI_SSTR(MI_INTERNAL_ERR));
-                }
-
-	} else if ( node->value.len==3 &&
-	(node->value.s[0]=='o'|| node->value.s[0]=='O') &&
-	(node->value.s[1]=='f'|| node->value.s[1]=='F') &&
-	(node->value.s[2]=='f'|| node->value.s[2]=='F'))
-	{
-		*trace_to_database_flag = 0;
-		return init_mi_tree( 200, MI_SSTR(MI_OK));
-	} else {
+		/* error here */
 		return init_mi_tree( 400, MI_SSTR(MI_BAD_PARM));
 	}
+
+	return NULL;
 }
 
-
-static int trace_send_duplicate(char *buf, int len)
+static int trace_send_duplicate(char *buf, int len, struct sip_uri *uri)
 {
 	union sockaddr_union* to;
 	struct socket_info* send_sock;
@@ -1733,7 +2139,7 @@ static int trace_send_duplicate(char *buf, int len)
 	if(buf==NULL || len <= 0)
 		return -1;
 
-	if(dup_uri_str.s==0 || dup_uri==NULL)
+	if(uri==NULL)
 		return 0;
 
 	to=(union sockaddr_union*)pkg_malloc(sizeof(union sockaddr_union));
@@ -1744,7 +2150,7 @@ static int trace_send_duplicate(char *buf, int len)
 
 	/* create a temporary proxy*/
 	proto = PROTO_UDP;
-	p=mk_proxy(&dup_uri->host, (dup_uri->port_no)?dup_uri->port_no:SIP_PORT,
+	p=mk_proxy(&uri->host, (uri->port_no)?uri->port_no:SIP_PORT,
 			proto, 0);
 	if (p==0){
 		LM_ERR("bad host name in uri\n");
@@ -1781,7 +2187,8 @@ static int trace_send_duplicate(char *buf, int len)
 }
 
 static int trace_send_hep_duplicate(str *body, str *fromproto, str *fromip,
-		unsigned short fromport, str *toproto, str *toip, unsigned short toport)
+		unsigned short fromport, str *toproto, str *toip,
+		unsigned short toport, struct sip_uri *uri)
 {
 	struct proxy_l * p=NULL /* make gcc happy */;
 	int ret;
@@ -1796,8 +2203,6 @@ static int trace_send_hep_duplicate(str *body, str *fromproto, str *fromip,
 	if(body->s==NULL || body->len <= 0)
 		return -1;
 
-	if(dup_uri_str.s==0 || dup_uri==NULL)
-		return 0;
 
 	/* Convert proto:ip:port to sockaddress union SRC IP */
 	/* proto is going to be converted to netinet proto */
@@ -1813,7 +2218,7 @@ static int trace_send_hep_duplicate(str *body, str *fromproto, str *fromip,
 
 
 	/* create a temporary proxy*/
-	p=mk_proxy(&dup_uri->host, (dup_uri->port_no)?dup_uri->port_no:SIP_PORT,proto, 0);
+	p=mk_proxy(&uri->host, (uri->port_no)?uri->port_no:SIP_PORT,proto, 0);
 	if (p==0){
 		LM_ERR("bad host name in uri\n");
 		return -1;
@@ -1899,7 +2304,7 @@ static int pipport2su (str *sproto, str *ip, unsigned short port,
 	}
 	else{
 	/*the address contains a port number*/
-		if (port<1024)
+		if (port<1024 || port>65535)
 		{
 			LM_ERR("invalid port number; must be in [1024,65536]\n");
 			return -1;

--- a/modules/siptrace/siptrace.h
+++ b/modules/siptrace/siptrace.h
@@ -1,0 +1,124 @@
+/*
+ * siptrace module - helper module to trace sip messages
+ *
+ * Copyright (C) 2006-2009 Voice Sistem S.R.L.
+ *
+ * This file is part of opensips, a free SIP server.
+ *
+ * opensips is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version
+ *
+ * opensips is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301  USA
+ *
+ */
+#ifndef _SIPTRACE_H
+#define _SIPTRACE_H
+
+#define NR_KEYS 14
+#define SIPTRACE_TABLE_VERSION 5
+
+enum trace_flags {TRACE_MESSAGE=(1<<0), TRACE_TRANSACTION=(1<<1),
+			TRACE_SL_TRANSACTION=(1<<2), /* transaction aware in stateless mode */
+			TRACE_DIALOG=(1<<3)};
+
+
+typedef struct st_db_struct {
+	str url;
+
+	db_con_t *con;
+	db_func_t funcs;
+	query_list_t *ins_list;
+
+	str table;
+} st_db_struct_t;
+
+
+enum types { TYPE_HEP=0, TYPE_SIP, TYPE_DB, TYPE_END };
+typedef struct tlist_elem {
+	str name;          /* name of the partition */
+	enum types type;   /* SIP-DB-HEP */
+	unsigned int hash; /* hash over the uri*/
+	unsigned char *traceable; /* whether or not this idd is traceable */
+
+	union {
+		st_db_struct_t  *db;
+		struct sip_uri  uri;
+	} el;
+
+
+	struct tlist_elem *next;
+} tlist_elem_t, *tlist_elem_p;
+
+enum tid_types {TYPE_LIST=0, TYPE_PVAR};
+typedef struct tid_param {
+	enum tid_types type;
+	union {
+		tlist_elem_p lst;
+		pv_elem_p el;
+	} u;
+} tid_param_t, *tid_param_p;
+
+
+typedef struct trace_info {
+	str *trace_attrs;
+	tlist_elem_p trace_list;
+} trace_info_t, *trace_info_p;
+
+static int sip_trace_fixup(void **param, int param_no);
+static int sip_trace_w(struct sip_msg*, char*, char*, char*);
+static int sip_trace(struct sip_msg*, trace_info_p);
+
+static int trace_dialog(struct sip_msg*, trace_info_p);
+static int trace_transaction(struct sip_msg* msg, trace_info_p info,
+								char dlg_tran);
+
+
+static void trace_onreq_out(struct cell* t, int type, struct tmcb_params *ps);
+static void trace_onreply_in(struct cell* t, int type, struct tmcb_params *ps);
+static void trace_onreply_out(struct cell* t, int type, struct tmcb_params *ps);
+static void trace_msg_out(struct sip_msg* req, str  *buffer,
+			struct socket_info* send_sock, int proto, union sockaddr_union *to,
+			trace_info_p info);
+static void siptrace_dlg_cancel(struct cell* t, int type, struct tmcb_params *param);
+
+/*
+ * callback used for statelessly forwarded requests; also catches the ACK in
+ * stateful transaction
+ */
+static void trace_slreq_out(struct sip_msg* req, str *buffer,int rpl_code,
+				union sockaddr_union *to, struct socket_info *sock, int proto);
+static void trace_slreply_out(struct sip_msg* req, str *buffer,int rpl_code,
+				union sockaddr_union *dst, struct socket_info *sock, int proto);
+
+#if 0
+static void trace_slack_in(struct sip_msg* req, str *buffer,int rpl_code,
+				union sockaddr_union *dst, struct socket_info *sock, int proto);
+#endif
+
+static struct mi_root* sip_trace_mi(struct mi_root* cmd, void* param );
+
+static int trace_send_duplicate(char *buf, int len, struct sip_uri *uri);
+static int trace_send_hep_duplicate(str *body, str *fromproto, str *fromip,
+		unsigned short fromport, str *toproto, str *toip,
+		unsigned short toport, struct sip_uri *uri);
+
+
+
+static int pipport2su (str *sproto, str *ip, unsigned short port,
+			union sockaddr_union *tmp_su, unsigned int *proto);
+
+static int parse_trace_id(unsigned int type, void *val);
+
+void free_trace_info_pkg(void *param);
+void free_trace_info_shm(void *param);
+#endif
+

--- a/scripts/db_berkeley/opensips/sip_trace
+++ b/scripts/db_berkeley/opensips/sip_trace
@@ -1,5 +1,5 @@
 METADATA_COLUMNS
-id(int) time_stamp(datetime) callid(str) traced_user(str) msg(str) method(str) status(str) from_proto(str) from_ip(str) from_port(int) to_proto(str) to_ip(str) to_port(int) fromtag(str) direction(str)
+id(int) time_stamp(datetime) callid(str) trace_attrs(str) msg(str) method(str) status(str) from_proto(str) from_ip(str) from_port(int) to_proto(str) to_ip(str) to_port(int) fromtag(str) direction(str)
 METADATA_KEY
 2 
 METADATA_READONLY

--- a/scripts/db_berkeley/opensips/version
+++ b/scripts/db_berkeley/opensips/version
@@ -105,7 +105,7 @@ rtpproxy_sockets|0
 silo|
 silo|6
 sip_trace|
-sip_trace|4
+sip_trace|5
 speed_dial|
 speed_dial|3
 subscriber|

--- a/scripts/dbtext/opensips/sip_trace
+++ b/scripts/dbtext/opensips/sip_trace
@@ -1,1 +1,1 @@
-id(int,auto) time_stamp(int) callid(string) traced_user(string,null) msg(string) method(string) status(string,null) from_proto(string) from_ip(string) from_port(int) to_proto(string) to_ip(string) to_port(int) fromtag(string) direction(string) 
+id(int,auto) time_stamp(int) callid(string) trace_attrs(string,null) msg(string) method(string) status(string,null) from_proto(string) from_ip(string) from_port(int) to_proto(string) to_ip(string) to_port(int) fromtag(string) direction(string) 

--- a/scripts/dbtext/opensips/version
+++ b/scripts/dbtext/opensips/version
@@ -46,7 +46,7 @@ rls_watchers:2
 route_tree:2
 rtpproxy_sockets:0
 silo:6
-sip_trace:4
+sip_trace:5
 speed_dial:3
 subscriber:7
 tls_mgm:1

--- a/scripts/mysql/siptrace-create.sql
+++ b/scripts/mysql/siptrace-create.sql
@@ -1,9 +1,9 @@
-INSERT INTO version (table_name, table_version) values ('sip_trace','4');
+INSERT INTO version (table_name, table_version) values ('sip_trace','5');
 CREATE TABLE sip_trace (
     id INT(10) UNSIGNED AUTO_INCREMENT PRIMARY KEY NOT NULL,
     time_stamp DATETIME DEFAULT '1900-01-01 00:00:01' NOT NULL,
     callid CHAR(255) DEFAULT '' NOT NULL,
-    traced_user CHAR(128) DEFAULT NULL,
+    trace_attrs CHAR(128) DEFAULT NULL,
     msg TEXT NOT NULL,
     method CHAR(32) DEFAULT '' NOT NULL,
     status CHAR(128) DEFAULT NULL,
@@ -17,7 +17,7 @@ CREATE TABLE sip_trace (
     direction CHAR(4) DEFAULT '' NOT NULL
 ) ENGINE=InnoDB;
 
-CREATE INDEX traced_user_idx ON sip_trace (traced_user);
+CREATE INDEX trace_attrs_idx ON sip_trace (trace_attrs);
 CREATE INDEX date_idx ON sip_trace (time_stamp);
 CREATE INDEX fromip_idx ON sip_trace (from_ip);
 CREATE INDEX callid_idx ON sip_trace (callid);

--- a/scripts/oracle/siptrace-create.sql
+++ b/scripts/oracle/siptrace-create.sql
@@ -1,9 +1,9 @@
-INSERT INTO version (table_name, table_version) values ('sip_trace','4');
+INSERT INTO version (table_name, table_version) values ('sip_trace','5');
 CREATE TABLE sip_trace (
     id NUMBER(10) PRIMARY KEY,
     time_stamp DATE DEFAULT to_date('1900-01-01 00:00:01','yyyy-mm-dd hh24:mi:ss'),
     callid VARCHAR2(255) DEFAULT '',
-    traced_user VARCHAR2(128) DEFAULT NULL,
+    trace_attrs VARCHAR2(128) DEFAULT NULL,
     msg CLOB,
     method VARCHAR2(32) DEFAULT '',
     status VARCHAR2(128) DEFAULT NULL,
@@ -25,7 +25,7 @@ END sip_trace_tr;
 /
 BEGIN map2users('sip_trace'); END;
 /
-CREATE INDEX sip_trace_traced_user_idx  ON sip_trace (traced_user);
+CREATE INDEX sip_trace_trace_attrs_idx  ON sip_trace (trace_attrs);
 CREATE INDEX sip_trace_date_idx  ON sip_trace (time_stamp);
 CREATE INDEX sip_trace_fromip_idx  ON sip_trace (from_ip);
 CREATE INDEX sip_trace_callid_idx  ON sip_trace (callid);

--- a/scripts/pi_http/pi_framework.xml
+++ b/scripts/pi_http/pi_framework.xml
@@ -838,7 +838,7 @@
 		<column><field>id</field><type>DB_INT</type></column>
 		<column><field>time_stamp</field><type>DB_DATETIME</type></column>
 		<column><field>callid</field><type>DB_STR</type></column>
-		<column><field>traced_user</field><type>DB_STR</type></column>
+		<column><field>trace_attrs</field><type>DB_STR</type></column>
 		<column><field>msg</field><type>DB_BLOB</type></column>
 		<column><field>method</field><type>DB_STR</type></column>
 		<column><field>status</field><type>DB_STR</type></column>
@@ -4101,7 +4101,7 @@
 				<col><field>id</field><link_cmd>update</link_cmd></col>
 				<col><field>time_stamp</field></col>
 				<col><field>callid</field></col>
-				<col><field>traced_user</field></col>
+				<col><field>trace_attrs</field></col>
 				<col><field>msg</field></col>
 				<col><field>method</field></col>
 				<col><field>status</field></col>
@@ -4121,7 +4121,7 @@
 			<query_cols>
 				<col><field>time_stamp</field></col>
 				<col><field>callid</field></col>
-				<col><field>traced_user</field></col>
+				<col><field>trace_attrs</field></col>
 				<col><field>msg</field></col>
 				<col><field>method</field></col>
 				<col><field>status</field></col>
@@ -4144,7 +4144,7 @@
 			<query_cols>
 				<col><field>time_stamp</field></col>
 				<col><field>callid</field></col>
-				<col><field>traced_user</field></col>
+				<col><field>trace_attrs</field></col>
 				<col><field>msg</field></col>
 				<col><field>method</field></col>
 				<col><field>status</field></col>

--- a/scripts/pi_http/siptrace-mod
+++ b/scripts/pi_http/siptrace-mod
@@ -7,7 +7,7 @@
 				<col><field>id</field><link_cmd>update</link_cmd></col>
 				<col><field>time_stamp</field></col>
 				<col><field>callid</field></col>
-				<col><field>traced_user</field></col>
+				<col><field>trace_attrs</field></col>
 				<col><field>msg</field></col>
 				<col><field>method</field></col>
 				<col><field>status</field></col>
@@ -27,7 +27,7 @@
 			<query_cols>
 				<col><field>time_stamp</field></col>
 				<col><field>callid</field></col>
-				<col><field>traced_user</field></col>
+				<col><field>trace_attrs</field></col>
 				<col><field>msg</field></col>
 				<col><field>method</field></col>
 				<col><field>status</field></col>
@@ -50,7 +50,7 @@
 			<query_cols>
 				<col><field>time_stamp</field></col>
 				<col><field>callid</field></col>
-				<col><field>traced_user</field></col>
+				<col><field>trace_attrs</field></col>
 				<col><field>msg</field></col>
 				<col><field>method</field></col>
 				<col><field>status</field></col>

--- a/scripts/pi_http/siptrace-table
+++ b/scripts/pi_http/siptrace-table
@@ -5,7 +5,7 @@
 		<column><field>id</field><type>DB_INT</type></column>
 		<column><field>time_stamp</field><type>DB_DATETIME</type></column>
 		<column><field>callid</field><type>DB_STR</type></column>
-		<column><field>traced_user</field><type>DB_STR</type></column>
+		<column><field>trace_attrs</field><type>DB_STR</type></column>
 		<column><field>msg</field><type>DB_BLOB</type></column>
 		<column><field>method</field><type>DB_STR</type></column>
 		<column><field>status</field><type>DB_STR</type></column>

--- a/scripts/postgres/siptrace-create.sql
+++ b/scripts/postgres/siptrace-create.sql
@@ -1,9 +1,9 @@
-INSERT INTO version (table_name, table_version) values ('sip_trace','4');
+INSERT INTO version (table_name, table_version) values ('sip_trace','5');
 CREATE TABLE sip_trace (
     id SERIAL PRIMARY KEY NOT NULL,
     time_stamp TIMESTAMP WITHOUT TIME ZONE DEFAULT '1900-01-01 00:00:01' NOT NULL,
     callid VARCHAR(255) DEFAULT '' NOT NULL,
-    traced_user VARCHAR(128) DEFAULT NULL,
+    trace_attrs VARCHAR(128) DEFAULT NULL,
     msg TEXT NOT NULL,
     method VARCHAR(32) DEFAULT '' NOT NULL,
     status VARCHAR(128) DEFAULT NULL,
@@ -18,7 +18,7 @@ CREATE TABLE sip_trace (
 );
 
 ALTER SEQUENCE sip_trace_id_seq MAXVALUE 2147483647 CYCLE;
-CREATE INDEX sip_trace_traced_user_idx ON sip_trace (traced_user);
+CREATE INDEX sip_trace_trace_attrs_idx ON sip_trace (trace_attrs);
 CREATE INDEX sip_trace_date_idx ON sip_trace (time_stamp);
 CREATE INDEX sip_trace_fromip_idx ON sip_trace (from_ip);
 CREATE INDEX sip_trace_callid_idx ON sip_trace (callid);

--- a/scripts/sqlite/siptrace-create.sql
+++ b/scripts/sqlite/siptrace-create.sql
@@ -1,9 +1,9 @@
-INSERT INTO version (table_name, table_version) values ('sip_trace','4');
+INSERT INTO version (table_name, table_version) values ('sip_trace','5');
 CREATE TABLE sip_trace (
     id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
     time_stamp DATETIME DEFAULT '1900-01-01 00:00:01' NOT NULL,
     callid CHAR(255) DEFAULT '' NOT NULL,
-    traced_user CHAR(128) DEFAULT NULL,
+    trace_attrs CHAR(128) DEFAULT NULL,
     msg TEXT NOT NULL,
     method CHAR(32) DEFAULT '' NOT NULL,
     status CHAR(128) DEFAULT NULL,
@@ -17,7 +17,7 @@ CREATE TABLE sip_trace (
     direction CHAR(4) DEFAULT '' NOT NULL
 );
 
-CREATE INDEX sip_trace_traced_user_idx  ON sip_trace (traced_user);
+CREATE INDEX sip_trace_trace_attrs_idx  ON sip_trace (trace_attrs);
 CREATE INDEX sip_trace_date_idx  ON sip_trace (time_stamp);
 CREATE INDEX sip_trace_fromip_idx  ON sip_trace (from_ip);
 CREATE INDEX sip_trace_callid_idx  ON sip_trace (callid);


### PR DESCRIPTION
* added trace_id parameter with which one is able to define
database urls and trace uris (HEP and SIP); the trace id is given
as an argument to sip_trace() function;
* multiple trace_id s can be defined under the same name which
will alow users to do multiple types of tracing using only one
function call;
* sip_trace() now accepts flags to specify what to trace: message,
transaction or dialog; in stateless mode only message trace does
a valid type of trace;
* traced_user_avp now is as an argument to sip_trace() function;
it's name now changed to trace_attrs and also the column in the
database and table version were modified;setting it won't duplicate
entries in the database; it will do only one insert setting the
trace_attrs column accordingly;
* most of the parameters in the modparam section(db_url, table,
duplicate_uri, duplicate_with_hep) are now part of a trace_id
called 'default'; removed the old ones completely; all that remains
now is the trace_on parameter which can be set/unset with mi
(read the docs for more info), trace_local_ip and trace id;
* the stateless part of the sip_trace module was completely
removed; this also caused that the ACKs that are forwarded
by OpenSIPS are caught only when they come(input) and not when
they leave(output); this was done using the stateless forward
callback but this is highly ineffective(registering a callback
that would be called for all the requests for only one type of
messages);