### PR TITLE
xlog.c: add $xlog_level pseudovariable

### DIFF
--- a/pvar.c
+++ b/pvar.c
@@ -3247,6 +3247,50 @@ int pv_get_log_level(struct sip_msg *msg,  pv_param_t *param, pv_value_t *res)
 	return 0;
 }
 
+int pv_get_xlog_level(struct sip_msg *msg,  pv_param_t *param, pv_value_t *res){
+	if (param==NULL) {
+		LM_CRIT("BUG - bad parameters\n");
+		return -1;
+	}
+
+	if(res == NULL) {
+		return -1;
+	}
+
+	switch(xlog_level) {
+	case L_ALERT:
+		res->rs.s = DP_ALERT_TEXT;
+		break;
+	case L_CRIT:
+		res->rs.s = DP_CRIT_TEXT;
+		break;
+	case L_ERR:
+		res->rs.s = DP_ERR_TEXT;
+		break;
+	case L_WARN:
+		res->rs.s = DP_WARN_TEXT;
+		break;
+	case L_NOTICE:
+		res->rs.s = DP_NOTICE_TEXT;
+		break;
+	case L_INFO:
+		res->rs.s = DP_INFO_TEXT;
+		break;
+	case L_DBG:
+		res->rs.s = DP_DBG_TEXT;
+		break;
+	default:
+		LM_CRIT("BUG - xlog_level value unrecognized: %d\n", xlog_level);
+		return -1;
+	}
+
+	res->rs.len = strlen(res->rs.s);
+
+	res->flags = PV_VAL_STR;
+
+	return 0;
+}
+
 
 
 /**
@@ -3578,6 +3622,8 @@ static pv_export_t _pv_names_table[] = {
 	{{"cfg_line", sizeof("cfg_line")-1}, PVT_LINE_NUMBER, pv_get_line_number, 0,
 		0, 0, 0, 0 },
 	{{"cfg_file", sizeof("cfg_file")-1}, PVT_CFG_FILE_NAME, pv_get_cfg_file_name, 0,
+	0, 0, 0, 0 },
+	{{"xlog_level", sizeof("xlog_level")-1}, PVT_XLOG_LEVEL, pv_get_xlog_level, 0,
 	0, 0, 0, 0 },
 	{{0,0}, 0, 0, 0, 0, 0, 0, 0}
 };

--- a/pvar.h
+++ b/pvar.h
@@ -109,6 +109,7 @@ enum _pv_type {
 	PVT_AUTH_ALGORITHM,   PVT_AUTH_OPAQUE,       PVT_AUTH_CNONCE,
 	PVT_RU_Q,             PVT_ROUTE_PARAM,       PVT_ROUTE_TYPE,
 	PVT_LINE_NUMBER,      PVT_CFG_FILE_NAME,     PVT_LOG_LEVEL,
+	PVT_XLOG_LEVEL,
 	/* registered by json module */
 	PVT_JSON,
 

--- a/xlog.c
+++ b/xlog.c
@@ -42,6 +42,7 @@ char *log_buf = NULL;
 int xlog_buf_size = 4096;
 int xlog_force_color = 0;
 int xlog_default_level = L_ERR;
+int xlog_level = L_ERR;
 
 static int buf_init(void)
 {
@@ -93,8 +94,10 @@ int xlog_2(struct sip_msg* msg, char* lev, char* frm)
 
 	log_len = xlog_buf_size;
 
+	xlog_level = level;
 	if(xl_print_log(msg, (pv_elem_t*)frm, &log_len)<0)
 		return -1;
+	xlog_level = xlog_default_level;
 
 	/* log_buf[log_len] = '\0'; */
 	LM_GEN1((int)level, "%.*s", log_len, log_buf);

--- a/xlog.h
+++ b/xlog.h
@@ -35,6 +35,7 @@ typedef struct _xl_level
 extern int xlog_buf_size;
 extern int xlog_force_color;
 extern int xlog_default_level;
+extern int xlog_level;
 
 int xlog_1(struct sip_msg*, char*, char*);
 int xlog_2(struct sip_msg*, char*, char*);


### PR DESCRIPTION
using the $xlog_level pseudovariable in the xlog function will insert
in the message generated the log level, example:
xlog("$xlog_level some text\n") will generate the line
ERROR: some text