### PR TITLE
add ds_probing_list parameter to specify which sets to probe

### DIFF
--- a/modules/dispatcher/dispatch.c
+++ b/modules/dispatcher/dispatch.c
@@ -67,6 +67,7 @@
 #include "../../rw_locking.h"
 
 #include "dispatch.h"
+#include "ds_fixups.h"
 #include "ds_bl.h"
 
 #define DS_TABLE_VERSION	7
@@ -2250,8 +2251,11 @@ void ds_check_timer(unsigned int ticks, void* param)
 		{
 			for(j=0; j<list->nr; j++)
 			{
-				/* If the Flag of the entry has "Probing set, send a probe:	*/
-				if ( ((list->dlist[j].flags&DS_INACTIVE_DST)==0) &&
+				/* If list is probed by this proxy and the Flag of
+                                 * the entry has "Probing" set, send a probe:
+                                 */
+				if ( (!ds_probing_list || in_int_list(ds_probing_list, list->id)==0) &&
+                                ((list->dlist[j].flags&DS_INACTIVE_DST)==0) &&
 				(ds_probing_mode==1 || (list->dlist[j].flags&DS_PROBING_DST)!=0
 				))
 				{

--- a/modules/dispatcher/dispatch.h
+++ b/modules/dispatcher/dispatch.h
@@ -194,7 +194,6 @@ extern int probing_threshhold; /* number of failed requests,
 						before a destination is taken into probing */
 extern int ds_probing_mode;
 
-
 int init_ds_db(ds_partition_t *partition);
 int ds_connect_db(ds_partition_t *partition);
 void ds_disconnect_db(ds_partition_t *partition);

--- a/modules/dispatcher/doc/dispatcher_admin.xml
+++ b/modules/dispatcher/doc/dispatcher_admin.xml
@@ -318,6 +318,30 @@ modparam("dispatcher", "ds_probing_mode", 1)
 	</section>
 
 	<section>
+		<title><varname>ds_probing_list</varname> (str)</title>
+		<para>
+                Defines a list of one or more setids that limits which
+                destinations are probed if probing is active.  This is useful
+                when multiple proxies share the same dispatcher table, but you
+                want to limit which ones are responsible for probing specific
+                destinations.
+		</para>
+		<para>
+		<emphasis>
+			Default value is <quote>NULL(none)</quote>.
+		</emphasis>
+		</para>
+		<example>
+		<title>Set the <quote>ds_probing_list</quote> parameter</title>
+<programlisting format="linespecific">
+...
+modparam("dispatcher", "ds_probing_list", "1,2,3")
+...
+</programlisting>
+		</example>
+	</section>
+
+	<section>
 		<title><varname>ds_define_blacklist</varname> (str)</title>
 		<para>
 		Defines a blacklist based on a dispatching setid from the 'default'

--- a/modules/dispatcher/ds_fixups.c
+++ b/modules/dispatcher/ds_fixups.c
@@ -581,6 +581,20 @@ void free_int_list(int_list_t *start, int_list_t *end)
 }
 
 /*
+ * Search for value in int_list_t
+*/
+
+int in_int_list(int_list_t *list, int val)
+{
+    int_list_t *tmp;
+    for (tmp=list;tmp!=NULL;tmp=tmp->next) {
+        if (tmp->type == GPARAM_TYPE_INT && tmp->v.ival == val)
+            return 0;
+    }
+    return -1;
+}
+
+/*
  * Get a partition and a set from a general ds_param structure
 */
 

--- a/modules/dispatcher/ds_fixups.h
+++ b/modules/dispatcher/ds_fixups.h
@@ -79,8 +79,11 @@ typedef struct max_list_param {
 	int type;
 } max_list_param_t, *max_list_param_p;
 
+extern int_list_t *ds_probing_list;
+
 int_list_t *set_list_from_pvs(struct sip_msg *msg, pv_spec_t *pvs, int_list_t *end);
 void free_int_list(int_list_t *start, int_list_t *end);
+int in_int_list(int_list_t *list, int val);
 
 int fixup_get_partition(struct sip_msg *msg, const gpartition_t *gpart,
 		ds_partition_t **partition);


### PR DESCRIPTION
Add support for a parameter that specifies which destinations this proxy is responsible for probing:

```
modparam("dispatcher", "ds_probing_list", "1")
```

I have a replicated database that includes all of my destination sets which multiple proxies load, but I want to be able to specify which sets a specific proxy is responsible for probing.

If this is something that is eventually accepted, I will update with the necessary documentation.