### PR TITLE
[sipcapture] full support for hep in sipcapture/proto_hep

### DIFF
--- a/modules/proto_hep/hep.c
+++ b/modules/proto_hep/hep.c
@@ -41,7 +41,7 @@
 #include "hep.h"
 #include "../compression/compression_api.h"
 
-#define OSIP_VENDOR_ID 0x0003
+#define GENERIC_VENDOR_ID 0x0000
 #define HEP_PROTO_SIP  0x01
 
 extern int hep_version;
@@ -133,13 +133,13 @@ static int pack_hepv3(union sockaddr_union* from_su, union sockaddr_union* to_su
 	memcpy(hg.header.id, HEP_HEADER_ID, HEP_HEADER_ID_LEN);
 
 	/* IP proto */
-	hg.ip_family.chunk.vendor_id = htons(OSIP_VENDOR_ID);
+	hg.ip_family.chunk.vendor_id = htons(GENERIC_VENDOR_ID);
 	hg.ip_family.chunk.type_id   = htons(0x0001);
 	hg.ip_family.data = from_su->s.sa_family;
 	hg.ip_family.chunk.length = htons(sizeof(hg.ip_family));
 
 	/* Proto ID */
-	hg.ip_proto.chunk.vendor_id = htons(OSIP_VENDOR_ID);
+	hg.ip_proto.chunk.vendor_id = htons(GENERIC_VENDOR_ID);
 	hg.ip_proto.chunk.type_id   = htons(0x0002);
 	hg.ip_proto.data = proto;
 	hg.ip_proto.chunk.length = htons(sizeof(hg.ip_proto));
@@ -148,13 +148,13 @@ static int pack_hepv3(union sockaddr_union* from_su, union sockaddr_union* to_su
 	/* IPv4 */
 	if(from_su->s.sa_family == AF_INET) {
 		/* SRC IP */
-		src_ip4.chunk.vendor_id = htons(OSIP_VENDOR_ID);
+		src_ip4.chunk.vendor_id = htons(GENERIC_VENDOR_ID);
 		src_ip4.chunk.type_id   = htons(0x0003);
 		src_ip4.data = from_su->sin.sin_addr;
 		src_ip4.chunk.length = htons(sizeof(src_ip4));
 
 		/* DST IP */
-		dst_ip4.chunk.vendor_id = htons(OSIP_VENDOR_ID);
+		dst_ip4.chunk.vendor_id = htons(GENERIC_VENDOR_ID);
 		dst_ip4.chunk.type_id   = htons(0x0004);
 		dst_ip4.data = to_su->sin.sin_addr;
 		dst_ip4.chunk.length = htons(sizeof(dst_ip4));
@@ -162,13 +162,13 @@ static int pack_hepv3(union sockaddr_union* from_su, union sockaddr_union* to_su
 		iplen = sizeof(dst_ip4) + sizeof(src_ip4);
 
 		/* SRC PORT */
-		hg.src_port.chunk.vendor_id = htons(OSIP_VENDOR_ID);
+		hg.src_port.chunk.vendor_id = htons(GENERIC_VENDOR_ID);
 		hg.src_port.chunk.type_id   = htons(0x0007);
 		hg.src_port.data = htons(from_su->sin.sin_port);
 		hg.src_port.chunk.length = htons(sizeof(hg.src_port));
 
 		/* DST PORT */
-		hg.dst_port.chunk.vendor_id = htons(OSIP_VENDOR_ID);
+		hg.dst_port.chunk.vendor_id = htons(GENERIC_VENDOR_ID);
 		hg.dst_port.chunk.type_id   = htons(0x0008);
 		hg.dst_port.data = htons(to_su->sin.sin_port);
 		hg.dst_port.chunk.length = htons(sizeof(hg.dst_port));
@@ -176,13 +176,13 @@ static int pack_hepv3(union sockaddr_union* from_su, union sockaddr_union* to_su
 	/* IPv6 */
 	else if(from_su->s.sa_family == AF_INET6) {
 		/* SRC IPv6 */
-		src_ip6.chunk.vendor_id = htons(OSIP_VENDOR_ID);
+		src_ip6.chunk.vendor_id = htons(GENERIC_VENDOR_ID);
 		src_ip6.chunk.type_id   = htons(0x0005);
 		src_ip6.data = from_su->sin6.sin6_addr;
 		src_ip6.chunk.length = htonl(sizeof(src_ip6));
 
 		/* DST IPv6 */
-		dst_ip6.chunk.vendor_id = htons(OSIP_VENDOR_ID);
+		dst_ip6.chunk.vendor_id = htons(GENERIC_VENDOR_ID);
 		dst_ip6.chunk.type_id   = htons(0x0006);
 		dst_ip6.data = from_su->sin6.sin6_addr;
 		dst_ip6.chunk.length = htonl(sizeof(dst_ip6));
@@ -190,33 +190,33 @@ static int pack_hepv3(union sockaddr_union* from_su, union sockaddr_union* to_su
 		iplen = sizeof(dst_ip6) + sizeof(src_ip6);
 
 		/* SRC PORT */
-		hg.src_port.chunk.vendor_id = htons(OSIP_VENDOR_ID);
+		hg.src_port.chunk.vendor_id = htons(GENERIC_VENDOR_ID);
 		hg.src_port.chunk.type_id   = htons(0x0007);
 		hg.src_port.data = htons(from_su->sin6.sin6_port);
 		hg.src_port.chunk.length = htons(sizeof(hg.src_port));
 
 		/* DST PORT */
-		hg.dst_port.chunk.vendor_id = htons(OSIP_VENDOR_ID);
+		hg.dst_port.chunk.vendor_id = htons(GENERIC_VENDOR_ID);
 		hg.dst_port.chunk.type_id   = htons(0x0008);
 		hg.dst_port.data = htons(to_su->sin6.sin6_port);
 		hg.dst_port.chunk.length = htons(sizeof(hg.dst_port));
 	}
 
 	/* TIMESTAMP SEC */
-	hg.time_sec.chunk.vendor_id = htons(OSIP_VENDOR_ID);
+	hg.time_sec.chunk.vendor_id = htons(GENERIC_VENDOR_ID);
 	hg.time_sec.chunk.type_id   = htons(0x0009);
 	hg.time_sec.data = htonl(tvb.tv_sec);
 	hg.time_sec.chunk.length = htons(sizeof(hg.time_sec));
 
 
 	/* TIMESTAMP USEC */
-	hg.time_usec.chunk.vendor_id = htons(OSIP_VENDOR_ID);
+	hg.time_usec.chunk.vendor_id = htons(GENERIC_VENDOR_ID);
 	hg.time_usec.chunk.type_id   = htons(0x000a);
 	hg.time_usec.data = htonl(tvb.tv_usec);
 	hg.time_usec.chunk.length = htons(sizeof(hg.time_usec));
 
 	/* Protocol TYPE */
-	hg.proto_t.chunk.vendor_id = htons(OSIP_VENDOR_ID);
+	hg.proto_t.chunk.vendor_id = htons(GENERIC_VENDOR_ID);
 	hg.proto_t.chunk.type_id   = htons(0x000b);
 	hg.proto_t.data = HEP_PROTO_SIP;
 	hg.proto_t.chunk.length = htons(sizeof(hg.proto_t));
@@ -225,13 +225,13 @@ static int pack_hepv3(union sockaddr_union* from_su, union sockaddr_union* to_su
 
 
 	/* Capture ID */
-	hg.capt_id.chunk.vendor_id = htons(OSIP_VENDOR_ID);
+	hg.capt_id.chunk.vendor_id = htons(GENERIC_VENDOR_ID);
 	hg.capt_id.chunk.type_id   = htons(0x000c);
 	/* */
 	hg.capt_id.data = htons(hep_capture_id);
 	hg.capt_id.chunk.length = htons(sizeof(hg.capt_id));
 
-	payload_chunk.vendor_id = htons(OSIP_VENDOR_ID);
+	payload_chunk.vendor_id = htons(GENERIC_VENDOR_ID);
 	payload_chunk.type_id   = payload_compression ? htons(0x0010) : htons(0x000f);
 
 
@@ -368,8 +368,6 @@ static int pack_hepv2(union sockaddr_union* from_su, union sockaddr_union* to_su
 		return -1;
 	}
 
-    /* copy hep_hdr */
-	memcpy(buffer, &hdr, sizeof(struct hep_hdr));
 	buflen = sizeof(struct hep_hdr);
 
 	switch (hdr.hp_f) {
@@ -399,6 +397,10 @@ static int pack_hepv2(union sockaddr_union* from_su, union sockaddr_union* to_su
 			hdr.hp_dport = htons(to_su->sin6.sin6_port); /* dst port */
 			break;
      }
+
+
+    /* copy hep_hdr */
+	memcpy(buffer, &hdr, sizeof(struct hep_hdr));
 
 	/* Version 2 has timestamp, captnode ID */
 	if(hep_version == 2) {
@@ -463,7 +465,11 @@ int unpack_hepv2(char *buf, int len, struct hep_desc* h)
 
 	/* hep_hdr */
 	heph = (struct hep_hdr*) buf;
+
 	h12.hdr = *heph;
+
+	h12.hdr.hp_sport = ntohs(h12.hdr.hp_sport);
+	h12.hdr.hp_dport = ntohs(h12.hdr.hp_dport);
 
 	switch(heph->hp_f){
 	case AF_INET:
@@ -563,8 +569,12 @@ int unpack_hepv3(char *buf, int len, struct hep_desc *h)
 	unsigned short tlen;
 	unsigned long decompress_len;
 
+	generic_chunk_t* gen_chunk, *it;
+
 	u_int16_t chunk_id;
 	str decompressed_payload={NULL, 0};
+
+	memset(&h3, 0, sizeof(struct hepv3));
 
 	h->version = 3;
 
@@ -577,7 +587,7 @@ int unpack_hepv3(char *buf, int len, struct hep_desc *h)
 		/* we don't look at vendor id; we only need to parse the buffer */
 		chunk_id = ((hep_chunk_t*)buf)->type_id;
 		switch (ntohs(chunk_id)) {
-		case 0x0001:
+		case HEP_PROTO_FAMILY:
 			/* ip family*/
 			h3.hg.ip_family = *((hep_chunk_uint8_t*)buf);
 
@@ -585,7 +595,7 @@ int unpack_hepv3(char *buf, int len, struct hep_desc *h)
 			UPDATE_BUFFER(buf, tlen, h3.hg.ip_family.chunk.length);
 
 			break;
-		case 0x0002:
+		case HEP_PROTO_ID:
 			/* ip protocol ID*/
 			h3.hg.ip_proto = *((hep_chunk_uint8_t*)buf);
 
@@ -593,7 +603,7 @@ int unpack_hepv3(char *buf, int len, struct hep_desc *h)
 			UPDATE_BUFFER(buf, tlen, h3.hg.ip_proto.chunk.length);
 
 			break;
-		case 0x0003:
+		case HEP_IPV4_SRC:
 			/* ipv4 source */
 			h3.addr.ip4_addr.src_ip4 = *((hep_chunk_ip4_t*)buf);
 
@@ -601,7 +611,7 @@ int unpack_hepv3(char *buf, int len, struct hep_desc *h)
 			UPDATE_BUFFER(buf, tlen, h3.addr.ip4_addr.src_ip4.chunk.length);
 
 			break;
-		case 0x0004:
+		case HEP_IPV4_DST:
 			/* ipv4 dest */
 			h3.addr.ip4_addr.dst_ip4 = *((hep_chunk_ip4_t*)buf);
 
@@ -609,7 +619,7 @@ int unpack_hepv3(char *buf, int len, struct hep_desc *h)
 			UPDATE_BUFFER(buf, tlen, h3.addr.ip4_addr.dst_ip4.chunk.length);
 
 			break;
-		case 0x0005:
+		case HEP_IPV6_SRC:
 			/* ipv6 source */
 			h3.addr.ip6_addr.src_ip6 = *((hep_chunk_ip6_t*)buf);
 
@@ -617,7 +627,7 @@ int unpack_hepv3(char *buf, int len, struct hep_desc *h)
 			UPDATE_BUFFER(buf, tlen, h3.addr.ip6_addr.src_ip6.chunk.length);
 
 			break;
-		case 0x0006:
+		case HEP_IPV6_DST:
 			/* ipv6 dest */
 			h3.addr.ip6_addr.dst_ip6 = *((hep_chunk_ip6_t*)buf);
 
@@ -625,7 +635,7 @@ int unpack_hepv3(char *buf, int len, struct hep_desc *h)
 			UPDATE_BUFFER(buf, tlen, h3.addr.ip6_addr.dst_ip6.chunk.length);
 
 			break;
-		case 0x0007:
+		case HEP_SRC_PORT:
 			/* source port */
 			h3.hg.src_port = *((hep_chunk_uint16_t*)buf);
 
@@ -635,7 +645,7 @@ int unpack_hepv3(char *buf, int len, struct hep_desc *h)
 			UPDATE_BUFFER(buf, tlen, h3.hg.src_port.chunk.length);
 
 			break;
-		case 0x0008:
+		case HEP_DST_PORT:
 			/* dest port */
 			h3.hg.dst_port = *((hep_chunk_uint16_t*)buf);
 
@@ -645,7 +655,7 @@ int unpack_hepv3(char *buf, int len, struct hep_desc *h)
 			UPDATE_BUFFER(buf, tlen, h3.hg.dst_port.chunk.length);
 
 			break;
-		case 0x0009:
+		case HEP_TIMESTAMP:
 			/* timestamp */
 			h3.hg.time_sec = *((hep_chunk_uint32_t*)buf);
 
@@ -655,7 +665,7 @@ int unpack_hepv3(char *buf, int len, struct hep_desc *h)
 			UPDATE_BUFFER(buf, tlen, h3.hg.time_sec.chunk.length);
 
 			break;
-		case 0x000a:
+		case HEP_TIMESTAMP_US:
 			/* timestamp microsecs offset */
 			h3.hg.time_usec = *((hep_chunk_uint32_t*)buf);
 
@@ -665,7 +675,7 @@ int unpack_hepv3(char *buf, int len, struct hep_desc *h)
 			UPDATE_BUFFER(buf, tlen, h3.hg.time_usec.chunk.length);
 
 			break;
-		case 0x000b:
+		case HEP_PROTO_TYPE:
 			/* proto type */
 			h3.hg.proto_t = *((hep_chunk_uint8_t*)buf);
 
@@ -673,7 +683,7 @@ int unpack_hepv3(char *buf, int len, struct hep_desc *h)
 			UPDATE_BUFFER(buf, tlen, h3.hg.proto_t.chunk.length);
 
 			break;
-		case 0x000c:
+		case HEP_AGENT_ID:
 			/* capture agent id */
 			h3.hg.capt_id = *((hep_chunk_uint32_t*)buf);
 
@@ -683,15 +693,7 @@ int unpack_hepv3(char *buf, int len, struct hep_desc *h)
 			UPDATE_BUFFER(buf, tlen, h3.hg.capt_id.chunk.length);
 
 			break;
-		case 0x000d:
-			/* keep alive timer */
-			LM_WARN("keep alive timer not implemented!\n");
-			goto safe_exit;
-		case 0x000e:
-			/* authenticate key */
-			LM_WARN("hep with tls not implemented!\n");
-			goto safe_exit;
-		case 0x000f:
+		case HEP_PAYLOAD:
 			/* captured packet payload */
 			h3.payload_chunk = *((hep_chunk_payload_t*)buf);
 			h3.payload_chunk.data = (char *)buf + sizeof(hep_chunk_t);
@@ -700,13 +702,8 @@ int unpack_hepv3(char *buf, int len, struct hep_desc *h)
 			UPDATE_BUFFER(buf, tlen, h3.payload_chunk.chunk.length);
 
 			break;
-		case 0x0010:
+		case HEP_COMPRESSED_PAYLOAD:
 			/* captured compressed payload(GZIP/inflate)*/
-			if (!payload_compression) {
-				LM_ERR("Received compressed payload but you don't have "
-						"\"payload\" parameter set! Can't do decompression!");
-				goto safe_exit;
-			}
 
 			h3.payload_chunk = *((hep_chunk_payload_t*)buf);
 			h3.payload_chunk.data = (char *)buf + sizeof(hep_chunk_t);
@@ -716,38 +713,52 @@ int unpack_hepv3(char *buf, int len, struct hep_desc *h)
 			CONVERT_TO_HBO(h3.payload_chunk.chunk);
 			UPDATE_BUFFER(buf, tlen, h3.payload_chunk.chunk.length);
 
-			compressed_payload = (unsigned char *)h3.payload_chunk.data;
-			compress_len =(unsigned long)
+			if (payload_compression) {
+				compressed_payload = (unsigned char *)h3.payload_chunk.data;
+				compress_len =(unsigned long)
 						(h3.payload_chunk.chunk.length - sizeof(hep_chunk_t));
 
-			rc=compression_api.decompress(compressed_payload, compress_len,
+				rc=compression_api.decompress(compressed_payload, compress_len,
 								&decompressed_payload, &decompress_len);
 
 
-			if (compression_api.check_rc(rc)) {
-				LM_ERR("payload decompression failed!\n");
-				goto safe_exit;
-			}
+				if (compression_api.check_rc(rc)) {
+					LM_ERR("payload decompression failed!\n");
+					goto safe_exit;
+				}
 
-			/* update the length based on the new length */
-			h3.payload_chunk.chunk.length += (decompress_len - compress_len);
-			h3.payload_chunk.data = decompressed_payload.s;
+				/* update the length based on the new length */
+				h3.payload_chunk.chunk.length += (decompress_len - compress_len);
+				h3.payload_chunk.data = decompressed_payload.s;
+			}/* else we're just a proxy; leaving everything as is */
 
 			break;
-		case 0x0011:
-			/* internal correlation id */
-			LM_WARN("keep alive timer not implemented!\n");
-			goto safe_exit;
-		case 0x0012:
-			/* vlan ID */
-			LM_WARN("vlan ID not implemented!\n");
-			goto safe_exit;
 		default:
-			LM_ERR("invalid chunk type ID!\n");
-			return -1;
+			/* FIXME hep struct will be in shm, but if we put these in shm
+			 * locking will be required */
+			if ((gen_chunk = pkg_malloc(sizeof(generic_chunk_t)))==NULL) {
+				LM_ERR("no more pkg mem!\n");
+				return -1;
+			}
+
+			memset(gen_chunk, 0, sizeof(generic_chunk_t));
+			gen_chunk->chunk = *((hep_chunk_t*)buf);
+			gen_chunk->data = (char *)buf + sizeof(hep_chunk_t);
+
+
+			CONVERT_TO_HBO(gen_chunk->chunk);
+			UPDATE_BUFFER(buf, tlen, gen_chunk->chunk.length);
+
+			if (h3.chunk_list == NULL) {
+				h3.chunk_list = gen_chunk;
+			} else {
+				for (it=h3.chunk_list; it->next; it=it->next);
+				it->next = gen_chunk;
+			}
+
+			break;
 		}
 	}
-
 
 safe_exit:
 	h->u.hepv3 = h3;

--- a/modules/proto_hep/hep.h
+++ b/modules/proto_hep/hep.h
@@ -32,6 +32,30 @@
 #define HEP_HEADER_ID_LEN (sizeof(HEP_HEADER_ID) - 1)
 
 #define HEP_SCRIPT_SKIP 0xFF
+#define HEP_MIN_INDEX 0x0001
+#define HEP_MAX_INDEX 0x0012
+
+#define HEP_IDENTIFIER 0x0fee0faa
+
+#define HEP_OPENSIPS_VENDOR_ID 0x0003
+
+enum hep_generic_chunks { HEP_PROTO_FAMILY=0x0001, HEP_PROTO_ID=0x0002,
+	HEP_IPV4_SRC=0x0003, HEP_IPV4_DST=0x0004, HEP_IPV6_SRC=0x0005,
+	HEP_IPV6_DST=0x0006, HEP_SRC_PORT=0x0007, HEP_DST_PORT=0x0008,
+	HEP_TIMESTAMP=0x0009, HEP_TIMESTAMP_US=0x000A, HEP_PROTO_TYPE=0x000B,
+	HEP_AGENT_ID=0x000C, HEP_KEEP_ALIVE=0x000D, HEP_AUTH_KEY=0x000E,
+	HEP_PAYLOAD=0x000F, HEP_COMPRESSED_PAYLOAD=0x0010,
+	HEP_CORRELATION_ID=0x0011, HEP_VLAN_ID=0x0012};
+
+#define HEP_STRUCT_CHUNKS ((1<<HEP_PROTO_FAMILY)|(1<<HEP_PROTO_ID)|           \
+		(1<<HEP_IPV4_SRC)|(1<<HEP_IPV4_DST)|(1<<HEP_IPV6_SRC)|                \
+		(1<<HEP_IPV6_DST)|(1<<HEP_SRC_PORT)|(1<<HEP_DST_PORT)|                \
+		(1<<HEP_TIMESTAMP)|(1<<HEP_TIMESTAMP_US)|(1<<HEP_PROTO_TYPE)|         \
+		(1<<HEP_AGENT_ID)|(1<<HEP_PAYLOAD)|(1<<HEP_COMPRESSED_PAYLOAD))
+
+#define CHUNK_IS_GENERIC(_cid) (_cid>=HEP_MIN_INDEX || _cid<=HEP_MAX_INDEX)
+
+#define CHUNK_IS_IN_HEPSTRUCT(_cid) ((1<<_cid)&HEP_STRUCT_CHUNKS)
 
 /* HEPv3 types */
 
@@ -151,6 +175,14 @@ struct hep_ip6hdr {
         struct in6_addr hp6_dst;        /* destination address */
 };
 
+typedef struct _generic_chunk {
+	hep_chunk_t chunk;
+	void* data; /* blob data */
+
+	struct _generic_chunk* next;
+} generic_chunk_t;
+
+
 
 struct hep_desc {
 	int version;
@@ -185,8 +217,15 @@ struct hep_desc {
 			} addr;
 
 			hep_chunk_payload_t payload_chunk;
+			generic_chunk_t* chunk_list;
 		} hepv3;
 	} u;
+};
+
+
+struct hep_context {
+	struct hep_desc h;
+	struct receive_info ri;
 };
 
 int pack_hep(union sockaddr_union* from_su, union sockaddr_union* to_su,
@@ -198,5 +237,6 @@ int unpack_hep(char *buf, int len, int version, struct hep_desc* h);
 
 typedef int (*pack_hep_t)(union sockaddr_union* from_su, union sockaddr_union* to_su,
 		int proto, char *payload, int plen, char **retbuf, int *retlen);
+typedef int (*get_hep_ctx_id_t)(void);
 #endif
 

--- a/modules/proto_hep/hep_cb.c
+++ b/modules/proto_hep/hep_cb.c
@@ -42,6 +42,7 @@
 #include "hep_cb.h"
 
 extern int hep_version;
+extern int hep_ctx_idx;
 
 struct hep_cb_list {
 	hep_cb_t cb;
@@ -49,6 +50,11 @@ struct hep_cb_list {
 };
 
 struct hep_cb_list *cb_list=0;
+
+int get_hep_ctx_id(void)
+{
+	return hep_ctx_idx;
+}
 
 int register_hep_cb(hep_cb_t cb)
 {
@@ -120,6 +126,7 @@ int bind_proto_hep(proto_hep_api_t *api)
 
 	api->pack_hep        = pack_hep;
 	api->register_hep_cb = register_hep_cb;
+	api->get_hep_ctx_id  = get_hep_ctx_id;
 
 	return 0;
 }

--- a/modules/proto_hep/hep_cb.h
+++ b/modules/proto_hep/hep_cb.h
@@ -43,6 +43,8 @@ typedef struct proto_hep_api {
 
 	register_hep_cb_t register_hep_cb;
 	pack_hep_t		  pack_hep;
+	get_hep_ctx_id_t  get_hep_ctx_id;
+
 } proto_hep_api_t;
 
 

--- a/modules/proto_hep/proto_hep.c
+++ b/modules/proto_hep/proto_hep.c
@@ -894,7 +894,7 @@ static inline int hep_handle_req(struct tcp_req *req,
 
 		/* skip receive msg if we were told so from at least one callback */
 		if (ret != HEP_SCRIPT_SKIP &&
-				receive_msg(msg_buf, msg_len, &local_rcv) <0)
+				receive_msg(msg_buf, msg_len, &local_rcv, NULL) <0)
 				LM_ERR("receive_msg failed \n");
 
 		if (!size && req != &hep_current_req) {
@@ -1192,7 +1192,7 @@ static int hep_udp_read_req(struct socket_info *si, int* bytes_read)
 
 	if (ret != HEP_SCRIPT_SKIP) {
 		/* receive_msg must free buf too!*/
-		receive_msg( msg.s, msg.len, &ri);
+		receive_msg( msg.s, msg.len, &ri, NULL);
 	}
 
 	return 0;

--- a/modules/proto_hep/proto_hep.c
+++ b/modules/proto_hep/proto_hep.c
@@ -935,6 +935,8 @@ static inline int hep_handle_req(struct tcp_req *req,
 				goto error_free_hep;
 			}
 
+			memset(ctx, 0, context_size(CONTEXT_GLOBAL));
+
 			context_put_ptr(CONTEXT_GLOBAL, ctx, hep_ctx_idx, hep_ctx);
 
 			/* run hep callbacks */
@@ -944,7 +946,7 @@ static inline int hep_handle_req(struct tcp_req *req,
 				goto error_free_hep;
 			}
 
-			msg_len = h.u.hepv3.payload_chunk.chunk.length-
+			msg_len = hep_ctx->h.u.hepv3.payload_chunk.chunk.length-
 											sizeof(hep_chunk_payload_t);
 			/* remove the hep header; leave only the payload */
 			msg_buf = hep_ctx->h.u.hepv3.payload_chunk.data;
@@ -1242,6 +1244,8 @@ static int hep_udp_read_req(struct socket_info *si, int* bytes_read)
 		LM_ERR("failed to allocate new context! skipping...\n");
 		goto error_free_hep;
 	}
+
+	memset(ctx, 0, context_size(CONTEXT_GLOBAL));
 
 	context_put_ptr(CONTEXT_GLOBAL, ctx, hep_ctx_idx, hep_ctx);
 

--- a/modules/proto_hep/proto_hep.h
+++ b/modules/proto_hep/proto_hep.h
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2015 - OpenSIPS Foundation
+ * Copyright (C) 2001-2003 FhG Fokus
+ *
+ * This file is part of opensips, a free SIP server.
+ *
+ * opensips is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version
+ *
+ * opensips is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *
+ *
+ * History:
+ * -------
+ *  2016-01-22  first version (Ionut Ionita)
+ */
+
+
+#ifndef _PROTO_HEP_
+#define _PROTO_HEP_
+extern int proto_tcp_read(struct tcp_connection*, struct tcp_req*);
+#endif

--- a/modules/proto_sctp/sctp_server.c
+++ b/modules/proto_sctp/sctp_server.c
@@ -193,7 +193,7 @@ int proto_sctp_read(struct socket_info *si, int* bytes_read)
 	}
 
 	/* receive_msg must free buf too!*/
-	receive_msg(buf, len, &ri);
+	receive_msg(buf, len, &ri, NULL);
 
 	return 0;
 }

--- a/modules/proto_ws/ws_common.h
+++ b/modules/proto_ws/ws_common.h
@@ -531,7 +531,7 @@ again:
 					"keeping connection \n");
 			}
 
-			if (receive_msg(msg_buf, msg_len, &local_rcv) <0)
+			if (receive_msg(msg_buf, msg_len, &local_rcv, NULL) <0)
 					LM_ERR("receive_msg failed \n");
 
 			*req->tcp.parsed = bk;

--- a/modules/sipcapture/README
+++ b/modules/sipcapture/README
@@ -45,17 +45,28 @@ Alexandr Dubovikov
         1.4. Exported Functions
 
               1.4.1. sip_capture()
+              1.4.2. hep_set([data_type,] chunk_id, [vendor_id,]
+                      chunk_data)
+
+              1.4.3. hep_get([data_type,] chunk_id, vendor_id_pv,
+                      chunk_data_pv)
+
+              1.4.4. hep_del(chunk_id)
 
         1.5. Exported Async Functions
 
               1.5.1. sip_capture()
 
-        1.6. MI Commands
+        1.6. Exported PseudoVariables
 
-              1.6.1. sip_capture
+              1.6.1. hep_net
 
-        1.7. Database setup
-        1.8. Limitation
+        1.7. MI Commands
+
+              1.7.1. sip_capture
+
+        1.8. Database setup
+        1.9. Limitation
 
    List of Examples
 
@@ -74,7 +85,11 @@ Alexandr Dubovikov
    1.13. Set capture_node parameter
    1.14. Set hep_store_no_script parameter
    1.15. sip_capture usage
-   1.16. sip_capture usage
+   1.16. hep_set usage
+   1.17. hep_set usage
+   1.18. hep_set usage
+   1.19. sip_capture usage
+   1.20. hep_net usage
 
 Chapter 1. Admin Guide
 
@@ -86,7 +101,12 @@ Chapter 1. Admin Guide
    OpenSIPs can capture SIP messages in three mode
      * IPIP encapsulation. (ETHHDR+IPHDR+IPHDR+UDPHDR).
      * Monitoring/mirroring port.
-     * Homer encapsulation protocl mode (HEP v1).
+     * Homer encapsulation protocl mode (HEP v1/2/3). With version
+       2.2 comes the new HEPv3 support using the proto _hep
+       module. Also header manipulation support for HEPv3 has been
+       added. See Section 1.4.2, “ hep_set([data_type,] chunk_id,
+       [vendor_id,] chunk_data) ” for more details. If you want
+       more information about hep protocol check this link.
 
    The capturing can be turned on/off using fifo commad.
 
@@ -100,6 +120,7 @@ Chapter 1. Admin Guide
 
    The following modules must be loaded before this module:
      * database module - mysql, postrgress, dbtext, unixodbc...
+     * proto_hep module - if hep capturing used
 
 1.2.2. External Libraries or Applications
 
@@ -310,6 +331,152 @@ if (is_method("REGISTER"))
         sip_capture();
 ...
 
+1.4.2.  hep_set([data_type,] chunk_id, [vendor_id,] chunk_data)
+
+   Set a hep chunk. If not exists, it shall be added.
+
+   This function can be used from
+   REQUEST_ROUTE,FAILURE_ROUTE,ONREPLY_ROUTE,BRANCH_ROUTE,LOCAL_RO
+   UTE.
+
+   Meaning of the parameters is as follows:
+     * data_type - data type of the data in the chunk. It can have
+       the following values:
+          + uint8 - byte unsigned integer
+          + uint16 - word unsigned integer
+          + uint32 - 4 byte unsigned integer
+          + inet4-addr - IPv4 address in human readable format
+          + inet6-addr - IPv6 address in human readable format
+          + utf8-string - UTF8 encoded character sequence
+          + octet-string - byte array
+     * chunk_id(string value with hex/int or string identifiere of
+       chunk) - id of the chunk to be added; most of the generic
+       chunks are in the internal hep structure. For these you can
+       skip the data_type and vendor_id since they are already
+       known. Generic chunks that don't have built in support are
+       the followinig: 0x000d(keep alive timer),
+       0x000e(authenticate key), 0x0011(internal correltion id),
+       0x0012(vlan ID). You can set these chunks, but only with
+       vendor id 0x0000, other values shall result in an error.
+       Timestamp(0x0009) and timestamp_us(0x000A) chunks can't be
+       set. For chunks that have built-in support you can also use
+       strings instead of chunk ids as follows:
+          + 0x0001 - proto_family(CAN'T BE SET; it shall be
+            automatically updated if you change the type of the
+            source/destination address from IPv4 to IPv6 or else)
+          + 0x0002 - proto_id; since it's quite hard to know the
+            int values for the protocol one can change this value
+            using the following string values:
+               o UDP
+               o TCP
+               o TLS
+               o SCTP
+               o WS
+               o WSS
+               o BIN
+               o HEP
+          + 0x0003 - src_ip
+          + 0x0004 - dst_ip
+          + 0x0005 - src_ip
+          + 0x0006 - dst_ip
+          + 0x0007 - src_port
+          + 0x0008 - dst_port
+          + 0x0009 - timestamp(CAN'T BE SET)
+          + 0x000A - timestamp_us(CAN'T BE SET)
+          + 0x000B - proto_type; for this variable there are
+            predefined strings which can be set:
+               o SIP
+               o XMPP
+               o SDP
+               o RTP
+               o RTCP
+               o MGCP
+               o MEGACO
+               o M2UA
+               o M3UA
+               o IAX
+               o H322
+               o H321
+          + 0x000C - captagent_id
+          + 0x000f - payload
+          + 0x0010 - payload
+     * vendor id(string value with hex or int) - there are some
+       vendor ids already defined; check hep proto docs for more
+       details.
+     * data(string) - data that the chunk shall contain;
+       internally it shall be converted to the requested data type
+
+   Example 1.16. hep_set usage
+...
+/* modify/add a generic chunk */
+hep_set("proto_type", "H321");
+
+/* add a custom chunk - int */
+hep_set("uint32", "31"/*chk id*/, "3"/*opensips vendor*/, "132")
+
+/* add a custom chunk - IPv4 address */
+hep_set("inet4-addr", "32"/*chk id*/, "3"/*opensips vendor*/, "192.168.5
+.14")
+...
+
+1.4.3.  hep_get([data_type,] chunk_id, vendor_id_pv, chunk_data_pv)
+
+   Set a hep chunk. If not exists, it shall be added.
+
+   This function can be used from
+   REQUEST_ROUTE,FAILURE_ROUTE,ONREPLY_ROUTE,BRANCH_ROUTE,LOCAL_RO
+   UTE.
+
+   Meaning of the parameters is as follows:
+     * data_type(string) - same meaning as in Section 1.4.2, “
+       hep_set([data_type,] chunk_id, [vendor_id,] chunk_data) ”;
+       can miss if it's a generic chunk
+     * chunk_id - same meaning as in Section 1.4.2, “
+       hep_set([data_type,] chunk_id, [vendor_id,] chunk_data) ”
+     * vendor_id_pv(writable pvar) - will hold the vendor id(int
+       value) of the chunk
+     * chunk_data_pv(writable pvar) - will hold the data inside
+       the chunk; some of the generic chunk data come in specific
+       format, as following:
+          + 0x0001 - proto_family(string) - AF_INET/AF_INET6
+          + 0x0002 proto_id(string) - see Section 1.4.2, “
+            hep_set([data_type,] chunk_id, [vendor_id,]
+            chunk_data) ” for possible values
+          + 0x0003/0x0004/0x0005/0x0006 src/dst_ip(string) - ip
+            addresses in human readable format
+          + 0x0009 timestamp(string) - time and date in human
+            readable format
+          + 0x000B proto_type(string) - see Section 1.4.2, “
+            hep_set([data_type,] chunk_id, [vendor_id,]
+            chunk_data) ” for possible values
+
+   Example 1.17. hep_set usage
+...
+/* get a generic chunk */
+hep_get("proto_type", "$var(vid)", "$var(data)");
+
+/* get custom chunk - you must know what kind of data is there */
+hep_set("uint32", "31"/*chk id*/, "$var(vid)", "$var(data)")
+...
+
+1.4.4.  hep_del(chunk_id)
+
+   Removes a hep chunk.
+
+   This function can be used from
+   REQUEST_ROUTE,FAILURE_ROUTE,ONREPLY_ROUTE,BRANCH_ROUTE,LOCAL_RO
+   UTE.
+
+   Meaning of the parameters is as follows:
+     * chunk_id - same meaning as the chunk_id in Section 1.4.2, “
+       hep_set([data_type,] chunk_id, [vendor_id,] chunk_data) ”.
+
+   Example 1.18. hep_set usage
+...
+/* get a generic chunk */
+hep_del("25"); /* removes chunk with chunk id 25 */
+...
+
 1.5. Exported Async Functions
 
 1.5.1.  sip_capture()
@@ -319,7 +486,7 @@ if (is_method("REGISTER"))
    The query might not be executed exactly at this moment, it
    depends on the max_async_queries parameter.
 
-   Example 1.16. sip_capture usage
+   Example 1.19. sip_capture usage
 ...
 {
         async(sip_capture(), capture_resume);
@@ -331,9 +498,45 @@ route[capture_resume] {
 }
 ...
 
-1.6. MI Commands
+1.6. Exported PseudoVariables
 
-1.6.1.  sip_capture
+1.6.1.  hep_net
+
+   Holds layer 3 and 4 information(IP addresses and ports) about
+   the node from where the hep message was received. The variable
+   is read-only and can be used only if it's referenced by it's
+   name.
+
+   Possible values for it's name are the following:
+     * proto_family - can be AF_INET/AF_INET6
+     * proto_id - it's PROTO_HEP since you receive the message as
+       hep.
+     * src_ip - IPv4/IPv6 address, depending on the proto_family,
+       of the sending node.
+     * dst_ip - IPv4/IPv6 address, depending on the proto_family,
+       of the receiving node(OpenSIPS hep interface ip on which
+       the message was received).
+     * src_port - Sending node port.
+     * dst_port - Receiving port(OpenSIPS hep interace port on
+       which the message was received).
+
+   Example 1.20. hep_net usage
+...
+        /* received this hep packet on interface 192.168.2.5*/
+        if ($hep_net(dst_ip) == "192.168.2.5") {
+                /* received this on 192.168.2.5:6060 interface */
+                if ($hep_net(dst_port) == 6060) {
+                        ...
+                /* received this on 192.168.2.5:6061 interface */
+                } else if ($hep_net(dst_port) == 6061) {
+                        ...
+                }
+        }
+...
+
+1.7. MI Commands
+
+1.7.1.  sip_capture
 
    Name: sip_capture
 
@@ -351,7 +554,7 @@ route[capture_resume] {
                 capture_mode
                 _empty_line_
 
-1.7. Database setup
+1.8. Database setup
 
    Before running OpenSIPS with sipcapture, you have to setup the
    database tables where the module will store the data. For that,
@@ -363,7 +566,7 @@ route[capture_resume] {
    documentation on the project webpage,
    http://www.opensips.org/html/docs/db/db-schema-devel.html.
 
-1.8. Limitation
+1.9. Limitation
 
    1. Only one capturing mode on RAW socket is supported: IPIP or
    monitoring/mirroring port. Don't activate both at the same

--- a/modules/sipcapture/doc/sipcapture_admin.xml
+++ b/modules/sipcapture/doc/sipcapture_admin.xml
@@ -24,7 +24,13 @@
                 </listitem>
 		<listitem>
 		<para>
-		Homer encapsulation protocl mode (HEP v1).
+			Homer encapsulation protocl mode (HEP v1/2/3). With version 2.2
+			comes the new HEPv3 support using the proto _hep module. Also
+			header manipulation support for HEPv3 has been added. See
+			<xref linkend="hep_set_id"/> for more details. If you want more
+			information about hep protocol check this
+			<ulink url="https://github.com/sipcapture/HEP/blob/master/docs/HEP3_rev11.pdf">
+			link</ulink>.
 		</para>
 		</listitem>
 		</itemizedlist>
@@ -53,6 +59,12 @@
 				dbtext, unixodbc...
 			</para>
 			</listitem>
+			<listitem>
+			<para>
+				<emphasis>proto_hep module</emphasis> - if hep capturing used
+			</para>
+			</listitem>
+
 			</itemizedlist>
 		</para>
 	</section>
@@ -397,6 +409,299 @@ if (is_method("REGISTER"))
 
 		</section>
 
+		<section id="hep_set_id">
+		<title>
+			<function moreinfo="none">hep_set([data_type,] chunk_id, [vendor_id,] chunk_data)</function>
+		</title>
+		<para>
+			Set a hep chunk. If not exists, it shall be added.
+		</para>
+		<para>
+			This function can be used from REQUEST_ROUTE,FAILURE_ROUTE,ONREPLY_ROUTE,BRANCH_ROUTE,LOCAL_ROUTE.
+		</para>
+		<para>Meaning of the parameters is as follows:</para>
+		<itemizedlist>
+		<listitem>
+			<para>
+			<emphasis>data_type</emphasis> - data type of the data in the chunk. It can have
+			the following values:
+			</para>
+			<itemizedlist>
+			<listitem>
+			<para>uint8  - byte unsigned integer</para>
+			</listitem>
+			<listitem>
+			<para>uint16 - word unsigned integer </para>
+			</listitem>
+			<listitem>
+			<para>uint32 - 4 byte unsigned integer </para>
+			</listitem>
+			<listitem>
+			<para>inet4-addr - IPv4 address in human readable format</para>
+			</listitem>
+			<listitem>
+			<para>inet6-addr - IPv6 address in human readable format</para>
+			</listitem>
+			<listitem>
+			<para>utf8-string - UTF8 encoded character sequence</para>
+			</listitem>
+			<listitem>
+			<para>octet-string - byte array</para>
+			</listitem>
+			</itemizedlist>
+		</listitem>
+		<listitem>
+			<para>
+				<emphasis>chunk_id(string value with hex/int or string identifiere of chunk)</emphasis>
+				- id of the chunk to be added; most of the generic
+			chunks are in the internal hep structure. For these you can skip the data_type
+			and vendor_id since they are already known. Generic chunks that don't have built
+			in support are the followinig: 0x000d(keep alive timer), 0x000e(authenticate key),
+			0x0011(internal correltion id), 0x0012(vlan ID). You can set these chunks, but
+			only with vendor id 0x0000, other values shall result in an error. Timestamp(0x0009)
+			and timestamp_us(0x000A) chunks can't be set. For chunks
+			that have built-in support you can also use strings instead of chunk ids as
+			follows:
+			<itemizedlist>
+			<listitem>
+				<para>0x0001 - proto_family(CAN'T BE SET; it shall be automatically updated
+					if you change the type of the source/destination address from IPv4 to IPv6
+					or else)
+				</para>
+			</listitem>
+			<listitem>
+				<para>0x0002 - proto_id; since it's quite hard to know the int values for the protocol
+				one can change this value using the following string values:</para>
+				<itemizedlist>
+				<listitem>
+				<para>UDP</para>
+				</listitem>
+				<listitem>
+				<para>TCP</para>
+				</listitem>
+				<listitem>
+				<para>TLS</para>
+				</listitem>
+				<listitem>
+				<para>SCTP</para>
+				</listitem>
+				<listitem>
+				<para>WS</para>
+				</listitem>
+				<listitem>
+				<para>WSS</para>
+				</listitem>
+				<listitem>
+				<para>BIN</para>
+				</listitem>
+				<listitem>
+				<para>HEP</para>
+				</listitem>
+				</itemizedlist>
+			</listitem>
+			<listitem>
+			<para>0x0003 - src_ip</para>
+			</listitem>
+			<listitem>
+			<para>0x0004 - dst_ip</para>
+			</listitem>
+			<listitem>
+			<para>0x0005 - src_ip</para>
+			</listitem>
+			<listitem>
+			<para>0x0006 - dst_ip</para>
+			</listitem>
+			<listitem>
+			<para>0x0007 - src_port</para>
+			</listitem>
+			<listitem>
+			<para>0x0008 - dst_port</para>
+			</listitem>
+			<listitem>
+			<para>0x0009 - timestamp(CAN'T BE SET)</para>
+			</listitem>
+			<listitem>
+			<para>0x000A - timestamp_us(CAN'T BE SET)</para>
+			</listitem>
+			<listitem>
+				<para>0x000B - proto_type; for this variable there are predefined
+				strings which can be set: </para>
+				<itemizedlist>
+				<listitem>
+				<para>SIP</para>
+				</listitem>
+				<listitem>
+				<para>XMPP</para>
+				</listitem>
+				<listitem>
+				<para>SDP</para>
+				</listitem>
+				<listitem>
+				<para>RTP</para>
+				</listitem>
+				<listitem>
+				<para>RTCP</para>
+				</listitem>
+				<listitem>
+				<para>MGCP</para>
+				</listitem>
+				<listitem>
+				<para>MEGACO</para>
+				</listitem>
+				<listitem>
+				<para>M2UA</para>
+				</listitem>
+				<listitem>
+				<para>M3UA</para>
+				</listitem>
+				<listitem>
+				<para>IAX</para>
+				</listitem>
+				<listitem>
+				<para>H322</para>
+				</listitem>
+				<listitem>
+				<para>H321</para>
+				</listitem>
+				</itemizedlist>
+			</listitem>
+			<listitem>
+			<para>0x000C - captagent_id</para>
+			</listitem>
+			<listitem>
+			<para>0x000f - payload</para>
+			</listitem>
+			<listitem>
+			<para>0x0010 - payload</para>
+			</listitem>
+			</itemizedlist>
+			</para>
+		</listitem>
+		<listitem>
+			<para><emphasis>vendor id(string value with hex or int)</emphasis> - there are
+				some vendor ids already defined; check
+				<ulink url="https://github.com/sipcapture/HEP/blob/master/docs/HEP3_rev11.pdf">
+					hep proto docs</ulink>
+				for more details.
+			</para>
+		</listitem>
+		<listitem>
+			<para><emphasis>data(string)</emphasis> - data that the chunk shall contain;
+			internally it shall be converted to the requested data type</para>
+		</listitem>
+		</itemizedlist>
+	<example>
+	<title><function>hep_set</function> usage</title>
+	<programlisting format="linespecific">
+...
+/* modify/add a generic chunk */
+hep_set("proto_type", "H321");
+
+/* add a custom chunk - int */
+hep_set("uint32", "31"/*chk id*/, "3"/*opensips vendor*/, "132")
+
+/* add a custom chunk - IPv4 address */
+hep_set("inet4-addr", "32"/*chk id*/, "3"/*opensips vendor*/, "192.168.5.14")
+...
+	</programlisting>
+	</example>
+
+		</section>
+
+		<section>
+		<title>
+			<function moreinfo="none">hep_get([data_type,] chunk_id, vendor_id_pv, chunk_data_pv)</function>
+		</title>
+		<para>
+			Set a hep chunk. If not exists, it shall be added.
+		</para>
+		<para>
+			This function can be used from REQUEST_ROUTE,FAILURE_ROUTE,ONREPLY_ROUTE,BRANCH_ROUTE,LOCAL_ROUTE.
+		</para>
+		<para>Meaning of the parameters is as follows:</para>
+		<itemizedlist>
+		<listitem>
+		<para><emphasis>data_type(string)</emphasis> - same meaning as in
+			<xref linkend="hep_set_id"/>; can miss if it's a generic chunk</para>
+		</listitem>
+		<listitem>
+		<para><emphasis>chunk_id</emphasis> - same meaning as in
+			<xref linkend="hep_set_id"/></para>
+		</listitem>
+		<listitem>
+			<para><emphasis>vendor_id_pv(writable pvar)</emphasis> - will hold the vendor id(int value)
+			of the chunk</para>
+		</listitem>
+		<listitem>
+			<para><emphasis>chunk_data_pv(writable pvar)</emphasis> - will hold the data inside the
+			chunk; some of the generic chunk data come in specific format, as following:</para>
+			<itemizedlist>
+			<listitem>
+				<para>0x0001 - proto_family(string) - AF_INET/AF_INET6</para>
+			</listitem>
+			<listitem>
+				<para>0x0002  proto_id(string) - see <xref linkend="hep_set_id"/> for possible values</para>
+			</listitem>
+			<listitem>
+				<para>0x0003/0x0004/0x0005/0x0006  src/dst_ip(string) - ip addresses in human readable format</para>
+			</listitem>
+			<listitem>
+				<para>0x0009  timestamp(string) - time and date in human readable format</para>
+			</listitem>
+			<listitem>
+				<para>0x000B  proto_type(string) - see <xref linkend="hep_set_id"/> for possible values</para>
+			</listitem>
+			</itemizedlist>
+		</listitem>
+		</itemizedlist>
+
+<example>
+<title><function>hep_set</function> usage</title>
+<programlisting format="linespecific">
+...
+/* get a generic chunk */
+hep_get("proto_type", "$var(vid)", "$var(data)");
+
+/* get custom chunk - you must know what kind of data is there */
+hep_set("uint32", "31"/*chk id*/, "$var(vid)", "$var(data)")
+...
+	</programlisting>
+	</example>
+
+		</section>
+
+		<section>
+		<title>
+			<function moreinfo="none">hep_del(chunk_id)</function>
+		</title>
+		<para>
+			Removes a hep chunk.
+		</para>
+		<para>
+			This function can be used from REQUEST_ROUTE,FAILURE_ROUTE,ONREPLY_ROUTE,BRANCH_ROUTE,LOCAL_ROUTE.
+		</para>
+		<para>Meaning of the parameters is as follows:</para>
+		<itemizedlist>
+		<listitem>
+			<para><emphasis>chunk_id</emphasis> - same meaning as the <emphasis>chunk_id</emphasis> in
+				<xref linkend="hep_set_id"/>.
+			</para>
+		</listitem>
+		</itemizedlist>
+<example>
+<title><function>hep_set</function> usage</title>
+<programlisting format="linespecific">
+...
+/* get a generic chunk */
+hep_del("25"); /* removes chunk with chunk id 25 */
+...
+	</programlisting>
+	</example>
+
+		</section>
+
+
+
 	</section>
 
 	<section>
@@ -430,6 +735,70 @@ route[capture_resume] {
 	</section>
 
 </section>
+
+
+	<section>
+	<title>Exported PseudoVariables</title>
+
+	<section>
+	<title>
+		<function moreinfo="none">hep_net</function>
+	</title>
+	<para>Holds layer 3 and 4 information(IP addresses and ports) about
+		the node from where the hep message was received. The variable is
+		read-only and can be used only if it's referenced by it's name.</para>
+	<para>Possible values for it's name are the following:</para>
+	<itemizedlist>
+	<listitem>
+		<para><emphasis>proto_family</emphasis> - can be AF_INET/AF_INET6</para>
+	</listitem>
+	<listitem>
+		<para><emphasis>proto_id</emphasis> - it's PROTO_HEP since you receive
+			the message as hep.</para>
+	</listitem>
+
+	<listitem>
+		<para><emphasis>src_ip</emphasis> - IPv4/IPv6 address, depending on the
+		proto_family, of the sending node.</para>
+	</listitem>
+	<listitem>
+		<para><emphasis>dst_ip</emphasis> - IPv4/IPv6 address, depending on the
+			proto_family, of the receiving node(&osips; hep interface ip on which
+			the message was received).</para>
+	</listitem>
+	<listitem>
+		<para><emphasis>src_port</emphasis> - Sending node port.</para>
+	</listitem>
+	<listitem>
+		<para><emphasis>dst_port</emphasis> - Receiving port(&osips; hep interace
+			port on which the message was received).</para>
+	</listitem>
+	</itemizedlist>
+	<example>
+	<title><function>hep_net</function> usage</title>
+	<programlisting format="linespecific">
+...
+	/* received this hep packet on interface 192.168.2.5*/
+	if ($hep_net(dst_ip) == "192.168.2.5") {
+		/* received this on 192.168.2.5:6060 interface */
+		if ($hep_net(dst_port) == 6060) {
+			...
+		/* received this on 192.168.2.5:6061 interface */
+		} else if ($hep_net(dst_port) == 6061) {
+			...
+		}
+	}
+...
+	</programlisting>
+	</example>
+	</section>
+
+
+
+
+
+</section>
+
 
     <section>
 	<title>MI Commands</title>

--- a/modules/sipcapture/sql/sipcapture.sql
+++ b/modules/sipcapture/sql/sipcapture.sql
@@ -39,6 +39,7 @@ CREATE TABLE `sip_capture` (
   `originator_port` int(10) NOT NULL,
   `proto` int(5) NOT NULL,
   `family` int(1) DEFAULT NULL,
+  `proto_type` int(8) DEFAULT NULL,
   `rtp_stat` varchar(256) NOT NULL,
   `type` int(2) NOT NULL,
   `node` varchar(125) NOT NULL,

--- a/net/proto_tcp/tcp_common.h
+++ b/net/proto_tcp/tcp_common.h
@@ -411,7 +411,7 @@ static inline int tcp_handle_req(struct tcp_req *req,
 			}
 
 			if (receive_msg(msg_buf, msg_len,
-				&local_rcv) <0)
+				&local_rcv, NULL) <0)
 					LM_ERR("receive_msg failed \n");
 
 			if (!size && req != &_tcp_common_current_req) {

--- a/net/proto_udp/proto_udp.c
+++ b/net/proto_udp/proto_udp.c
@@ -187,7 +187,7 @@ static int udp_read_req(struct socket_info *si, int* bytes_read)
 	}
 
 	/* receive_msg must free buf too!*/
-	receive_msg( msg.s, msg.len, &ri);
+	receive_msg( msg.s, msg.len, &ri, NULL);
 
 	return 0;
 }

--- a/receive.c
+++ b/receive.c
@@ -96,7 +96,8 @@ unsigned int get_next_msg_no(void)
 /*! \note WARNING: buf must be 0 terminated (buf[len]=0) or some things might
  * break (e.g.: modules/textops)
  */
-int receive_msg(char* buf, unsigned int len, struct receive_info* rcv_info)
+int receive_msg(char* buf, unsigned int len, struct receive_info* rcv_info,
+		context_p existing_context)
 {
 	static context_p ctx = NULL;
 	struct sip_msg* msg;
@@ -107,6 +108,7 @@ int receive_msg(char* buf, unsigned int len, struct receive_info* rcv_info)
 
 	in_buff.len = len;
 	in_buff.s = buf;
+	ctx = existing_context;
 
 	/* the raw processing callbacks can change the buffer,
 	further use in_buff.s and at the end try to free in_buff.s
@@ -172,8 +174,10 @@ int receive_msg(char* buf, unsigned int len, struct receive_info* rcv_info)
 		/* set request route type --bogdan*/
 		set_route_type( REQUEST_ROUTE );
 
-		/* prepare and set a new processing context for this request */
-		prepare_context( ctx, parse_error );
+		/* prepare and set a new processing context for this request only if
+		 * no context was set from the upper layers */
+		if (existing_context == NULL)
+			prepare_context( ctx, parse_error );
 		current_processing_ctx = ctx;
 
 		/* execute pre-script callbacks, if any;
@@ -213,8 +217,10 @@ int receive_msg(char* buf, unsigned int len, struct receive_info* rcv_info)
 		/* set reply route type --bogdan*/
 		set_route_type( ONREPLY_ROUTE );
 
-		/* prepare and set a new processing context for this reply */
-		prepare_context( ctx, parse_error );
+		/* prepare and set a new processing context for this reply only if
+		 * no context was set from the upper layers */
+		if (existing_context == NULL)
+			prepare_context( ctx, parse_error );
 		current_processing_ctx = ctx;
 
 		/* execute pre-script callbacks, if any ;

--- a/receive.h
+++ b/receive.h
@@ -28,8 +28,10 @@
 #define receive_h
 
 #include "ip_addr.h"
+#include "context.h"
 
-int receive_msg(char* buf, unsigned int len, struct receive_info *ri);
+int receive_msg(char* buf, unsigned int len, struct receive_info *ri,
+		context_p existing_context);
 
 unsigned int get_next_msg_no(void);
 


### PR DESCRIPTION
* predefied context for receive_msg
* proto_hep now can read custom chunks
* changing the receive_info when a hep message arrived was moved from sipcapture to proto_hep
* set/get/del functions for hep chunks
* hep_net variable which stores info from the original receive_info
* sipcapture stores an extra parameter: proto_type(SIP, XMPP etc.) parameter 