### PR TITLE
Make s.int also operate on floats/doubles by truncating them to an int

### DIFF
--- a/Makefile.defs
+++ b/Makefile.defs
@@ -1315,7 +1315,7 @@ endif
 DEFAULT_YACC=bison
 
 # on solaris add -lxnet (e.g. LIBS= -lxnet)
-LIBS= -ldl -lresolv
+LIBS= -ldl -lresolv -lm
 
 #os specific stuff
 ifeq ($(OS), linux)


### PR DESCRIPTION
This actually makes two changes:

1. It makes it so that when {s.int} is performed on an empty string it returns 0. This was the old/original behavior that was changed by https://github.com/OpenSIPS/opensips/commit/4fdb55bfab9b7cfcc3dfbf15093e2becafe7ec4b

Not sure if it was intended to affect the transformation or not. While I think the change is good for the primary use of that function, for the script level transformation we should be more lax.

2. {s.int} now also accepts a double/float and returns an int. It always truncates the number (e.g. 2.9 is 2, 2.3 is 2, -2.9 is -2, -2.3 is -2), which I think is a sane default. If someone needs more control over the rounding they can use the mathops module.

See issue #788 for some a bit of discussion on making {s.int} more permissive.

Not sure where to update the documentation for the transformations. If someone can point me at the right spot I am glad to update the documentation as well to reflect these changes.

Thanks.