### PR TITLE
[db_sqlite] use DB_STRING type when the column value type is DB_STRING

### DIFF
--- a/modules/db_sqlite/row.c
+++ b/modules/db_sqlite/row.c
@@ -116,7 +116,7 @@ int db_sqlite_convert_row(const db_con_t* _h, db_res_t* _res, db_row_t* _r)
 				memcpy(VAL_STR(_v).s, db_value, VAL_STR(_v).len);
 
 				VAL_STR(_v).s[VAL_STR(_v).len]='\0';
-				VAL_TYPE(_v) = DB_STR;
+				VAL_TYPE(_v) = DB_STRING;
 				break;
 			default:
 				LM_ERR("invalid type for sqlite!\n");


### PR DESCRIPTION
I was running into an issue trying to use db_sqlite with the clusterer module that I traced down to a type error because clusterer required a DB_STRING type for text columns, but db_sqlite was setting DB_STR.   I'm not sure why db_sqlite used DB_STR in favor of DB_STRING, but this fixes my issue and I've had no side effects from making this change.

clusterer.c:
```check_val(description_col, ROW_VALUES(row) + 3, DB_STRING, 0, 0);```

db_sqlite/row.c:
```
                        case DB_STRING:                                         
                                VAL_STR(_v).len = sqlite3_column_bytes(CON_SQLITE_PS(_h), col);
                                db_value = (char *)sqlite3_column_text(CON_SQLITE_PS(_h), col);
                                                                                
                                VAL_STR(_v).s = pkg_malloc(VAL_STR(_v).len+1);  
                                memcpy(VAL_STR(_v).s, db_value, VAL_STR(_v).len);
                                                                                
                                VAL_STR(_v).s[VAL_STR(_v).len]='\0';            
                                VAL_TYPE(_v) = DB_STR;          <--- Here was the culpit             
                                break;            
```