### PR TITLE
Make it possible to listen at all interfaces again

### DIFF
--- a/socket_info.h
+++ b/socket_info.h
@@ -45,6 +45,11 @@
 int add_listen_iface(char* name, unsigned short port, unsigned short proto,
 							char *adv_name, unsigned short adv_port,
 							unsigned short children, enum si_flags flags);
+
+int add_interfaces(char* if_name, int family, unsigned short port,
+			unsigned short proto, unsigned short children,
+			struct socket_info** list);
+
 struct socket_info *
 new_sock_info(char* name, unsigned short port, unsigned short proto,
 							char *adv_name, unsigned short adv_port,


### PR DESCRIPTION
There was a nice feature in OpenSIPS 1.11. It used to listen at all available interfaces when no listeners are declared in configuration file. It's useful in case of multiple network interfaces because it's easy to provide default configuration when IP or network interfaces are not known in advance. Unfortunately this feature has been lost after SIP transport protocols rework. So since OpenSIPS 2.1 if no listeners are declared in configuration file via 'listen=...' statement OpenSIPs will not bind to any network interface.

I'd like to restore old behaviour, i.e. if some transport module is loaded via 'loadmodule' statement in configuration file and no listeners are declared for this module via 'listen=...' statement then listeners list will be populated with all network interfaces that are currently available.