### PR TITLE
db_mysql: fix build against MariaDB 10.2

### DIFF
--- a/modules/db_mysql/my_con.c
+++ b/modules/db_mysql/my_con.c
@@ -34,6 +34,7 @@ extern struct tls_domain *tls_dom;
 
 int db_mysql_connect(struct my_con* ptr)
 {
+	my_bool reconnect = 0;
 	/* if connection already in use, close it first*/
 	if (ptr->init)
 		mysql_close(ptr->con);
@@ -81,7 +82,11 @@ int db_mysql_connect(struct my_con* ptr)
 		return -1;
 	}
 	/* force no auto reconnection */
+#if MYSQL_VERSION_ID >= 50013
+	mysql_options(ptr->con, MYSQL_OPT_RECONNECT, &reconnect);
+#else
 	ptr->con->reconnect = 0;
+#endif
 
 	LM_DBG("connection type is %s\n", mysql_get_host_info(ptr->con));
 	LM_DBG("protocol version is %d\n", mysql_get_proto_info(ptr->con));


### PR DESCRIPTION
Fixes the following build error while building against MariaDB 10.2
library:

```
my_con.c: In function 'db_mysql_connect':
my_con.c:68:10: error: 'MYSQL {aka struct st_mysql}' has no member named
'reconnect'
ptr->con->reconnect = 0;
          ^~
```

In this new version of the library the reconnect field was moved to
another struct. Setting it through API seems to be a better approach.