### PR TITLE
bugfix in rest_client module: avoid waiting too long for libcurl connection

### DIFF
--- a/modules/rest_client/rest_methods.c
+++ b/modules/rest_client/rest_methods.c
@@ -127,7 +127,7 @@ int start_async_http_req(struct sip_msg *msg, enum rest_client_method method,
 	fd_set rset, wset, eset;
 	int max_fd, fd, i;
 	long busy_wait, timeout;
-	long retry_time, check_time = 5; /* 5ms looping time */
+	long retry_time, check_time = 5000; /* 5000 micro seconds = 5ms looping time */
 	int msgs_in_queue;
 	CURLMsg *cmsg;
 
@@ -259,7 +259,7 @@ int start_async_http_req(struct sip_msg *msg, enum rest_client_method method,
 				}
 			}
 
-			usleep(1000UL * check_time);
+			usleep(check_time);
 		}
 	}
 


### PR DESCRIPTION
The error is in the loop:

long retry_time, check_time = 5;
for (i = 0; i < busy_wait; i += check_time) {
    ....
    sleep(1000 * check_time)
}

We sleep 5 **miliseconds** but increase only 5 **microsecond** in each loop.

