### PR TITLE
fix memory leak in cpl-c write_to_db

### DIFF
--- a/modules/cpl_c/cpl_db.c
+++ b/modules/cpl_c/cpl_db.c
@@ -247,6 +247,7 @@ int write_to_db(str *username, str *domain, str *xml, str *bin)
 error:
 	if (res)
 		cpl_dbf.free_result( db_hdl, res);
+	return -1;
 }
 
 

--- a/modules/cpl_c/cpl_db.c
+++ b/modules/cpl_c/cpl_db.c
@@ -242,9 +242,11 @@ int write_to_db(str *username, str *domain, str *xml, str *bin)
 		}
 	}
 
+	cpl_dbf.free_result( db_hdl, res);
 	return 1;
 error:
-	return -1;
+	if (res)
+		cpl_dbf.free_result( db_hdl, res);
 }
 
 


### PR DESCRIPTION
In write_to_db, the underlying db driver alloc's memory for a query, but it is never freed before return.