### PR TITLE
Correct `misleading-indentation` warnings

### DIFF
--- a/modules/b2b_entities/b2b_entities.c
+++ b/modules/b2b_entities/b2b_entities.c
@@ -627,16 +627,16 @@ static inline int mi_print_b2be_dlg(struct mi_node *rpl, b2b_table htable, unsig
 				if(node1 == NULL) goto error;
 				if(dlg->uac_tran)
 					attr = add_mi_attr(node1,MI_DUP_VALUE,"uac",3,NULL,0);
-					if(attr == NULL) goto error;
+				if(attr == NULL) goto error;
 				if(dlg->uas_tran)
 					attr = add_mi_attr(node1,MI_DUP_VALUE,"uas",3,NULL,0);
-					if(attr == NULL) goto error;
+				if(attr == NULL) goto error;
 				if(dlg->update_tran)
 					attr = add_mi_attr(node1,MI_DUP_VALUE,"update",6,NULL,0);
-					if(attr == NULL) goto error;
+				if(attr == NULL) goto error;
 				if(dlg->cancel_tm_tran)
 					attr = add_mi_attr(node1,MI_DUP_VALUE,"cancel_tm",9,NULL,0);
-					if(attr == NULL) goto error;
+				if(attr == NULL) goto error;
 			}
 
 			if ( (leg=dlg->legs)!=NULL ) {

--- a/modules/cachedb_sql/cachedb_sql.c
+++ b/modules/cachedb_sql/cachedb_sql.c
@@ -450,8 +450,8 @@ static int dbcache_fetch_counter(cachedb_con *con,str *attr,int *ret_val)
 		case DB_INT:
 			if (ret_val)
 				*ret_val = RES_ROWS(db_res)[0].values[0].val.int_val;
-				if (CACHEDBSQL_FUNC(con).free_result(CACHEDBSQL_CON(con), db_res) < 0)
-					LM_ERR("failed to freeing result of query\n");
+			if (CACHEDBSQL_FUNC(con).free_result(CACHEDBSQL_CON(con), db_res) < 0)
+				LM_ERR("failed to freeing result of query\n");
 			break;
 		default:
 			LM_ERR("unknown type of DB user column\n");

--- a/modules/dialog/dlg_handlers.c
+++ b/modules/dialog/dlg_handlers.c
@@ -2053,10 +2053,10 @@ int fix_route_dialog(struct sip_msg *req,struct dlg_cell *dlg)
 			for (it=req->route;it;it=it->sibling)
 				if (it->parsed && ((rr_t*)it->parsed)->deleted)
 					continue;
-				if ((lmp = del_lump(req,it->name.s - buf,it->len,HDR_ROUTE_T)) == 0) {
-					LM_ERR("del_lump failed \n");
-					return -1;
-				}
+			if ((lmp = del_lump(req,it->name.s - buf,it->len,HDR_ROUTE_T)) == 0) {
+				LM_ERR("del_lump failed \n");
+				return -1;
+			}
 		}
 
 		if ( leg->route_set.len !=0 && leg->route_set.s) {

--- a/modules/presence/event_list.c
+++ b/modules/presence/event_list.c
@@ -378,7 +378,7 @@ int search_event_params(event_t* ev, event_t* searched_ev)
 					found= 1;
 					break;
 				}
-				p= p->next;
+			p= p->next;
 		}
 		if(found== 0)
 			return -1;

--- a/modules/rtpengine/rtpengine_funcs.c
+++ b/modules/rtpengine/rtpengine_funcs.c
@@ -294,7 +294,7 @@ ser_memmem(const void *b1, const void *b2, size_t len1, size_t len2)
                         if (memcmp(sp, pp, len2) == 0)
                                 return sp;
 
-                        sp++;
+                sp++;
         }
 
         return NULL;

--- a/modules/rtpproxy/nhelpr_funcs.c
+++ b/modules/rtpproxy/nhelpr_funcs.c
@@ -215,7 +215,7 @@ ser_memmem(const void *b1, const void *b2, size_t len1, size_t len2)
                         if (memcmp(sp, pp, len2) == 0)
                                 return sp;
 
-                        sp++;
+                sp++;
         }
 
         return NULL;

--- a/modules/seas/encode_contact.c
+++ b/modules/seas/encode_contact.c
@@ -144,10 +144,10 @@ int encode_contact(char *hdrstart,int hdrlen,contact_t *body,unsigned char *wher
       return -1;
    }else{
       if((j=encode_uri2(hdrstart,hdrlen,body->uri,&puri,&where[i]))<0){
-	 LM_ERR("failed to codify the URI\n");
-	 return -1;
+        LM_ERR("failed to codify the URI\n");
+        return -1;
       }else{
-	 i+=j;
+        i+=j;
       }
    }
    where[0]=flags;
@@ -250,8 +250,8 @@ int dump_contact_body_test(char *hdr,int hdrlen,unsigned char *payload,int payle
    }
    if(segregationLevel & (JUNIT|SEGREGATE|ONLY_URIS)){
       for(i=0,offset=2+numcontacts;i<numcontacts;i++){
-	 dump_contact_test(hdr,hdrlen,&payload[offset],payload[2+i],fd,segregationLevel,prefix);
-	 offset+=payload[2+i];
+          dump_contact_test(hdr,hdrlen,&payload[offset],payload[2+i],fd,segregationLevel,prefix);
+          offset+=payload[2+i];
       }
    }
    return 1;
@@ -289,24 +289,27 @@ int dump_contact_test(char *hdr,int hdrlen,unsigned char* payload,int paylen,int
          n=write(fd,&hdr[payload[i]],payload[i+1]);
          n=write(fd,"\n",1);
          i+=2;
-      }else
+      } else {
          n=write(fd,"(null)\n",7);
-         n=write(fd,prefix,strlen(prefix));
-         n=write(fd,"getQValue=(F)",13);
+      }
+      n=write(fd,prefix,strlen(prefix));
+      n=write(fd,"getQValue=(F)",13);
       if(flags & HAS_Q_F){
          n=write(fd,&hdr[payload[i]],payload[i+1]);
          n=write(fd,"\n",1);
          i+=2;
-      }else
+      } else {
          n=write(fd,"(null)\n",7);
-         n=write(fd,prefix,strlen(prefix));
-         n=write(fd,"getExpires=(I)",14);
+      }
+      n=write(fd,prefix,strlen(prefix));
+      n=write(fd,"getExpires=(I)",14);
       if(flags & HAS_EXPIRES_F){
          n=write(fd,&hdr[payload[i]],payload[i+1]);
          n=write(fd,"\n",1);
          i+=2;
-      }else
+      } else {
          n=write(fd,"(null)\n",7);
+      }
       if(flags & HAS_RECEIVED_F){
          i+=2;
       }
@@ -316,12 +319,12 @@ int dump_contact_test(char *hdr,int hdrlen,unsigned char* payload,int paylen,int
       n=write(fd,prefix,strlen(prefix));
       n=write(fd,"getParameter=(SAVP)",19);
       for(i+=payload[1];i<paylen-1;i+=2){
-	 printf("%.*s=",payload[i+1]-payload[i]-1,&hdr[payload[i]]);
-	 printf("%.*s;",(payload[i+2]-payload[i+1])==0?0:(payload[i+2]-payload[i+1]-1),&hdr[payload[i+1]]);
+          printf("%.*s=",payload[i+1]-payload[i]-1,&hdr[payload[i]]);
+          printf("%.*s;",(payload[i+2]-payload[i+1])==0?0:(payload[i+2]-payload[i+1]-1),&hdr[payload[i+1]]);
       }
       n=write(fd,"\n",1);
-	  if (n < 0)
-		  LM_ERR("error while writing the final eol\n");
+      if (n < 0)
+        LM_ERR("error while writing the final eol\n");
    }
    return 0;
 }

--- a/modules/siptrace/siptrace.c
+++ b/modules/siptrace/siptrace.c
@@ -2185,8 +2185,8 @@ static struct mi_root* sip_trace_mi(struct mi_root* cmd_tree, void* param )
 
 		return rpl_tree ;
 	} else {
-	if(trace_on_flag==NULL)
-		return init_mi_tree( 500, MI_SSTR(MI_INTERNAL_ERR));
+		if(trace_on_flag==NULL)
+			return init_mi_tree( 500, MI_SSTR(MI_INTERNAL_ERR));
 
 		/* <on/off> global or trace_id name */
 		if (node && !node->next) {

--- a/parser/sdp/sdp_helpr_funcs.c
+++ b/parser/sdp/sdp_helpr_funcs.c
@@ -91,7 +91,7 @@ static void * ser_memmem(const void *b1, const void *b2, size_t len1, size_t len
 			if (memcmp(sp, pp, len2) == 0)
 				return sp;
 
-			sp++;
+		sp++;
 	}
 
 	return NULL;


### PR DESCRIPTION
While compiling the 2.2 branch I noticed all these `misleading-indentation` warnings from the compiler.
In one file I also replaced tabs with spaces since the remainder of the file used spaces.