### PR TITLE
Added enable/disable replication to drouting and load_balancer

### DIFF
--- a/modules/drouting/dr_replication.c
+++ b/modules/drouting/dr_replication.c
@@ -1,3 +1,28 @@
+/*
+ * Copyright (C) 2017 OpenSIPS Project
+ *
+ * This file is part of opensips, a free SIP server.
+ *
+ * opensips is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * opensips is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ *
+ * history:
+ * ---------
+ *  2017-02-15 created by Jeremy Martinez
+ */
+
 #include "../../ip_addr.h"
 #include "../../ut.h"
 #include "prefix_tree.h"

--- a/modules/drouting/dr_replication.c
+++ b/modules/drouting/dr_replication.c
@@ -1,0 +1,49 @@
+#include "../../ip_addr.h"
+#include "../../ut.h"
+#include "prefix_tree.h"
+#include "dr_partitions.h"
+#include "dr_replication.h"
+
+str repl_dr_module_name = str_init("drouting");
+struct clusterer_binds clusterer_api;
+
+void replicate_dr_gw_status_event(pgw_t *gw, int cluster_id)
+{
+	if (bin_init(&repl_dr_module_name, REPL_GW_STATUS_UPDATE, BIN_VERSION) != 0) {
+		LM_ERR("failed to replicate this event\n");
+		return;
+	}
+
+	bin_push_int(clusterer_api.get_my_id());
+
+	bin_push_str(&gw->id);
+	bin_push_int(gw->flags);
+
+	if (clusterer_api.send_to(cluster_id, PROTO_BIN) < 0) {
+		LM_ERR("replicate dr_gw_status send failed\n");
+ 	}
+}
+
+int replicate_gw_status_update(struct head_db * head_db_ref)
+{
+	static str id;
+	int flags;
+	pgw_t *gw;
+
+	bin_pop_str(&id);
+	bin_pop_int(&flags);
+
+	lock_start_read(head_db_ref->ref_lock);
+
+	gw = get_gw_by_id( (*head_db_ref->rdata)->pgw_tree, &id);
+	if (gw && (gw->flags != flags))
+	{
+		gw->flags = flags;
+		lock_stop_read(head_db_ref->ref_lock);
+		return 0;
+	}
+
+	lock_stop_read(head_db_ref->ref_lock);
+
+	return -1;
+}

--- a/modules/drouting/dr_replication.h
+++ b/modules/drouting/dr_replication.h
@@ -1,0 +1,18 @@
+#ifndef _DROUTING_REPLICATION_H_
+#define _DROUTING_REPLICATION_H_
+
+#include "../../sr_module.h"
+#include "../../bin_interface.h"
+#include "../clusterer/api.h"
+
+#define BIN_VERSION 1
+
+#define REPL_GW_STATUS_UPDATE 1
+
+extern str repl_dr_module_name;
+extern struct clusterer_binds clusterer_api;
+
+void replicate_dr_gw_status_event(pgw_t *gw, int cluster_id);
+int replicate_gw_status_update(struct head_db * head_db_ref);
+
+#endif

--- a/modules/drouting/dr_replication.h
+++ b/modules/drouting/dr_replication.h
@@ -1,3 +1,28 @@
+/*
+ * Copyright (C) 2017 OpenSIPS Project
+ *
+ * This file is part of opensips, a free SIP server.
+ *
+ * opensips is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * opensips is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ *
+ * history:
+ * ---------
+ *  2017-02-15 created by Jeremy Martinez
+ */
+
 #ifndef _DROUTING_REPLICATION_H_
 #define _DROUTING_REPLICATION_H_
 

--- a/modules/load_balancer/lb_data.c
+++ b/modules/load_balancer/lb_data.c
@@ -34,7 +34,9 @@
 #include "../../mem/shm_mem.h"
 #include "../../evi/evi.h"
 #include "lb_parser.h"
+#include "../../rw_locking.h"
 #include "lb_data.h"
+#include "lb_replication.h"
 #include "lb_db.h"
 
 /* dialog stuff */
@@ -1206,6 +1208,10 @@ void lb_raise_event(struct lb_dst *dst)
 {
 	evi_params_p list = NULL;
 
+	if ((lb_status_replicate_cluster > 0) && dst)
+	{
+		replicate_lb_status(dst);
+	}
 	if (lb_evi_id == EVI_ERROR || !evi_probe_event(lb_evi_id))
 		return;
 

--- a/modules/load_balancer/lb_replication.c
+++ b/modules/load_balancer/lb_replication.c
@@ -1,3 +1,28 @@
+/*
+ * Copyright (C) 2017 OpenSIPS Project
+ *
+ * This file is part of opensips, a free SIP server.
+ *
+ * opensips is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * opensips is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ *
+ * history:
+ * ---------
+ *  2017-02-15 created by Jeremy Martinez
+ */
+
 #include "../../ut.h"
 #include "../../rw_locking.h"
 #include "lb_data.h"

--- a/modules/load_balancer/lb_replication.c
+++ b/modules/load_balancer/lb_replication.c
@@ -1,0 +1,49 @@
+#include "../../ut.h"
+#include "../../rw_locking.h"
+#include "lb_data.h"
+#include "lb_bl.h"
+#include "lb_replication.h"
+
+str repl_lb_module_name = str_init("load_balancer");
+struct clusterer_binds clusterer_api;
+
+void replicate_lb_status(struct lb_dst *dst)
+{
+	if (bin_init(&repl_lb_module_name, REPL_LB_STATUS_UPDATE, BIN_VERSION) != 0) {
+		LM_ERR("failed to replicate this event\n");
+		return;
+	}
+
+	bin_push_int(clusterer_api.get_my_id());
+	bin_push_int(dst->group);
+	bin_push_str(&dst->uri);
+	bin_push_int(dst->flags);
+
+	if (clusterer_api.send_to(lb_status_replicate_cluster, PROTO_BIN) < 0) {
+		LM_ERR("replicate lb_status send failed\n");
+ 	}
+}
+
+int replicate_lb_status_update(struct lb_data *data)
+{
+	struct lb_dst *dst;
+	unsigned int group, flags;
+	str uri;
+	bin_pop_int(&group);
+	bin_pop_str(&uri);
+	bin_pop_int(&flags);
+
+	for( dst=data->dsts; dst; dst=dst->next )
+	{
+		if((dst->group == group) && (strncmp(dst->uri.s, uri.s, dst->uri.len) == 0))
+		{
+			if (dst->flags != flags)
+			{
+				dst->flags = flags;
+				return 0;
+			}
+		}
+	}
+
+	return -1;
+}

--- a/modules/load_balancer/lb_replication.h
+++ b/modules/load_balancer/lb_replication.h
@@ -1,3 +1,28 @@
+/*
+ * Copyright (C) 2017 OpenSIPS Project
+ *
+ * This file is part of opensips, a free SIP server.
+ *
+ * opensips is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * opensips is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ *
+ * history:
+ * ---------
+ *  2017-02-15 created by Jeremy Martinez
+ */
+
 #ifndef _LB_REPLICATION_H_
 #define _LB_REPLICATION_H_
 

--- a/modules/load_balancer/lb_replication.h
+++ b/modules/load_balancer/lb_replication.h
@@ -1,0 +1,19 @@
+#ifndef _LB_REPLICATION_H_
+#define _LB_REPLICATION_H_
+
+#include "../../sr_module.h"
+#include "../../bin_interface.h"
+#include "../clusterer/api.h"
+
+#define BIN_VERSION 1
+
+#define REPL_LB_STATUS_UPDATE 1
+
+extern str repl_lb_module_name;
+extern struct clusterer_binds clusterer_api;
+extern int lb_status_replicate_cluster;
+
+void replicate_lb_status(struct lb_dst *dst);
+int replicate_lb_status_update(struct lb_data *data);
+
+#endif

--- a/modules/load_balancer/load_balancer.c
+++ b/modules/load_balancer/load_balancer.c
@@ -33,7 +33,6 @@
 #include "../../mod_fix.h"
 #include "../../rw_locking.h"
 #include "../../usr_avp.h"
-
 #include "../dialog/dlg_load.h"
 #include "../tm/tm_load.h"
 #include "../freeswitch/fs_api.h"
@@ -41,10 +40,13 @@
 #include "lb_parser.h"
 #include "lb_db.h"
 #include "lb_data.h"
+#include "lb_replication.h"
 #include "lb_prober.h"
 #include "lb_bl.h"
 
 
+int accept_replicated_lb_status = 0;
+int lb_status_replicate_cluster = 0;
 
 /* db stuff */
 static str db_url = {NULL, 0};
@@ -115,7 +117,9 @@ static int w_lb_count_call(struct sip_msg *req, char *ip, char *port, char *grp,
 
 
 static void lb_prob_handler(unsigned int ticks, void* param);
+
 static void lb_update_max_loads(unsigned int ticks, void *param);
+static void receive_lb_binary_packet(int packet_type, struct receive_info *ri, void *att);
 
 
 
@@ -164,6 +168,8 @@ static param_export_t mod_params[]={
 	{ "probing_from",          STR_PARAM, &lb_probe_from.s          },
 	{ "probing_reply_codes",   STR_PARAM, &lb_probe_replies.s       },
 	{ "lb_define_blacklist",   STR_PARAM|USE_FUNC_PARAM, (void*)set_lb_bl},
+	{"accept_replicated_lb_status",INT_PARAM, &accept_replicated_lb_status },
+	{"replicate_lb_status_to", INT_PARAM, &lb_status_replicate_cluster },
 	{ "fetch_freeswitch_stats", INT_PARAM, &fetch_freeswitch_stats},
 	{ "initial_freeswitch_load", INT_PARAM, &initial_fs_load},
 	{ 0,0,0 }
@@ -177,6 +183,14 @@ static mi_export_t mi_cmds[] = {
 	{ "lb_status",   0, mi_lb_status,   0,                  0,  0},
 	{ 0, 0, 0, 0, 0, 0}
 };
+
+static module_dependency_t *get_deps_clusterer(param_export_t *param)
+{
+	int cluster_id = *(int *)param->param_pointer;
+	if (cluster_id <= 0)
+		return NULL;
+	return alloc_module_dep(MOD_TYPE_DEFAULT, "clusterer", DEP_ABORT);
+}
 
 static module_dependency_t *get_deps_probing_interval(param_export_t *param)
 {
@@ -201,8 +215,10 @@ static dep_export_t deps = {
 		{ MOD_TYPE_NULL, NULL, 0 },
 	},
 	{ /* modparam dependencies */
-		{ "probing_interval",      get_deps_probing_interval },
+		{ "probing_interval", get_deps_probing_interval },
 		{ "fetch_freeswitch_stats", get_deps_fetch_fs_load },
+		{ "accept_replicated_lb_status", get_deps_clusterer},
+		{ "replicate_lb_status_to", get_deps_clusterer},
 		{ NULL, NULL },
 	},
 };
@@ -548,6 +564,19 @@ static int mod_init(void)
 		return -1;
 	}
 
+	if( (lb_status_replicate_cluster > 0 || accept_replicated_lb_status > 0)
+		&& load_clusterer_api(&clusterer_api)!=0){
+		LM_DBG("failed to find clusterer API - is clusterer module loaded?\n");
+		return -1;
+	}
+	if (accept_replicated_lb_status > 0
+		&& bin_register_cb(repl_lb_module_name.s, receive_lb_binary_packet, NULL) < 0) {
+		LM_ERR("cannot register binary packet callback!\n");
+		return -1;
+	}
+	if(lb_status_replicate_cluster < 0){
+		lb_status_replicate_cluster = 0;
+	}
 	return 0;
 }
 
@@ -1258,4 +1287,43 @@ error:
 	lock_stop_read( ref_lock );
 	free_mi_tree(rpl_tree);
 	return 0;
+}
+
+static void receive_lb_binary_packet(int packet_type, struct receive_info *ri, void *att)
+{
+	int server_id;
+	char *ip;
+	unsigned short port;
+
+	LM_DBG("received a binary packet [%d]!\n", packet_type);
+
+	if(get_bin_pkg_version() != BIN_VERSION)
+	{
+		LM_ERR("incompatible bin protocol version\n");
+		return;
+	}
+
+	if (bin_pop_int(&server_id) < 0)
+	{
+		LM_ERR("failed to obtain server id from binary packet\n");
+		return;
+	}
+
+	if (!clusterer_api.check(accept_replicated_lb_status, &ri->src_su, server_id, ri->proto))
+	{
+			get_su_info(&ri->src_su.s, ip, port);
+			LM_WARN("received bin packet from unknown source: %s:%hu\n", ip, port);
+			return;
+	}
+
+	if (packet_type == REPL_LB_STATUS_UPDATE)
+	{
+		lock_start_read(ref_lock);
+		replicate_lb_status_update(*curr_data);
+		lock_stop_read(ref_lock);
+	}
+	else
+	{
+		LM_ERR("invalid load_balancer binary packet type: %d\n", packet_type);
+	}
 }


### PR DESCRIPTION
I created four new opensips.cfg modparams replicate_lb_status_to, accept_replicated_lb_status, replicate_gw_status_to, and accept_replicated_gw_status. These commands use the clusterer module and were based off of the previously implemented clusterer commands used by the dialog and usrloc modules.

replicate_gw_status_to and accept_replicated_gw_status can be tested with the command:
opensipsctl fifo dr_gw_status

replicate_lb_status_to and accept_replicated_lb_status can be tested with opensips the command:
opensipsctl fifo lb_status