### PR TITLE
Improve qvalue parsing

### DIFF
--- a/cfg.y
+++ b/cfg.y
@@ -125,7 +125,7 @@ extern int yylex();
 static void yyerror(char* s);
 static void yyerrorf(char* fmt, ...);
 static char* tmp;
-static int i_tmp;
+static int i_tmp, rc;
 static void* cmd_tmp;
 static struct socket_id* lst_tmp;
 static int rt;  /* Type of route block for find_export */
@@ -2233,12 +2233,17 @@ cmd:	 FORWARD LPAREN STRING RPAREN	{ mk_action2( $$, FORWARD_T,
 		| STRIP LPAREN error RPAREN { $$=0; yyerror("bad argument, "
 														"number expected"); }
 		| APPEND_BRANCH LPAREN STRING COMMA STRING RPAREN {
-				{   qvalue_t q;
-				if (str2q(&q, $5, strlen($5)) < 0) {
-					yyerror("bad argument, q value expected");
-				}
+			{
+				qvalue_t q;
+
+				rc = str2q(&q, $5, strlen($5));
+				if (rc < 0)
+					yyerrorf("bad qvalue (%.*s): %s",
+							 strlen($5), $5, qverr2str(rc));
+
 				mk_action2( $$, APPEND_BRANCH_T, STR_ST, NUMBER_ST, $3,
-						(void *)(long)q); }
+						(void *)(long)q);
+			}
 		}
 		| APPEND_BRANCH LPAREN STRING RPAREN { mk_action2( $$, APPEND_BRANCH_T,
 						STR_ST, NUMBER_ST, $3, (void *)Q_UNSPECIFIED) ; }

--- a/error.c
+++ b/error.c
@@ -103,10 +103,6 @@ int err2reason_phrase(
 			error_txt="q parameter too big";
 			*sip_error=-E_BAD_REQ;
 			break;
-		case E_Q_DEC_MISSING:
-			error_txt="Decimal part missing in q";
-			*sip_error=-E_BAD_REQ;
-			break;
 		case E_NO_DESTINATION:
 			error_txt="No destination available";
 			*sip_error=-E_BAD_SERVER;

--- a/error.h
+++ b/error.h
@@ -44,8 +44,7 @@
 #define E_Q_INV_CHAR        -15		/*!< Invalid character in q */
 #define E_Q_EMPTY           -16		/*!< Empty q */
 #define E_Q_TOO_BIG         -17		/*!< q too big (> 1) */
-#define E_Q_DEC_MISSING     -18		/*!< Decimal part missing */
-#define E_NO_DESTINATION    -19		/*!< No available destination */
+#define E_NO_DESTINATION    -18		/*!< No available destination */
 
 /* opensips specific error codes */
 #define E_IP_BLOCKED      -473		/*!< destination filtered */

--- a/modules/registrar/sip_msg.c
+++ b/modules/registrar/sip_msg.c
@@ -279,12 +279,16 @@ void calc_contact_expires(struct sip_msg* _m, param_t* _ep, int* _e, struct save
  */
 int calc_contact_q(param_t* _q, qvalue_t* _r)
 {
+	int rc;
+
 	if (!_q || (_q->body.len == 0)) {
 		*_r = default_q;
 	} else {
-		if (str2q(_r, _q->body.s, _q->body.len) < 0) {
+		rc = str2q(_r, _q->body.s, _q->body.len);
+		if (rc < 0) {
 			rerrno = R_INV_Q; /* Invalid q parameter */
-			LM_ERR("invalid q parameter\n");
+			LM_ERR("invalid qvalue (%.*s): %s\n",
+					_q->body.len, _q->body.s, qverr2str(rc));
 			return -1;
 		}
 	}

--- a/modules/uac_redirect/rd_funcs.c
+++ b/modules/uac_redirect/rd_funcs.c
@@ -104,7 +104,7 @@ static void sort_contacts(contact_t *ct_list, str *ct_array,
 {
 	param_t *q_para;
 	qvalue_t q;
-	int i,j;
+	int i, j, rc;
 	char backup;
 
 	for( ; ct_list ; ct_list = ct_list->next ) {
@@ -121,8 +121,10 @@ static void sort_contacts(contact_t *ct_list, str *ct_array,
 		if (q_para==0 || q_para->body.len==0) {
 			q = DEFAULT_Q_VALUE;
 		} else {
-			if (str2q( &q, q_para->body.s, q_para->body.len)!=0) {
-				LM_ERR("invalid q param\n");
+			rc = str2q( &q, q_para->body.s, q_para->body.len);
+			if (rc != 0) {
+				LM_ERR("invalid qvalue (%.*s): %s\n",
+						q_para->body.len, q_para->body.s, qverr2str(rc));
 				/* skip this contact */
 				continue;
 			}

--- a/qvalue.c
+++ b/qvalue.c
@@ -73,6 +73,7 @@ int str2q(qvalue_t* q, char* s, int len)
 				break;
 
 			case '.':
+				*q = 0;
 				state = ST_0_PT;
 				break;
 
@@ -165,15 +166,8 @@ int str2q(qvalue_t* q, char* s, int len)
 		}
 	}
 
-	switch(state) {
-	case ST_START:
+	if (state == ST_START)
 		return E_Q_EMPTY;
 
-	case ST_0_PT:
-	case ST_1_PT:
-		return E_Q_DEC_MISSING;
-
-	default:
-		return 0;
-	}
+	return 0;
 }

--- a/qvalue.h
+++ b/qvalue.h
@@ -74,6 +74,10 @@ typedef int qvalue_t;
 #define Q_PREFIX "0."
 #define Q_PREFIX_LEN (sizeof(Q_PREFIX) - 1)
 
+#define qverr2str(rc) \
+	(rc == E_Q_INV_CHAR ? "bad characters" : \
+	 rc == E_Q_EMPTY ? "empty value" : \
+	 rc == E_Q_TOO_BIG ? "max value is 1.0" : "bad qvalue")
 
 
 /*! \brief


### PR DESCRIPTION
According to `RFC 3261`:

> qvalue         =  ( "0" [ "." 0\*3DIGIT ] )
>                         / ( "1" [ "." 0\*3("0") ] )

This means that `1.` and `0.` qvalues MUST be supported. This PR corrects this problem.