### PR TITLE
free_disposition for any negative return error code

### DIFF
--- a/modules/sipmsgops/sipmsgops.c
+++ b/modules/sipmsgops/sipmsgops.c
@@ -1604,12 +1604,10 @@ static int sip_validate_hdrs(struct sip_msg *msg)
 				}
 				memset(disp, 0, sizeof(struct disposition));
 
-				switch (parse_disposition(&(hf->body), disp)) {
-					case -2:
-						free_disposition(&disp);
-					case -1:
-						LM_DBG("cannot parse disposition\n");
-						goto failed;
+                                if (parse_disposition(&(hf->body), disp) < 0) {
+                                        free_disposition(&disp);
+                                        LM_DBG("cannot parse disposition\n");
+                                        goto failed;
 				}
 				break;
 


### PR DESCRIPTION
I believe #822 is still occurring and that the disposition memory should be freed when ANY negative error code is received.  The package memory was still allocated just a few lines prior and a return code of -1 from `parse_disposition` only means that a disposition parameter was unable to allocate pkg memory.