### PR TITLE
move appending require: timer to 200 OK where it belongs

### DIFF
--- a/modules/sst/sst_handlers.c
+++ b/modules/sst/sst_handlers.c
@@ -663,12 +663,14 @@ static void sst_dialog_response_fwded_CB(struct dlg_cell* did, int type,
 						MAX(minfo.se, sst_min_se), info_dirty, tmp_info);
 				snprintf(se_buf, 80, "Session-Expires: %d;refresher=uac\r\n",
 						info->interval);
+
+				if (add_timer_ext(msg))
+					LM_ERR("failed to append timer extension to Required\n");
+
 				if (append_header(msg, se_buf)) {
 					LM_ERR("failed to append Session-Expires header\n");
 					return;
 				}
-				if (add_timer_ext(msg))
-					LM_ERR("failed to append timer extension to Required\n");
 
 				/* Set the dialog timeout HERE */
 				set_dialog_lifetime(did, info->interval);


### PR DESCRIPTION
The logic for this fix originally put a Require: timer header on the request which is not what RFC 4028 specifies.  

> if the UAS does not support Session Timers, a proxy
can add the Session-Expires header initially negociated in the reply, but
must also add the "timer" extension in the Require header.

I have moved appending the Require: timer header to the section where the reply is processed and tested the change.  This resolves issue #992.