### PR TITLE
Add <sys/uio.h> where writev(2) is used.

### DIFF
--- a/modules/cpl_c/cpl_loader.c
+++ b/modules/cpl_c/cpl_loader.c
@@ -33,7 +33,6 @@
 #include <unistd.h>
 #include <sys/stat.h>
 #include <fcntl.h>
-#include <sys/uio.h>
 #include <errno.h>
 #include <string.h>
 #include <ctype.h>

--- a/modules/db_flatstore/flatstore.c
+++ b/modules/db_flatstore/flatstore.c
@@ -30,6 +30,7 @@
 #include <fcntl.h>
 #include <sys/types.h>
 #include <sys/stat.h>
+#include <sys/uio.h>
 #include <unistd.h>
 #include "../../mem/mem.h"
 #include "../../dprint.h"

--- a/modules/event_flatstore/event_flatstore.c
+++ b/modules/event_flatstore/event_flatstore.c
@@ -28,6 +28,7 @@
 #include <libgen.h>
 #include <sys/types.h>
 #include <sys/stat.h>
+#include <sys/uio.h>
 
 #include "event_flatstore.h"
 #include "../../mem/mem.h"

--- a/modules/event_xmlrpc/xmlrpc_send.c
+++ b/modules/event_xmlrpc/xmlrpc_send.c
@@ -30,6 +30,7 @@
 #include "../../pt.h"
 #include "xmlrpc_send.h"
 #include "event_xmlrpc.h"
+#include <sys/uio.h>
 #include <fcntl.h>
 #include <unistd.h>
 

--- a/modules/proto_ws/proto_ws.c
+++ b/modules/proto_ws/proto_ws.c
@@ -27,6 +27,7 @@
 #include <errno.h>
 #include <unistd.h>
 #include <netinet/tcp.h>
+#include <sys/uio.h>
 #include <poll.h>
 
 #include "../../pt.h"

--- a/modules/proto_ws/ws_tcp.c
+++ b/modules/proto_ws/ws_tcp.c
@@ -29,6 +29,7 @@
 #include "../../globals.h"
 #include "../../tsend.h"
 #include "ws_tcp.h"
+#include <sys/uio.h>
 #include <unistd.h>
 
 /**************  READ related functions ***************/

--- a/modules/proto_wss/proto_wss.c
+++ b/modules/proto_wss/proto_wss.c
@@ -27,6 +27,7 @@
 #include <errno.h>
 #include <unistd.h>
 #include <netinet/tcp.h>
+#include <sys/uio.h>
 #include <poll.h>
 
 #include "../../pt.h"


### PR DESCRIPTION
This avoids compiler warning(s) particularly on FreeBSD. There is also one file where uio.h has been included twice.