### PR TITLE
tls_mgm: load actual files from db not paths to files

### DIFF
--- a/modules/tls_mgm/tls_domain.h
+++ b/modules/tls_mgm/tls_domain.h
@@ -127,6 +127,8 @@ void tls_release_domain(struct tls_domain* dom);
 
 void tls_release_all_domains(struct tls_domain* dom);
 
-int set_all_domain_attr(struct tls_domain **dom, char **str_vals, int *int_vals);
+int set_all_domain_attr(struct tls_domain **dom, char **str_vals, int *int_vals,  str* blob_vals);
+int set_all_default_domain_attr(struct tls_domain *dom, char **str_vals, int *int_vals,  str* blob_vals);
+
 
 #endif

--- a/modules/tls_mgm/tls_helper.h
+++ b/modules/tls_mgm/tls_helper.h
@@ -24,11 +24,11 @@ struct tls_domain {
 	int             verify_cert;
 	int             require_client_cert;
 	int             crl_check_all;
-	char           *cert_file;
-	char           *pkey_file;
+	str            cert;
+	str            pkey;
 	char           *crl_directory;
-	char           *ca_file;
-	char           *tmp_dh_file;
+	str            ca;
+	str            dh_param;
 	char           *tls_ec_curve;
 	char           *ca_directory;
 	char           *ciphers_list;

--- a/modules/tls_mgm/tls_mgm.c
+++ b/modules/tls_mgm/tls_mgm.c
@@ -1,3 +1,42 @@
+ /*
+ * Copyright (C) 2001-2003 FhG Fokus
+ * Copyright (C) 2015 OpenSIPS Foundation
+ *
+ * This file is part of opensips, a free SIP server.
+ *
+ * opensips is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version
+ *
+ * In addition, as a special exception, the copyright holders give
+ * permission to link the code of portions of this program with the
+ * OpenSSL library under certain conditions as described in each
+ * individual source file, and distribute linked combinations
+ * including the two.
+ * You must obey the GNU General Public License in all respects
+ * for all of the code used other than OpenSSL.  If you modify
+ * file(s) with this exception, you may extend this exception to your
+ * version of the file(s), but you are not obligated to do so.  If you
+ * do not wish to do so, delete this exception statement from your
+ * version.  If you delete this exception statement from all source
+ * files in the program, then also delete it here.
+ *
+ * opensips is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301  USA
+ *
+ *
+ * History:
+ * -------
+ *  2015-02-12  first version (bogdan)
+ */
+
 #include <openssl/ui.h>
 #include <openssl/ssl.h>
 #include <openssl/opensslv.h>
@@ -353,6 +392,34 @@ set_dh_params(SSL_CTX * ctx, char *filename)
 	return 0;
 }
 
+static int set_dh_params_db(SSL_CTX * ctx, str *blob)
+{
+	LM_DBG("Entered\n");
+	BIO *bio;
+	DH *dh;
+
+	bio = BIO_new_mem_buf((void*)blob->s,blob->len);
+	if (!bio) {
+		LM_ERR("unable to create bio \n");
+		return -1;
+	}
+
+	dh = PEM_read_bio_DHparams(bio, 0, 0, 0);
+	BIO_free(bio);
+	if (!dh) {
+		LM_ERR("unable to read dh params from bio\n");
+		return -1;
+	}
+
+	if (!SSL_CTX_set_tmp_dh(ctx, dh)) {
+		LM_ERR("unable to set dh params\n");
+		return -1;
+	}
+
+	DH_free(dh);
+	LM_DBG("DH params from successfully set\n");
+	return 0;
+}
 
 /*
  * Set elliptic curve.
@@ -388,7 +455,8 @@ int load_info(db_func_t *dr_dbf, db_con_t* db_hdl, str *db_table,
 	struct tls_domain **serv_dom, struct tls_domain **cli_dom)
 {
 	int int_vals[4];
-	char *str_vals[11];
+	char *str_vals[8];
+	str blob_vals[4];
 	int i, n;
 	int no_rows = 5;
 	int db_cols = 15;
@@ -419,7 +487,7 @@ int load_info(db_func_t *dr_dbf, db_con_t* db_hdl, str *db_table,
 	columns[14] = &eccurve_col;
 
 	/* checking if the table version is up to date*/
-	if (db_check_table_version(dr_dbf, db_hdl, db_table, 1/*version*/) != 0)
+	if (db_check_table_version(dr_dbf, db_hdl, db_table, 2/*version*/) != 0)
 		goto error;
 
 	/* table to use*/
@@ -434,8 +502,8 @@ int load_info(db_func_t *dr_dbf, db_con_t* db_hdl, str *db_table,
 			LM_ERR("DB query failed - retrieve valid connections \n");
 			goto error;
 		}
-		no_rows = estimate_available_rows(10 + 45 + 4 + 45 + 4 + 4 + 45 +
-			45 + 4 + 45 + 45 + 45 + 45 + 45 + 45, db_cols);
+		no_rows = estimate_available_rows(4 + 45 + 4 + 45 + 4 + 4 + 45 +
+			45 + 4 + 45 + 45 + 45 + 3 * 4096, db_cols);
 		if (no_rows == 0) no_rows = 5;
 		if (dr_dbf->fetch_result(db_hdl, &res, no_rows) < 0) {
 			LM_ERR("Error fetching rows\n");
@@ -474,11 +542,11 @@ int load_info(db_func_t *dr_dbf, db_con_t* db_hdl, str *db_table,
 			check_val(require_cert_col, ROW_VALUES(row) + 5, DB_INT, 0, 0);
 			int_vals[INT_VALS_REQUIRE_CERT_COL] = VAL_INT(ROW_VALUES(row) + 5);
 
-			check_val(certificate_col, ROW_VALUES(row) + 6, DB_STRING, 0, 0);
-			str_vals[STR_VALS_CERTIFICATE_COL] = (char *) VAL_STRING(ROW_VALUES(row) + 6);
+			check_val(certificate_col, ROW_VALUES(row) + 6, DB_BLOB, 0, 0);
+			blob_vals[BLOB_VALS_CERTIFICATE_COL] = VAL_BLOB(ROW_VALUES(row) + 6);
 
-			check_val(pk_col, ROW_VALUES(row) + 7, DB_STRING, 0, 0);
-			str_vals[STR_VALS_PK_COL] = (char *) VAL_STRING(ROW_VALUES(row) + 7);
+			check_val(pk_col, ROW_VALUES(row) + 7, DB_BLOB, 0, 0);
+			blob_vals[BLOB_VALS_PK_COL] = VAL_BLOB(ROW_VALUES(row) + 7);
 
 			check_val(crl_check_col, ROW_VALUES(row) + 8, DB_INT, 0, 0);
 			int_vals[INT_VALS_CRL_CHECK_COL] = VAL_INT(ROW_VALUES(row) + 8);
@@ -486,8 +554,8 @@ int load_info(db_func_t *dr_dbf, db_con_t* db_hdl, str *db_table,
 			check_val(crl_dir_col, ROW_VALUES(row) + 9, DB_STRING, 0, 0);
 			str_vals[STR_VALS_CRL_DIR_COL] = (char *) VAL_STRING(ROW_VALUES(row) + 9);
 
-			check_val(calist_col, ROW_VALUES(row) + 10, DB_STRING, 0, 0);
-			str_vals[STR_VALS_CALIST_COL] = (char *) VAL_STRING(ROW_VALUES(row) + 10);
+			check_val(calist_col, ROW_VALUES(row) + 10, DB_BLOB, 0, 0);
+			blob_vals[BLOB_VALS_CALIST_COL] = VAL_BLOB(ROW_VALUES(row) + 10);
 
 			check_val(cadir_col, ROW_VALUES(row) + 11, DB_STRING, 0, 0);
 			str_vals[STR_VALS_CADIR_COL] = (char *) VAL_STRING(ROW_VALUES(row) + 11);
@@ -495,13 +563,13 @@ int load_info(db_func_t *dr_dbf, db_con_t* db_hdl, str *db_table,
 			check_val(cplist_col, ROW_VALUES(row) + 12, DB_STRING, 0, 0);
 			str_vals[STR_VALS_CPLIST_COL] = (char *) VAL_STRING(ROW_VALUES(row) + 12);
 
-			check_val(dhparams_col, ROW_VALUES(row) + 13, DB_STRING, 0, 0);
-			str_vals[STR_VALS_DHPARAMS_COL] = (char *) VAL_STRING(ROW_VALUES(row) + 13);
+			check_val(dhparams_col, ROW_VALUES(row) + 13, DB_BLOB, 0, 0);
+			blob_vals[BLOB_VALS_DHPARAMS_COL] = VAL_BLOB(ROW_VALUES(row) + 13);
 
 			check_val(eccurve_col, ROW_VALUES(row) + 14, DB_STRING, 0, 0);
 			str_vals[STR_VALS_ECCURVE_COL] = (char *) VAL_STRING(ROW_VALUES(row) + 14);
 
-			tlsp_db_add_domain(str_vals, int_vals, serv_dom, cli_dom);
+			tlsp_db_add_domain(str_vals, int_vals, blob_vals, serv_dom, cli_dom);
 			
 			n++;
 		}
@@ -626,20 +694,26 @@ int verify_callback(int pre_verify_ok, X509_STORE_CTX *ctx) {
  */
 static int init_ssl_ctx_behavior( struct tls_domain *d ) {
 	int verify_mode;
+	int use_default = 0;
 
 #if (OPENSSL_VERSION_NUMBER > 0x10001000L)
 	/*
 	 * set dh params
 	 */
-	if (!d->tmp_dh_file) {
+	if (!d->dh_param.s) {
+		use_default = 1;
 		LM_DBG("no DH params file for tls[%s:%d] defined, "
 				"using default '%s'\n", ip_addr2a(&d->addr), d->port,
 				tls_tmp_dh_file);
-		d->tmp_dh_file = tls_tmp_dh_file;
+		d->dh_param.s = tls_tmp_dh_file;
+		d->dh_param.len = len(tls_tmp_dh_file);
 	}
-	if (d->tmp_dh_file && set_dh_params(d->ctx, d->tmp_dh_file) < 0)
-		return -1;
-
+	if (!tls_db_enabled || use_default) {
+		if (d->dh_param.s && set_dh_params(d->ctx, d->dh_param.s) < 0)
+			return -1;
+	} else {
+		set_dh_params_db(d->ctx, &d->dh_param);
+	}
 	if (d->tls_ec_curve) {
 		if (set_ec_params(d->ctx, d->tls_ec_curve) < 0) {
 			return -1;
@@ -782,6 +856,36 @@ static int load_certificate(SSL_CTX * ctx, char *filename)
 	return 0;
 }
 
+/* TODO: currently we can't load a chain of certificates from database
+*/
+static int load_certificate_db(SSL_CTX * ctx, str *blob)
+{
+	LM_DBG("entered\n");
+	X509 *cert = NULL;
+	BIO *cbio;
+
+	cbio = BIO_new_mem_buf((void*)blob->s,blob->len);
+	if (!cbio) {
+		LM_ERR("Unable to create BIO buf\n");
+		return -1;
+	}
+
+	cert = PEM_read_bio_X509(cbio, NULL, 0, NULL);
+	BIO_free(cbio);
+	if (!cert) {
+		LM_ERR("unable to load certificate from buffer\n");
+		return -1;
+	}
+
+	if (! SSL_CTX_use_certificate(ctx, cert)) {
+		LM_ERR("unable to use certificate\n");
+	}
+
+	X509_free(cert);
+	LM_DBG("successfully loaded\n");
+	return 0;
+}
+
 static int load_crl(SSL_CTX * ctx, char *crl_directory, int crl_check_all)
 {
 #if OPENSSL_VERSION_NUMBER >= 0x10000000L
@@ -888,6 +992,47 @@ static int load_ca(SSL_CTX * ctx, char *filename)
 	return 0;
 }
 
+static int load_ca_db(SSL_CTX * ctx, str *blob)
+{
+	X509_STORE *store;
+	X509 *cert;
+	BIO *cbio;
+
+	LM_DBG("Entered\n");
+
+	cbio = BIO_new_mem_buf((void*)blob->s,blob->len);
+
+	if (!cbio) {
+		LM_ERR("Unable to create BIO buf\n");
+		return -1;
+	}
+
+	cert = PEM_read_bio_X509(cbio, NULL, 0, NULL);
+	BIO_free(cbio);
+
+	if (!cert) {
+		LM_ERR("unable to load certificate from buffer\n");
+		return -1;
+	}
+
+	store =  SSL_CTX_get_cert_store(ctx);
+	if(!store) {
+		X509_free(cert);
+		LM_ERR("Unable to get X509 store from ssl context\n");
+		return -1;
+	}
+
+	if (!X509_STORE_add_cert(store, cert)){
+		X509_free(cert);
+		LM_ERR("Unable to add ca\n");
+		return -1;
+	}
+
+	X509_free(cert);
+	LM_DBG("CA successfully loaded\n");
+	return 0;
+}
+
 /*
  * Load a caList from a directory instead of a single file.
  */
@@ -966,6 +1111,49 @@ static int load_private_key(SSL_CTX * ctx, char *filename)
 	return 0;
 }
 
+static int load_private_key_db(SSL_CTX * ctx, str *blob)
+{
+#define NUM_RETRIES 3
+	int idx;
+	BIO *kbio;
+	EVP_PKEY *key;
+	LM_DBG("entered\n");
+
+	kbio = BIO_new_mem_buf((void*)blob->s, blob->len);
+
+	if (!kbio) {
+		LM_ERR("Unable to create BIO buf\n");
+		return -1;
+	}
+
+	for(idx = 0; idx < NUM_RETRIES; idx++ ) {
+		key = PEM_read_bio_PrivateKey(kbio,NULL, passwd_cb, "database");
+		if ( key ) {
+			break;
+		} else {
+			LM_ERR("unable to load private key. \n"
+				   "Retry (%d left) (check password case)\n",  (NUM_RETRIES - idx -1) );
+			continue;
+		}
+	}
+
+	BIO_free(kbio);
+	if(!key) {
+		LM_ERR("unable to load private key from buffer\n");
+		return -1;
+	}
+
+	if (!SSL_CTX_use_PrivateKey(ctx, key)) {
+		EVP_PKEY_free(key);
+		LM_ERR("key does not match the public key of the certificate\n");
+		return -1;
+	}
+
+	EVP_PKEY_free(key);
+	LM_DBG("key successfully loaded\n");
+	return 0;
+}
+
 
 /*
  * initialize tls virtual domains
@@ -973,6 +1161,7 @@ static int load_private_key(SSL_CTX * ctx, char *filename)
 static int init_tls_domains(struct tls_domain *d)
 {
 	struct tls_domain *dom;
+	int use_default = 0;
 
 	dom = d;
 	while (d) {
@@ -1008,14 +1197,22 @@ static int init_tls_domains(struct tls_domain *d)
 		/*
 		 * load certificate
 		 */
-		if (!d->cert_file) {
+		if (!d->cert.s) {
+			use_default = 1;
 			LM_NOTICE("no certificate for tls[%s:%d] defined, using default"
 					"'%s'\n", ip_addr2a(&d->addr), d->port,	tls_cert_file);
-			d->cert_file = tls_cert_file;
+			d->cert.s = tls_cert_file;
+			d->cert.len = len(tls_cert_file);
 		}
 
-		if (load_certificate(d->ctx, d->cert_file) < 0)
-			return -1;
+		if (!tls_db_enabled || use_default) {
+			if (load_certificate(d->ctx, d->cert.s) < 0)
+				return -1;
+		} else
+			if (load_certificate_db(d->ctx, &d->cert) < 0)
+				return -1;
+
+		use_default = 0;
 
 		/**
 		 * load crl from directory
@@ -1030,15 +1227,23 @@ static int init_tls_domains(struct tls_domain *d)
 		/*
 		 * load ca
 		 */
-		if (!d->ca_file) {
+		if (!d->ca.s) {
+			use_default = 1;
 			LM_NOTICE("no CA for tls[%s:%d] defined, "
 					"using default '%s'\n", ip_addr2a(&d->addr), d->port,
 					tls_ca_file);
-			d->ca_file = tls_ca_file;
+			d->ca.s = tls_ca_file;
+			d->ca.len = len(tls_ca_file);
 		}
-		if (d->ca_file && load_ca(d->ctx, d->ca_file) < 0)
-			return -1;
 
+		if (!tls_db_enabled || use_default) {
+			if (d->ca.s && load_ca(d->ctx, d->ca.s) < 0)
+				return -1;
+		} else {
+			if (load_ca_db(d->ctx, &d->ca) < 0)
+				return -1;
+		}
+		use_default = 0;
 		/*
 		 * load ca from directory
 		 */
@@ -1061,13 +1266,21 @@ static int init_tls_domains(struct tls_domain *d)
 	 */
 	d = dom;
 	while (d) {
-		if (!d->pkey_file) {
+		if (!d->pkey.s) {
 			LM_NOTICE("no private key for tls[%s:%d] defined, using default"
 					"'%s'\n", ip_addr2a(&d->addr), d->port, tls_pkey_file);
-			d->pkey_file = tls_pkey_file;
+			d->pkey.s = tls_pkey_file;
+			d->pkey.len = len(tls_pkey_file);
+			use_default = 1;
 		}
-		if (load_private_key(d->ctx, d->pkey_file) < 0)
-			return -1;
+		if (!tls_db_enabled || use_default) {
+			if (load_private_key(d->ctx, d->pkey.s) < 0)
+				return -1;
+		} else {
+			if (load_private_key_db(d->ctx, &d->pkey) < 0)
+				return -1;
+		}
+		use_default = 0;
 		d = d->next;
 	}
 
@@ -1328,6 +1541,11 @@ static int mod_init(void){
 	tls_default_server_domain.type = TLS_DOMAIN_DEF|TLS_DOMAIN_SRV;
 	tls_default_server_domain.addr.af = AF_INET;
 
+	if (tls_db_enabled && load_info(&dr_dbf, db_hdl, &tls_db_table, &tls_server_domains,
+			&tls_client_domains)){
+		return -1;
+	}
+
 	/*
 	 * now initialize tls default domains
 	 */
@@ -1341,12 +1559,6 @@ static int mod_init(void){
 	/*
 	 * now initialize tls virtual domains
 	 */
-	
-	if (tls_db_enabled && load_info(&dr_dbf, db_hdl, &tls_db_table, &tls_server_domains,
-			&tls_client_domains)){
-		return -1;
-	}
-
 	if ( (n=init_tls_domains(tls_server_domains)) ) {
 		return n;
 	}
@@ -1390,6 +1602,16 @@ static void mod_destroy(void)
 		lock_dealloc(d->lock);
 		d = d->next;
 	}
+
+	if(tls_db_enabled) {
+		if(tls_default_server_domain.id.s){
+			shm_free(tls_default_server_domain.id.s);
+		}
+		if(tls_default_client_domain.id.s){
+			shm_free(tls_default_client_domain.id.s);
+		}
+	}
+
 	if (tls_default_server_domain.ctx) {
 		SSL_CTX_free(tls_default_server_domain.ctx);
 	}
@@ -1552,35 +1774,40 @@ static int list_domain(struct mi_node *root, struct tls_domain *d)
 			child = add_mi_node_child(node, 0, "CRL_CHECKALL", 12, "no", 2);
 		if (child == NULL) goto error;
 
-		child = add_mi_node_child(node, MI_DUP_VALUE, "CERT_FILE", 9,
-			d->cert_file, len(d->cert_file));
-		if (child == NULL) goto error;
+		if(!tls_db_enabled) {
+			child = add_mi_node_child(node, MI_DUP_VALUE, "CERT_FILE", 9,
+				d->cert.s, d->cert.len);
+			if (child == NULL) goto error;
+		}
 
 		child = add_mi_node_child(node, MI_DUP_VALUE, "CRL_DIR", 7,
 			d->crl_directory, len(d->crl_directory));
 		if (child == NULL) goto error;
 
-		child = add_mi_node_child(node, MI_DUP_VALUE, "CA_FILE", 7,
-			d->ca_file, len(d->ca_file));
-		if (child == NULL) goto error;
-
+		if(!tls_db_enabled) {
+			child = add_mi_node_child(node, MI_DUP_VALUE, "CA_FILE", 7,
+				d->ca.s, d->ca.len);
+			if (child == NULL) goto error;
+		}
 		child = add_mi_node_child(node, MI_DUP_VALUE, "CA_DIR", 6,
 			d->ca_directory, len(d->ca_directory));
 		if (child == NULL) goto error;
 
-		child = add_mi_node_child(node, MI_DUP_VALUE, "PKEY_FILE", 9,
-			d->pkey_file, len(d->pkey_file));
+		if(!tls_db_enabled) {
+			child = add_mi_node_child(node, MI_DUP_VALUE, "PKEY_FILE", 9,
+				d->pkey.s, d->pkey.len);
 
-		if (child == NULL) goto error;
-
+			if (child == NULL) goto error;
+		}
 		child = add_mi_node_child(node, MI_DUP_VALUE, "CIPHER_LIST", 11,
 			d->ciphers_list, len(d->ciphers_list));
 
 		if (child == NULL) goto error;
 
-		child = add_mi_node_child(node, MI_DUP_VALUE, "DH_PARAMS", 9,
-			d->tmp_dh_file, len(d->tmp_dh_file));
-
+		if(!tls_db_enabled) {
+			child = add_mi_node_child(node, MI_DUP_VALUE, "DH_PARAMS", 9,
+				d->dh_param.s, d->dh_param.len);
+		}
 		if (child == NULL) goto error;
 
 		child = add_mi_node_child(node, MI_DUP_VALUE, "EC_CURVE", 8,

--- a/modules/tls_mgm/tls_params.c
+++ b/modules/tls_mgm/tls_params.c
@@ -165,7 +165,7 @@ int tlsp_add_cli_domain(modparam_t type, void *val)
 	return 1;
 }
 
-int tlsp_db_add_domain(char **str_vals, int *int_vals, struct tls_domain **serv_dom, struct tls_domain **cli_dom){
+int tlsp_db_add_domain(char **str_vals, int *int_vals, str* blob_vals, struct tls_domain **serv_dom, struct tls_domain **cli_dom){
 	struct ip_addr *ip;
 	unsigned int port;
 	str domain;
@@ -194,12 +194,12 @@ int tlsp_db_add_domain(char **str_vals, int *int_vals, struct tls_domain **serv_
 			}
 
 		}
-		if (set_all_domain_attr(cli_dom, str_vals, int_vals) < 0){
+		if (set_all_domain_attr(cli_dom, str_vals, int_vals, blob_vals) < 0){
 			LM_ERR("failed to set domain [%.*s] attr\n",  domain.len, domain.s);
 			return -1;
 		}
 
-	} else {
+	} else if (int_vals[INT_VALS_TYPE_COL] == SERVER_DOMAIN) {
 		if (ip) {
 
 			if (tls_new_server_domain(&id, ip, port, serv_dom) < 0) {
@@ -210,8 +210,17 @@ int tlsp_db_add_domain(char **str_vals, int *int_vals, struct tls_domain **serv_
 			LM_ERR("server domains do not support 'domain name' in definition\n");
 			return -1;
 		}
-		if (set_all_domain_attr(serv_dom, str_vals, int_vals) < 0){
+		if (set_all_domain_attr(serv_dom, str_vals, int_vals,blob_vals) < 0){
 			LM_ERR("failed to set domain [%.*s] attr\n", domain.len, domain.s );
+			return -1;
+		}
+	} else { /* default domain setting */
+		if (set_all_default_domain_attr(&tls_default_server_domain, str_vals, int_vals,blob_vals) < 0){
+			LM_ERR("failed to set default server domain attr\n");
+			return -1;
+		}
+		if (set_all_default_domain_attr(&tls_default_client_domain, str_vals, int_vals,blob_vals) < 0){
+			LM_ERR("failed to set default client domain attr\n");
 			return -1;
 		}
 	}
@@ -263,6 +272,27 @@ static void split_param_val(char *in, str *id, str *val)
 		} \
 	} while(0)
 
+#define set_domain_str_attr( _id, _field, _val, _len_field, _len) \
+	do { \
+		struct tls_domain *_d; \
+		if ((_id).s) { \
+			/* specific TLS domain */ \
+			if ( (_d=tls_find_domain_by_id(&(_id)))==NULL ) { \
+				LM_ERR("TLS domain [%.*s] not defined in [%s]\n", \
+					(_id).len, (_id).s, (char*)in); \
+				return -1; \
+			} \
+			_d->_field = _val; \
+			_d->_len_field = _len; \
+		} else { \
+			/* set default domains */ \
+			tls_default_server_domain._field = _val; \
+			tls_default_client_domain._field = _val; \
+			tls_default_server_domain._len_field = _len; \
+			tls_default_client_domain._len_field = _len; \
+		} \
+	} while(0)
+
 
 
 int tlsp_set_method(modparam_t type, void *in)
@@ -273,7 +303,7 @@ int tlsp_set_method(modparam_t type, void *in)
 
 	split_param_val( (char*)in, &id, &val);
 
-	if (tls_db_enabled && id.s)
+	if (tls_db_enabled)
 		return -1;
 
 	if ( strcasecmp( val.s, "SSLV23")==0 || strcasecmp( val.s, "TLSany")==0 )
@@ -300,7 +330,7 @@ int tlsp_set_verify(modparam_t type, void *in)
 
 	split_param_val( (char*)in, &id, &val);
 
-	if (tls_db_enabled && id.s)
+	if (tls_db_enabled)
 		return -1;
 	
 	if (str2int( &val, &verify)!=0) {
@@ -321,7 +351,7 @@ int tlsp_set_require(modparam_t type, void *in)
 
 	split_param_val( (char*)in, &id, &val);
 
-	if (tls_db_enabled && id.s)
+	if (tls_db_enabled)
 		return -1;
 	
 	if (str2int( &val, &req)!=0) {
@@ -341,7 +371,7 @@ int tlsp_set_crl_check(modparam_t type, void *in)
 
        split_param_val( (char*)in, &id, &val);
 
-       if (tls_db_enabled && id.s)
+       if (tls_db_enabled)
 		return -1;
        
        if (str2int( &val, &check)!=0) {
@@ -360,7 +390,7 @@ int tlsp_set_crldir(modparam_t type, void *in)
 
        split_param_val( (char*)in, &id, &val);
 
-       if (tls_db_enabled && id.s)
+       if (tls_db_enabled)
 		return -1;
        
        set_domain_attr( id, crl_directory, val.s);
@@ -374,10 +404,10 @@ int tlsp_set_certificate(modparam_t type, void *in)
 
 	split_param_val( (char*)in, &id, &val);
 	
-	if (tls_db_enabled && id.s)
+	if (tls_db_enabled)
 		return -1;
 	
-	set_domain_attr( id, cert_file, val.s);
+	set_domain_str_attr( id, cert.s, val.s, cert.len, val.len);
 	return 1;
 }
 
@@ -389,10 +419,10 @@ int tlsp_set_pk(modparam_t type, void *in)
 
 	split_param_val( (char*)in, &id, &val);
 
-	if (tls_db_enabled && id.s)
+	if (tls_db_enabled)
 		return -1;
 
-	set_domain_attr( id, pkey_file, val.s);
+	set_domain_str_attr( id, pkey.s, val.s, pkey.len, val.len);
 	return 1;
 }
 
@@ -404,10 +434,10 @@ int tlsp_set_calist(modparam_t type, void *in)
 
 	split_param_val( (char*)in, &id, &val);
 
-	if (tls_db_enabled && id.s)
+	if (tls_db_enabled)
 		return -1;
 
-	set_domain_attr( id, ca_file, val.s);
+	set_domain_str_attr( id, ca.s, val.s, ca.len, val.len);
 	return 1;
 }
 
@@ -419,7 +449,7 @@ int tlsp_set_cadir(modparam_t type, void *in)
 
 	split_param_val( (char*)in, &id, &val);
 
-	if (tls_db_enabled && id.s)
+	if (tls_db_enabled)
 		return -1;
 
 	set_domain_attr( id, ca_directory, val.s);
@@ -434,7 +464,7 @@ int tlsp_set_cplist(modparam_t type, void *in)
 
 	split_param_val( (char*)in, &id, &val);
 
-	if (tls_db_enabled && id.s)
+	if (tls_db_enabled)
 		return -1;
 	
 	set_domain_attr( id, ciphers_list, val.s);
@@ -449,10 +479,10 @@ int tlsp_set_dhparams(modparam_t type, void *in)
 
 	split_param_val( (char*)in, &id, &val);
 
-	if (tls_db_enabled && id.s)
+	if (tls_db_enabled)
 		return -1;
 	
-	set_domain_attr( id, tmp_dh_file, val.s);
+	set_domain_str_attr( id, dh_param.s, val.s, dh_param.len, val.len);
 	return 1;
 }
 
@@ -464,7 +494,7 @@ int tlsp_set_eccurve(modparam_t type, void *in)
 
 	split_param_val( (char*)in, &id, &val);
 
-	if (tls_db_enabled && id.s)
+	if (tls_db_enabled)
 		return -1;
 	
 	set_domain_attr( id, tls_ec_curve, val.s);

--- a/modules/tls_mgm/tls_params.h
+++ b/modules/tls_mgm/tls_params.h
@@ -46,22 +46,24 @@
 #define STR_VALS_ID_COL             0
 #define STR_VALS_ADDRESS_COL        1
 #define STR_VALS_METHOD_COL         2
-#define STR_VALS_CERTIFICATE_COL    3
-#define STR_VALS_PK_COL             4
-#define STR_VALS_CRL_DIR_COL        5
-#define STR_VALS_CALIST_COL         6
-#define STR_VALS_CADIR_COL          7
-#define STR_VALS_CPLIST_COL         8
-#define STR_VALS_DHPARAMS_COL       9
-#define STR_VALS_ECCURVE_COL        10
+#define STR_VALS_CRL_DIR_COL        3
+#define STR_VALS_CADIR_COL          4
+#define STR_VALS_CPLIST_COL         5
+#define STR_VALS_ECCURVE_COL        6
 
 #define INT_VALS_TYPE_COL           0
 #define INT_VALS_VERIFY_CERT_COL    1
 #define INT_VALS_REQUIRE_CERT_COL   2
 #define INT_VALS_CRL_CHECK_COL      3
 
+#define BLOB_VALS_CERTIFICATE_COL    0
+#define BLOB_VALS_PK_COL             1
+#define BLOB_VALS_CALIST_COL         2
+#define BLOB_VALS_DHPARAMS_COL       3
+
 #define CLIENT_DOMAIN       0
 #define SERVER_DOMAIN       1
+#define DEFAULT_DOMAIN      2
 
 int tlsp_add_srv_domain(modparam_t type, void *val);
 
@@ -91,8 +93,8 @@ int tlsp_set_dhparams(modparam_t type, void *val);
 
 int tlsp_set_eccurve(modparam_t type, void *val);
 
-int tlsp_db_add_domain(char **str_vals, int *int_vals, struct tls_domain **serv_dom,
-                                                            struct tls_domain **cli_dom);
+int tlsp_db_add_domain(char **str_vals, int *int_vals, str* blob_vals,
+    struct tls_domain **serv_dom, struct tls_domain **cli_dom);
 
 #endif
 

--- a/scripts/mysql/tls_mgm-create.sql
+++ b/scripts/mysql/tls_mgm-create.sql
@@ -6,14 +6,14 @@ CREATE TABLE tls_mgm (
     method CHAR(16),
     verify_cert INT(1),
     require_cert INT(1),
-    certificate CHAR(255),
-    private_key CHAR(255),
+    certificate BLOB,
+    private_key BLOB,
     crl_check_all INT(1),
     crl_dir CHAR(255),
-    ca_list CHAR(255),
+    ca_list BLOB,
     ca_dir CHAR(255),
     cipher_list CHAR(255),
-    dh_params CHAR(255),
+    dh_params BLOB,
     ec_curve CHAR(255)
 ) ENGINE=InnoDB;
 


### PR DESCRIPTION
the certificate, private_key, ca_list and dh_params columns from database
now need to contain the actual files to be used by tls, path to files are no
longer supported for this columns
domains can be set either by database or by script but not both at the same time
to avoid errors
default domains can be now loaded from database (their type needs to be different from
client and server type)
