### PR TITLE
event_rabbitmq order of _rmq_send attributes

### DIFF
--- a/modules/event_rabbitmq/rabbitmq_send.h
+++ b/modules/event_rabbitmq/rabbitmq_send.h
@@ -35,8 +35,8 @@
 
 typedef struct _rmq_send {
 	evi_reply_sock *sock;
-	char msg[0];
 	int process_idx;
+	char msg[0];
 } rmq_send_t;
 
 void rmq_process(int rank);


### PR DESCRIPTION
I was having an issue where the `rmq_buffer` was correctly populated with evi params, but what was transmitted over the wire was empty.  The `_rmq_send` structure contains the `msg` attribute declared as char[0] which contains the full message by allocating memory for the struct itself as well as the rmq_buffer_len: `shm_malloc(sizeof(rmq_send_t) + len)`

Moving `int process_idx` above `char msg[0]` so that msg was the last attribute which was added from commit 1bc8baf84a1fbca84bf6581071bc59c58eac6552 seems to fix the problem for me. 

Am I missing something else or should it work the way it is since that commit has been in place since Jul 22, 2015?  I just couldn't get my E_ACC_CDR events published to rabbitmq on master until I tracked it down and changed this.  Thanks.