### PR TITLE
Gracefully handling missing or malformed Contact and Expires headers in REGISTER requests to mid_registrar module

### DIFF
--- a/lib/reg/sip_msg.c
+++ b/lib/reg/sip_msg.c
@@ -97,6 +97,7 @@ int check_contacts(struct sip_msg* _m, int* _s)
 	*_s = 0;
 	/* Message without contacts is OK */
 	if (_m->contact == 0) return 0;
+	if (_m->contact->parsed == 0) return 0;
 
 	if (((contact_body_t*)_m->contact->parsed)->star == 1) {
 		/* The first Contact HF is star */
@@ -157,6 +158,7 @@ static struct hdr_field* act_contact_2;
 static contact_t* __get_first_contact(struct sip_msg* _m, struct hdr_field **act_contact)
 {
 	if (_m->contact == 0) return 0;
+	if (_m->contact->parsed == 0) return 0;
 
 	*act_contact = _m->contact;
 	return (((contact_body_t*)_m->contact->parsed)->contacts);

--- a/modules/mid_registrar/mid_registrar.c
+++ b/modules/mid_registrar/mid_registrar.c
@@ -433,7 +433,7 @@ int get_expires_hf(struct sip_msg* _m)
 
 	if (_m->expires) {
 		p = (exp_body_t*)_m->expires->parsed;
-		if (p->valid) {
+		if (p != NULL && p->valid) {
 			if (p->val != 0) {
 				return p->val;
 			} else return 0;

--- a/modules/mid_registrar/save.c
+++ b/modules/mid_registrar/save.c
@@ -304,7 +304,7 @@ static int replace_expires(contact_t *c, struct sip_msg *msg, int new_expires,
 
 	/* TODO FIXME we're now assuming the request has an "Expires: " header */
 	if (c->expires == NULL || c->expires->body.len == 0) {
-		if (*skip_exp_header == 0) {
+		if (*skip_exp_header == 0 && msg->expires != NULL && msg->expires->body.len > 0) {
 			LM_DBG("....... Exp hdr: '%.*s'\n",
 			       msg->expires->body.len, msg->expires->body.s);
 			lump = del_lump(msg, msg->expires->body.s - msg->buf,

--- a/modules/mid_registrar/save.c
+++ b/modules/mid_registrar/save.c
@@ -1981,7 +1981,7 @@ int mid_reg_save(struct sip_msg *msg, char *dom, char *flags_gp,
                           char *to_uri_gp, char *expires_gp)
 {
 	udomain_t *ud = (udomain_t *)dom;
-	urecord_t *rec;
+	urecord_t *rec = NULL;
 	str flags_str = { NULL, 0 }, to_uri = { NULL, 0 };
 	struct save_ctx sctx;
 	int rc = -1, st;
@@ -2064,7 +2064,8 @@ quick_reply:
 	/* forwarding not needed! This REGISTER will be absorbed */
 
 	/* prepare the Contact header field for a quick 200 OK response */
-	build_contact(rec->contacts, msg);
+	if (rec != NULL && rec->contacts != NULL)
+		build_contact(rec->contacts, msg);
 
 	/* no contacts need updating on the far end registrar */
 	ul_api.unlock_udomain(ud, &sctx.aor);


### PR DESCRIPTION
Gracefully handling missing or malformed Contact and Expires headers in REGISTER requests that are often received from SIP scanners and other malicious UAs.