### PR TITLE
[sipcapture] special route for hep messages

### DIFF
--- a/modules/proto_hep/hep.c
+++ b/modules/proto_hep/hep.c
@@ -736,14 +736,18 @@ int unpack_hepv3(char *buf, int len, struct hep_desc *h)
 		default:
 			/* FIXME hep struct will be in shm, but if we put these in shm
 			 * locking will be required */
-			if ((gen_chunk = pkg_malloc(sizeof(generic_chunk_t)))==NULL) {
+			if ((gen_chunk = shm_malloc(sizeof(generic_chunk_t)))==NULL) {
 				LM_ERR("no more pkg mem!\n");
 				return -1;
 			}
 
 			memset(gen_chunk, 0, sizeof(generic_chunk_t));
 			gen_chunk->chunk = *((hep_chunk_t*)buf);
-			gen_chunk->data = (char *)buf + sizeof(hep_chunk_t);
+
+			gen_chunk->data =
+				shm_malloc(gen_chunk->chunk.length - sizeof(hep_chunk_t));
+			memcpy(gen_chunk->data, (char *)buf + sizeof(hep_chunk_t),
+					gen_chunk->chunk.length - sizeof(hep_chunk_t));
 
 
 			CONVERT_TO_HBO(gen_chunk->chunk);

--- a/modules/proto_hep/hep.h
+++ b/modules/proto_hep/hep.h
@@ -32,6 +32,7 @@
 #define HEP_HEADER_ID_LEN (sizeof(HEP_HEADER_ID) - 1)
 
 #define HEP_SCRIPT_SKIP 0xFF
+
 #define HEP_MIN_INDEX 0x0001
 #define HEP_MAX_INDEX 0x0012
 

--- a/modules/proto_hep/hep_cb.c
+++ b/modules/proto_hep/hep_cb.c
@@ -38,6 +38,7 @@
 #include "../../net/proto_tcp/tcp_common_defs.h"
 #include "../../pt.h"
 #include "../../ut.h"
+#include "../../context.h"
 #include "hep.h"
 #include "hep_cb.h"
 
@@ -82,13 +83,13 @@ int register_hep_cb(hep_cb_t cb)
 	return 0;
 }
 
-int run_hep_cbs(struct hep_desc *h, struct receive_info *rcv)
+int run_hep_cbs(void)
 {
 	int ret, fret=-1;
 	struct hep_cb_list *cb_el;
 
 	for (cb_el=cb_list; cb_el; cb_el=cb_el->next) {
-		ret=cb_el->cb(h, rcv);
+		ret=cb_el->cb();
 		if (ret < 0) {
 			LM_ERR("hep callback failed! Continuing with the other ones!\n");
 		} else if (ret == HEP_SCRIPT_SKIP) {

--- a/modules/proto_hep/hep_cb.h
+++ b/modules/proto_hep/hep_cb.h
@@ -30,7 +30,7 @@
 #include "../../sr_module.h"
 
 
-typedef int (*hep_cb_t)(struct hep_desc *h, struct receive_info *rcv);
+typedef int (*hep_cb_t)(void);
 
 
 /* in order to register a callback one must import hep.h header
@@ -38,13 +38,19 @@ typedef int (*hep_cb_t)(struct hep_desc *h, struct receive_info *rcv);
  * headers and also the sip payload */
 typedef int (*register_hep_cb_t)(hep_cb_t cb);
 
+/*
+ * receive message in hep route
+ * it receives the route id
+ * the hep context must have been set when calling this function
+ *
+ */
+
 typedef struct proto_hep_api {
 	int version;
 
 	register_hep_cb_t register_hep_cb;
 	pack_hep_t		  pack_hep;
 	get_hep_ctx_id_t  get_hep_ctx_id;
-
 } proto_hep_api_t;
 
 
@@ -53,7 +59,7 @@ typedef int (*bind_proto_hep_t)(proto_hep_api_t* api);
 int bind_proto_hep(proto_hep_api_t *api);
 typedef int (*load_hep_f)(proto_hep_api_t *api);
 
-int run_hep_cbs(struct hep_desc *h, struct receive_info *rcv);
+int run_hep_cbs(void);
 void free_hep_cbs(void);
 
 static inline int load_hep_api(proto_hep_api_t* api )
@@ -71,7 +77,6 @@ static inline int load_hep_api(proto_hep_api_t* api )
 
 	return 0;
 }
-
 
 
 #endif

--- a/modules/sipcapture/README
+++ b/modules/sipcapture/README
@@ -40,7 +40,7 @@ Alexandr Dubovikov
               1.3.11. promiscuous_on (integer)
               1.3.12. raw_moni_bpf_on (integer)
               1.3.13. capture_node (str)
-              1.3.14. hep_store_no_script (int)
+              1.3.14. hep_route (string)
 
         1.4. Exported Functions
 
@@ -84,7 +84,7 @@ Alexandr Dubovikov
    1.11. Set promiscuous_on parameter
    1.12. Set raw_moni_bpf_on parameter
    1.13. Set capture_node parameter
-   1.14. Set hep_store_no_script parameter
+   1.14. Set hep_route parameter
    1.15. sip_capture usage
    1.16. hep_set usage
    1.17. hep_set usage
@@ -304,17 +304,31 @@ modparam("sipcapture", "raw_moni_bpf_on", 1)
 modparam("sipcapture", "capture_node", "homer03")
 ...
 
-1.3.14. hep_store_no_script (int)
+1.3.14. hep_route (string)
 
-   Flag that specifies whether or not the HEP message should pass
-   through the script. If this flag set, the message will be
-   stored in the database just after it will be received.
+   Specifies what path your hep messages should take. Possible
+   values are the following:
+     * none - don't go through the script; do directly
+       sip_capture();
+     * sip(default) - go through the main request route; here the
+       message is parsed and you can do anything you want with it;
+     * any other string value - define a route name through which
+       your hep messages should go; the message is not parsed
+       because of efficiency reasons; from here you can modify the
+       hep chunks(if hep version 3 is used) and relay the hep
+       messages to other hep capture nodes;
 
-   Default value is 0(passing through the script).
+   Default value is sip(going thorugh the main request route).
 
-   Example 1.14. Set hep_store_no_script parameter
+   Example 1.14. Set hep_route parameter
 ...
-modparam("sipcapture", "hep_store_no_script", 1)
+modparam("sipcapture", "hep_route", "my_hep_route")
+...
+
+route[my_hep_route] {
+        /* do hep stuff in here */
+        ...
+}
 ...
 
 1.4. Exported Functions

--- a/modules/sipcapture/doc/sipcapture_admin.xml
+++ b/modules/sipcapture/doc/sipcapture_admin.xml
@@ -361,22 +361,42 @@ modparam("sipcapture", "capture_node", "homer03")
 		</example>
 	</section>
 	<section>
-		<title><varname>hep_store_no_script</varname> (int)</title>
+		<title><varname>hep_route</varname> (string)</title>
 		<para>
-			Flag that specifies whether or not the HEP message should
-		pass through the script. If this flag set, the message will
-		be stored in the database just after it will be received.
+			Specifies what path your hep messages should take. Possible
+		values are the following:
 		</para>
+		<itemizedlist>
+			<listitem><para><emphasis>none</emphasis> - don't go through the script;
+					do directly sip_capture(); </para>
+			</listitem>
+			<listitem><para><emphasis>sip(default)</emphasis> - go through the main
+					request route; here the message is parsed and you can do anything you
+					want with it;</para>
+			</listitem>
+
+			<listitem><para><emphasis>any other string value</emphasis> - define a route name
+					through which your hep messages should go; the message is not parsed because
+					of efficiency reasons; from here you can modify the hep chunks(if hep version
+					3 is used) and relay the hep messages to other hep capture nodes; </para>
+			</listitem>
+		</itemizedlist>
 		<para>
 		<emphasis>
-			Default value is 0(passing through the script).
+			Default value is sip(going thorugh the main request route).
 		</emphasis>
 		</para>
 		<example>
-		<title>Set <varname>hep_store_no_script</varname> parameter</title>
+		<title>Set <varname>hep_route</varname> parameter</title>
 		<programlisting format="linespecific">
 ...
-modparam("sipcapture", "hep_store_no_script", 1)
+modparam("sipcapture", "hep_route", "my_hep_route")
+...
+
+route[my_hep_route] {
+	/* do hep stuff in here */
+	...
+}
 ...
 </programlisting>
 		</example>

--- a/modules/sipcapture/sipcapture.c
+++ b/modules/sipcapture/sipcapture.c
@@ -44,6 +44,7 @@
 #include "../../context.h"
 #include "../../mod_fix.h"
 #include "../../msg_translator.h"
+#include "../../action.h"
 
 /* BPF structure */
 #ifdef __OS_linux
@@ -158,7 +159,7 @@ static int async_sip_capture(struct sip_msg* msg, async_resume_module **resume_f
 		void **resume_param, str* s1, str* s2);
 static int w_sip_capture(struct sip_msg *msg,
 				async_resume_module **resume_f, void **resume_param);
-int hep_msg_received(struct hep_desc *h, struct receive_info *ri);
+int hep_msg_received(void);
 int extract_host_port(void);
 int raw_capture_socket(struct ip_addr* ip, str* iface, int port_start, int port_end, int proto);
 int raw_capture_rcv_loop(int rsock, int port1, int port2, int ipip);
@@ -184,6 +185,9 @@ static int
 w_get_hep(struct sip_msg* msg, char* type, char* id, char* vid, char* data);
 static int
 w_get_hep_generic(struct sip_msg* msg, char* id, char* vid, char* data);
+
+
+static int parse_hep_route(char *val);
 
 
 /* remove chunk functions */
@@ -287,6 +291,9 @@ static str hep_app_protos[]= {
 #define MAX_PAYLOAD 32767
 static char payload_buf[MAX_PAYLOAD];
 
+/* dummy request for the hep route */
+struct sip_msg dummy_req;
+
 
 /* values to be set from script for hep pvar */
 
@@ -329,7 +336,13 @@ int *capture_on_flag = NULL;
 int promisc_on = 0;
 int bpf_on = 0;
 
-int hep_store_no_script=0;
+char* hep_route=0;
+str hep_route_s;
+
+#define HEP_NO_ROUTE -1
+#define HEP_SIP_ROUTE 0
+static char* hep_route_name=NULL;
+static int hep_route_id=HEP_SIP_ROUTE;
 
 str raw_socket_listen = { 0, 0 };
 str raw_interface = { 0, 0 };
@@ -453,7 +466,7 @@ static param_export_t params[] = {
 	{"raw_interface",     		STR_PARAM, &raw_interface.s   },
         {"promiscious_on",  		INT_PARAM, &promisc_on   },
         {"raw_moni_bpf_on",  		INT_PARAM, &bpf_on   },
-	{"hep_store_no_script",		INT_PARAM, &hep_store_no_script},
+	{"hep_route",		STR_PARAM, &hep_route_name},
 	{0, 0, 0}
 };
 
@@ -532,6 +545,39 @@ struct module_exports exports = {
 	destroy,    /*!< destroy function */
 	child_init  /*!< child initialization function */
 };
+
+static int parse_hep_route(char *val)
+{
+	static const str hep_sip_route = str_init("sip");
+	static const str hep_no_route = str_init("none");
+	str route_name = {val, strlen(val)};
+
+	if ( route_name.len == hep_no_route.len &&
+			strncasecmp(route_name.s, hep_no_route.s, hep_no_route.len ) == 0) {
+		hep_route_id = HEP_NO_ROUTE;
+	} else if ( route_name.len == hep_sip_route.len &&
+			strncasecmp(route_name.s, hep_sip_route.s, hep_sip_route.len ) == 0) {
+		hep_route_id = HEP_SIP_ROUTE;
+	} else {
+		hep_route_id=get_script_route_ID_by_name( route_name.s, rlist, RT_NO);
+		if ( hep_route_id == -1 ) {
+			LM_ERR("route <%s> not defined!\n", route_name.s);
+			return -1;
+		}
+	}
+
+	return 0;
+}
+
+void build_dummy_msg(void) {
+	memset(&dummy_req, 0, sizeof(struct sip_msg));
+	dummy_req.first_line.type = SIP_REQUEST;
+	dummy_req.first_line.u.request.method.s= "DUMMY";
+	dummy_req.first_line.u.request.method.len= 5;
+	dummy_req.first_line.u.request.uri.s= "sip:user@domain.com";
+	dummy_req.first_line.u.request.uri.len= 19;
+}
+
 
 
 /*! \brief Initialize sipcapture module */
@@ -655,6 +701,18 @@ static int mod_init(void) {
 		if (hep_api.register_hep_cb(hep_msg_received)) {
 			LM_ERR("failed to register hep callback\n");
 			return -1;
+		}
+
+		if (hep_route_name != NULL) {
+			if ( parse_hep_route(hep_route_name) < 0 ) {
+				LM_ERR("bad hep route name %s\n", hep_route_name);
+				return -1;
+			}
+
+			if (hep_route_id > HEP_SIP_ROUTE) {
+				/* builds a dummy message for being able to use the hep route */
+				build_dummy_msg();
+			}
 		}
 	}
 
@@ -1980,16 +2038,27 @@ destroy_continue:
 /**
  * HEP message
  */
-int hep_msg_received(struct hep_desc *h, struct receive_info *ri)
+int hep_msg_received(void)
 {
-
 	struct sip_msg msg;
+
+	struct hep_desc *h;
+	struct hep_context* ctx;
+
+	if ((ctx=HEP_GET_CONTEXT(hep_api))==NULL) {
+		LM_WARN("not a hep message!\n");
+		return -1;
+	}
+
+	h = &ctx->h;
+
+
 
 	if(!hep_capture_on) {
 		LM_ERR("HEP is not enabled\n");
 		return 0;
 	}
-	if (hep_store_no_script) {
+	if ( hep_route_id == HEP_NO_ROUTE ) {
 		memset(&msg, 0, sizeof(struct sip_msg));
 
 		switch (h->version) {
@@ -2028,7 +2097,21 @@ int hep_msg_received(struct hep_desc *h, struct receive_info *ri)
 			return -1;
 		}
 
-		/* return a special code which will tell hep not to run the script */
+		/* don't go through the main route */
+		return HEP_SCRIPT_SKIP;
+	} else if (hep_route_id > HEP_SIP_ROUTE) {
+		/* set request route type */
+		set_route_type( REQUEST_ROUTE );
+
+
+		/* run given hep route */
+		run_top_route(rlist[hep_route_id].a, &dummy_req);
+
+		/* free possible loaded avps */
+		reset_avps();
+
+		/* don't go through the main route; we want to avoid
+		 * message parsing */
 		return HEP_SCRIPT_SKIP;
 	}
 
@@ -2710,16 +2793,21 @@ static int w_sip_capture(struct sip_msg *msg,
 		sco.destination_port = msg->rcv.dst_port;
 	}
 
-	if(sco.proto == PROTO_UDP) sco.proto=IPPROTO_UDP;
-	else if(sco.proto == PROTO_TCP) sco.proto=IPPROTO_TCP;
-	else if(sco.proto == PROTO_TLS) sco.proto=IPPROTO_IDP;
-											/* fake protocol */
-	else if(sco.proto == PROTO_SCTP) sco.proto=IPPROTO_SCTP;
-	else if(sco.proto == PROTO_WS) sco.proto=IPPROTO_ESP;
-                                            /* fake protocol */
-	else {
-		LM_ERR("unknown protocol [%d]\n",sco.proto);
-		sco.proto = PROTO_NONE;
+	/* we change to internal proto id only for version 3; for version
+	 * 1/2 we don't change the buffer inside opensips so we don't need
+	 * internal protocol id */
+	if (h && h->version == 3) {
+		if(sco.proto == PROTO_UDP) sco.proto=IPPROTO_UDP;
+		else if(sco.proto == PROTO_TCP) sco.proto=IPPROTO_TCP;
+		else if(sco.proto == PROTO_TLS) sco.proto=IPPROTO_IDP;
+												/* fake protocol */
+		else if(sco.proto == PROTO_SCTP) sco.proto=IPPROTO_SCTP;
+		else if(sco.proto == PROTO_WS) sco.proto=IPPROTO_ESP;
+												/* fake protocol */
+		else {
+			LM_ERR("unknown protocol [%d]\n",sco.proto);
+			sco.proto = PROTO_NONE;
+		}
 	}
 
 
@@ -2739,8 +2827,8 @@ static int w_sip_capture(struct sip_msg *msg,
 		sco.msg.s = h->u.hepv3.payload_chunk.data;
 		sco.msg.len = h->u.hepv3.payload_chunk.chunk.length - sizeof(hep_chunk_t);
 	} else {
-		sco.msg.s = msg->buf;
-		sco.msg.len = msg->len;
+		sco.msg.s = h->u.hepv12.payload;
+		sco.msg.len = strlen(h->u.hepv12.payload);
 	}
 	//EMPTY_STR(sco.msg);
 

--- a/modules/sipcapture/sipcapture.c
+++ b/modules/sipcapture/sipcapture.c
@@ -576,6 +576,8 @@ void build_dummy_msg(void) {
 	dummy_req.first_line.u.request.method.len= 5;
 	dummy_req.first_line.u.request.uri.s= "sip:user@domain.com";
 	dummy_req.first_line.u.request.uri.len= 19;
+	dummy_req.rcv.src_ip.af = AF_INET;
+	dummy_req.rcv.dst_ip.af = AF_INET;
 }
 
 


### PR DESCRIPTION
hep_store_no_script parameter now changed into hep_route. Using
this parameter one can either do sip_capture() without going
through the script or define a route where messages can be
forwarded using hep_relay() function and modified if hep version
3 is used, withot parsing the sip message, or go through the
main request route as usual where the message will be parsed.
For the second version, the hep route, sip_capture() won't be
available since the message it's not parsed. This functionality
stands only for routing/modifying the message.
