### PR TITLE
Fix the lagging behind of time_keeper process

### DIFF
--- a/timer.h
+++ b/timer.h
@@ -50,6 +50,11 @@ typedef void (utimer_function)(utime_t uticks, void* param);
 #define TIMER_FLAG_SKIP_ON_DELAY   (1<<1)
 #define TIMER_FLAG_DELAY_ON_DELAY  (1<<2)
 
+/* try to synchronize with system time every 5 seconds */
+#define TIMER_SYNC_TICKS 5000000
+/* synchronize if drift is greater than internal timer tick */
+#define TIMER_MAX_DRIFT_TICKS ITIMER_TICK
+
 struct os_timer{
 	/* unique ID in the list of timer handlers - not really used */
 	unsigned short id;


### PR DESCRIPTION
Solution involves occasionally synchronizing with the system time in the time_keeper and also time drift compensation in the timer process.