### PR TITLE
Fix memory leak: after sqlite prepare was deleted stmt compiled, free…

### DIFF
--- a/db/db_row.c
+++ b/db/db_row.c
@@ -90,6 +90,7 @@ int db_free_row(db_row_t* _r)
 		}
 	}
 
+	pkg_free(ROW_VALUES(_r));
 	ROW_VALUES(_r) = NULL;
 	return 0;
 }

--- a/modules/db_sqlite/dbase.h
+++ b/modules/db_sqlite/dbase.h
@@ -45,5 +45,5 @@ int db_sqlite_replace(const db_con_t* _h, const db_key_t* _k, const db_val_t* _v
 int db_last_inserted_id(const db_con_t* _h);
  int db_insert_update(const db_con_t* _h, const db_key_t* _k, const db_val_t* _v,
 	const int _n);
-int db_sqlite_free_result(db_con_t* _h, db_res_t* _r);
+int db_sqlite_free_result(const db_con_t* _h, db_res_t* _r);
 #endif

--- a/modules/db_sqlite/row.c
+++ b/modules/db_sqlite/row.c
@@ -106,6 +106,7 @@ int db_sqlite_convert_row(const db_con_t* _h, db_res_t* _res, db_row_t* _r)
 
 				VAL_BLOB(_v).s[VAL_BLOB(_v).len]='\0';
 				VAL_TYPE(_v) = DB_BLOB;
+				VAL_FREE(_v) = 1;
 
 				break;
 			case DB_STRING:
@@ -117,6 +118,8 @@ int db_sqlite_convert_row(const db_con_t* _h, db_res_t* _res, db_row_t* _r)
 
 				VAL_STR(_v).s[VAL_STR(_v).len]='\0';
 				VAL_TYPE(_v) = DB_STR;
+				VAL_FREE(_v) = 1;
+
 				break;
 			default:
 				LM_ERR("invalid type for sqlite!\n");


### PR DESCRIPTION
Fix memory leak: after sqlite prepare was deleted stmt compiled, freed error message after sqlite exec, allocated rows was set to free and it also db_free_row was repaired.
These points were made:
1) In function db_sqlite_free_result, it was added a sqlite3_finalize. This implies on free sqlite statements allocated from sqlite3_prepare_v2 called by functions db_sqlite_raw_query and db_sqlite_query.
2) In function db_sqlite_free_result was changed to call db_free_result. It is a reuse suggestion.
3) In function db_free_row was fixed to free allocated rows. This function is called by db_free_result.
4) In function db_sqlite_convert_row for lines that use pkg_malloc, the flag VAL_FREE was set to enable. This flag was changed to db_free_row free allocated rows content.
5) After sqlite3_exec was included sqlite3_free, to free allocated error message by sqlite.

Best Regards,
Daniel Fussia

Inatel Competence Center
Embedded Software
