### PR TITLE
Fix what seems to be a typo in the commit e2a6df0c16c42

### DIFF
--- a/mem/module_info.c
+++ b/mem/module_info.c
@@ -200,12 +200,12 @@ int alloc_group_stat(void) {
 			set_indexes(core_index);
 
 		} else {
-			update_module_stats(sizeof(stat_val) * 4 + sizeof(struct module_info) + sizeof(get_lock), sizeof(stat_val) * 4 +
-					 sizeof(struct module_info) + 5 * FRAG_OVERHEAD + sizeof(get_lock), 5, core_index);
+			update_module_stats(sizeof(stat_val) * 4 + sizeof(struct module_info) + sizeof(gen_lock_t), sizeof(stat_val) * 4 +
+					 sizeof(struct module_info) + 5 * FRAG_OVERHEAD + sizeof(gen_lock_t), 5, core_index);
 		}
 	} else {
-		update_module_stats(sizeof(stat_val) * 4 + sizeof(struct module_info) + sizeof(get_lock), sizeof(stat_val) * 4 +
-					 sizeof(struct module_info) + 5 * FRAG_OVERHEAD + sizeof(get_lock), 5, 0);
+		update_module_stats(sizeof(stat_val) * 4 + sizeof(struct module_info) + sizeof(gen_lock_t), sizeof(stat_val) * 4 +
+					 sizeof(struct module_info) + 5 * FRAG_OVERHEAD + sizeof(gen_lock_t), 5, 0);
 	}
 
 


### PR DESCRIPTION
Fix what seems to be a typo in the commit e2a6df0c16c42:

get_lock -> gen_lock_t

This unbreaks build with the USE_PTHREAD_MUTEX, which is when
this symbol is not defined.