### PR TITLE
Fix a crash in the python module.

### DIFF
--- a/modules/python/python_msgobj.c
+++ b/modules/python/python_msgobj.c
@@ -269,7 +269,8 @@ msg_call_function(msgobject *self, PyObject *args)
 
     rval = do_action(act, self->msg);
 
-    if ((act->elem[2].type == MODFIXUP_ST) && (act->elem[2].u.data)) {
+    if ((act->elem[2].type == MODFIXUP_ST) && (act->elem[2].u.data) &&
+      (act->elem[2].u.data != arg2)) {
        pkg_free(act->elem[2].u.data);
     }
 


### PR DESCRIPTION
Only pkg_free(act->elem[2].u.data) if it's value has been altered by the "fixup" function. This fixes crash in the following piece of python code:

 msg.call_function('www_authorize', get_realm(), \
          'accounts')

[...]
#2  0x0000000800c7f309 in abort () from /lib/libc.so.7
#3  0x0000000803bc57d5 in msg_call_function (self=0x800822198, args=0x80aaf3730) at python_msgobj.c:270
