### PR TITLE
Fix several FreeBSD-related issues

### DIFF
--- a/Makefile.defs
+++ b/Makefile.defs
@@ -120,12 +120,21 @@ ifeq ($(OS),solaris)
 		ISSMP ?= yes
 	endif
 else
+ifeq ($(OS),freebsd)
+	SMP_STR = $(shell sysctl kern.smp.active | grep 1)
+	ifeq (,$(SMP_STR))
+		ISSMP ?= no
+	else
+		ISSMP ?= yes
+	endif
+else
 	SMP_STR = $(shell uname -v | grep -i "SMP")
 	ifeq (,$(SMP_STR))
 		ISSMP ?= no
 	else
 		ISSMP ?= yes
 	endif
+endif
 endif
 
 #set some vars from the environment (and not make builtins)
@@ -328,12 +337,16 @@ cfg_dir = etc/$(MAIN_NAME)/
 bin_dir = sbin/
 
 ARCH_B = $(shell echo $(ARCH) | sed -e 's/.*64.*/64b/')
+ifeq ($(OS),freebsd)
+	LIBDIR ?= lib
+else
 ifeq ($(ARCH_B),64b)
 	LIBDIR ?= lib64
 else
 	LIBDIR ?= lib
 	# assume 32b - it is not really used further
 	ARCH_B=32b
+endif
 endif
 
 lib_dir = $(LIBDIR)/$(MAIN_NAME)

--- a/Makefile.defs
+++ b/Makefile.defs
@@ -1469,12 +1469,13 @@ ifeq ($(OS), freebsd)
 		-DHAVE_SCHED_YIELD -DHAVE_MSGHDR_MSG_CONTROL \
 		-DHAVE_CONNECT_ECONNRESET_BUG -DHAVE_TIMEGM \
 		-DHAVE_NETINET_IN_SYSTM
+	LIBS=  #dlopen is in libc
 	ifneq ($(found_lock_method), yes)
 		DEFS+= -DUSE_PTHREAD_MUTEX  # try pthread sems
 		found_lock_method=yes
-		LIBS= -pthread  #dlopen is in libc
-	else
-		LIBS=  #dlopen is in libc
+	endif
+	ifneq (,$(findstring USE_PTHREAD_MUTEX, $(DEFS)))
+		LIBS+=-lpthread
 	endif
 	# check for ver >= 4.1
 	ifeq ($(shell [ $(OSREL_N) -gt 4001 ] && echo has_kqueue), has_kqueue)

--- a/lock_ops.h
+++ b/lock_ops.h
@@ -96,6 +96,10 @@ inline static gen_lock_t* lock_init(gen_lock_t* lock)
 #endif
 
 #elif defined USE_PTHREAD_MUTEX
+# if defined(__FreeBSD__)
+#  warning Inter-process mutexes are not supported on FreeBSD as if yet :(
+# endif
+
 #include <pthread.h>
 
 typedef pthread_mutex_t gen_lock_t;


### PR DESCRIPTION
1. Properly set LIBDIR 
2. Properly detect ISSMP 
3. Fix linking with USE_PTHREAD_MUTEX set in Makefile.conf
4. Warn that as of now, there is no support for inter-process pthread mutexes on FreeBSD