### PR TITLE
Avoid segfault and return NULL value for $si if empty

### DIFF
--- a/pvar.c
+++ b/pvar.c
@@ -1046,7 +1046,17 @@ static int pv_get_srcip(struct sip_msg *msg, pv_param_t *param,
 	if(msg==NULL)
 		return -1;
 
+	//SRCIP not populated. Local Message?
+	if (msg->rcv.src_ip.len == 0) {
+		return pv_get_null(msg, param, res);
+	}
+
 	s.s = ip_addr2a(&msg->rcv.src_ip);
+	//Check for failure to avoid segfault
+	if(s.s == 0) {
+		return -1;
+	}
+
 	s.len = strlen(s.s);
 	return pv_get_strval(msg, param, res, &s);
 }


### PR DESCRIPTION
After upgrading some systems from 1.10 to 1.11 I started receiving segfaults that I traced back to accessing $si when it was not populated in the msg and a failure to correctly check the return value of ip_addr2a(). I believe it only happened on internally generated requests.

Not sure what changed between 1.10 and 1.11 to trigger this, but this patch fixes the crash and seems to match 1.10 behavior.