### PR TITLE
drouting: Fix out-of-bound initialization

### DIFF
--- a/modules/drouting/routing.c
+++ b/modules/drouting/routing.c
@@ -111,7 +111,7 @@ int parse_destination_list(rt_data_t* rd, char *dstlist,
 				LM_ERR("not enough shm mem to resize\n");
 				goto error;
 			}
-			memset( p+pgwl_size, 0, 2*pgwl_size*sizeof(pgw_list_t));
+			memset( p+pgwl_size, 0, pgwl_size*sizeof(pgw_list_t));
 			memcpy( p, pgwl, pgwl_size*sizeof(pgw_list_t));
 			pkg_free(pgwl);
 			pgwl_size*=2;


### PR DESCRIPTION
Upon load/reload of drouting tables, if parse_destination_list() needs to
increase destinations array size, it asks for a new array twice the size of
the previous one.
It memset() the newly allocated capacity, skipping memory that is to be filled
with already learnt destinations, but using the array size instead of the
remaining capacity.
This patch fixes the size for this memset().

Closes OpenSIPS/opensips#1039