### PR TITLE
Added support to fast_lock for mips and mips64el

### DIFF
--- a/Makefile.defs
+++ b/Makefile.defs
@@ -222,6 +222,7 @@ ppc64_macros= __ppc64__ _ARCH_PPC64
 mips_macros= __mips__ __mips _MIPS_ARCH_MIPS1
 mips2_macros= _MIPS_ISA_MIPS2 _MIPS_ISA_MIPS3 _MIPS_ISA_MIPS4 \
 			_MIPS_ARCH_MIPS2 _MIPS_ARCH_MIPS3 _MIPS_ARCH_MIPS4
+mips32_macros= _MIPS_ISA_MIPS32 _MIPS_ARCH_MIPS32R2 _MIPS_ARCH_MIPS32
 mips64_macros= _MIPS_ISA_MIPS64 _MIPS_ARCH_MIPS64
 
 alpha_macros= __alpha__ __alpha _M_ALPHA_
@@ -259,6 +260,8 @@ else ifneq ($(strip $(filter $(mips_macros), $(predef_macros))),)
 
 ifneq ($(strip $(filter $(mips64_macros), $(predef_macros))),)
 CC_ARCH=mips64
+else ifneq ($(strip $(filter $(mips32_macros), $(predef_macros))),)
+CC_ARCH=mips32
 else ifneq ($(strip $(filter $(mips2_macros), $(predef_macros))),)
 CC_ARCH=mips2
 else # mips2_macros
@@ -730,6 +733,14 @@ endif
 ifeq ($(ARCH), mips2)
 # mips2 arch and newer (mips3=R4000, mips4=R5000 a.s.o)
 	use_fast_lock=yes
+endif
+
+ifeq ($(ARCH), mips32)
+        use_fast_lock=yes
+endif
+
+ifeq ($(ARCH), mips64)
+        use_fast_lock=yes
 endif
 
 ifeq ($(ARCH), alpha)

--- a/fastlock.h
+++ b/fastlock.h
@@ -137,7 +137,7 @@ inline static int tsl(volatile int* lock)
 			: "r"(1), "b" (lock) :
 			"memory", "cc"
         );
-#elif defined __CPU_mips2
+#elif defined(__CPU_mips2) || defined(__CPU_mips32) || defined(__CPU_mips64)
 	long tmp;
 	tmp=1; /* just to kill a gcc 2.95 warning */
 
@@ -269,7 +269,7 @@ inline static void release_lock(fl_lock_t* lock_struct)
 			: "memory"
     );
 	*lock = 0;
-#elif defined __CPU_mips2
+#elif defined(__CPU_mips2) || defined(__CPU_mips32) || defined(__CPU_mips64)
 	asm volatile(
 		".set noreorder \n\t"
 		"    sync \n\t"

--- a/futex_lock.h
+++ b/futex_lock.h
@@ -154,7 +154,7 @@ inline static int _atomic_xchg(volatile int *lock, int val)
 			: "r"(1), "b" (lock) :
 			"memory", "cc"
         );
-#elif defined __CPU_mips2
+#elif defined(__CPU_mips2) || defined(__CPU_mips32) || defined(__CPU_mips64)
 	long tmp;
 	tmp=1; /* just to kill a gcc 2.95 warning */
 


### PR DESCRIPTION
Hi,

During the investigation of the build failure on Debian (https://bugs.debian.org/833749)
we have found that the package does not support fast_lock for mips64el and mips.
The proposed solution fixes the build issues, but it uses posix semaphores.
Since mipsel (mips2) has fast_lock support we think it will be useful to support/enable
fast_lock for mips (mips32) and mip64el.
This pull request adds support to detect mips32 architecture (as mips BE had been migrated to
MIP32R2 ISA) in Makefile.defs and enables fast_lock (hardware locking support)
The detection is achieved by adding a check for predefined compiler macros for
mips32 architecture (_MIPS_ISA_MIPS32, _MIPS_ARCH_MIPS32R2, _MIPS_ARCH_MIPS32).
For mips and mips64el arch specific definitions are added to enable fast_lock.
Mips and mips64el use the same assembler routines for the fast architecture
dependant locking primitives as mips2 implementation.

Thanks,
Daniel