### PR TITLE
exec: Flush the pipe after writing the message

### DIFF
--- a/modules/exec/exec.c
+++ b/modules/exec/exec.c
@@ -71,7 +71,7 @@ int exec_msg(struct sip_msg *msg, char *cmd )
 
 	LM_DBG("Forked pid %d\n", pid);
 
-	if (fwrite(msg->buf, 1, msg->len, pipe)!=msg->len) {
+	if (fwrite(msg->buf, 1, msg->len, pipe)!=msg->len || fflush(pipe)) {
 		LM_ERR("failed to write to pipe\n");
 		ser_error=E_EXEC;
 		goto error01;


### PR DESCRIPTION
I found that when using exec_msg (on 1.11) sometimes the executed script doesn't receive anything on its standard input.
Flushing the pipe after writing the message fixed the issue.

Please backport to the stable branches.