### PR TITLE
Improve exception debugging in the python module

### DIFF
--- a/modules/python/python_exec.c
+++ b/modules/python/python_exec.c
@@ -103,7 +103,7 @@ python_exec2(struct sip_msg *_msg, char *method_name, char *mystr)
     Py_DECREF(pFunc);
     if (PyErr_Occurred()) {
         Py_XDECREF(pResult);
-        python_handle_exception("python_exec2");
+        python_handle_exception("python_exec2", method_name);
         PyThreadState_Swap(NULL);
         PyEval_ReleaseLock();
         return -1;

--- a/modules/python/python_mod.c
+++ b/modules/python/python_mod.c
@@ -205,7 +205,7 @@ mod_init(void)
 
     if (PyErr_Occurred()) {
         PyErr_Print();
-        python_handle_exception("mod_init");
+        python_handle_exception("mod_init", NULL);
         Py_XDECREF(handler_obj);
         Py_DECREF(format_exc_obj);
         PyEval_ReleaseLock();
@@ -276,7 +276,9 @@ child_init(int rank)
     Py_DECREF(pArgs);
 
     if (PyErr_Occurred()) {
-        python_handle_exception("child_init");
+        char srank[16];
+        snprintf(srank, sizeof(srank), "%d", rank);
+        python_handle_exception("child_init", srank);
         Py_XDECREF(pResult);
         PyThreadState_Swap(NULL);
         PyEval_ReleaseLock();

--- a/modules/python/python_support.c
+++ b/modules/python/python_support.c
@@ -27,7 +27,7 @@
 #include <stdio.h>
 
 void
-python_handle_exception(const char *fname)
+python_handle_exception(const char *fname, const char *farg)
 {
     PyObject *pResult;
     const char *msg;
@@ -35,7 +35,12 @@ python_handle_exception(const char *fname)
     PyObject *line;
     int i;
 
-    LM_ERR("%s: Unhandled exception in the Python code:\n", fname);
+    if (farg == NULL) {
+        LM_ERR("%s: Unhandled exception in the Python code:\n", fname);
+    } else {
+        LM_ERR("%s(\"%s\"): Unhandled exception in the Python code:\n",
+            fname, farg);
+    }
     PyErr_Fetch(&exception, &v, &tb);
     PyErr_Clear();
     if (exception == NULL) {

--- a/modules/python/python_support.h
+++ b/modules/python/python_support.h
@@ -22,6 +22,6 @@
 #ifndef _PYTHON_SUPPORT_H
 #define  _PYTHON_SUPPORT_H
 
-void python_handle_exception(const char *);
+void python_handle_exception(const char *, const char *);
 
 #endif


### PR DESCRIPTION
Improve exception debugging in the python module by printing function argument (when available) along with the function name.

Output before:

Feb 10 10:04:18 jenv_1 /usr/local/sbin/opensips[1491]: ERROR:python:python_handle_exception: python_exec2: Unhandled exception in the Python code:
Feb 10 10:04:18 jenv_1 /usr/local/sbin/opensips[1491]: ERROR:python:python_handle_exception:    RuntimeError: no such function

Output after:

Feb 10 12:52:20 jenv_1 /usr/local/sbin/opensips[1514]: ERROR:python:python_handle_exception: python_exec2("www_authenticate"): Unhandled exception in the Python code:
Feb 10 12:52:20 jenv_1 /usr/local/sbin/opensips[1514]: ERROR:python:python_handle_exception:    RuntimeError: no such function
