### PR TITLE
Add support for SIP URIs without user part in 'avpops' module.

### DIFF
--- a/modules/avpops/avpops_impl.c
+++ b/modules/avpops/avpops_impl.c
@@ -327,16 +327,32 @@ int ops_dbload_avps (struct sip_msg* msg, struct fis_param *sp,
 			goto error;
 		}
 
-		/* check uri */
-		if(!uri.user.s|| !uri.user.len|| !uri.host.len|| !uri.host.s)
-		{
-			LM_ERR("incomplet uri <%.*s>\n", uuid.len, uuid.s);
-			goto error;
-		}
-		if((sp->opd&AVPOPS_FLAG_URI0)||(sp->opd&AVPOPS_FLAG_USER0))
-			s1 = &uri.user;
+                if((sp->opd&AVPOPS_FLAG_URI0)||(sp->opd&AVPOPS_FLAG_USER0))
+                {
+			/* check that uri contains user part */
+			if(!uri.user.s|| !uri.user.len)
+			{
+				LM_ERR("incomplet uri <%.*s> missing user\n", uuid.len, uuid.s);
+				goto error;
+			}
+			else
+			{
+				s1 = &uri.user;
+			}
+                }
 		if((sp->opd&AVPOPS_FLAG_URI0)||(sp->opd&AVPOPS_FLAG_DOMAIN0))
-			s2 = &uri.host;
+		{
+			/* check that uri contains host part */
+			if(!uri.host.len|| !uri.host.s)
+			{
+				LM_ERR("incomplet uri <%.*s> missing host\n", uuid.len, uuid.s);
+				goto error;
+			}
+			else
+			{
+				s2 = &uri.host;
+			}
+		}
 	}
 
 	/* is dynamic avp name ? */
@@ -489,16 +505,32 @@ int ops_dbdelete_avps (struct sip_msg* msg, struct fis_param *sp,
 			goto error;
 		}
 
-		/* check uri */
-		if(!uri.user.s|| !uri.user.len|| !uri.host.len|| !uri.host.s)
-		{
-			LM_ERR("incomplet uri <%.*s>\n", uuid.len, uuid.s);
-			goto error;
-		}
 		if((sp->opd&AVPOPS_FLAG_URI0)||(sp->opd&AVPOPS_FLAG_USER0))
-			s1 = &uri.user;
+		{
+			/* check that uri contains user part */
+			if(!uri.user.s|| !uri.user.len)
+			{
+				LM_ERR("incomplet uri <%.*s> missing user\n", uuid.len, uuid.s);
+				goto error;
+			}
+			else
+			{
+				s1 = &uri.user;
+			}
+		}
 		if((sp->opd&AVPOPS_FLAG_URI0)||(sp->opd&AVPOPS_FLAG_DOMAIN0))
-			s2 = &uri.host;
+		{
+			/* check tah uri contains host part */
+			if(!uri.host.len|| !uri.host.s)
+			{
+				LM_ERR("incomplet uri <%.*s> missing host\n", uuid.len, uuid.s);
+				goto error;
+			}
+			else
+			{
+				s2 = &uri.host;
+			}
+		}
 	}
 
 	/* is dynamic avp name ? */
@@ -608,16 +640,32 @@ int ops_dbstore_avps (struct sip_msg* msg, struct fis_param *sp,
 			goto error;
 		}
 
-		/* check uri */
-		if(!uri.user.s|| !uri.user.len|| !uri.host.len|| !uri.host.s)
-		{
-			LM_ERR("incomplet uri <%.*s>\n", uuid.len, uuid.s);
-			goto error;
-		}
 		if((sp->opd&AVPOPS_FLAG_URI0)||(sp->opd&AVPOPS_FLAG_USER0))
-			s1 = &uri.user;
+		{
+			/* check tha uri contains user part */
+			if(!uri.user.s|| !uri.user.len)
+			{
+				LM_ERR("incomplet uri <%.*s> missing user\n", uuid.len, uuid.s);
+				goto error;
+			}
+			else
+			{
+				s1 = &uri.user;
+			}
+		}
 		if((sp->opd&AVPOPS_FLAG_URI0)||(sp->opd&AVPOPS_FLAG_DOMAIN0))
-			s2 = &uri.host;
+		{
+			/* check that uri contains host part */
+			if(!uri.host.len|| !uri.host.s)
+			{
+				LM_ERR("incomplet uri <%.*s> missing host\n", uuid.len, uuid.s);
+				goto error;
+			}
+			else
+			{
+				s2 = &uri.host;
+			}
+		}
 	}
 
 	/* set values for keys  */


### PR DESCRIPTION
OpenSIPS 1.11.6

In config I'am using following statement:
```
avp_db_load("$ru/domain", "a/domain_preferences")
```
If $ru doesn't contain username, for instance it looks like this "sip:192.168.0.10" I see following error message in log:
```
Apr 14 19:06:33 hostname /usr/sbin/opensips[5313]: ERROR:avpops:ops_dbload_avps: incomplet uri <sip:192.168.0.10>
```
This happens because avp_db_load and similar functions return error if 'uri' or 'username' or 'domain' flag is specified and username or domain is missing in parsed URI. It seems to be wrong because if domain/username flag is specified and parsed SIP URI contains  domain/username part respectively, specified value can still be successfully loaded, stored or deleted from database. If 'uri' flag is specified then both username and domain must be present in parsed SIP URI.