### PR TITLE
Fix an issue with IPv6 in the rtpproxy module

### DIFF
--- a/modules/rtpproxy/rtpproxy.c
+++ b/modules/rtpproxy/rtpproxy.c
@@ -3921,7 +3921,11 @@ force_rtp_proxy_body(struct sip_msg* msg, struct force_rtpp_args *args, pv_spec_
 				 * 3) no ip in rtpproxy response (started using unix socket and no -l param)
 				 *    must revert to default of proxy ip
 				 */
-				newip.s = args->arg2 ? args->arg2 : argv[1] ? argv[1] : ip_addr2a(&msg->rcv.dst_ip);
+				newip.s = args->arg2 ? args->arg2 : argv[1];
+				if (newip.s == NULL) {
+					newip.s = ip_addr2a(&msg->rcv.dst_ip);
+					pf1 = msg->rcv.dst_ip.af;
+				}
 				newip.len = strlen(newip.s);
 			}
 			/* marker to double check : newport goes: str -> int -> str ?!?! */


### PR DESCRIPTION
There is an old issue in the OpenSIPS which may result in SDP containing mismatching protocols, when processing rtpproxy_offer() on a IPv6 message with default flags. This has been revealed by the new version of the [voiptests](https://travis-ci.org/sippy/voiptests/)

<MSG IN>
00:00:03.089/GLOBAL/alice_ua: SENDING message to [::1]:5060:
INVITE sip:bob_6@[::1]:5060 SIP/2.0
v: SIP/2.0/UDP [::1]:5061;branch=z9hG4bKfffb7b9e25497c853146ea72a3399f5c;rport
Max-Forwards: 70
f: "Alice Smith" <sip:alice_6_ipv6@[::1]>;tag=628b36c02f1d1d5a7b4305c050a3feb6
t: <sip:bob_6@[::1]>
i: 759e9723cfa1bc5c9c294b2a6c816e77@184.71.172.86
CSeq: 200 INVITE
m: Anonymous <sip:alice_6_ipv6@[::1]:5061>
Expires: 300
User-Agent: Sippy
cisco-GUID: 3824430197-1272056386-4229849152-47475815
h323-conf-id: 3824430197-1272056386-4229849152-47475815
c: application/sdp
l: 409

v=0
o=- 986474003697 986474003697 IN IP6 ::1
s=-
c=IN IP6 2001:0:0:0:7c1:0:52b8:0
t=0 0
m=audio 40534 RTP/AVP 18 0 2 4 8 96 97 98 101
a=rtpmap:18 G729a/8000
a=rtpmap:0 PCMU/8000
a=rtpmap:2 G726-32/8000
a=rtpmap:4 G723/8000
a=rtpmap:8 PCMA/8000
a=rtpmap:96 G726-40/8000
a=rtpmap:97 G726-24/8000
a=rtpmap:98 G726-16/8000
a=rtpmap:101 telephone-event/8000
a=fmtp:101 0-15
a=ptime:30
a=sendrecv
</MSG IN>

<MSG OUT>
00:00:03.090/GLOBAL/bob_ua: RECEIVED message from [::1]:5060:
INVITE sip:bob_6@[::1]:5062 SIP/2.0
Record-Route: <sip:[0:0:0:0:0:0:0:1];lr;ftag=628b36c02f1d1d5a7b4305c050a3feb6>
Via: SIP/2.0/UDP [0:0:0:0:0:0:0:1]:5060;branch=z9hG4bKddc6.7a0c3345.0
v: SIP/2.0/UDP [::1]:5061;received=0:0:0:0:0:0:0:1;branch=z9hG4bKfffb7b9e25497c853146ea72a3399f5c;rport=5061
Max-Forwards: 69
f: "Alice Smith" <sip:alice_6_ipv6@[::1]>;tag=628b36c02f1d1d5a7b4305c050a3feb6
t: <sip:bob_6@[::1]>
i: 759e9723cfa1bc5c9c294b2a6c816e77@184.71.172.86
CSeq: 200 INVITE
m: Anonymous <sip:alice_6_ipv6@[::1]:5061>
Expires: 300
User-Agent: Sippy
cisco-GUID: 3824430197-1272056386-4229849152-47475815
h323-conf-id: 3824430197-1272056386-4229849152-47475815
c: application/sdp
Content-Length: 419

v=0
o=- 986474003697 986474003697 IN IP6 ::1
s=-
c=IN IP4 0:0:0:0:0:0:0:1
t=0 0
m=audio 12260 RTP/AVP 18 0 2 4 8 96 97 98 101
a=rtpmap:18 G729a/8000
a=rtpmap:0 PCMU/8000
a=rtpmap:2 G726-32/8000
a=rtpmap:4 G723/8000
a=rtpmap:8 PCMA/8000
a=rtpmap:96 G726-40/8000
a=rtpmap:97 G726-24/8000
a=rtpmap:98 G726-16/8000
a=rtpmap:101 telephone-event/8000
a=fmtp:101 0-15
a=ptime:30
a=sendrecv
a=nortpproxy:yes
</MSG OUT>