### PR TITLE
Don't include <mysql/mysql_version.h> directly

### DIFF
--- a/modules/db_mysql/dbase.c
+++ b/modules/db_mysql/dbase.c
@@ -35,7 +35,6 @@
 #include <mysql/mysql.h>
 #include <mysql/errmsg.h>
 #include <mysql/mysqld_error.h>
-#include <mysql/mysql_version.h>
 #include "../../mem/mem.h"
 #include "../../dprint.h"
 #include "../../db/db_query.h"

--- a/modules/db_mysql/my_con.c
+++ b/modules/db_mysql/my_con.c
@@ -23,7 +23,7 @@
 #include "my_con.h"
 #include "db_mysql.h"
 #include "dbase.h"
-#include <mysql/mysql_version.h>
+#include <mysql/mysql.h>
 
 #include "../tls_mgm/tls_helper.h"
 #include "../../mem/mem.h"


### PR DESCRIPTION
It seems that this header shouldn't be included directly. And sometimes
it may cause compilation issues (depending on MariaDB/MySQL version,
compiler, etc). See build log for the example:

	make[1]: Entering directory '/builddir/build/BUILD/opensips-2.2.5/modules/db_mysql'
	Compiling row.c
	gcc -fPIC -DPIC -O2 -g -pipe -Wall -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2 -fexceptions -fstack-protector-strong --param=ssp-buffer-size=4 -grecord-gcc-switches -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -m64 -mtune=generic -fgnu89-inline -Wcast-align -DMOD_NAME='db_mysql'  -I/usr/include/json-c -DPKG_MALLOC  -DSHM_MMAP  -DUSE_MCAST  -DDISABLE_NAGLE  -DSTATISTICS  -DHAVE_RESOLV_RES  -DF_MALLOC   -DNAME='"opensips"' -DVERSION='"2.2.5"' -DARCH='"x86_64"' -DOS='"linux"' -DCOMPILER='"gcc 7"' -D__CPU_x86_64 -D__OS_linux -D__SMP_yes -DCFG_DIR='"/etc/opensips/"'  -DUSE_FREERADIUS -DFAST_LOCK -DADAPTIVE_WAIT -DADAPTIVE_WAIT_LOOPS=1024 -DHAVE_GETHOSTBYNAME2 -DHAVE_UNION_SEMUN -DHAVE_SCHED_YIELD -DHAVE_MSG_NOSIGNAL -DHAVE_MSGHDR_MSG_CONTROL -DHAVE_ALLOCA_H -DHAVE_TIMEGM -DHAVE_EPOLL -DHAVE_SIGIO_RT -DHAVE_SELECT -I/usr/include -c row.c -o row.o
	Compiling my_con.c
	gcc -fPIC -DPIC -O2 -g -pipe -Wall -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2 -fexceptions -fstack-protector-strong --param=ssp-buffer-size=4 -grecord-gcc-switches -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -m64 -mtune=generic -fgnu89-inline -Wcast-align -DMOD_NAME='db_mysql'  -I/usr/include/json-c -DPKG_MALLOC  -DSHM_MMAP  -DUSE_MCAST  -DDISABLE_NAGLE  -DSTATISTICS  -DHAVE_RESOLV_RES  -DF_MALLOC   -DNAME='"opensips"' -DVERSION='"2.2.5"' -DARCH='"x86_64"' -DOS='"linux"' -DCOMPILER='"gcc 7"' -D__CPU_x86_64 -D__OS_linux -D__SMP_yes -DCFG_DIR='"/etc/opensips/"'  -DUSE_FREERADIUS -DFAST_LOCK -DADAPTIVE_WAIT -DADAPTIVE_WAIT_LOOPS=1024 -DHAVE_GETHOSTBYNAME2 -DHAVE_UNION_SEMUN -DHAVE_SCHED_YIELD -DHAVE_MSG_NOSIGNAL -DHAVE_MSGHDR_MSG_CONTROL -DHAVE_ALLOCA_H -DHAVE_TIMEGM -DHAVE_EPOLL -DHAVE_SIGIO_RT -DHAVE_SELECT -I/usr/include -c my_con.c -o my_con.o
	Compiling val.c
	gcc -fPIC -DPIC -O2 -g -pipe -Wall -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2 -fexceptions -fstack-protector-strong --param=ssp-buffer-size=4 -grecord-gcc-switches -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -m64 -mtune=generic -fgnu89-inline -Wcast-align -DMOD_NAME='db_mysql'  -I/usr/include/json-c -DPKG_MALLOC  -DSHM_MMAP  -DUSE_MCAST  -DDISABLE_NAGLE  -DSTATISTICS  -DHAVE_RESOLV_RES  -DF_MALLOC   -DNAME='"opensips"' -DVERSION='"2.2.5"' -DARCH='"x86_64"' -DOS='"linux"' -DCOMPILER='"gcc 7"' -D__CPU_x86_64 -D__OS_linux -D__SMP_yes -DCFG_DIR='"/etc/opensips/"'  -DUSE_FREERADIUS -DFAST_LOCK -DADAPTIVE_WAIT -DADAPTIVE_WAIT_LOOPS=1024 -DHAVE_GETHOSTBYNAME2 -DHAVE_UNION_SEMUN -DHAVE_SCHED_YIELD -DHAVE_MSG_NOSIGNAL -DHAVE_MSGHDR_MSG_CONTROL -DHAVE_ALLOCA_H -DHAVE_TIMEGM -DHAVE_EPOLL -DHAVE_SIGIO_RT -DHAVE_SELECT -I/usr/include -c val.c -o val.o
	In file included from my_con.c:25:0:
	/usr/include/mysql/mysql_version.h:3:2: warning: #warning This file should not be included by clients, include only <mysql.h> [-Wcpp]
	 #warning This file should not be included by clients, include only <mysql.h>
	  ^~~~~~~
	/usr/include/mysql/mysql_version.h:5:10: fatal error: mariadb_version.h: No such file or directory
	 #include <mariadb_version.h>
		  ^~~~~~~~~~~~~~~~~~~
	compilation terminated.
	make[1]: *** [../../Makefile.rules:25: my_con.o] Error 1
	make[1]: *** Waiting for unfinished jobs....
	make[1]: Leaving directory '/builddir/build/BUILD/opensips-2.2.5/modules/db_mysql'
	make: *** [Makefile:201: modules] Error 2

See also kamailio/kamailio@c31535072a04273b52a5cbc015e7ed1423d5dc33

Signed-off-by: Peter Lemenkov <lemenkov@gmail.com>