### PR TITLE
drop_accounting function for acc

### DIFF
--- a/modules/acc/README
+++ b/modules/acc/README
@@ -91,11 +91,12 @@ Irina-Maria Stanescu
         1.7. Exported Functions
 
               1.7.1. do_accounting(type, flags, table)
-              1.7.2. acc_log_request(comment)
-              1.7.3. acc_db_request(comment, table)
-              1.7.4. acc_aaa_request(comment)
-              1.7.5. acc_diam_request(comment)
-              1.7.6. acc_evi_request(comment)
+              1.7.2. cancel_accounting([type], [flags])
+              1.7.3. acc_log_request(comment)
+              1.7.4. acc_db_request(comment, table)
+              1.7.5. acc_aaa_request(comment)
+              1.7.6. acc_diam_request(comment)
+              1.7.7. acc_evi_request(comment)
 
         1.8. Exported Events
 
@@ -138,12 +139,13 @@ Irina-Maria Stanescu
    1.29. evi_extra example
    1.30. evi_extra_bye example
    1.31. acc_created_avp_name example
-   1.32. acc_log_request usage
-   1.33. acc_log_request usage
-   1.34. acc_db_request usage
-   1.35. acc_aaa_request usage
-   1.36. acc_diam_request usage
-   1.37. acc_evi_request usage
+   1.32. do_accounting usage
+   1.33. cancel_accounting usage
+   1.34. acc_log_request usage
+   1.35. acc_db_request usage
+   1.36. acc_aaa_request usage
+   1.37. acc_diam_request usage
+   1.38. acc_evi_request usage
 
 Chapter 1. Admin Guide
 
@@ -808,9 +810,8 @@ modparam("acc", "acc_created_avp_name", "call_created_avp")
    This function can be used from REQUEST_ROUTE, FAILURE_ROUTE,
    BRANCH_ROUTE and LOCAL_ROUTE.
 
-   Example 1.32. acc_log_request usage
+   Example 1.32. do_accounting usage
                 ...
-                acc_log_request("403 Destination not allowed");
                 if (!has_totag()) {
                         if (is_method("INVITE")) {
                         /* enable cdr and missed calls accounting in the
@@ -828,7 +829,61 @@ y_acc");
                 }
                 ...
 
-1.7.2.  acc_log_request(comment)
+1.7.2.  cancel_accounting([type], [flags])
+
+   cancel_accounting() resets flags and types of accounting set
+   with do_accounting(). If called with no arguments all
+   accounting will be stopped. If called with only one argument
+   all accounting for that type will be stopped. If called with
+   two arguments normal accounting will still be enabled.
+
+   Meaning of the parameters is as follows:
+     * type - the type of accounting you want to stop. All the
+       types have to be separated by '|'. The following parameters
+       can be used:
+          + log - stop syslog accounting;
+          + db - stop database accounting;
+          + aaa - stop aaa specific accounting;
+          + evi - stop Event Interface accounting;
+          + diam - stop Diameter accounting;
+     * flags - flags to be reset for the accouting type you have
+       selected. All the types have to be separated by '|'. The
+       following parameters can be used:
+          + cdr - stop CDR accounting;
+          + missed - stop logging missed calls;
+          + failed - stop failed transaction accounting;
+
+   This function can be used from REQUEST_ROUTE, FAILURE_ROUTE,
+   BRANCH_ROUTE and LOCAL_ROUTE.
+
+   Example 1.33. cancel_accounting usage
+                ...
+                acc_log_request("403 Destination not allowed");
+                if (!has_totag()) {
+                        if (is_method("INVITE")) {
+                        /* enable cdr and missed calls accounting in the
+ database
+                         * and to syslog; db accounting shall be done in
+ "my_acc" table */
+                                do_accounting("db|log", "cdr|missed", "m
+y_acc");
+                        }
+                }
+                ...
+                /* later in your script */
+                if (...) { /* you don't want accounting anymore */
+                        /* stop all syslog accounting */
+                        cancel_accounting("log");
+                        /* or stop missed calls and cdr accounting for s
+yslog;
+                         * normal accounting will still be enabled */
+                        cancel_accounting("log","missed|cdr");
+                        /* or stop all types of accounting  */
+                        cancel_accounting();
+                }
+                ...
+
+1.7.3.  acc_log_request(comment)
 
    acc_request reports on a request, for example, it can be used
    to report on missed calls to off-line users who are replied 404
@@ -845,12 +900,12 @@ y_acc");
    This function can be used from REQUEST_ROUTE, FAILURE_ROUTE,
    BRANCH_ROUTE and LOCAL_ROUTE.
 
-   Example 1.33. acc_log_request usage
+   Example 1.34. acc_log_request usage
 ...
 acc_log_request("403 Destination not allowed");
 ...
 
-1.7.3.  acc_db_request(comment, table)
+1.7.4.  acc_db_request(comment, table)
 
    Like acc_log_request, acc_db_request reports on a request. The
    report is sent to database at “db_url”, in the table referred
@@ -866,13 +921,13 @@ acc_log_request("403 Destination not allowed");
    This function can be used from REQUEST_ROUTE, FAILURE_ROUTE,
    BRANCH_ROUTE and LOCAL_ROUTE.
 
-   Example 1.34. acc_db_request usage
+   Example 1.35. acc_db_request usage
 ...
 acc_db_request("Some comment", "Some table");
 acc_db_request("$T_reply_code $(<reply>rr)","acc");
 ...
 
-1.7.4.  acc_aaa_request(comment)
+1.7.5.  acc_aaa_request(comment)
 
    Like acc_log_request, acc_aaa_request reports on a request. It
    reports to aaa server as configured in “aaa_url”.
@@ -886,12 +941,12 @@ acc_db_request("$T_reply_code $(<reply>rr)","acc");
    This function can be used from REQUEST_ROUTE, FAILURE_ROUTE,
    BRANCH_ROUTE and LOCAL_ROUTE.
 
-   Example 1.35. acc_aaa_request usage
+   Example 1.36. acc_aaa_request usage
 ...
 acc_aaa_request("403 Destination not allowed");
 ...
 
-1.7.5.  acc_diam_request(comment)
+1.7.6.  acc_diam_request(comment)
 
    Like acc_log_request, acc_diam_request reports on a request. It
    reports to the configured Diameter server.
@@ -905,12 +960,12 @@ acc_aaa_request("403 Destination not allowed");
    This function can be used from REQUEST_ROUTE, FAILURE_ROUTE,
    BRANCH_ROUTE and LOCAL_ROUTE.
 
-   Example 1.36. acc_diam_request usage
+   Example 1.37. acc_diam_request usage
 ...
 acc_diam_request("403 Destination not allowed");
 ...
 
-1.7.6.  acc_evi_request(comment)
+1.7.7.  acc_evi_request(comment)
 
    Like acc_log_request, acc_evi_request reports on a request. The
    report is packed as an event sent through the OpenSIPS Event
@@ -928,7 +983,7 @@ acc_diam_request("403 Destination not allowed");
    This function can be used from REQUEST_ROUTE, FAILURE_ROUTE,
    BRANCH_ROUTE and LOCAL_ROUTE.
 
-   Example 1.37. acc_evi_request usage
+   Example 1.38. acc_evi_request usage
 ...
 acc_evi_request("403 Destination not allowed");
 ...

--- a/modules/acc/README
+++ b/modules/acc/README
@@ -91,7 +91,7 @@ Irina-Maria Stanescu
         1.7. Exported Functions
 
               1.7.1. do_accounting(type, flags, table)
-              1.7.2. cancel_accounting([type], [flags])
+              1.7.2. drop_accounting([type], [flags])
               1.7.3. acc_log_request(comment)
               1.7.4. acc_db_request(comment, table)
               1.7.5. acc_aaa_request(comment)
@@ -140,7 +140,7 @@ Irina-Maria Stanescu
    1.30. evi_extra_bye example
    1.31. acc_created_avp_name example
    1.32. do_accounting usage
-   1.33. cancel_accounting usage
+   1.33. drop_accounting usage
    1.34. acc_log_request usage
    1.35. acc_db_request usage
    1.36. acc_aaa_request usage
@@ -829,13 +829,13 @@ y_acc");
                 }
                 ...
 
-1.7.2.  cancel_accounting([type], [flags])
+1.7.2.  drop_accounting([type], [flags])
 
-   cancel_accounting() resets flags and types of accounting set
-   with do_accounting(). If called with no arguments all
-   accounting will be stopped. If called with only one argument
-   all accounting for that type will be stopped. If called with
-   two arguments normal accounting will still be enabled.
+   drop_accounting() resets flags and types of accounting set with
+   do_accounting(). If called with no arguments all accounting
+   will be stopped. If called with only one argument all
+   accounting for that type will be stopped. If called with two
+   arguments normal accounting will still be enabled.
 
    Meaning of the parameters is as follows:
      * type - the type of accounting you want to stop. All the
@@ -856,7 +856,7 @@ y_acc");
    This function can be used from REQUEST_ROUTE, FAILURE_ROUTE,
    BRANCH_ROUTE and LOCAL_ROUTE.
 
-   Example 1.33. cancel_accounting usage
+   Example 1.33. drop_accounting usage
                 ...
                 acc_log_request("403 Destination not allowed");
                 if (!has_totag()) {
@@ -873,13 +873,13 @@ y_acc");
                 /* later in your script */
                 if (...) { /* you don't want accounting anymore */
                         /* stop all syslog accounting */
-                        cancel_accounting("log");
+                        drop_accounting("log");
                         /* or stop missed calls and cdr accounting for s
 yslog;
                          * normal accounting will still be enabled */
-                        cancel_accounting("log","missed|cdr");
+                        drop_accounting("log","missed|cdr");
                         /* or stop all types of accounting  */
-                        cancel_accounting();
+                        drop_accounting();
                 }
                 ...
 

--- a/modules/acc/acc_logic.c
+++ b/modules/acc/acc_logic.c
@@ -57,6 +57,8 @@ extern str table_str;
 extern str acc_created_avp_name;
 extern int acc_created_avp_id;
 
+extern int acc_flags_ctx_idx;
+
 struct acc_enviroment acc_env;
 
 static query_list_t *acc_ins_list = NULL;
@@ -139,6 +141,7 @@ static void acc_dlg_callback(struct dlg_cell *dlg, int type,
 void free_acc_mask(void* param) {
 	shm_free((unsigned long long *)param);
 }
+
 
 static inline struct hdr_field* get_rpl_to( struct cell *t,
 														struct sip_msg *reply)
@@ -374,59 +377,6 @@ static inline int has_totag(struct sip_msg *msg)
 }
 
 
-
-/* prepare message and transaction context for later accounting */
-void acc_onreq( struct cell* t, int type, struct tmcb_params *ps )
-{
-#if 0
-	int tmcb_types;
-	int is_invite;
-	int_str _avp_created_value;
-
-	if ( ps->req && !skip_cancel(ps->req) &&
-	(is_acc_on(ps->req) || is_mc_on(ps->req)) ) {
-		/* do some parsing in advance */
-		if (acc_preparse_req(ps->req)<0)
-			return;
-		is_invite = (ps->req->REQ_METHOD==METHOD_INVITE)?1:0;
-		/* install additional handlers */
-		tmcb_types =
-			/* report on completed transactions */
-			TMCB_RESPONSE_OUT |
-			/* get incoming replies ready for processing */
-			TMCB_RESPONSE_IN |
-			/* report on missed calls */
-			((is_invite && is_mc_on(ps->req))?TMCB_ON_FAILURE:0) ;
-
-		/* if cdr accounting is enabled */
-		if (is_cdr_acc_on(ps->req) && !has_totag(ps->req)) {
-			_avp_created_value.n = time(NULL);
-
-			if ( add_avp(0, acc_created_avp_id, _avp_created_value) != 0) {
-				LM_ERR("failed to add created avp value!\n");
-				return;
-			}
-
-			if (is_invite && create_acc_dlg(ps->req) < 0) {
-				LM_ERR("cannot use dialog accounting module\n");
-				return;
-			}
-		}
-		if (tmb.register_tmcb( 0, t, tmcb_types, tmcb_func, 0, 0 )<=0) {
-			LM_ERR("cannot register additional callbacks\n");
-			return;
-		}
-		/* if required, determine request direction */
-		if( detect_direction && !rrb.is_direction(ps->req,RR_FLOW_UPSTREAM) ) {
-			LM_DBG("detected an UPSTREAM req -> flaging it\n");
-			ps->req->msg_flags |= FL_REQ_UPSTREAM;
-		}
-	}
-#endif
-}
-
-
-
 /* is this reply of interest for accounting ? */
 static inline int should_acc_reply(struct sip_msg *req,struct sip_msg *rpl,
 								int code, unsigned long long* flags)
@@ -554,7 +504,7 @@ void acc_loaded_callback(struct dlg_cell *dlg, int type,
 
 		/* register database callbacks */
 		if (dlg_api.register_dlgcb(dlg, DLGCB_TERMINATED |
-				DLGCB_EXPIRED, acc_dlg_callback, flags_s.s, free_acc_mask)){
+				DLGCB_EXPIRED, acc_dlg_callback, flags_s.s, 0)){
 			LM_ERR("cannot register callback for database accounting\n");
 			return;
 		}
@@ -658,7 +608,7 @@ static inline void acc_onreply( struct cell* t, struct sip_msg *req,
 
 		/* register database callbacks */
 		if (dlg_api.register_dlgcb(dlg, DLGCB_TERMINATED |
-				DLGCB_EXPIRED, acc_dlg_callback,flags_s.s,0) != 0) {
+				DLGCB_EXPIRED, acc_dlg_callback,flags_s.s,free_acc_mask) != 0) {
 			LM_ERR("cannot register callback for database accounting\n");
 			return;
 		}
@@ -990,7 +940,7 @@ int w_do_acc_2(struct sip_msg* msg, char* type, char* flags)
 int w_do_acc_3(struct sip_msg* msg, char* type_p, char* flags_p, char* table_p)
 {
 	unsigned long long type=0, flags=0;
-	unsigned long long *flag_mask;
+	unsigned long long *flag_mask_p, flag_mask;
 
 	acc_type_param_t* acc_param;
 
@@ -1022,13 +972,21 @@ int w_do_acc_3(struct sip_msg* msg, char* type_p, char* flags_p, char* table_p)
 		}
 	}
 
-
 	if (flags_p != NULL) {
 		flags= *(unsigned long long*)flags_p;
 	}
 
-	flag_mask=shm_malloc(sizeof(unsigned long long));
-	if (flag_mask==NULL) {
+	flag_mask = type + type * flags;
+
+	/* if already called the function once */
+	if ((flag_mask_p=ACC_GET_FLAGS) != NULL) {
+		*flag_mask_p |= flag_mask;
+		return 1;
+	}
+
+
+	flag_mask_p=shm_malloc(sizeof(unsigned long long));
+	if (flag_mask_p==NULL) {
 		LM_ERR("No more shm mem!\n");
 		return -1;
 	}
@@ -1041,8 +999,8 @@ int w_do_acc_3(struct sip_msg* msg, char* type_p, char* flags_p, char* table_p)
 	 * so we keep the first bits in each byte and on the following positions
 	 * next flags
 	 */
-	*flag_mask = type  + type*flags;
-
+	*flag_mask_p = flag_mask;
+	ACC_PUT_FLAGS(flag_mask_p);
 
 	if (table_p != NULL) {
 		if (fixup_get_svalue(msg, (gparam_p)table_p, &table_name) < 0) {
@@ -1053,7 +1011,7 @@ int w_do_acc_3(struct sip_msg* msg, char* type_p, char* flags_p, char* table_p)
 
 
 	if ( msg && !skip_cancel(msg) &&
-	(is_acc_on(*flag_mask) || is_mc_acc_on(*flag_mask)) ) {
+	(is_acc_on(*flag_mask_p) || is_mc_acc_on(*flag_mask_p)) ) {
 		/* do some parsing in advance */
 		if (acc_preparse_req(msg)<0)
 			return -1;
@@ -1065,10 +1023,10 @@ int w_do_acc_3(struct sip_msg* msg, char* type_p, char* flags_p, char* table_p)
 			/* get incoming replies ready for processing */
 			TMCB_RESPONSE_IN |
 			/* report on missed calls */
-			((is_invite && is_mc_acc_on(*flag_mask))?TMCB_ON_FAILURE:0) ;
+			((is_invite && is_mc_acc_on(*flag_mask_p))?TMCB_ON_FAILURE:0) ;
 
 		/* if cdr accounting is enabled */
-		if (is_cdr_acc_on(*flag_mask) && !has_totag(msg)) {
+		if (is_cdr_acc_on(*flag_mask_p) && !has_totag(msg)) {
 			_avp_created_value.n = time(NULL);
 
 			if ( add_avp(0, acc_created_avp_id, _avp_created_value) != 0) {
@@ -1083,10 +1041,11 @@ int w_do_acc_3(struct sip_msg* msg, char* type_p, char* flags_p, char* table_p)
 		}
 
 		if (tmb.register_tmcb( msg, 0, tmcb_types, tmcb_func,
-				flag_mask, is_cdr_acc_on(*flag_mask) ? 0 : free_acc_mask)<=0) {
+				flag_mask_p, is_cdr_acc_on(*flag_mask_p) ? 0 : free_acc_mask)<=0) {
 			LM_ERR("cannot register additional callbacks\n");
 			return -1;
 		}
+
 
 		/* if required, determine request direction */
 		if( detect_direction && !rrb.is_direction(msg,RR_FLOW_UPSTREAM) ) {
@@ -1097,3 +1056,67 @@ int w_do_acc_3(struct sip_msg* msg, char* type_p, char* flags_p, char* table_p)
 
 	return 1;
 }
+
+/* reset all flags */
+int w_cancel_acc_0(struct sip_msg* msg) {
+	return w_cancel_acc_2(msg, NULL, NULL);
+}
+
+int w_cancel_acc_1(struct sip_msg* msg, char* type)
+{
+	return w_cancel_acc_2(msg, type, NULL);
+}
+
+int w_cancel_acc_2(struct sip_msg* msg, char* type_p, char* flags_p)
+{
+	unsigned long long type=0;
+	/* if not set, we reset all flags for the type of accounting requested */
+	unsigned long long flags=ALL_ACC_FLAGS;
+	unsigned long long flag_mask;
+	unsigned long long *context_flags_p=ACC_GET_FLAGS;
+
+
+	acc_type_param_t* acc_param;
+
+	str in;
+
+	if (context_flags_p == NULL) {
+		LM_ERR("do_accounting() not used! This function resets flags in "
+				"do_accounting()!\n");
+		return -1;
+	}
+
+	if (type_p != NULL) {
+		acc_param = (acc_type_param_t *)type_p;
+		if (acc_param->t == DO_ACC_PARAM_TYPE_VALUE) {
+			type = acc_param->u.ival;
+		} else {
+			if (pv_printf_s(msg, acc_param->u.pval, &in) < 0) {
+				LM_ERR("failed to fetch type value!\n");
+				return -1;
+			}
+
+			if ((type=do_acc_parse(&in, do_acc_type_parser)) < 0) {
+				LM_ERR("Invalid expression <%.*s> for acc type!\n", in.len, in.s);
+				return -1;
+			}
+		}
+	}
+
+	if (flags_p != NULL) {
+		flags= *(unsigned long long*)flags_p;
+	}
+
+	flag_mask = type * flags;
+
+	/* reset all flags */
+	if (flag_mask == 0) {
+		*context_flags_p = 0;
+	} else {
+		reset_flags(*context_flags_p, flag_mask);
+	}
+
+	return 1;
+}
+
+

--- a/modules/acc/acc_logic.c
+++ b/modules/acc/acc_logic.c
@@ -1058,16 +1058,16 @@ int w_do_acc_3(struct sip_msg* msg, char* type_p, char* flags_p, char* table_p)
 }
 
 /* reset all flags */
-int w_cancel_acc_0(struct sip_msg* msg) {
-	return w_cancel_acc_2(msg, NULL, NULL);
+int w_drop_acc_0(struct sip_msg* msg) {
+	return w_drop_acc_2(msg, NULL, NULL);
 }
 
-int w_cancel_acc_1(struct sip_msg* msg, char* type)
+int w_drop_acc_1(struct sip_msg* msg, char* type)
 {
-	return w_cancel_acc_2(msg, type, NULL);
+	return w_drop_acc_2(msg, type, NULL);
 }
 
-int w_cancel_acc_2(struct sip_msg* msg, char* type_p, char* flags_p)
+int w_drop_acc_2(struct sip_msg* msg, char* type_p, char* flags_p)
 {
 	unsigned long long type=0;
 	/* if not set, we reset all flags for the type of accounting requested */

--- a/modules/acc/acc_logic.h
+++ b/modules/acc/acc_logic.h
@@ -123,8 +123,8 @@ int w_do_acc_1(struct sip_msg* msg, char* type);
 int w_do_acc_2(struct sip_msg* msg, char* type, char* flags);
 int w_do_acc_3(struct sip_msg* msg, char* type_p, char* flags_p, char* table_p);
 
-int w_cancel_acc_0(struct sip_msg* msg);
-int w_cancel_acc_1(struct sip_msg* msg, char* type);
-int w_cancel_acc_2(struct sip_msg* msg, char* type, char* flags);
+int w_drop_acc_0(struct sip_msg* msg);
+int w_drop_acc_1(struct sip_msg* msg, char* type);
+int w_drop_acc_2(struct sip_msg* msg, char* type, char* flags);
 
 #endif

--- a/modules/acc/acc_logic.h
+++ b/modules/acc/acc_logic.h
@@ -42,6 +42,7 @@
 #define DO_ACC_CDR    (1<<1)
 #define DO_ACC_MISSED (1<<2)
 #define DO_ACC_FAILED (1<<3)
+#define ALL_ACC_FLAGS (DO_ACC|DO_ACC_CDR|DO_ACC_MISSED|DO_ACC_FAILED)
 
 #define DO_ACC_PARAM_TYPE_PV    (1<<0)
 #define DO_ACC_PARAM_TYPE_VALUE (1<<1)
@@ -57,6 +58,16 @@
 #define DO_ACC_FAILED_STR "failed"
 
 #define DO_ACC_PARAM_DELIMITER '|'
+
+#define ACC_PUT_FLAGS(_ptr) \
+	context_put_ptr(CONTEXT_GLOBAL, current_processing_ctx, \
+			acc_flags_ctx_idx, _ptr)
+
+
+#define ACC_GET_FLAGS \
+	context_get_ptr(CONTEXT_GLOBAL, current_processing_ctx, \
+			acc_flags_ctx_idx)
+
 
 typedef unsigned long long (*do_acc_parser)(str*);
 
@@ -87,8 +98,6 @@ struct acc_param {
 };
 
 
-void acc_onreq( struct cell* t, int type, struct tmcb_params *ps );
-
 int w_acc_log_request(struct sip_msg *rq, pv_elem_t* comment, char *foo);
 
 int w_acc_aaa_request(struct sip_msg *rq, pv_elem_t* comment, char *foo);
@@ -113,5 +122,9 @@ int do_acc_fixup(void** param, int param_no);
 int w_do_acc_1(struct sip_msg* msg, char* type);
 int w_do_acc_2(struct sip_msg* msg, char* type, char* flags);
 int w_do_acc_3(struct sip_msg* msg, char* type_p, char* flags_p, char* table_p);
+
+int w_cancel_acc_0(struct sip_msg* msg);
+int w_cancel_acc_1(struct sip_msg* msg, char* type);
+int w_cancel_acc_2(struct sip_msg* msg, char* type, char* flags);
 
 #endif

--- a/modules/acc/acc_mod.c
+++ b/modules/acc/acc_mod.c
@@ -210,16 +210,16 @@ static cmd_export_t cmds[] = {
 		do_acc_fixup, NULL,
 		REQUEST_ROUTE|FAILURE_ROUTE|BRANCH_ROUTE|LOCAL_ROUTE},
 
-	{"cancel_accounting", (cmd_function)w_cancel_acc_0, 0, 0, NULL,
+	{"drop_accounting", (cmd_function)w_drop_acc_0, 0, 0, NULL,
 		REQUEST_ROUTE|FAILURE_ROUTE|BRANCH_ROUTE|LOCAL_ROUTE},
 
 	/* we use the same fixup function since the parameters
 	 * have the same meanining as for do_accounting  */
-	{"cancel_accounting", (cmd_function)w_cancel_acc_1, 1,
+	{"drop_accounting", (cmd_function)w_drop_acc_1, 1,
 		do_acc_fixup, NULL,
 		REQUEST_ROUTE|FAILURE_ROUTE|BRANCH_ROUTE|LOCAL_ROUTE},
 
-	{"cancel_accounting", (cmd_function)w_cancel_acc_2, 2,
+	{"drop_accounting", (cmd_function)w_drop_acc_2, 2,
 		do_acc_fixup, NULL,
 		REQUEST_ROUTE|FAILURE_ROUTE|BRANCH_ROUTE|LOCAL_ROUTE},
 

--- a/modules/acc/acc_mod.c
+++ b/modules/acc/acc_mod.c
@@ -167,7 +167,8 @@ struct acc_extra *evi_extra_bye = 0;
 str acc_created_avp_name = str_init("accX_created");
 int acc_created_avp_id = -1;
 
-
+/* acc context position */
+int acc_flags_ctx_idx;
 
 /* ------------- fixup function --------------- */
 static int acc_fixup(void** param, int param_no);
@@ -206,6 +207,19 @@ static cmd_export_t cmds[] = {
 	/* type of acc(db,evi...) and flags(log cdr, log missed)
 	 * and db table */
 	{"do_accouting", (cmd_function)w_do_acc_3, 3,
+		do_acc_fixup, NULL,
+		REQUEST_ROUTE|FAILURE_ROUTE|BRANCH_ROUTE|LOCAL_ROUTE},
+
+	{"cancel_accounting", (cmd_function)w_cancel_acc_0, 0, 0, NULL,
+		REQUEST_ROUTE|FAILURE_ROUTE|BRANCH_ROUTE|LOCAL_ROUTE},
+
+	/* we use the same fixup function since the parameters
+	 * have the same meanining as for do_accounting  */
+	{"cancel_accounting", (cmd_function)w_cancel_acc_1, 1,
+		do_acc_fixup, NULL,
+		REQUEST_ROUTE|FAILURE_ROUTE|BRANCH_ROUTE|LOCAL_ROUTE},
+
+	{"cancel_accounting", (cmd_function)w_cancel_acc_2, 2,
 		do_acc_fixup, NULL,
 		REQUEST_ROUTE|FAILURE_ROUTE|BRANCH_ROUTE|LOCAL_ROUTE},
 
@@ -506,6 +520,7 @@ static int mod_init( void )
 
 #endif
 
+	acc_flags_ctx_idx = context_register_ptr(CONTEXT_GLOBAL, NULL);
 
 	return 0;
 }

--- a/modules/acc/doc/acc_admin.xml
+++ b/modules/acc/doc/acc_admin.xml
@@ -1058,10 +1058,10 @@ modparam("acc", "acc_created_avp_name", "call_created_avp")
 
 	<section id="cancel_accouting">
 		<title>
-			<function moreinfo="none">cancel_accounting([type], [flags])</function>
+			<function moreinfo="none">drop_accounting([type], [flags])</function>
 		</title>
 		<para>
-			<function moreinfo="none">cancel_accounting()</function> resets flags
+			<function moreinfo="none">drop_accounting()</function> resets flags
 			and types of accounting set with do_accounting(). If called with no
 			arguments all accounting will be stopped. If called with only one argument
 			all accounting for that type will be stopped. If called with two arguments
@@ -1116,7 +1116,7 @@ modparam("acc", "acc_created_avp_name", "call_created_avp")
 		</para>
 
 		<example>
-				<title>cancel_accounting usage</title>
+				<title>drop_accounting usage</title>
 				<programlisting format="linespecific">
 		...
 		acc_log_request("403 Destination not allowed");
@@ -1131,12 +1131,12 @@ modparam("acc", "acc_created_avp_name", "call_created_avp")
 		/* later in your script */
 		if (...) { /* you don't want accounting anymore */
 			/* stop all syslog accounting */
-			cancel_accounting("log");
+			drop_accounting("log");
 			/* or stop missed calls and cdr accounting for syslog;
 			 * normal accounting will still be enabled */
-			cancel_accounting("log","missed|cdr");
+			drop_accounting("log","missed|cdr");
 			/* or stop all types of accounting  */
-			cancel_accounting();
+			drop_accounting();
 		}
 		...
 		</programlisting>

--- a/modules/acc/doc/acc_admin.xml
+++ b/modules/acc/doc/acc_admin.xml
@@ -14,11 +14,11 @@
 	</para>
 	<para>
 		To account a transaction and to choose which set of backends to be
-		used, the script writer just has to use mark the transaction for 
+		used, the script writer just has to use mark the transaction for
 		accouting by using the <xref linkend="do_accouting"/> script function.
 		Note that the function is not actually doing the accounting at that
 		very process, it is just setting a marker - the actual accouting
-		will be done later when the transaction or dialog will be 
+		will be done later when the transaction or dialog will be
 		completed.
 		</para>
 		<para>
@@ -346,7 +346,7 @@ if (uri=~"sip:+40") /* calls to Romania */ {
 			<title>Configuration</title>
 			<para>
 			In order to have CDRs accounting, first you need to set the
-			<emphasis>cdr</emphasis> flag when calling 
+			<emphasis>cdr</emphasis> flag when calling
 			<xref linkend="do_accouting"/> script function for the
 			initial INVITE of the dialog.
 			</para>
@@ -1035,10 +1035,9 @@ modparam("acc", "acc_created_avp_name", "call_created_avp")
 		</para>
 
 		<example>
-				<title>acc_log_request usage</title>
+				<title>do_accounting usage</title>
 				<programlisting format="linespecific">
 		...
-		acc_log_request("403 Destination not allowed");
 		if (!has_totag()) {
 			if (is_method("INVITE")) {
 			/* enable cdr and missed calls accounting in the database
@@ -1056,6 +1055,96 @@ modparam("acc", "acc_created_avp_name", "call_created_avp")
 		</example>
 
 	</section>
+
+	<section id="cancel_accouting">
+		<title>
+			<function moreinfo="none">cancel_accounting([type], [flags])</function>
+		</title>
+		<para>
+			<function moreinfo="none">cancel_accounting()</function> resets flags
+			and types of accounting set with do_accounting(). If called with no
+			arguments all accounting will be stopped. If called with only one argument
+			all accounting for that type will be stopped. If called with two arguments
+			normal accounting will still be enabled.</para>
+
+		<para>
+		Meaning of the parameters is as follows:</para>
+		<itemizedlist>
+		<listitem>
+			<para><emphasis>type</emphasis> - the type of accounting you want to stop.
+			All the types have to be separated by '|'. The following parameters can
+			be used: </para>
+			<itemizedlist>
+				<listitem>
+					<para><emphasis>log</emphasis> - stop syslog accounting;</para>
+				</listitem>
+				<listitem>
+					<para><emphasis>db</emphasis> - stop database accounting;</para>
+				</listitem>
+				<listitem>
+					<para><emphasis>aaa</emphasis> - stop aaa specific accounting;</para>
+				</listitem>
+				<listitem>
+					<para><emphasis>evi</emphasis> - stop Event Interface accounting;</para>
+				</listitem>
+				<listitem>
+					<para><emphasis>diam</emphasis> - stop Diameter accounting;</para>
+				</listitem>
+			</itemizedlist>
+		</listitem>
+		<listitem>
+			<para><emphasis>flags</emphasis> - flags to be reset for the accouting type you have
+			selected. All the types have to be separated by '|'. The following
+			parameters can be used: </para>
+			<itemizedlist>
+				<listitem>
+					<para><emphasis>cdr</emphasis> - stop CDR accounting;</para>
+				</listitem>
+				<listitem>
+					<para><emphasis>missed</emphasis> - stop logging missed calls;</para>
+				</listitem>
+				<listitem>
+					<para><emphasis>failed</emphasis> -  stop failed transaction accounting;</para>
+				</listitem>
+			</itemizedlist>
+		</listitem>
+		</itemizedlist>
+
+		<para>
+			This function can be used from REQUEST_ROUTE, FAILURE_ROUTE,
+			BRANCH_ROUTE and LOCAL_ROUTE.
+		</para>
+
+		<example>
+				<title>cancel_accounting usage</title>
+				<programlisting format="linespecific">
+		...
+		acc_log_request("403 Destination not allowed");
+		if (!has_totag()) {
+			if (is_method("INVITE")) {
+			/* enable cdr and missed calls accounting in the database
+			 * and to syslog; db accounting shall be done in "my_acc" table */
+				do_accounting("db|log", "cdr|missed", "my_acc");
+			}
+		}
+		...
+		/* later in your script */
+		if (...) { /* you don't want accounting anymore */
+			/* stop all syslog accounting */
+			cancel_accounting("log");
+			/* or stop missed calls and cdr accounting for syslog;
+			 * normal accounting will still be enabled */
+			cancel_accounting("log","missed|cdr");
+			/* or stop all types of accounting  */
+			cancel_accounting();
+		}
+		...
+		</programlisting>
+		</example>
+
+	</section>
+
+
 
 	<section>
 		<title>

--- a/modules/acc/doc/acc_admin.xml
+++ b/modules/acc/doc/acc_admin.xml
@@ -1056,7 +1056,7 @@ modparam("acc", "acc_created_avp_name", "call_created_avp")
 
 	</section>
 
-	<section id="cancel_accouting">
+	<section id="drop_accouting">
 		<title>
 			<function moreinfo="none">drop_accounting([type], [flags])</function>
 		</title>


### PR DESCRIPTION
This function allows unsetting parameters set by do accounting
function. It has the same parameters excepting the table name.