### PR TITLE
Fixed memory leak on modules/drouting/drouting.c

### DIFF
--- a/modules/drouting/drouting.c
+++ b/modules/drouting/drouting.c
@@ -1896,7 +1896,12 @@ static inline int get_group_id(struct sip_uri *uri, struct head_db *
 
 	if (RES_ROW_N(res) == 0) {
 		if (dr_default_grp!=-1)
+		{
+			if (res)
+				(current_partition->db_funcs).free_result(*(current_partition->db_con), res);
+
 			return dr_default_grp;
+		}
 		LM_ERR("no group for user "
 				"\"%.*s\"@\"%.*s\"\n", uri->user.len, uri->user.s,
 				uri->host.len, uri->host.s);


### PR DESCRIPTION
A small memory leak occurs in function get_group_id() inside modules/drouting.c when do_routing is called without parameters in opensips.cfg ( do_routing()).
In this case the dr_default_grp variable is not equal -1 and 'return dr_default_grp' is executed without freeing the res variable previously allocated for query execution.

------------------------------------------------------------------------------------------

I run in production an old version of opensips (1.11) and valgrind sometimes detects a memory leak on drouting.c inside get_group_id() function.
The leak is resolved if I comment out the dr_dbf.free_result call.

'''
...
if ( dr_dbf.query(db_hdl,keys_cmp,0,vals_cmp,keys_ret,n,1,0,&res)<0 ) {
                LM_ERR("DB query failed\n");
                goto error;
        }

        if (RES_ROW_N(res) == 0) {  
                if (dr_default_grp!=-1)
                {
                        /*if (res) dr_dbf.free_result(db_hdl, res);*/
                        return dr_default_grp;
                }
...
'''

In the latest version of opensips the drouting.c is slightly different but It can be that the memory leak is still present, that's why I am submitting this pl.
Hope this helps.
