### PR TITLE
fix: invalid complaint of "module compile flags mismatch"

### DIFF
--- a/modules/nathelper/nathelper.c
+++ b/modules/nathelper/nathelper.c
@@ -59,6 +59,7 @@
 #include <netinet/udp.h>
 #include <arpa/inet.h>
 
+#include "../../sr_module.h"
 #include "../../data_lump.h"
 #include "../../data_lump_rpl.h"
 #include "../../forward.h"

--- a/modules/rtpproxy/rtpproxy.c
+++ b/modules/rtpproxy/rtpproxy.c
@@ -155,6 +155,7 @@
 #include <stdlib.h>
 #include <sys/uio.h>
 
+#include "../../sr_module.h"
 #include "../../dprint.h"
 #include "../../data_lump.h"
 #include "../../data_lump_rpl.h"


### PR DESCRIPTION
shm_mem.h and mem.h may change compile flags, e.g.
define F_MALLOC and DBG_F_MALLOC but not define DBG_QM_MALLOC

And it's dangerous to use compile flags which may be modified  in multi-files.