### PR TITLE
Spread timer wakeups across threads to prevent thundering herd

### DIFF
--- a/cfg.lex
+++ b/cfg.lex
@@ -354,6 +354,7 @@ DISABLE_STATELESS_FWD	"disable_stateless_fwd"
 DB_VERSION_TABLE "db_version_table"
 DB_DEFAULT_URL "db_default_url"
 DB_MAX_ASYNC_CONNECTIONS "db_max_async_connections"
+CHILDREN_PER_TIMER	children_per_timer
 DISABLE_503_TRANSLATION "disable_503_translation"
 
 MPATH	mpath
@@ -650,6 +651,8 @@ IMPORTFILE      "import_file"
 									return DB_DEFAULT_URL; }
 <INITIAL>{DB_MAX_ASYNC_CONNECTIONS}	{	count(); yylval.strval=yytext;
 									return DB_MAX_ASYNC_CONNECTIONS; }
+<INITIAL>{CHILDREN_PER_TIMER}		{	count(); yylval.strval=yytext;
+									return CHILDREN_PER_TIMER; }
 <INITIAL>{DISABLE_503_TRANSLATION}	{	count(); yylval.strval=yytext;
 									return DISABLE_503_TRANSLATION; }
 

--- a/cfg.y
+++ b/cfg.y
@@ -392,10 +392,10 @@ static struct multi_str *tmp_mod;
 %token DB_VERSION_TABLE
 %token DB_DEFAULT_URL
 %token DB_MAX_ASYNC_CONNECTIONS
+%token CHILDREN_PER_TIMER
 %token DISABLE_503_TRANSLATION
 %token SYNC_TOKEN
 %token ASYNC_TOKEN
-
 
 
 
@@ -1080,6 +1080,8 @@ assign_stm: DEBUG EQUAL snumber
 		| DB_MAX_ASYNC_CONNECTIONS EQUAL error {
 				yyerror("integer value expected");
 				}
+		| CHILDREN_PER_TIMER EQUAL NUMBER { children_per_timer=$3; }
+		| CHILDREN_PER_TIMER EQUAL error { yyerror("integer value expected"); }
 		| DISABLE_503_TRANSLATION EQUAL NUMBER { disable_503_translation=$3; }
 		| DISABLE_503_TRANSLATION EQUAL error {
 				yyerror("integer value expected");

--- a/globals.h
+++ b/globals.h
@@ -140,6 +140,9 @@ extern int db_max_async_connections;
 
 extern int disable_503_translation;
 
+/*Timer behavior*/
+extern int children_per_timer;
+
 extern int enable_asserts;
 extern int abort_on_assert;
 #endif

--- a/main.c
+++ b/main.c
@@ -236,6 +236,9 @@ int gid = 0;
 int disable_core_dump=0; /* by default enabled */
 int open_files_limit=-1; /* don't touch it by default */
 
+/* timer config options */
+int children_per_timer=0;
+
 #ifdef USE_MCAST
 int mcast_loopback = 0;
 int mcast_ttl = -1; /* if -1, don't touch it, use the default (usually 1) */
@@ -1161,7 +1164,8 @@ try_again:
 	}
 
 	/* init timer */
-	if (init_timer(children_no + tcp_children_no)<0){
+	/* Enforce 1 global timer pipe based on config */
+	if (init_timer(children_per_timer <= 0 ? 1 : ((children_no + tcp_children_no)/children_per_timer))<0) {
 		LM_CRIT("could not initialize timer, exiting...\n");
 		goto error;
 	}

--- a/main.c
+++ b/main.c
@@ -1161,7 +1161,7 @@ try_again:
 	}
 
 	/* init timer */
-	if (init_timer()<0){
+	if (init_timer(children_no + tcp_children_no)<0){
 		LM_CRIT("could not initialize timer, exiting...\n");
 		goto error;
 	}

--- a/net/net_tcp_proc.c
+++ b/net/net_tcp_proc.c
@@ -114,7 +114,7 @@ inline static int handle_io(struct fd_map* fm, int idx,int event_type)
 
 	switch(fm->type){
 		case F_TIMER_JOB:
-			handle_timer_job();
+			handle_timer_job(fm->fd);
 			break;
 		case F_SCRIPT_ASYNC:
 			async_script_resume_f( &fm->fd, fm->data);
@@ -291,7 +291,7 @@ static inline void tcp_receive_timeout(void)
 
 
 
-void tcp_worker_proc( int unix_sock)
+void tcp_worker_proc( int unix_sock, int timer_pipe_id)
 {
 	/* init reactor for TCP worker */
 	tcpmain_sock=unix_sock; /* init com. socket */
@@ -300,7 +300,7 @@ void tcp_worker_proc( int unix_sock)
 	}
 
 	/* start watching for the timer jobs */
-	if (reactor_add_reader( timer_fd_out, F_TIMER_JOB, RCT_PRIO_TIMER,NULL)<0){
+	if (reactor_add_reader( timer_fds_out[timer_pipe_id], F_TIMER_JOB, RCT_PRIO_TIMER,NULL)<0){
 		LM_CRIT("failed to add timer pipe_out to reactor\n");
 		goto error;
 	}

--- a/net/net_tcp_proc.h
+++ b/net/net_tcp_proc.h
@@ -27,6 +27,6 @@
 #define _NET_net_tcp_proc_h
 
 /* Loop implementing a TCP worker */
-void tcp_worker_proc( int fd);
+void tcp_worker_proc( int fd, int timer_pipe_id);
 
 #endif

--- a/net/net_udp.c
+++ b/net/net_udp.c
@@ -261,7 +261,7 @@ inline static int handle_io(struct fd_map* fm, int idx,int event_type)
 			update_stat( pt[process_no].load, -1 );
 			return n;
 		case F_TIMER_JOB:
-			handle_timer_job();
+			handle_timer_job(fm->fd);
 			return 0;
 		case F_SCRIPT_ASYNC:
 			async_script_resume_f( &fm->fd, fm->data);
@@ -286,7 +286,7 @@ inline static int handle_io(struct fd_map* fm, int idx,int event_type)
  * \see main_loop
  * \return -1 for errors
  */
-int udp_rcv_loop( struct socket_info *si )
+int udp_rcv_loop( struct socket_info *si, int timer_pipe_id)
 {
 
 	/* create the reactor for UDP proc */
@@ -296,7 +296,7 @@ int udp_rcv_loop( struct socket_info *si )
 	}
 
 	/* init: start watching for the timer jobs */
-	if (reactor_add_reader( timer_fd_out, F_TIMER_JOB, RCT_PRIO_TIMER,NULL)<0){
+	if (reactor_add_reader( timer_fds_out[timer_pipe_id], F_TIMER_JOB, RCT_PRIO_TIMER,NULL)<0){
 		LM_CRIT("failed to add timer pipe_out to reactor\n");
 		goto error;
 	}
@@ -322,7 +322,7 @@ int udp_start_processes(int *chd_rank, int *startup_done)
 	struct socket_info *si;
 	stat_var *load_p = NULL;
 	pid_t pid;
-	int i,p;
+	int i,p,timer_pipe_id;
 
 	if (udp_disabled)
 		return 0;
@@ -338,6 +338,11 @@ int udp_start_processes(int *chd_rank, int *startup_done)
 			}
 
 			for (i=0;i<si->children;i++) {
+
+				//Timer pipe id for this child to listen on
+				//This will cause it to wrap in the event of more children than pipes
+		                timer_pipe_id = (*chd_rank) % timer_pipe_count;
+
 				(*chd_rank)++;
 				if ( (pid=internal_fork( "UDP receiver"))<0 ) {
 					LM_CRIT("cannot fork UDP process\n");
@@ -372,7 +377,7 @@ int udp_start_processes(int *chd_rank, int *startup_done)
 					/* all UDP listeners on same interface
 					 * have same SHM load pointer */
 					pt[process_no].load = load_p;
-					udp_rcv_loop( si );
+					udp_rcv_loop( si, timer_pipe_id );
 					exit(-1);
 				} else {
 					/*parent*/

--- a/timer.c
+++ b/timer.c
@@ -67,14 +67,21 @@ static unsigned int  *jiffies=0;
 static utime_t       *ujiffies=0;
 static utime_t       *ijiffies=0;
 static unsigned short timer_id=0;
-static int            timer_pipe[2];
+static int	      timer_pipes[TIMER_MAX_PIPES];
+static int	      timer_pipe_current = 0;
 
-int timer_fd_out = -1 ;
+//Number of pips made
+int	      timer_pipe_count = TIMER_MAX_PIPES;
+
+/*Reader pipes for children*/
+int timer_fds_out[TIMER_MAX_PIPES] = { [0 ... (TIMER_MAX_PIPES - 1) ] = -1 };
 
 
 /* ret 0 on success, <0 on error*/
-int init_timer(void)
+/* accepts number of pipes to create */
+int init_timer(int pipe_cnt)
 {
+	int i = 0;
 	int optval;
 
 	jiffies  = shm_malloc(sizeof(unsigned int));
@@ -100,24 +107,47 @@ int init_timer(void)
 	*ujiffies=0;
 	*ijiffies=0;
 
-	/* create the pipe for dispatching the timer jobs */
-	if ( pipe(timer_pipe)!=0 ) {
-		LM_ERR("failed to create time pipe (%s)!\n",strerror(errno));
-		return E_UNSPEC;
+	//Make as many pipes as children or up to TIMER_MAX_PIPES
+	if (pipe_cnt < TIMER_MAX_PIPES) {
+		timer_pipe_count = pipe_cnt;
 	}
-	/* make reading fd non-blocking */
-	optval=fcntl(timer_pipe[0], F_GETFL);
-	if (optval==-1){
-		LM_ERR("fcntl failed: (%d) %s\n", errno, strerror(errno));
-		return E_UNSPEC;
+
+	//Make one pipe set for each child
+	while (i < timer_pipe_count) {
+		int new_pipe[2];
+		/* create the pipe for dispatching the timer jobs */
+		if ( pipe(new_pipe)!=0 ) {
+			LM_ERR("failed to create time pipe (%s)!\n",strerror(errno));
+			return E_UNSPEC;
+		}
+		/* make reading fd non-blocking */
+		optval=fcntl(new_pipe[0], F_GETFL);
+		if (optval==-1){
+			LM_ERR("fcntl failed: (%d) %s\n", errno, strerror(errno));
+			return E_UNSPEC;
+		}
+		if (fcntl(new_pipe[0],F_SETFL,optval|O_NONBLOCK)==-1){
+			LM_ERR("set non-blocking failed: (%d) %s\n",
+				errno, strerror(errno));
+			return E_UNSPEC;
+		}
+
+		/* make writing fd non-blocking */
+		optval=fcntl(new_pipe[1], F_GETFL);
+		if (optval==-1){
+			LM_ERR("fcntl failed: (%d) %s\n", errno, strerror(errno));
+			return E_UNSPEC;
+		}
+		if (fcntl(new_pipe[1],F_SETFL,optval|O_NONBLOCK)==-1){
+			LM_ERR("set non-blocking failed: (%d) %s\n",
+				errno, strerror(errno));
+			return E_UNSPEC;
+		}
+
+		timer_fds_out[i] = new_pipe[0];
+		timer_pipes[i] = new_pipe[1];
+		i++;
 	}
-	if (fcntl(timer_pipe[0],F_SETFL,optval|O_NONBLOCK)==-1){
-		LM_ERR("set non-blocking failed: (%d) %s\n",
-			errno, strerror(errno));
-		return E_UNSPEC;
-	}
-	/* make visible the "read" part of the pipe */
-	timer_fd_out = timer_pipe[0];
 
 	return 0;
 }
@@ -287,6 +317,7 @@ static inline void timer_ticker(struct os_timer *timer_list)
 	struct os_timer* t;
 	unsigned int j;
 	ssize_t l;
+	int push_attempt;
 
 	/* we need to store the original time as while executing the
 	   the handlers, the time may pass, affecting the way we
@@ -318,13 +349,36 @@ static inline void timer_ticker(struct os_timer *timer_list)
 			t->trigger_time = *ijiffies;
 			t->time = j;
 			/* push the jobs for execution */
-again:
-			l = write( timer_pipe[1], &t, sizeof(t));
-			if (l==-1) {
-				if (errno==EAGAIN || errno==EINTR || errno==EWOULDBLOCK )
-					goto again;
-				LM_ERR("writing failed:[%d] %s, skipping job <%s> at %d s\n",
+
+			push_attempt = 0;
+
+			/*We will attempt to push the timer to the next available pipe.
+			  If there is a failure we attempt to push it to the next available pipe
+                          until we have exhausted all pipes*/
+			while (push_attempt < timer_pipe_count) {
+				l = write( timer_pipes[timer_pipe_current], &t, sizeof(t));
+				//Advance pipe for next timer push
+				timer_pipe_current++;
+				if (timer_pipe_current >= timer_pipe_count) {
+				//Wrap back to start
+					timer_pipe_current = 0;
+				}
+
+				push_attempt++;
+
+				//Check for write errors and log
+				if (l==-1) {
+					LM_WARN("writing failed:[%d] %s, skipping pipe for job <%s> at %d us\n",
 					errno, strerror(errno),t->label, j);
+				} else {
+				//Write was fine, go to next timer job
+					break;
+				}
+			}
+
+			if (l==-1) {
+				LM_ERR("writing failed:[%d] %s, skipping job <%s> at %d us\n",
+				errno, strerror(errno),t->label, j);
 			}
 		}
 	}
@@ -337,7 +391,7 @@ static inline void utimer_ticker(struct os_timer *utimer_list)
 	struct os_timer* t;
 	utime_t uj;
 	ssize_t l;
-
+	int push_attempt;
 	/* see comment on timer_ticket */
 	uj = *ujiffies;
 
@@ -364,14 +418,37 @@ static inline void utimer_ticker(struct os_timer *utimer_list)
 			t->expires = uj + t->interval;
 			t->trigger_time = *ijiffies;
 			t->time = uj;
+
 			/* push the jobs for execution */
-again:
-			l = write( timer_pipe[1], &t, sizeof(t));
-			if (l==-1) {
-				if (errno==EAGAIN || errno==EINTR || errno==EWOULDBLOCK )
-					goto again;
-				LM_ERR("writing failed:[%d] %s, skipping job <%s> at %lld us\n",
+			push_attempt = 0;
+
+			/*We will attempt to push the timer to the next available pipe.
+			  If there is a failure we attempt to push it to the next available pipe
+                          until we have exhausted all pipes*/
+			while (push_attempt < timer_pipe_count) {
+				l = write( timer_pipes[timer_pipe_current], &t, sizeof(t));
+				//Advance pipe for next timer push
+				timer_pipe_current++;
+				if (timer_pipe_current >= timer_pipe_count) {
+				//Wrap back to start
+					timer_pipe_current = 0;
+				}
+
+				push_attempt++;
+
+				//Check for write errors and log
+				if (l==-1) {
+					LM_WARN("writing failed:[%d] %s, skipping pipe for job <%s> at %lld us\n",
 					errno, strerror(errno),t->label, uj);
+				} else {
+				//Write was fine, go to next timer job
+					break;
+				}
+			}
+
+			if (l==-1) {
+				LM_ERR("writing failed:[%d] %s, skipping job <%s> at %lld us\n",
+				errno, strerror(errno),t->label, uj);
 			}
 		}
 	}
@@ -609,7 +686,7 @@ inline static int handle_io(struct fd_map* fm, int idx,int event_type)
 {
 	switch(fm->type){
 		case F_TIMER_JOB:
-			handle_timer_job();
+			handle_timer_job(fm->fd);
 			return 0;
 		case F_SCRIPT_ASYNC:
 			async_script_resume_f( &fm->fd, fm->data);
@@ -628,6 +705,7 @@ inline static int handle_io(struct fd_map* fm, int idx,int event_type)
 int start_timer_extra_processes(int *chd_rank)
 {
 	pid_t pid;
+	int i = 0;
 
 	(*chd_rank)++;
 	if ( (pid=internal_fork( "Timer handler"))<0 ) {
@@ -650,13 +728,16 @@ int start_timer_extra_processes(int *chd_rank)
 				goto error;
 			}
 
-			/* init: start watching for the timer jobs */
-			if (reactor_add_reader( timer_fd_out, F_TIMER_JOB,
-			RCT_PRIO_TIMER,NULL)<0){
-				LM_CRIT("failed to add timer pipe_out to reactor\n");
-				goto error;
+			/* init: start watching for the timer jobs
+			   We listen on all timer pipes to pickup slack incase all other works are busy*/
+			while (i < timer_pipe_count) {
+				if (reactor_add_reader( timer_fds_out[i], F_TIMER_JOB,
+				RCT_PRIO_TIMER,NULL)<0){
+					LM_CRIT("failed to add timer pipe_out to reactor\n");
+					goto error;
+				}
+				i++;
 			}
-
 			/* launch the reactor */
 			reactor_main_loop( 1/*timeout in sec*/, error , );
 
@@ -671,13 +752,13 @@ error:
 }
 
 
-void handle_timer_job(void)
+void handle_timer_job(int timer_pipe)
 {
 	struct os_timer *t;
 	ssize_t l;
 
 	/* read one "os_timer" pointer from the pipe (non-blocking) */
-	l = read( timer_fd_out, &t, sizeof(t) );
+	l = read( timer_pipe, &t, sizeof(t) );
 	if (l==-1) {
 		if (errno==EAGAIN || errno==EINTR || errno==EWOULDBLOCK )
 			return;

--- a/timer.c
+++ b/timer.c
@@ -78,7 +78,7 @@ int timer_fds_out[TIMER_MAX_PIPES] = { [0 ... (TIMER_MAX_PIPES - 1) ] = -1 };
 
 
 /* ret 0 on success, <0 on error*/
-/* accepts number of pipes to create */
+/* accepts number of children to create pipes for */
 int init_timer(int pipe_cnt)
 {
 	int i = 0;
@@ -107,9 +107,14 @@ int init_timer(int pipe_cnt)
 	*ujiffies=0;
 	*ijiffies=0;
 
-	//Make as many pipes as children or up to TIMER_MAX_PIPES
-	if (pipe_cnt < TIMER_MAX_PIPES) {
+	//Limit max number of pipes to children count or TIMER_MAX_PIPES
+	if (pipe_cnt < timer_pipe_count) {
 		timer_pipe_count = pipe_cnt;
+	}
+
+	//Make sure we make atleast one pipe
+	if (timer_pipe_count <= 0) {
+		timer_pipe_count = 1;
 	}
 
 	//Make one pipe set for each child

--- a/timer.h
+++ b/timer.h
@@ -56,6 +56,9 @@ typedef void (utimer_function)(utime_t uticks, void* param);
 /* synchronize if drift is greater than internal timer tick */
 #define TIMER_MAX_DRIFT_TICKS ITIMER_TICK
 
+/* Define max number of timer pipes to create*/
+#define TIMER_MAX_PIPES 100
+
 struct os_timer{
 	/* unique ID in the list of timer handlers - not really used */
 	unsigned short id;
@@ -82,10 +85,10 @@ struct os_timer{
 	struct os_timer* next;
 };
 
+extern int timer_pipe_count;
+extern int timer_fds_out[];
 
-extern int timer_fd_out;
-
-int init_timer(void);
+int init_timer(int pipe_cnt);
 
 void destroy_timer(void);
 
@@ -111,6 +114,6 @@ int start_timer_extra_processes(int *chd_rank);
 
 int register_route_timers(void);
 
-void handle_timer_job(void);
+void handle_timer_job(int timer_pipe);
 
 #endif


### PR DESCRIPTION
The current timer method causes a thundering heard effect every time a timer is fired. This is because all children listen on the same timer pipe. Every write to that pipe cause all children to wake up, even though only the first one is able to grab the timer job. This isn't a very big problem at low children and timer counts, but as both of these grow it gets much worse.

This patch instead creates a timer pipe per worker child, up to TIMER_MAX_PIPES, at which point children start sharing timer pipes. The extra process that prevents timer starvation listens on all timer pipes, so it is still able to perform work if all children are busy.

When dispatching timer events we round-robin through the active timer pipes for each event. This allows us to balance timer events among the children. In case of an error we advance to the next pipe, eventually trying all pipes before giving up.

In most cases this results in only two threads being woken (the one child worker and the timer process) per timer event. This is in contrast to every child worker + the timer process being woken per timer event.

Some numbers (Taken from a VM running Centos 6 w/6 cores and watching vmstat on an idle system):
(Note: No TCP workers, just udp)

Pre-Patch:
Children = 30
TM timer_partitions = 16
Results: 1.5k-2k Interrupts/Sec 8-12k Context switches/Sec

Children = 200
TM timer_partitions = 16
Results: 8k-13k Interrupts/Sec 60k-80k Context switches/Sec

Post-Patch:
Children = 30
TM timer_partitions = 16
Results: 170-220 Interrupts/Sec 400-480 Context switches/Sec

Children = 200
TM timer_partitions = 16
Results: 260-350 Interrupts/Sec 880-1100 Context switches/Sec

The 200 children example is a bit extreme for this vm, but it demonstrates the scaling issues.

I think spurious wake-ups could be reduced further on kernels >= 2.6.35 by giving the timer process a dedicated pipe with a limited buffer size and only waking children when that becomes full. At the moment my testing systems are still on Cent 6, so they don't support it, but if there is interest I could work on adding that later.

This patch works on all systems and takes care of the bulk of the issue.

Because of the current regressive behaviour it might be worthwhile to look at applying this to the 2.2 LTS as well.

Appreciate any input and additional testing on this.