### PR TITLE
Replace *-dev dependencies with usual one for Debian packages

### DIFF
--- a/packaging/debian/common/control
+++ b/packaging/debian/common/control
@@ -28,6 +28,7 @@ Build-Depends: bison,
                librabbitmq-dev,
                libsctp-dev,
                libsnmp-dev,
+               libssl-dev,
                libxml2-dev,
                libxmlrpc-core-c3-dev,
                pkg-config,
@@ -515,7 +516,7 @@ Description: Emerrgency call module for OpenSIPS
 Package: opensips-tlsmgm-module
 Architecture: any
 Multi-Arch: same
-Depends: libssl-dev,
+Depends: libssl1.0.0,
          opensips (= ${binary:Version}),
          ${misc:Depends},
          ${shlibs:Depends}
@@ -529,7 +530,7 @@ Description: TLS management module for OpenSIPS
 Package: opensips-tls-module
 Architecture: any
 Multi-Arch: same
-Depends: libssl-dev,
+Depends: libssl1.0.0,
          opensips (= ${binary:Version}),
          opensips-tlsmgm-module (= ${binary:Version}),
          ${misc:Depends},
@@ -544,7 +545,7 @@ Description: TLS transport module for OpenSIPS
 Package: opensips-wss-module
 Architecture: any
 Multi-Arch: same
-Depends: libssl-dev,
+Depends: libssl1.0.0,
          opensips (= ${binary:Version}),
          opensips-tlsmgm-module (= ${binary:Version}),
          ${misc:Depends},
@@ -559,7 +560,7 @@ Description: WebSocket Secure (WSS) transport module for OpenSIPS
 Package: opensips-sctp-module
 Architecture: any
 Multi-Arch: same
-Depends: libsctp-dev,
+Depends: libsctp1,
          opensips (= ${binary:Version}),
          ${misc:Depends},
          ${shlibs:Depends}
@@ -573,7 +574,7 @@ Description: SCTP transport module for OpenSIPS
 Package: opensips-restclient-module
 Architecture: any
 Multi-Arch: same
-Depends: libcurl4-gnutls-dev,
+Depends: libcurl3-gnutls,
          opensips (= ${binary:Version}),
          ${misc:Depends},
          ${shlibs:Depends}


### PR DESCRIPTION
Some Debian packages produced by OpenSIPS have '*-dev' packages as dependencies. For instance 'opensips-restclient-module' package depends on 'libcurl4-gnutls-dev' package. As a result when 'opensips-restclient-module' installed a lot redundant packages are being installed as 'libcurl4-gnutls-dev' dependencies such as: 'libkrb5-dev', 'librtmp-dev' and so on. And this is a minor problem.

There is also another problem: in Debian '\*-dev' package usually depends on non '\*-dev' package via '=' dependency so if I need patched version of some package on which 'libcurl4-gnutls-dev' depends via direct or transitive dependencies, for instance librtmp I can't install my custom version of librtmp and opensips-restclient-module at the same time.

So my proposal is to replace '*-dev' dependencies with usual one.

Following changes have been made:
- 'libssl-dev' package has been added as build dependency because some modules require libssl at build time
- 'libssl-dev' dependency has been replaced with 'libssl1.0.0' for following packages: 'opensips-tlsmgm-module', 'opensips-tls-module' and 'opensips-wss-module'.
- 'libcurl4-gnutls-dev' dependency has been replaced with 'libcurl3-gnutls' for 'opensips-restclient-module' package.
- 'libsctp-dev' dependency has been replaced with 'libsctp1' for 'opensips-sctp-module' package.

According to https://packages.debian.org/wheezy/libsctp1 libsctp1 is present both in Debian Wheezy and Jessie. The same is true for libssl1.0.0 (https://packages.debian.org/wheezy/libssl1.0.0) and libcurl3-gnutls (https://packages.debian.org/wheezy/libcurl3-gnutls).

And for Ubuntu: http://packages.ubuntu.com/search?keywords=libcurl3-gnutls, http://packages.ubuntu.com/search?keywords=libssl1.0.0, http://packages.ubuntu.com/search?keywords=libsctp1