### PR TITLE
Feature - Load Balancer Round Robin Queue for Destination Selection

### DIFF
--- a/modules/load_balancer/lb_data.c
+++ b/modules/load_balancer/lb_data.c
@@ -817,6 +817,15 @@ int lb_route(struct sip_msg *req, int group, struct lb_res_str_list *rl,
 			if( it_d == dst ) { dst_bitmap_cur[i] &= ~(1 << j); break; }
 			if( ++j == (8 * sizeof(unsigned int)) ) { i++; j=0; }
 		}
+
+		//Move members around in virtual queue
+		for( it_d=data->dsts; it_d; it_d=it_d->next){
+		if(it_d->queue_loc > dst->queue_loc){it_d->queue_loc--;}
+		}
+	
+		//Move chosen dst to end of virtual queue
+		dst->queue_loc = data->dst_no;
+
 	} else {
 		LM_DBG("%s call of LB - no destination found\n",
 			(reuse ? "sequential" : "initial"));

--- a/modules/load_balancer/lb_data.c
+++ b/modules/load_balancer/lb_data.c
@@ -831,13 +831,6 @@ int lb_route(struct sip_msg *req, int group, struct lb_res_str_list *rl,
 			(reuse ? "sequential" : "initial"));
 	}
 
-	//Move members around in virtual queue
-	for( it_d=data->dsts; it_d; it_d=it_d->next){
-		if(it_d->queue_loc > dst->queue_loc){it_d->queue_loc--;}
-	}
-	//Move chosen dst to end of virtual queue
-	dst->queue_loc = data->dst_no;
-
 	/* unlock resources */
 	for( i=0 ; i<res_cur_n ; i++ )
 		lock_release(res_cur[i]->lock);

--- a/modules/load_balancer/lb_data.h
+++ b/modules/load_balancer/lb_data.h
@@ -39,6 +39,7 @@
 #define LB_FLAGS_RELATIVE (1<<0) /* do relative versus absolute estimation. default is absolute */
 #define LB_FLAGS_NEGATIVE (1<<1) /* do not skip negative loads. default to skip */
 #define LB_FLAGS_RANDOM   (1<<2) /* pick a random destination among all selected dsts with equal load */
+#define LB_FLAGS_QUEUE    (1<<3) /* picks the next destination in the virtual queue*/
 #define LB_FLAGS_DEFAULT  0
 
 #define LB_DST_PING_DSBL_FLAG   (1<<0)
@@ -76,6 +77,7 @@ struct lb_dst {
 	unsigned short int protos[LB_MAX_IPS]; /* Protocol of the request URI */
 	unsigned short ips_cnt;
 	struct lb_dst *next;
+	unsigned int queue_loc;
 };
 
 struct lb_data {

--- a/modules/load_balancer/load_balancer.c
+++ b/modules/load_balancer/load_balancer.c
@@ -232,7 +232,7 @@ static int fixup_resources(void** param, int param_no)
 		/* try first as number */
 		s.s = (char*)*param;
 		s.len = strlen(s.s);
-		if (str2int(&s, (unsigned int*)&lbgp->grp_no)==0) {
+		if (str2sint(&s, (int*)&lbgp->grp_no)==0) {
 			lbgp->grp_pv = NULL;
 			pkg_free(*param);
 		} else {
@@ -607,6 +607,10 @@ static int w_lb_start(struct sip_msg *req, char *grp, char *rl, char *fl)
 				case 's':
 					flags |= LB_FLAGS_RANDOM;
 					LM_DBG("pick a random destination among all selected dsts with equal load\n");
+					break;
+				case 'q':
+					flags |= LB_FLAGS_QUEUE;
+					LM_DBG("cycle destinations through a virtual queue");
 					break;
 				default:
 					LM_DBG("skipping unknown flag: [%c]\n", *f);


### PR DESCRIPTION
Requesting the addition of a new destination selection method for load balancer module. Organizes a virtual queue for destinations and uses this information to select destinations on a round robin basis (in order to balance load when selections are staggered and not simultaneous). Raising new flag 'q' at load balance start will modify selection to use this information.
This feature is used to fulfill a customer requirement to utilize the least used resource during balance selection.

Additional fixes include bug fix to group selection (using -1 for all was not working) and spelling fix in one location.