### PR TITLE
Add JSONOID to pg_type.h for supporting JSON return types as DB_STRING

### DIFF
--- a/modules/db_postgres/pg_type.h
+++ b/modules/db_postgres/pg_type.h
@@ -46,6 +46,7 @@
 #define XIDOID 			28
 #define CIDOID 			29
 #define OIDVECTOROID		30
+#define JSONOID                 114
 #define POINTOID		600
 #define LSEGOID			601
 #define PATHOID			602

--- a/modules/db_postgres/res.c
+++ b/modules/db_postgres/res.c
@@ -149,6 +149,7 @@ int db_postgres_get_columns(const db_con_t* _h, db_res_t* _r)
 			case VARCHAROID:
 			case BPCHAROID:
 			case TEXTOID:
+			case JSONOID:
 				LM_DBG("use DB_STRING result type\n");
 				RES_TYPES(_r)[col] = DB_STRING;
 			break;


### PR DESCRIPTION
I receive the following error when my PostgreSQL stored procedures return JSON type or I use row_to_json in an avp_db_query:

```WARNING:db_postgres:db_postgres_get_columns: unhandled data type column (server_detail) type id (114), use DB_STRING as default```

This just defines JSONOID as DB_STRING in `db_postgres_get_columns` as opposed to letting it default to DB_STRING and generate the warnings.
