### PR TITLE
Fix callid in local replies for out of dialog topo hidden requests

### DIFF
--- a/modules/topology_hiding/topo_hiding_logic.c
+++ b/modules/topology_hiding/topo_hiding_logic.c
@@ -1483,7 +1483,8 @@ int topo_callid_post_raw(str *data, struct sip_msg* foo)
 			dlg->legs[0].tag.s,dlg->legs[0].tag.len) == 0) {
 				/* reply going to caller -
 				decode was done on the receiving end, let it unchanged */
-			} else {
+			/*Callid may already be encoded from req*/
+			} else if (!dlg_th_needs_decoding(&msg)){
 				/* reply going to callee , need to encode callid */
 				if (dlg_th_encode_callid(&msg) < 0) {
 					LM_ERR("Failed to decode callid for reply\n");

--- a/modules/topology_hiding/topo_hiding_logic.c
+++ b/modules/topology_hiding/topo_hiding_logic.c
@@ -1377,6 +1377,15 @@ int topo_callid_pre_raw(str *data, struct sip_msg* foo)
 		if (get_to(&msg)->tag_value.len>0) {
 			/* sequential request, check if callid needs to be unmasked */
 			if (dlg_th_needs_decoding(&msg)) {
+				/* Keep a copy of the original callid incase we need it in reply */
+				foo->orig_callid = pkg_malloc(sizeof(struct hdr_field));
+				if (foo->orig_callid==0) {
+					LM_ERR("out of pkg memory\n");
+					goto error;
+				}
+
+				memcpy(foo->orig_callid, msg.callid, sizeof(struct hdr_field));
+
 				if (dlg_th_decode_callid(&msg) < 0) {
 					LM_ERR("Failed to decode callid for sequential request\n");
 					goto error;

--- a/msg_translator.c
+++ b/msg_translator.c
@@ -2386,8 +2386,14 @@ char * build_res_buf_from_sip_req( unsigned int code, str *text ,str *new_tag,
 				/* RR only for 1xx and 2xx replies */
 				if (code<180 || code>=300)
 					break;
-			case HDR_FROM_T:
 			case HDR_CALLID_T:
+				if (msg->orig_callid != NULL) {
+					len += msg->orig_callid->len;
+				} else {
+					len += hdr->len;
+				}
+				break;
+			case HDR_FROM_T:
 			case HDR_CSEQ_T:
 				/* we keep the original termination for these headers*/
 				len += hdr->len;
@@ -2530,10 +2536,16 @@ char * build_res_buf_from_sip_req( unsigned int code, str *text ,str *new_tag,
 					bmark->to_tag_val.len = 0;
 				}
 			case HDR_FROM_T:
-			case HDR_CALLID_T:
 			case HDR_CSEQ_T:
 					append_str(p, hdr->name.s, hdr->len);
 					break;
+			case HDR_CALLID_T:
+				if (msg->orig_callid != NULL) {
+					append_str(p, msg->orig_callid->name.s, msg->orig_callid->len);
+				} else {
+					append_str(p, hdr->name.s, hdr->len);
+				}
+				break;
 			default:
 				/* do nothing, we are interested only in the above headers */
 				;

--- a/parser/msg_parser.c
+++ b/parser/msg_parser.c
@@ -686,6 +686,7 @@ void free_sip_msg(struct sip_msg* msg)
 	if (msg->body_lumps)  free_lump_list(msg->body_lumps);
 	if (msg->reply_lump)   free_reply_lump(msg->reply_lump);
 	if (msg->body )    { free_sip_body(msg->body);msg->body = 0;}
+	if (msg->orig_callid)  pkg_free(msg->orig_callid);
 	/* don't free anymore -- now a pointer to a static buffer */
 #	ifdef DYN_BUF
 	pkg_free(msg->buf);

--- a/parser/msg_parser.h
+++ b/parser/msg_parser.h
@@ -284,6 +284,9 @@ struct sip_msg {
 	int parsed_orig_ruri_ok;
 	struct sip_uri parsed_orig_ruri;
 
+	/* Original call-id received */
+	struct hdr_field* orig_callid;
+
 	/* modifications */
 	struct lump* add_rm;       /* used for all the forwarded requests/replies */
 	struct lump* body_lumps;     /* Lumps that update Content-Length */


### PR DESCRIPTION
This patch fixes replies generated for out of dialog requests where topology hiding was used. Specifically, requests from the caller side that contain the encoded callid, which is decoded when the request is received. Currently if the dialog no longer exists the reply does not properly re-encode the callid in locally generated replies, which means they caller does not recognize our replies.

This patch causes us to keep a copy of the original callid if we decoded the callid for topology hiding and this is used for locally generated replies.

See issue #1073.

Initial testing looks good, but I plan to do some further testing.
If this fix looks acceptable it should be back-ported to 2.2 and probably 2.1.