### PR TITLE
Handle unset DB_PATH in opensipsctl.sqlite

### DIFF
--- a/scripts/opensipsctl.sqlite
+++ b/scripts/opensipsctl.sqlite
@@ -9,6 +9,11 @@
 ### SQLITE specific variables and functions
 #
 
+# path to the db_sqlite database
+if [ -z "$DB_PATH" ]; then
+	DB_PATH="/usr/local/etc/opensips/sqlite"
+fi
+
 ##### ----------------------------------------------- #####
 ### load SQL base
 #


### PR DESCRIPTION
When DB_PATH is unset, sqlite_query will invoke the sqlite executable
with a single parameter. This causes sqlite to interpret the query as
the path to the database file and subsquently enter interactive mode,
causing opensipsctl to freeze. Prevent this by setting DB_PATH to a
default value when the variable is unset.