### PR TITLE
Set 'CURLOPT_FAILONERROR' option to '0' in rest_client module

### DIFF
--- a/modules/rest_client/rest_methods.c
+++ b/modules/rest_client/rest_methods.c
@@ -218,6 +218,7 @@ int start_async_http_req(struct sip_msg *msg, enum rest_client_method method,
 
 	w_curl_easy_setopt(handle, CURLOPT_VERBOSE, 1);
 	w_curl_easy_setopt(handle, CURLOPT_STDERR, stdout);
+	w_curl_easy_setopt(handle, CURLOPT_FAILONERROR, 0);
 
 	w_curl_easy_setopt(handle, CURLOPT_WRITEFUNCTION, write_func);
 	w_curl_easy_setopt(handle, CURLOPT_WRITEDATA, body);
@@ -487,6 +488,7 @@ int rest_get_method(struct sip_msg *msg, char *url,
 
 	w_curl_easy_setopt(handle, CURLOPT_VERBOSE, 1);
 	w_curl_easy_setopt(handle, CURLOPT_STDERR, stdout);
+	w_curl_easy_setopt(handle, CURLOPT_FAILONERROR, 0);
 
 	w_curl_easy_setopt(handle, CURLOPT_WRITEFUNCTION, write_func);
 	w_curl_easy_setopt(handle, CURLOPT_WRITEDATA, &body);
@@ -604,6 +606,7 @@ int rest_post_method(struct sip_msg *msg, char *url, char *body, char *ctype,
 
 	w_curl_easy_setopt(handle, CURLOPT_VERBOSE, 1);
 	w_curl_easy_setopt(handle, CURLOPT_STDERR, stdout);
+	w_curl_easy_setopt(handle, CURLOPT_FAILONERROR, 0);
 
 	w_curl_easy_setopt(handle, CURLOPT_WRITEFUNCTION, write_func);
 	w_curl_easy_setopt(handle, CURLOPT_WRITEDATA, &res_body);


### PR DESCRIPTION
This is done in order to archive following goals:
- suppress error log messages like 'curl_easy_perform: ...' when HTTP server returns response with status code larger or equal to 400.
- make 'rest_xxx' functions to have the same behaviour with different Curl distributions. Now for different Curls these functions may return different exit codes for the same HTTP response.

There is an option in Curl named 'CURLOPT_FAILONERROR'. If it's set to '1' then if returned HTTP code is equal to or larger than 400 the HTTP request is considered as failed and 'curl_easy_perform' returns non 'CURLE_OK' code. In vanilla (upstream) Curl this option is set to '0' (do not fail) but some patched Curl versions set this option to '1' (at least this is true for Debian Wheezy). As result we have a different behaviour for different Curl derivatives. So it seems to be better to enforce setting this option to '0' in order to have the same behaviour for different Curls.