### PR TITLE
Fix build error on FreeBSD

### DIFF
--- a/modules/tls_mgm/tls_mgm.c
+++ b/modules/tls_mgm/tls_mgm.c
@@ -3,6 +3,9 @@
 #include <openssl/opensslv.h>
 #include <openssl/err.h>
 
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <netinet/in.h>
 #include <netinet/in_systm.h>
 #include <netinet/tcp.h>
 #include <netinet/ip.h>


### PR DESCRIPTION
Fix build error on FreeBSD  by including proper headers for the struct in_addr.