### PR TITLE
Updated opensipsctl.base to also search /sbin

### DIFF
--- a/scripts/opensipsctl.base
+++ b/scripts/opensipsctl.base
@@ -26,6 +26,11 @@ locate_tool() {
 			TOOLPATH="/bin/$1"
 			return
 		fi
+		#The md5 tool on FreeBSD 8.3 is located in /sbin/
+		if [ -x "/sbin/$1" ] ; then
+			TOOLPATH="/sbin/$1"
+			return
+		fi
 		if [ -x "/usr/local/bin/$1" ] ; then
 			TOOLPATH="/usr/local/bin/$1"
 			return


### PR DESCRIPTION
The md5 utility is located at /sbin/md5 on FreeBSD 8.3. An additional common location was added to allow the script to accommodate this.