### PR TITLE
More comprehensive fix for the fixup-related crashes in the python.so module (follow-up to #1050)

### DIFF
--- a/modules/python/python_msgobj.c
+++ b/modules/python/python_msgobj.c
@@ -237,7 +237,7 @@ msg_call_function(msgobject *self, PyObject *args)
     elems[0].type = CMD_ST;
     elems[0].u.data = fexport;
     elems[1].type = STRING_ST;
-    if (arg1 != NULL) {
+    if (i > 1 && arg1 != NULL) {
         elems[1].u.data = pkg_strdup(arg1);
         if (elems[1].u.data == NULL) {
             PyErr_SetString(PyExc_RuntimeError, "pkg_strdup() failed");
@@ -247,7 +247,7 @@ msg_call_function(msgobject *self, PyObject *args)
         elems[1].u.data = NULL;
     }
     elems[2].type = STRING_ST;
-    if (arg2 != NULL) {
+    if (i > 2 && arg2 != NULL) {
         elems[2].u.data = pkg_strdup(arg2);
         if (elems[2].u.data == NULL) {
             PyErr_SetString(PyExc_RuntimeError, "pkg_strdup() failed");


### PR DESCRIPTION
Prevent fixup function from trying to deallocate string allocated by the python interpreter by creating a copy of it and passing that down the pipe.

Improve failure handling by not leaking a memory while I am here.