### PR TITLE
Make the s.int transformation more permissive

### DIFF
--- a/transformations.c
+++ b/transformations.c
@@ -182,8 +182,12 @@ int tr_eval_string(struct sip_msg *msg, tr_param_t *tp, int subtype,
 		case TR_S_INT:
 			if(!(val->flags&PV_VAL_INT))
 			{
-				if(str2sint(&val->rs, &val->ri)!=0)
-					return -1;
+				//Default conversion to 0
+				val->ri = 0;
+				/*Ignore the return value of str2sint.
+				  str2sint will convert the string up until it finds a non-number char
+				  which is the desired behavior for the script level transformation*/
+				str2sint(&val->rs, &val->ri);
 			} else {
 				if(!(val->flags&PV_VAL_STR))
 					val->rs.s = int2str(val->ri, &val->rs.len);

--- a/ut.h
+++ b/ut.h
@@ -537,6 +537,8 @@ static inline int str2sint(str* _s, int* _r)
 			*_r *= 10;
 			*_r += _s->s[i] - '0';
 		} else {
+			//Preserve sign for partially converted strings
+			*_r *= s;
 			return -1;
 		}
 	}


### PR DESCRIPTION
Replacing pull request #836

This makes the {s.int} transformation more permissive.

Empty/Null strings convert to 0.
Floating/Doubles convert to truncated ints (2.34 -> 2, -4.66 -> 4).
Strings prefixed with a number convert until the first bad input (45dLkd -> 45).
Invalid input converts to 0.

I also had to modify the str2sint function to preserve the sign on partially converted strings.
