### PR TITLE
Fix typo in startup error message

### DIFF
--- a/main.c
+++ b/main.c
@@ -670,7 +670,7 @@ static int main_loop(void)
 
 	/* fork all processes required by UDP network layer */
 	if (udp_start_processes( &chd_rank, startup_done)<0) {
-		LM_CRIT("cannot start TCP processes\n");
+		LM_CRIT("cannot start UDP processes\n");
 		goto error;
 	}
 


### PR DESCRIPTION
I had an issue where OpenSIPs wouldn't start and I couldn't figure out if it was the UDP or TCP stack that was broken on my system due to the duplicate error messages.