### PR TITLE
Increase amount of debug produced by the rtpproxy module on error

### DIFF
--- a/modules/rtpproxy/rtpproxy.c
+++ b/modules/rtpproxy/rtpproxy.c
@@ -2242,6 +2242,8 @@ send_rtpp_command(struct rtpp_node *node, struct iovec *v, int vcnt)
 	cp = buf;
 
 	if (node->rn_umode == 0) {
+		int s_errno;
+
 		memset(&addr, 0, sizeof(addr));
 		addr.sun_family = AF_LOCAL;
 		strncpy(addr.sun_path, node->rn_address,
@@ -2272,9 +2274,11 @@ send_rtpp_command(struct rtpp_node *node, struct iovec *v, int vcnt)
 		do {
 			len = read(fd, buf, sizeof(buf) - 1);
 		} while (len == -1 && errno == EINTR);
+		s_errno = (len < 0) ? errno : 0;
 		close(fd);
 		if (len <= 0) {
-			LM_ERR("can't read reply from a RTP proxy\n");
+			LM_ERR("can't read reply from a RTP proxy, e = %d\n",
+                            s_errno);
 			goto badproxy;
 		}
 	} else {
@@ -2302,11 +2306,15 @@ send_rtpp_command(struct rtpp_node *node, struct iovec *v, int vcnt)
 			}
 			while ((poll(fds, 1, rtpproxy_tout) == 1) &&
 			    (fds[0].revents & POLLIN) != 0) {
+				int s_errno;
+
 				do {
 					len = recv(rtpp_socks[node->idx], buf, sizeof(buf)-1, 0);
 				} while (len == -1 && errno == EINTR);
+				s_errno = (len < 0) ? errno : 0;
 				if (len <= 0) {
-					LM_ERR("can't read reply from a RTP proxy\n");
+					LM_ERR("can't read reply from a RTP proxy, e = %d\n",
+					    s_errno);
 					goto badproxy;
 				}
 				if (len >= (v[0].iov_len - 1) &&


### PR DESCRIPTION
Increase amount of debug produced by the rtpproxy module when
read() or recv() from the rtpproxy fails to also include relevant
errno. This is to debug sporadic errors we are observing with voiptests
during the module initialization phase, such as:

Jul 24 21:53:41 [21066] ERROR:rtpproxy:send_rtpp_command: can't read reply from a RTP proxy
Jul 24 21:53:41 [21058] ERROR:rtpproxy:send_rtpp_command: can't read reply from a RTP proxy
Jul 24 21:53:41 [21058] ERROR:rtpproxy:send_rtpp_command: proxy <unix:/home/travis/build/sippy/voiptests/rtpproxy.sock> does not respond, disable it
Jul 24 21:53:41 [21066] ERROR:rtpproxy:send_rtpp_command: proxy <unix:/home/travis/build/sippy/voiptests/rtpproxy.sock> does not respond, disable it
Jul 24 21:53:41 [21066] WARNING:rtpproxy:rtpp_test: RTP proxy went down during version query
Jul 24 21:53:41 [21066] WARNING:rtpproxy:rtpp_test: support for RTP proxy <unix:/home/travis/build/sippy/voiptests/rtpproxy.sock> has been disabled temporarily
Jul 24 21:53:41 [21066] ERROR:core:tcp_start_processes: failed to send 0 status code
Jul 24 21:53:41 [21067] ERROR:rtpproxy:send_rtpp_command: can't read reply from a RTP proxy
Jul 24 21:53:41 [21067] ERROR:rtpproxy:send_rtpp_command: proxy <unix:/home/travis/build/sippy/voiptests/rtpproxy.sock> does not respond, disable it
Jul 24 21:53:41 [21067] WARNING:rtpproxy:rtpp_test: RTP proxy went down during version query
Jul 24 21:53:41 [21067] WARNING:rtpproxy:rtpp_test: support for RTP proxy <unix:/home/travis/build/sippy/voiptests/rtpproxy.sock> has been disabled temporarily