### PR TITLE
Parameter "use_domain" not imported from usrloc in mid-registrar module

### DIFF
--- a/modules/mid_registrar/mid_registrar.c
+++ b/modules/mid_registrar/mid_registrar.c
@@ -306,6 +306,11 @@ static int mod_init(void)
 		}
 	}
 
+	/*
+	 * Import use_domain parameter from usrloc
+	 */
+	reg_use_domain = ul_api.use_domain;
+
 	if (rcv_avp_param && *rcv_avp_param) {
 		s.s = rcv_avp_param; s.len = strlen(s.s);
 		if (pv_parse_spec(&s, &avp_spec)==0


### PR DESCRIPTION
Variable reg_use_domain is initialized to 0, but not imported from usrloc module as eluded in docs. Added import of "use_domain" parameter from usrloc module to initialize reg_use_domain (taken from registrar module).