### PR TITLE
[acc]flags used for accounting now replaced by do_accounting()

### DIFF
--- a/modules/acc/README
+++ b/modules/acc/README
@@ -57,57 +57,45 @@ Irina-Maria Stanescu
         1.6. Exported Parameters
 
               1.6.1. early_media (integer)
-              1.6.2. failed_transaction_flag (string/integer)
-              1.6.3. report_cancels (integer)
-              1.6.4. detect_direction (integer)
-              1.6.5. multi_leg_info (string)
-              1.6.6. multi_leg_bye_info (string)
-              1.6.7. log_flag (string/integer)
-              1.6.8. log_missed_flag (string/integer)
-              1.6.9. log_level (integer)
-              1.6.10. log_facility (string)
-              1.6.11. log_extra (string)
-              1.6.12. log_extra_bye (string)
-              1.6.13. aaa_url (string)
-              1.6.14. aaa_flag (string/integer)
-              1.6.15. aaa_missed_flag (string/integer)
-              1.6.16. service_type (integer)
-              1.6.17. aaa_extra (string)
-              1.6.18. aaa_extra_bye (string)
-              1.6.19. db_flag (string/integer)
-              1.6.20. db_missed_flag (string/integer)
-              1.6.21. db_table_acc (string)
-              1.6.22. db_table_avp (string)
-              1.6.23. db_table_missed_calls (string)
-              1.6.24. db_url (string)
-              1.6.25. acc_method_column (string)
-              1.6.26. acc_from_tag_column (string)
-              1.6.27. acc_to_tag_column (string)
-              1.6.28. acc_callid_column (string)
-              1.6.29. acc_sip_code_column (string)
-              1.6.30. acc_sip_reason_column (string)
-              1.6.31. acc_time_column (string)
-              1.6.32. db_extra (string)
-              1.6.33. db_extra_bye (string)
-              1.6.34. diameter_flag (string/integer)
-              1.6.35. diameter_missed_flag (string/integer)
-              1.6.36. diameter_client_host (string)
-              1.6.37. diameter_client_port (int)
-              1.6.38. diameter_extra (string)
-              1.6.39. evi_flag (string/integer)
-              1.6.40. evi_missed_flag (string/integer)
-              1.6.41. evi_extra (string)
-              1.6.42. evi_extra_bye (string)
-              1.6.43. cdr_flag (string/integer)
-              1.6.44. acc_created_avp_name (string)
+              1.6.2. report_cancels (integer)
+              1.6.3. detect_direction (integer)
+              1.6.4. multi_leg_info (string)
+              1.6.5. multi_leg_bye_info (string)
+              1.6.6. log_level (integer)
+              1.6.7. log_facility (string)
+              1.6.8. log_extra (string)
+              1.6.9. log_extra_bye (string)
+              1.6.10. aaa_url (string)
+              1.6.11. service_type (integer)
+              1.6.12. aaa_extra (string)
+              1.6.13. aaa_extra_bye (string)
+              1.6.14. db_table_acc (string)
+              1.6.15. db_table_missed_calls (string)
+              1.6.16. db_url (string)
+              1.6.17. acc_method_column (string)
+              1.6.18. acc_from_tag_column (string)
+              1.6.19. acc_to_tag_column (string)
+              1.6.20. acc_callid_column (string)
+              1.6.21. acc_sip_code_column (string)
+              1.6.22. acc_sip_reason_column (string)
+              1.6.23. acc_time_column (string)
+              1.6.24. db_extra (string)
+              1.6.25. db_extra_bye (string)
+              1.6.26. diameter_client_host (string)
+              1.6.27. diameter_client_port (int)
+              1.6.28. diameter_extra (string)
+              1.6.29. evi_extra (string)
+              1.6.30. evi_extra_bye (string)
+              1.6.31. acc_created_avp_name (string)
 
         1.7. Exported Functions
 
-              1.7.1. acc_log_request(comment)
-              1.7.2. acc_db_request(comment, table)
-              1.7.3. acc_aaa_request(comment)
-              1.7.4. acc_diam_request(comment)
-              1.7.5. acc_evi_request(comment)
+              1.7.1. do_accounting(type, flags, table)
+              1.7.2. acc_log_request(comment)
+              1.7.3. acc_db_request(comment, table)
+              1.7.4. acc_aaa_request(comment)
+              1.7.5. acc_diam_request(comment)
+              1.7.6. acc_evi_request(comment)
 
         1.8. Exported Events
 
@@ -120,54 +108,42 @@ Irina-Maria Stanescu
    List of Examples
 
    1.1. early_media example
-   1.2. failed_transaction_flag example
-   1.3. report_cancels example
-   1.4. detect_direction example
-   1.5. multi_leg_info example
-   1.6. multi_leg_bye_info example
-   1.7. log_flag example
-   1.8. log_missed_flag example
-   1.9. log_level example
-   1.10. log_facility example
-   1.11. log_extra example
-   1.12. log_extra_bye example
-   1.13. Set aaa_url parameter
-   1.14. aaa_flag example
-   1.15. aaa_missed_flag example
-   1.16. service_type example
-   1.17. aaa_extra example
-   1.18. aaa_extra_bye example
-   1.19. db_flag example
-   1.20. db_missed_flag example
-   1.21. db_table_acc example
-   1.22. db_table_avp example
-   1.23. db_table_missed_calls example
-   1.24. db_url example
-   1.25. acc_method_column example
-   1.26. acc_from_tag_column example
-   1.27. acc_to_tag_column example
-   1.28. acc_callid_column example
-   1.29. acc_sip_code_column example
-   1.30. acc_sip_reason_column example
-   1.31. acc_time_column example
-   1.32. db_extra example
-   1.33. db_extra_bye example
-   1.34. diameter_flag example
-   1.35. diameter_missed_flag example
-   1.36. diameter_client_host example
-   1.37. diameter_client_host example
-   1.38. diameter_extra example
-   1.39. evi_flag example
-   1.40. evi_missed_flag example
-   1.41. evi_extra example
-   1.42. evi_extra_bye example
-   1.43. cdr_flag example
-   1.44. acc_created_avp_name example
-   1.45. acc_log_request usage
-   1.46. acc_db_request usage
-   1.47. acc_aaa_request usage
-   1.48. acc_diam_request usage
-   1.49. acc_evi_request usage
+   1.2. report_cancels example
+   1.3. detect_direction example
+   1.4. multi_leg_info example
+   1.5. multi_leg_bye_info example
+   1.6. log_level example
+   1.7. log_facility example
+   1.8. log_extra example
+   1.9. log_extra_bye example
+   1.10. Set aaa_url parameter
+   1.11. service_type example
+   1.12. aaa_extra example
+   1.13. aaa_extra_bye example
+   1.14. db_table_acc example
+   1.15. db_table_missed_calls example
+   1.16. db_url example
+   1.17. acc_method_column example
+   1.18. acc_from_tag_column example
+   1.19. acc_to_tag_column example
+   1.20. acc_callid_column example
+   1.21. acc_sip_code_column example
+   1.22. acc_sip_reason_column example
+   1.23. acc_time_column example
+   1.24. db_extra example
+   1.25. db_extra_bye example
+   1.26. diameter_client_host example
+   1.27. diameter_client_host example
+   1.28. diameter_extra example
+   1.29. evi_extra example
+   1.30. evi_extra_bye example
+   1.31. acc_created_avp_name example
+   1.32. acc_log_request usage
+   1.33. acc_log_request usage
+   1.34. acc_db_request usage
+   1.35. acc_aaa_request usage
+   1.36. acc_diam_request usage
+   1.37. acc_evi_request usage
 
 Chapter 1. Admin Guide
 
@@ -210,9 +186,11 @@ Chapter 1. Admin Guide
    Note that:
      * A single INVITE may produce multiple accounting reports --
        that's due to SIP forking feature.
-     * All flags related to accounting need to be set in request
-       processing route - only the "missed-call" flag may be
-       toggled from other types of routes.
+     * Since version 2.2 all flags used for accounting have been
+       replaced by the do_accounting function. No need to worry
+       anymore of whether you have set the flags or not, or be
+       confused by various flag names, now you only have to call
+       the function and it will do all the work for you.
      * OpenSIPS now supports session/dialog accounting. It can
        automatically correlate INVITEs with BYEs for generating
        proper CDRs, for example for purpose of billing.
@@ -453,20 +431,7 @@ Note
    Example 1.1. early_media example
 modparam("acc", "early_media", 1)
 
-1.6.2. failed_transaction_flag (string/integer)
-
-   Per transaction flag which says if the transaction should be
-   accounted also in case of failure (status>=300).
-
-   WARNING: Setting INT flags is deprecated! Use quoted strings
-   instead!
-
-   Default value is not-set (no flag).
-
-   Example 1.2. failed_transaction_flag example
-modparam("acc", "failed_transaction_flag", "FAIL_TRANS_FLAG")
-
-1.6.3. report_cancels (integer)
+1.6.2. report_cancels (integer)
 
    By default, CANCEL reporting is disabled -- most accounting
    applications wants to see INVITE's cancellation status. Turn on
@@ -474,10 +439,10 @@ modparam("acc", "failed_transaction_flag", "FAIL_TRANS_FLAG")
 
    Default value is 0 (no).
 
-   Example 1.3. report_cancels example
+   Example 1.2. report_cancels example
 modparam("acc", "report_cancels", 1)
 
-1.6.4. detect_direction (integer)
+1.6.3. detect_direction (integer)
 
    Controls the direction detection for sequential requests. If
    enabled (non zero value), for sequential requests with upstream
@@ -490,10 +455,10 @@ modparam("acc", "report_cancels", 1)
 
    Default value is 0 (disabled).
 
-   Example 1.4. detect_direction example
+   Example 1.3. detect_direction example
 modparam("acc", "detect_direction", 1)
 
-1.6.5. multi_leg_info (string)
+1.6.4. multi_leg_info (string)
 
    Defines the AVP set to be used in per-call-leg accounting. See
    Section 1.3, “Multi Call-Legs accounting” for a detailed
@@ -503,7 +468,7 @@ modparam("acc", "detect_direction", 1)
 
    Default value is 0 (disabled).
 
-   Example 1.5. multi_leg_info example
+   Example 1.4. multi_leg_info example
 # for syslog-based accounting, use any text you want to be printed
 modparam("acc", "multi_leg_info",
     "text1=$avp(src);text2=$avp(dst)")
@@ -517,7 +482,7 @@ modparam("acc", "multi_leg_info",
 modparam("acc", "multi_leg_info",
     "2345=$avp(src);2346=$avp(dst)")
 
-1.6.6. multi_leg_bye_info (string)
+1.6.5. multi_leg_bye_info (string)
 
    Defines the AVP set to be used in per-call-leg accounting. See
    Section 1.3, “Multi Call-Legs accounting” for a detailed
@@ -530,7 +495,7 @@ modparam("acc", "multi_leg_info",
 
    Default value is 0 (disabled).
 
-   Example 1.6. multi_leg_bye_info example
+   Example 1.5. multi_leg_bye_info example
 # for syslog-based accounting, use any text you want to be printed
 modparam("acc", "multi_leg_bye_info",
     "text1=$avp(src);text2=$avp(dst)")
@@ -541,42 +506,16 @@ modparam("acc", "multi_leg_bye_info",
 modparam("acc", "multi_leg_bye_info",
     "AAA_LEG_SRC=$avp(src);AAA_LEG_SRC=$avp(dst)")
 
-1.6.7. log_flag (string/integer)
-
-   Request flag which needs to be set to account a transaction via
-   syslog.
-
-   WARNING: Setting INT flags is deprecated! Use quoted strings
-   instead!
-
-   Default value is not-set (no flag).
-
-   Example 1.7. log_flag example
-modparam("acc", "log_flag", "LOG_FLAG")
-
-1.6.8. log_missed_flag (string/integer)
-
-   Request flag which needs to be set to account missed calls via
-   syslog.
-
-   WARNING: Setting INT flags is deprecated! Use quoted strings
-   instead!
-
-   Default value is not-set (no flag).
-
-   Example 1.8. log_missed_flag example
-modparam("acc", "log_missed_flag", "LOG_MISSED_FLAG")
-
-1.6.9. log_level (integer)
+1.6.6. log_level (integer)
 
    Log level at which accounting messages are issued to syslog.
 
    Default value is L_NOTICE.
 
-   Example 1.9. log_level example
+   Example 1.6. log_level example
 modparam("acc", "log_level", 2)   # Set log_level to 2
 
-1.6.10. log_facility (string)
+1.6.7. log_facility (string)
 
    Log facility to which accounting messages are issued to syslog.
    This allows to easily seperate the accounting specific logging
@@ -584,31 +523,31 @@ modparam("acc", "log_level", 2)   # Set log_level to 2
 
    Default value is LOG_DAEMON.
 
-   Example 1.10. log_facility example
+   Example 1.7. log_facility example
 modparam("acc", "log_facility", "LOG_DAEMON")
 
-1.6.11. log_extra (string)
+1.6.8. log_extra (string)
 
    Extra values to be logged.
 
    Default value is NULL.
 
-   Example 1.11. log_extra example
+   Example 1.8. log_extra example
 modparam("acc", "log_extra",
         "uaA=$hdr(User-Agent);uaB=$hdr(Server)/reply;uuid=$avp(123)")
 
-1.6.12. log_extra_bye (string)
+1.6.9. log_extra_bye (string)
 
    Extra values to be logged to logfile. Note that this parameter
    makes sense only when the cdr_flag is used.
 
    Default value is NULL.
 
-   Example 1.12. log_extra_bye example
+   Example 1.9. log_extra_bye example
 modparam("acc", "log_extra_bye",
         "uaA=$hdr(User-Agent);uaB=$hdr(Server)/reply;uuid=$avp(123)")
 
-1.6.13. aaa_url (string)
+1.6.10. aaa_url (string)
 
    This is the url representing the AAA protocol used and the
    location of the configuration file of this protocol.
@@ -618,59 +557,33 @@ modparam("acc", "log_extra_bye",
 
    Default value is “NULL”.
 
-   Example 1.13. Set aaa_url parameter
+   Example 1.10. Set aaa_url parameter
 ...
 modparam("acc", "aaa_url", "radius:/etc/radiusclient-ng/radiusclient.con
 f")
 ...
 
-1.6.14. aaa_flag (string/integer)
-
-   Request flag which needs to be set to account a transaction --
-   AAA specific.
-
-   WARNING: Setting INT flags is deprecated! Use quoted strings
-   instead!
-
-   Default value is not-set (no flag).
-
-   Example 1.14. aaa_flag example
-modparam("acc", "aaa_flag", "AAA_FLAG")
-
-1.6.15. aaa_missed_flag (string/integer)
-
-   Request flag which needs to be set to account missed calls --
-   AAA specific.
-
-   WARNING: Setting INT flags is deprecated! Use quoted strings
-   instead!
-
-   Default value is not-set (no flag).
-
-   Example 1.15. aaa_missed_flag example
-modparam("acc", "aaa_missed_flag", "AAA_MISSED_FLAG")
-
-1.6.16. service_type (integer)
+1.6.11. service_type (integer)
 
    AAA service type used for accounting.
 
    Default value is not-set.
 
-   Example 1.16. service_type example
+   Example 1.11. service_type example
 # Default value of service type for SIP is 15
 modparam("acc", "service_type", 15)
 
-1.6.17. aaa_extra (string)
+1.6.12. aaa_extra (string)
 
    Extra values to be logged via AAA - AAA specific.
 
    Default value is NULL.
 
-   Example 1.17. aaa_extra example
+   Example 1.12. aaa_extra example
 modparam("acc", "aaa_extra",
         "via=$hdr(Via[*]); email=$avp(email); Bcontact=$ct / reply")
 
-1.6.18. aaa_extra_bye (string)
+1.6.13. aaa_extra_bye (string)
 
    Extra values to be logged via AAA when a BYE message is
    received - AAA specific. Note that this parameter makes sense
@@ -678,168 +591,119 @@ modparam("acc", "aaa_extra",
 
    Default value is NULL.
 
-   Example 1.18. aaa_extra_bye example
+   Example 1.13. aaa_extra_bye example
 modparam("acc", "aaa_extra_bye",
         "via=$hdr(Via[*]); email=$avp(email); Bcontact=$ct / reply")
 
-1.6.19. db_flag (string/integer)
-
-   Request flag which needs to be set to account a transaction --
-   database specific.
-
-   WARNING: Setting INT flags is deprecated! Use quoted strings
-   instead!
-
-   Default value is not-set (no flag).
-
-   Example 1.19. db_flag example
-modparam("acc", "db_flag", "DB_FLAG")
-
-1.6.20. db_missed_flag (string/integer)
-
-   Request flag which needs to be set to account missed calls --
-   database specific.
-
-   WARNING: Setting INT flags is deprecated! Use quoted strings
-   instead!
-
-   Default value is not-set (no flag).
-
-   Example 1.20. db_missed_flag example
-modparam("acc", "db_missed_flag", "DB_MISSED_FLAG")
-
-1.6.21. db_table_acc (string)
+1.6.14. db_table_acc (string)
 
    Table name of accounting successfull calls -- database
    specific.
 
    Default value is “acc”
 
-   Example 1.21. db_table_acc example
+   Example 1.14. db_table_acc example
 modparam("acc", "db_table_acc", "myacc_table")
 
-1.6.22. db_table_avp (string)
-
-   This parameter should contain a string with an AVP. This AVP
-   should be populated later in the script with the database table
-   name where the request accounting should be stored. This
-   parameter is optional and if it is not used or set in the
-   script, all requests will be stored in the table specified by
-   db_table_acc parameter or it's default value.
-
-   NOTE: when using auto CDR generation, the AVP with the table
-   name should be set in the initial INVITE.
-
-   Default value is “acc”
-
-   Example 1.22. db_table_avp example
-modparam("acc", "db_table_avp", "$avp(acc_table)")
-...
-route(OUTBOUND_ACC) {
-        setflag(CDR_FLAG); # do accounting
-        $avp(acc_table) = "acc_outbound"; # store request in the "acc_ou
-tbound" table
-}
-
-1.6.23. db_table_missed_calls (string)
+1.6.15. db_table_missed_calls (string)
 
    Table name for accounting missed calls -- database specific.
 
    Default value is “missed_calls”
 
-   Example 1.23. db_table_missed_calls example
+   Example 1.15. db_table_missed_calls example
 modparam("acc", "db_table_missed_calls", "myMC_table")
 
-1.6.24. db_url (string)
+1.6.16. db_url (string)
 
    SQL address -- database specific. If is set to NULL or empty
    string, the SQL support is disabled.
 
    Default value is “NULL” (SQL disabled).
 
-   Example 1.24. db_url example
+   Example 1.16. db_url example
 modparam("acc", "db_url", "mysql://user:password@localhost/opensips")
 
-1.6.25. acc_method_column (string)
+1.6.17. acc_method_column (string)
 
    Column name in accounting table to store the request's method
    name as string.
 
    Default value is “method”.
 
-   Example 1.25. acc_method_column example
+   Example 1.17. acc_method_column example
 modparam("acc", "acc_method_column", "method")
 
-1.6.26. acc_from_tag_column (string)
+1.6.18. acc_from_tag_column (string)
 
    Column name in accounting table to store the From header TAG
    parameter.
 
    Default value is “from_tag”.
 
-   Example 1.26. acc_from_tag_column example
+   Example 1.18. acc_from_tag_column example
 modparam("acc", "acc_from_tag_column", "from_tag")
 
-1.6.27. acc_to_tag_column (string)
+1.6.19. acc_to_tag_column (string)
 
    Column name in accounting table to store the To header TAG
    parameter.
 
    Default value is “to_tag”.
 
-   Example 1.27. acc_to_tag_column example
+   Example 1.19. acc_to_tag_column example
 modparam("acc", "acc_to_tag_column", "to_tag")
 
-1.6.28. acc_callid_column (string)
+1.6.20. acc_callid_column (string)
 
    Column name in accounting table to store the request's Callid
    value.
 
    Default value is “callid”.
 
-   Example 1.28. acc_callid_column example
+   Example 1.20. acc_callid_column example
 modparam("acc", "acc_callid_column", "callid")
 
-1.6.29. acc_sip_code_column (string)
+1.6.21. acc_sip_code_column (string)
 
    Column name in accounting table to store the final reply's
    numeric code value in string format.
 
    Default value is “sip_code”.
 
-   Example 1.29. acc_sip_code_column example
+   Example 1.21. acc_sip_code_column example
 modparam("acc", "acc_sip_code_column", "sip_code")
 
-1.6.30. acc_sip_reason_column (string)
+1.6.22. acc_sip_reason_column (string)
 
    Column name in accounting table to store the final reply's
    reason phrase value.
 
    Default value is “sip_reason”.
 
-   Example 1.30. acc_sip_reason_column example
+   Example 1.22. acc_sip_reason_column example
 modparam("acc", "acc_sip_reason_column", "sip_reason")
 
-1.6.31. acc_time_column (string)
+1.6.23. acc_time_column (string)
 
    Column name in accounting table to store the time stamp of the
    transaction completion in date-time format.
 
    Default value is “time”.
 
-   Example 1.31. acc_time_column example
+   Example 1.23. acc_time_column example
 modparam("acc", "acc_time_column", "time")
 
-1.6.32. db_extra (string)
+1.6.24. db_extra (string)
 
    Extra values to be logged into database - DB specific.
 
    Default value is NULL.
 
-   Example 1.32. db_extra example
+   Example 1.24. db_extra example
 modparam("acc", "db_extra", "ct=$hdr(Content-type); email=$avp(email)")
 
-1.6.33. db_extra_bye (string)
+1.6.25. db_extra_bye (string)
 
    Extra values to be logged into database when a BYE message is
    received - DB specific. Note that this parameter makes sense
@@ -847,103 +711,51 @@ modparam("acc", "db_extra", "ct=$hdr(Content-type); email=$avp(email)")
 
    Default value is NULL.
 
-   Example 1.33. db_extra_bye example
+   Example 1.25. db_extra_bye example
 modparam("acc", "db_extra_bye", "ct=$hdr(Content-type); email=$avp(email
 )")
 
-1.6.34. diameter_flag (string/integer)
-
-   Request flag which needs to be set to account a transaction --
-   DIAMETER specific.
-
-   WARNING: Setting INT flags is deprecated! Use quoted strings
-   instead!
-
-   Default value is not-set (no flag).
-
-   Example 1.34. diameter_flag example
-modparam("acc", "diameter_flag", "DIAMETER_FLAG")
-
-1.6.35. diameter_missed_flag (string/integer)
-
-   Request flag which needs to be set to account missed calls --
-   DIAMETER specific.
-
-   WARNING: Setting INT flags is deprecated! Use quoted strings
-   instead!
-
-   Default value is not-set (no flag).
-
-   Example 1.35. diameter_missed_flag example
-modparam("acc", "diameter_missed_flag", "DIAMETER_MISSED_FLAG")
-
-1.6.36. diameter_client_host (string)
+1.6.26. diameter_client_host (string)
 
    Hostname of the machine where the DIAMETER Client is running --
    DIAMETER specific.
 
    Default value is “localhost”.
 
-   Example 1.36. diameter_client_host example
+   Example 1.26. diameter_client_host example
 modparam("acc", "diameter_client_host", "3a_server.net")
 
-1.6.37. diameter_client_port (int)
+1.6.27. diameter_client_port (int)
 
    Port number where the Diameter Client is listening -- DIAMETER
    specific.
 
    Default value is “3000”.
 
-   Example 1.37. diameter_client_host example
+   Example 1.27. diameter_client_host example
 modparam("acc", "diameter_client_port", 3000)
 
-1.6.38. diameter_extra (string)
+1.6.28. diameter_extra (string)
 
    Extra values to be logged via DIAMETER - DIAMETER specific.
 
    Default value is NULL.
 
-   Example 1.38. diameter_extra example
+   Example 1.28. diameter_extra example
 modparam("acc", "diameter_extra", "7846=$hdr(Content-type);7847=$avp(ema
 il)")
 
-1.6.39. evi_flag (string/integer)
-
-   Request flag which needs to be set to account a transaction
-   through the Event Interface.
-
-   WARNING: Setting INT flags is deprecated! Use quoted strings
-   instead!
-
-   Default value is not-set (no flag).
-
-   Example 1.39. evi_flag example
-modparam("acc", "evi_flag", "EVI_FLAG")
-
-1.6.40. evi_missed_flag (string/integer)
-
-   Request flag which needs to be set to account missed calls
-   throught the Event Interface.
-
-   WARNING: Setting INT flags is deprecated! Use quoted strings
-   instead!
-
-   Default value is not-set (no flag).
-
-   Example 1.40. evi_missed_flag example
-modparam("acc", "evi_missed_flag", "EVI_MISSED_FLAG")
-
-1.6.41. evi_extra (string)
+1.6.29. evi_extra (string)
 
    Extra values to be attached as event's parameters.
 
    Default value is NULL.
 
-   Example 1.41. evi_extra example
+   Example 1.29. evi_extra example
 modparam("acc", "evi_extra",
         "uaA=$hdr(User-Agent);uaB=$hdr(Server)/reply;uuid=$avp(123)")
 
-1.6.42. evi_extra_bye (string)
+1.6.30. evi_extra_bye (string)
 
    Extra values to be attached as event's parameters for BYE
    messages. Note that this parameter makes sense only when the
@@ -951,24 +763,11 @@ modparam("acc", "evi_extra",
 
    Default value is NULL.
 
-   Example 1.42. evi_extra_bye example
+   Example 1.30. evi_extra_bye example
 modparam("acc", "evi_extra_bye",
         "uaA=$hdr(User-Agent);uaB=$hdr(Server)/reply;uuid=$avp(123)")
 
-1.6.43. cdr_flag (string/integer)
-
-   Request flag which needs to be set to account a transaction,
-   including CDR details.
-
-   WARNING: Setting INT flags is deprecated! Use quoted strings
-   instead!
-
-   Default value is not-set (no flag).
-
-   Example 1.43. cdr_flag example
-modparam("acc", "cdr_flag", "CDR_FLAG")
-
-1.6.44. acc_created_avp_name (string)
+1.6.31. acc_created_avp_name (string)
 
    The name of the openSips avp that will be used to hold the time
    when the call was created. This time will only be logged on
@@ -976,12 +775,64 @@ modparam("acc", "cdr_flag", "CDR_FLAG")
 
    Default value is "accX_created".
 
-   Example 1.44. acc_created_avp_name example
+   Example 1.31. acc_created_avp_name example
 modparam("acc", "acc_created_avp_name", "call_created_avp")
 
 1.7. Exported Functions
 
-1.7.1.  acc_log_request(comment)
+1.7.1.  do_accounting(type, flags, table)
+
+   do_accounting() replace all the *_flag and, *_missed_flag,
+   cdr_flag, failed transaction_flag and the db_table_avp modpara.
+   Just call do_accounting(), select where you want to do
+   accounting and how and the function will do all the job for
+   you.
+
+   Meaning of the parameters is as follows:
+     * type - the type of accounting you want to do. All the types
+       have to be separated by '|'. The following parameters can
+       be used:
+          + log - syslog accounting;
+          + db - database accounting;
+          + aaa - aaa specific accounting;
+          + evi - Event Interface accounting;
+          + diam - Diameter accounting;
+     * flags - flags for the accouting type you have selected. All
+       the types have to be separated by '|'. The following
+       parameters can be used:
+          + cdr - also set CDR details when doing accounting;
+            DIALOG MODULE HAS TO BE LOADED;
+          + missed - log missed calls;
+          + missed - log missed calls;
+          + failed - flag which says if the transaction should be
+            accounted also in case of failure (status>=300);
+     * table - table where to do the accounting; it replaces old
+       table_avp parameter;
+
+   This function can be used from REQUEST_ROUTE, FAILURE_ROUTE,
+   BRANCH_ROUTE and LOCAL_ROUTE.
+
+   Example 1.32. acc_log_request usage
+                ...
+                acc_log_request("403 Destination not allowed");
+                if (!has_totag()) {
+                        if (is_method("INVITE")) {
+                        /* enable cdr and missed calls accounting in the
+ database
+                         * and to syslog; db accounting shall be done in
+ "my_acc" table */
+                                do_accounting("db|log", "cdr|missed", "m
+y_acc");
+                        }
+                }
+                ...
+                if (is_method("BYE")) {
+                        /* do normal accounting via aaa */
+                        do_accounting("aaa");
+                }
+                ...
+
+1.7.2.  acc_log_request(comment)
 
    acc_request reports on a request, for example, it can be used
    to report on missed calls to off-line users who are replied 404
@@ -998,12 +849,12 @@ modparam("acc", "acc_created_avp_name", "call_created_avp")
    This function can be used from REQUEST_ROUTE, FAILURE_ROUTE,
    BRANCH_ROUTE and LOCAL_ROUTE.
 
-   Example 1.45. acc_log_request usage
+   Example 1.33. acc_log_request usage
 ...
 acc_log_request("403 Destination not allowed");
 ...
 
-1.7.2.  acc_db_request(comment, table)
+1.7.3.  acc_db_request(comment, table)
 
    Like acc_log_request, acc_db_request reports on a request. The
    report is sent to database at “db_url”, in the table referred
@@ -1019,13 +870,13 @@ acc_log_request("403 Destination not allowed");
    This function can be used from REQUEST_ROUTE, FAILURE_ROUTE,
    BRANCH_ROUTE and LOCAL_ROUTE.
 
-   Example 1.46. acc_db_request usage
+   Example 1.34. acc_db_request usage
 ...
 acc_db_request("Some comment", "Some table");
 acc_db_request("$T_reply_code $(<reply>rr)","acc");
 ...
 
-1.7.3.  acc_aaa_request(comment)
+1.7.4.  acc_aaa_request(comment)
 
    Like acc_log_request, acc_aaa_request reports on a request. It
    reports to aaa server as configured in “aaa_url”.
@@ -1039,12 +890,12 @@ acc_db_request("$T_reply_code $(<reply>rr)","acc");
    This function can be used from REQUEST_ROUTE, FAILURE_ROUTE,
    BRANCH_ROUTE and LOCAL_ROUTE.
 
-   Example 1.47. acc_aaa_request usage
+   Example 1.35. acc_aaa_request usage
 ...
 acc_aaa_request("403 Destination not allowed");
 ...
 
-1.7.4.  acc_diam_request(comment)
+1.7.5.  acc_diam_request(comment)
 
    Like acc_log_request, acc_diam_request reports on a request. It
    reports to the configured Diameter server.
@@ -1058,12 +909,12 @@ acc_aaa_request("403 Destination not allowed");
    This function can be used from REQUEST_ROUTE, FAILURE_ROUTE,
    BRANCH_ROUTE and LOCAL_ROUTE.
 
-   Example 1.48. acc_diam_request usage
+   Example 1.36. acc_diam_request usage
 ...
 acc_diam_request("403 Destination not allowed");
 ...
 
-1.7.5.  acc_evi_request(comment)
+1.7.6.  acc_evi_request(comment)
 
    Like acc_log_request, acc_evi_request reports on a request. The
    report is packed as an event sent through the OpenSIPS Event
@@ -1081,7 +932,7 @@ acc_diam_request("403 Destination not allowed");
    This function can be used from REQUEST_ROUTE, FAILURE_ROUTE,
    BRANCH_ROUTE and LOCAL_ROUTE.
 
-   Example 1.49. acc_evi_request usage
+   Example 1.37. acc_evi_request usage
 ...
 acc_evi_request("403 Destination not allowed");
 ...

--- a/modules/acc/acc.c
+++ b/modules/acc/acc.c
@@ -362,7 +362,7 @@ int acc_log_cdrs(struct dlg_cell *dlg, struct sip_msg *msg)
 
 	/* terminating line */
 	*(p++) = '\n';
-	*(p++) = 0;		
+	*(p++) = 0;
 
 	LM_GEN2(acc_log_facility, acc_log_level,
 		"%.*screated=%lu;call_start_time=%lu;duration=%lu;ms_duration=%lu;setuptime=%lu%s",
@@ -569,7 +569,6 @@ int acc_db_init(const str* db_url)
 
 	acc_db_close();
 
-	acc_db_init_keys();
 
 	return 0;
 }
@@ -579,6 +578,11 @@ int acc_db_init(const str* db_url)
  * returns 0 on success, -1 on error */
 int acc_db_init_child(const str *db_url)
 {
+
+	/* CDR flag will be checked at fixup so we need to init the keys in
+	 * here where we have that flag */
+	acc_db_init_keys();
+
 	db_handle=acc_dbf.init(db_url);
 	if (db_handle==0){
 		LM_ERR("unable to connect to the database\n");
@@ -722,7 +726,7 @@ int acc_db_cdrs(struct dlg_cell *dlg, struct sip_msg *msg)
 	VAL_INT(db_vals_cdrs+ret+nr_vals+nr_bye_vals+1) = start_time.tv_sec - created;
 	VAL_TIME(db_vals_cdrs+ret+nr_vals+nr_bye_vals+2) = created;
 	VAL_INT(db_vals_cdrs+ret+nr_vals+nr_bye_vals+3) = end.tv_sec - start_time.tv_sec;
-	VAL_INT(db_vals_cdrs+ret+nr_vals+nr_bye_vals+4) = 
+	VAL_INT(db_vals_cdrs+ret+nr_vals+nr_bye_vals+4) =
 		(end.tv_sec-start_time.tv_sec)*1000+(end.tv_usec-start_time.tv_usec)%1000;
 
 	total = ret + 5;

--- a/modules/acc/acc_logic.h
+++ b/modules/acc/acc_logic.h
@@ -32,6 +32,41 @@
 #include "../tm/t_hooks.h"
 #include "../dialog/dlg_cb.h"
 
+#define DO_ACC_LOG  (1<<(0*8))
+#define DO_ACC_AAA  (1<<(1*8))
+#define DO_ACC_DB   (1<<(2*8))
+#define DO_ACC_DIAM (1<<(3*8))
+#define DO_ACC_EVI  ((unsigned long long)1<<(4*8))
+
+#define DO_ACC        (1<<0) /* generic accouting flag - internal only */
+#define DO_ACC_CDR    (1<<1)
+#define DO_ACC_MISSED (1<<2)
+#define DO_ACC_FAILED (1<<3)
+
+#define DO_ACC_PARAM_TYPE_PV    (1<<0)
+#define DO_ACC_PARAM_TYPE_VALUE (1<<1)
+
+#define DO_ACC_LOG_STR  "log"
+#define DO_ACC_AAA_STR  "aaa"
+#define DO_ACC_DB_STR   "db"
+#define DO_ACC_DIAM_STR "diam"
+#define DO_ACC_EVI_STR  "evi"
+
+#define DO_ACC_CDR_STR    "cdr"
+#define DO_ACC_MISSED_STR "missed"
+#define DO_ACC_FAILED_STR "failed"
+
+#define DO_ACC_PARAM_DELIMITER '|'
+
+typedef unsigned long long (*do_acc_parser)(str*);
+
+typedef struct acc_type_param {
+	int t;
+	union {
+		unsigned long long ival;
+		pv_elem_p pval;
+	} u;
+} acc_type_param_t;
 
 /* various acc variables */
 struct acc_enviroment {
@@ -70,5 +105,13 @@ int w_acc_diam_request(struct sip_msg *rq, char *comment, char *foo);
 #endif
 
 int w_acc_evi_request(struct sip_msg *rq, pv_elem_t* comment, char *foo);
+
+
+int do_acc_fixup(void** param, int param_no);
+
+
+int w_do_acc_1(struct sip_msg* msg, char* type);
+int w_do_acc_2(struct sip_msg* msg, char* type, char* flags);
+int w_do_acc_3(struct sip_msg* msg, char* type_p, char* flags_p, char* table_p);
 
 #endif

--- a/modules/acc/doc/acc_admin.xml
+++ b/modules/acc/doc/acc_admin.xml
@@ -69,9 +69,11 @@
 		</listitem>
 		<listitem>
 			<para>
-			All flags related to accounting need to be set in request processing
-			route - only the "missed-call" flag may be toggled from other
-			types of routes.
+			Since version 2.2 all flags used for accounting have been replaced
+			by the do_accounting function. No need to worry anymore of whether
+			you have set the flags or not, or be confused by various flag names,
+			now you only have to call the function and it will do all the work
+			for you.
 			</para>
 		</listitem>
 		<listitem>
@@ -432,26 +434,6 @@ modparam("acc", "early_media", 1)
 		</example>
 	</section>
 	<section>
-		<title><varname>failed_transaction_flag</varname> (string/integer)</title>
-		<para>
-		Per transaction flag which says if the transaction should be
-		accounted also in case of failure (status>=300).
-		</para>
-		<para>
-		<emphasis>WARNING: </emphasis>Setting INT flags is deprecated!
-		Use quoted strings instead!
-		</para>
-		<para>
-		Default value is not-set (no flag).
-		</para>
-		<example>
-		<title>failed_transaction_flag example</title>
-		<programlisting format="linespecific">
-modparam("acc", "failed_transaction_flag", "FAIL_TRANS_FLAG")
-</programlisting>
-		</example>
-	</section>
-	<section>
 		<title><varname>report_cancels</varname> (integer)</title>
 		<para>
 		By default, CANCEL reporting is disabled -- most accounting
@@ -552,45 +534,6 @@ modparam("acc", "multi_leg_bye_info",
 		</example>
 	</section>
 
-	<!-- SYSLOG specific ACC parameters -->
-	<section>
-		<title><varname>log_flag</varname> (string/integer)</title>
-		<para>
-		Request flag which needs to be set to account a transaction via syslog.
-		</para>
-		<para>
-		<emphasis>WARNING: </emphasis>Setting INT flags is deprecated!
-		Use quoted strings instead!
-		</para>
-		<para>
-		Default value is not-set (no flag).
-		</para>
-		<example>
-		<title>log_flag example</title>
-		<programlisting format="linespecific">
-modparam("acc", "log_flag", "LOG_FLAG")
-</programlisting>
-		</example>
-	</section>
-	<section>
-		<title><varname>log_missed_flag</varname> (string/integer)</title>
-		<para>
-		Request flag which needs to be set to account missed calls via syslog.
-		</para>
-		<para>
-		<emphasis>WARNING: </emphasis>Setting INT flags is deprecated!
-		Use quoted strings instead!
-		</para>
-		<para>
-		Default value is not-set (no flag).
-		</para>
-		<example>
-		<title>log_missed_flag example</title>
-		<programlisting format="linespecific">
-modparam("acc", "log_missed_flag", "LOG_MISSED_FLAG")
-</programlisting>
-		</example>
-	</section>
 	<section>
 		<title><varname>log_level</varname> (integer)</title>
 		<para>
@@ -684,46 +627,6 @@ modparam("acc", "aaa_url", "radius:/etc/radiusclient-ng/radiusclient.conf")
 	</section>
 
 	<section>
-		<title><varname>aaa_flag</varname> (string/integer)</title>
-		<para>
-		Request flag which needs to be set to account a
-		transaction -- AAA specific.
-		</para>
-		<para>
-		<emphasis>WARNING: </emphasis>Setting INT flags is deprecated!
-		Use quoted strings instead!
-		</para>
-		<para>
-		Default value is not-set (no flag).
-		</para>
-		<example>
-		<title>aaa_flag example</title>
-		<programlisting format="linespecific">
-modparam("acc", "aaa_flag", "AAA_FLAG")
-</programlisting>
-		</example>
-	</section>
-	<section>
-		<title><varname>aaa_missed_flag</varname> (string/integer)</title>
-		<para>
-		Request flag which needs to be set to account missed
-		calls -- AAA specific.
-		</para>
-		<para>
-		<emphasis>WARNING: </emphasis>Setting INT flags is deprecated!
-		Use quoted strings instead!
-		</para>
-		<para>
-		Default value is not-set (no flag).
-		</para>
-		<example>
-		<title>aaa_missed_flag example</title>
-		<programlisting format="linespecific">
-modparam("acc", "aaa_missed_flag", "AAA_MISSED_FLAG")
-</programlisting>
-		</example>
-	</section>
-	<section>
 		<title><varname>service_type</varname> (integer)</title>
 		<para>
 		AAA service type used for accounting.
@@ -775,46 +678,6 @@ modparam("acc", "aaa_extra_bye",
 	</section>
 	<!-- SQL specific ACC parameters -->
 	<section>
-		<title><varname>db_flag</varname> (string/integer)</title>
-		<para>
-		Request flag which needs to be set to account a
-		transaction -- database specific.
-		</para>
-		<para>
-		<emphasis>WARNING: </emphasis>Setting INT flags is deprecated!
-		Use quoted strings instead!
-		</para>
-		<para>
-		Default value is not-set (no flag).
-		</para>
-		<example>
-		<title>db_flag example</title>
-		<programlisting format="linespecific">
-modparam("acc", "db_flag", "DB_FLAG")
-</programlisting>
-		</example>
-	</section>
-	<section>
-		<title><varname>db_missed_flag</varname> (string/integer)</title>
-		<para>
-		Request flag which needs to be set to account missed
-		calls -- database specific.
-		</para>
-		<para>
-		<emphasis>WARNING: </emphasis>Setting INT flags is deprecated!
-		Use quoted strings instead!
-		</para>
-		<para>
-		Default value is not-set (no flag).
-		</para>
-		<example>
-		<title>db_missed_flag example</title>
-		<programlisting format="linespecific">
-modparam("acc", "db_missed_flag", "DB_MISSED_FLAG")
-</programlisting>
-		</example>
-	</section>
-	<section>
 		<title><varname>db_table_acc</varname> (string)</title>
 		<para>
 		Table name of accounting successfull calls -- database specific.
@@ -826,35 +689,6 @@ modparam("acc", "db_missed_flag", "DB_MISSED_FLAG")
 		<title>db_table_acc example</title>
 		<programlisting format="linespecific">
 modparam("acc", "db_table_acc", "myacc_table")
-</programlisting>
-		</example>
-	</section>
-	<section>
-		<title><varname>db_table_avp</varname> (string)</title>
-		<para>
-		This parameter should contain a string with an AVP. This AVP should
-		be populated later in the script with the database table name where
-		the request accounting should be stored. This parameter is optional
-		and if it is not used or set in the script, all requests will be
-		stored in the table specified by <emphasis>db_table_acc</emphasis>
-		parameter or it's default value.
-		</para>
-		<para>
-			NOTE: when using auto CDR generation, the AVP with the table name
-			should be set in the initial INVITE.
-		</para>
-		<para>
-		Default value is <quote>acc</quote>
-		</para>
-		<example>
-		<title>db_table_avp example</title>
-		<programlisting format="linespecific">
-modparam("acc", "db_table_avp", "$avp(acc_table)")
-...
-route(OUTBOUND_ACC) {
-	setflag(CDR_FLAG); # do accounting
-	$avp(acc_table) = "acc_outbound"; # store request in the "acc_outbound" table
-}
 </programlisting>
 		</example>
 	</section>
@@ -1031,47 +865,6 @@ modparam("acc", "db_extra_bye", "ct=$hdr(Content-type); email=$avp(email)")
 		</example>
 	</section>
 
-	<!-- DIAMETER specific ACC parameters -->
-	<section>
-		<title><varname>diameter_flag</varname> (string/integer)</title>
-		<para>
-		Request flag which needs to be set to account a
-		transaction -- DIAMETER specific.
-		</para>
-		<para>
-		<emphasis>WARNING: </emphasis>Setting INT flags is deprecated!
-		Use quoted strings instead!
-		</para>
-		<para>
-		Default value is not-set (no flag).
-		</para>
-		<example>
-		<title>diameter_flag example</title>
-		<programlisting format="linespecific">
-modparam("acc", "diameter_flag", "DIAMETER_FLAG")
-</programlisting>
-		</example>
-	</section>
-	<section>
-		<title><varname>diameter_missed_flag</varname> (string/integer)</title>
-		<para>
-		Request flag which needs to be set to account missed
-		calls -- DIAMETER specific.
-		</para>
-		<para>
-		<emphasis>WARNING: </emphasis>Setting INT flags is deprecated!
-		Use quoted strings instead!
-		</para>
-		<para>
-		Default value is not-set (no flag).
-		</para>
-		<example>
-		<title>diameter_missed_flag example</title>
-		<programlisting format="linespecific">
-modparam("acc", "diameter_missed_flag", "DIAMETER_MISSED_FLAG")
-</programlisting>
-		</example>
-	</section>
 	<section>
 		<title><varname>diameter_client_host</varname> (string)</title>
 		<para>
@@ -1120,49 +913,6 @@ modparam("acc", "diameter_extra", "7846=$hdr(Content-type);7847=$avp(email)")
 		</example>
 	</section>
 
-
-	<!-- Event Interface specific ACC parameters -->
-	<section>
-		<title><varname>evi_flag</varname> (string/integer)</title>
-		<para>
-			Request flag which needs to be set to account a transaction through
-			the Event Interface.
-		</para>
-		<para>
-		<emphasis>WARNING: </emphasis>Setting INT flags is deprecated!
-		Use quoted strings instead!
-		</para>
-		<para>
-		Default value is not-set (no flag).
-		</para>
-		<example>
-		<title>evi_flag example</title>
-		<programlisting format="linespecific">
-modparam("acc", "evi_flag", "EVI_FLAG")
-</programlisting>
-		</example>
-	</section>
-	<section>
-		<title><varname>evi_missed_flag</varname> (string/integer)</title>
-		<para>
-			Request flag which needs to be set to account missed calls throught
-			the Event Interface.
-		</para>
-		<para>
-		<emphasis>WARNING: </emphasis>Setting INT flags is deprecated!
-		Use quoted strings instead!
-		</para>
-		<para>
-		Default value is not-set (no flag).
-		</para>
-		<example>
-		<title>evi_missed_flag example</title>
-		<programlisting format="linespecific">
-modparam("acc", "evi_missed_flag", "EVI_MISSED_FLAG")
-</programlisting>
-		</example>
-	</section>
-
 	<section>
 		<title><varname>evi_extra</varname> (string)</title>
 		<para>
@@ -1197,31 +947,6 @@ modparam("acc", "evi_extra_bye",
 		</example>
 	</section>
 
-
-	<!-- CDR specific ACC parameters -->
-	<section>
-		<title><varname>cdr_flag</varname> (string/integer)</title>
-		<para>
-		Request flag which needs to be set to account a
-		transaction, including CDR details.
-		</para>
-		<para>
-		<emphasis>WARNING: </emphasis>Setting INT flags is deprecated!
-		Use quoted strings instead!
-		</para>
-		<para>
-		Default value is not-set (no flag).
-		</para>
-		<example>
-		<title>cdr_flag example</title>
-		<programlisting format="linespecific">
-modparam("acc", "cdr_flag", "CDR_FLAG")
-</programlisting>
-		</example>
-	</section>
-
-
-
 	<section>
 		<title><varname>acc_created_avp_name</varname> (string)</title>
 		<para>
@@ -1243,6 +968,98 @@ modparam("acc", "acc_created_avp_name", "call_created_avp")
 
 	<section>
 	<title>Exported Functions</title>
+	<section>
+		<title>
+			<function moreinfo="none">do_accounting(type, flags, table)</function>
+		</title>
+		<para>
+			<function moreinfo="none">do_accounting()</function> replace all the
+			*_flag and, *_missed_flag, cdr_flag, failed transaction_flag and the
+			db_table_avp modpara. Just call do_accounting(), select where you want
+			to do accounting and how and the function will do all the job for you.
+		</para>
+
+		<para>
+		Meaning of the parameters is as follows:</para>
+		<itemizedlist>
+		<listitem>
+			<para><emphasis>type</emphasis> - the type of accounting you want to do.
+			All the types have to be separated by '|'. The following parameters can
+			be used: </para>
+			<itemizedlist>
+				<listitem>
+					<para><emphasis>log</emphasis> - syslog accounting;</para>
+				</listitem>
+				<listitem>
+					<para><emphasis>db</emphasis> - database accounting;</para>
+				</listitem>
+				<listitem>
+					<para><emphasis>aaa</emphasis> - aaa specific accounting;</para>
+				</listitem>
+				<listitem>
+					<para><emphasis>evi</emphasis> - Event Interface accounting;</para>
+				</listitem>
+				<listitem>
+					<para><emphasis>diam</emphasis> - Diameter accounting;</para>
+				</listitem>
+			</itemizedlist>
+		</listitem>
+		<listitem>
+			<para><emphasis>flags</emphasis> - flags for the accouting type you have
+			selected. All the types have to be separated by '|'. The following
+			parameters can be used: </para>
+			<itemizedlist>
+				<listitem>
+					<para><emphasis>cdr</emphasis> - also set CDR details when doing
+						accounting; DIALOG MODULE HAS TO BE LOADED;</para>
+				</listitem>
+				<listitem>
+					<para><emphasis>missed</emphasis> - log missed calls;</para>
+				</listitem>
+				<listitem>
+					<para><emphasis>missed</emphasis> - log missed calls;</para>
+				</listitem>
+				<listitem>
+					<para><emphasis>failed</emphasis> -  flag which says if the
+						transaction should be accounted also in case
+						of failure (status>=300);</para>
+				</listitem>
+			</itemizedlist>
+		</listitem>
+		<listitem>
+			<para><emphasis>table</emphasis> - table where to do the accounting;
+			it replaces old table_avp parameter;</para>
+		</listitem>
+		</itemizedlist>
+
+		<para>
+			This function can be used from REQUEST_ROUTE, FAILURE_ROUTE,
+			BRANCH_ROUTE and LOCAL_ROUTE.
+		</para>
+
+		<example>
+				<title>acc_log_request usage</title>
+				<programlisting format="linespecific">
+		...
+		acc_log_request("403 Destination not allowed");
+		if (!has_totag()) {
+			if (is_method("INVITE")) {
+			/* enable cdr and missed calls accounting in the database
+			 * and to syslog; db accounting shall be done in "my_acc" table */
+				do_accounting("db|log", "cdr|missed", "my_acc");
+			}
+		}
+		...
+		if (is_method("BYE")) {
+			/* do normal accounting via aaa */
+			do_accounting("aaa");
+		}
+		...
+		</programlisting>
+		</example>
+
+	</section>
+
 	<section>
 		<title>
 			<function moreinfo="none">acc_log_request(comment)</function>


### PR DESCRIPTION
Introducing new do_accounting() function. It has 3 arguments,
first one is used to specify the type of accounting separated
by '|'(db, log, aaa, evi, diam), second one to specify the flags
used for accounting also separated by '|' (cdr, missed, failed -
failed_transaction_flag) and the third parameter represents the
name of the table used for accounting.