### PR TITLE
presence module: move strlen check to avoid pkg_malloc(0)

### DIFF
--- a/modules/presence/notify.c
+++ b/modules/presence/notify.c
@@ -1083,9 +1083,9 @@ str* get_p_notify_body(str pres_uri, pres_ev_t* event, str* etag, str* publ_body
 
 			if(row_vals[extra_hdrs_col].val.string_val!= NULL)
 			{
-				if (extra_hdrs && !extra_hdrs->s)
+				len = strlen(row_vals[extra_hdrs_col].val.string_val);
+				if (len > 0 && extra_hdrs && !extra_hdrs->s)
 				{
-					len = strlen(row_vals[extra_hdrs_col].val.string_val);
 					extra_hdrs->s = (char*)pkg_malloc(len);
 					if (extra_hdrs->s == NULL)
 					{
@@ -1151,9 +1151,9 @@ str* get_p_notify_body(str pres_uri, pres_ev_t* event, str* etag, str* publ_body
 
 				if(row_vals[extra_hdrs_col].val.string_val!= NULL)
 				{
-					if (extra_hdrs && !extra_hdrs->s)
+					len = strlen(row_vals[extra_hdrs_col].val.string_val);
+					if (len > 0 && extra_hdrs && !extra_hdrs->s)
 					{
-						len = strlen(row_vals[extra_hdrs_col].val.string_val);
 						extra_hdrs->s = (char*)pkg_malloc(len);
 						if (extra_hdrs->s == NULL)
 						{
@@ -1203,9 +1203,9 @@ str* get_p_notify_body(str pres_uri, pres_ev_t* event, str* etag, str* publ_body
 
 				if(row_vals[extra_hdrs_col].val.string_val!= NULL)
 				{
-					if (extra_hdrs && !extra_hdrs->s)
+					len = strlen(row_vals[extra_hdrs_col].val.string_val);
+					if (len > 0 && extra_hdrs && !extra_hdrs->s)
 					{
-						len = strlen(row_vals[extra_hdrs_col].val.string_val);
 						extra_hdrs->s = (char*)pkg_malloc(len);
 						if (extra_hdrs->s == NULL)
 						{


### PR DESCRIPTION
We made this change and found it to greatly improve reliability in our production environment. I also believe this was the intention of the code to begin with, but I could be wrong there. In general, it seems malloc'ing size 0 eventually leads to problems.