### PR TITLE
proto_bin: add check for packet marker, use proto_tcp_read function

### DIFF
--- a/bin_interface.h
+++ b/bin_interface.h
@@ -30,8 +30,8 @@
 
 #define BIN_PACKET_MARKER      "P4CK"
 #define BIN_PACKET_MARKER_SIZE 4
-#define PKG_LEN_FIELD_SIZE     4
-#define VERSION_FIELD_SIZE     4
+#define PKG_LEN_FIELD_SIZE     2
+#define VERSION_FIELD_SIZE     2
 #define LEN_FIELD_SIZE         sizeof(int)
 #define CMD_FIELD_SIZE         sizeof(int)
 #define HEADER_SIZE            (BIN_PACKET_MARKER_SIZE + PKG_LEN_FIELD_SIZE + VERSION_FIELD_SIZE)

--- a/modules/proto_bin/proto_bin.h
+++ b/modules/proto_bin/proto_bin.h
@@ -3,4 +3,6 @@
 
 #define MARKER_SIZE 4
 
+extern int proto_tcp_read(struct tcp_connection* ,struct tcp_req* );
+
 #endif


### PR DESCRIPTION
when receiving a bin packet check if the packet marker is correct
replace bin_read with proto_tcp_read
fix header len