### PR TITLE
Oracle NUMBER not NUM in application

### DIFF
--- a/modules/db_oracle/db_oracle.c
+++ b/modules/db_oracle/db_oracle.c
@@ -69,7 +69,7 @@ struct module_exports exports = {
 	0,               /* exported statistics */
 	0,               /* exported MI functions */
 	0,               /* exported pseudo-variables */
-	0,				 /* exported transformations */
+	0,               /* exported transformations */
 	0,               /* extra processes */
 	oracle_mod_init, /* module initialization function */
 	0,               /* response function*/

--- a/modules/db_oracle/res.c
+++ b/modules/db_oracle/res.c
@@ -128,6 +128,7 @@ set_bitmap:
 			LM_DBG("use DB_BITMAP type\n");
 			RES_TYPES(_r)[i] = DB_BITMAP;
 			len = sizeof(VAL_BITMAP((db_val_t*)NULL));
+			dtype = SQLT_UIN;
 			break;
 
 		case SQLT_INT:		/* (ORANET TYPE) integer */
@@ -135,41 +136,44 @@ set_int:
 			LM_DBG("use DB_INT result type\n");
 			RES_TYPES(_r)[i] = DB_INT;
 			len = sizeof(VAL_INT((db_val_t*)NULL));
+			dtype = SQLT_INT;
 			break;
 
 		case SQLT_LNG:		/* long */
 		case SQLT_VNU:		/* NUM with preceding length byte */
-		case SQLT_NUM:		/* (ORANET TYPE) oracle numeric */
+		case SQLT_NUM:		/* (ORANET TYPE) oracle numeric */ {
+			sb1 sc;
+			status = OCIAttrGet(param, OCI_DTYPE_PARAM,
+				(dvoid**)(dvoid*)&sc, NULL,
+				OCI_ATTR_SCALE, con->errhp);
+			if (status != OCI_SUCCESS) goto ora_err;
+			if (sc) goto set_flt;
+
 			len = 0; /* PRECISION is ub1 */
 			status = OCIAttrGet(param, OCI_DTYPE_PARAM,
 				(dvoid**)(dvoid*)&len, NULL, OCI_ATTR_PRECISION,
 				con->errhp);
 			if (status != OCI_SUCCESS) goto ora_err;
-			if (len <= 11) {
-				sb1 sc;
-				status = OCIAttrGet(param, OCI_DTYPE_PARAM,
-					(dvoid**)(dvoid*)&sc, NULL,
-					OCI_ATTR_SCALE, con->errhp);
-				if (status != OCI_SUCCESS) goto ora_err;
-				if (!sc) {
-					dtype = SQLT_INT;
-					if (len != 11) goto set_int;
-					dtype = SQLT_UIN;
-					goto set_bitmap;
-				}
-			}
+
+			if (len < 11)
+				goto set_int;
+			else if (len == 11)
+				goto set_bitmap;
+
+			/* len > 11 */
 			LM_DBG("use DB_BIGINT result type\n");
 			RES_TYPES(_r)[i] = DB_BIGINT;
 			len = sizeof(VAL_BIGINT((db_val_t*)NULL));
-			dtype = SQLT_NUM;
+			dtype = SQLT_INT;
 			break;
-
+		}
 		case SQLT_FLT:		/* (ORANET TYPE) Floating point number */
 		case SQLT_BFLOAT:       /* Native Binary float*/
 		case SQLT_BDOUBLE:	/* NAtive binary double */
 		case SQLT_IBFLOAT:	/* binary float canonical */
 		case SQLT_IBDOUBLE:	/* binary double canonical */
 		case SQLT_PDN:		/* (ORANET TYPE) Packed Decimal Numeric */
+set_flt:
 			LM_DBG("use DB_DOUBLE result type\n");
 			RES_TYPES(_r)[i] = DB_DOUBLE;
 			len = sizeof(VAL_DOUBLE((db_val_t*)NULL));

--- a/modules/db_oracle/val.c
+++ b/modules/db_oracle/val.c
@@ -98,7 +98,7 @@ int db_oracle_val2bind(bmap_t* _m, const db_val_t* _v, OCIDate* _o)
 	case DB_BIGINT:
 		_m->addr = (int*)&VAL_BIGINT(_v);
 		_m->size = sizeof(VAL_BIGINT(_v));
-		_m->type = SQLT_NUM;
+		_m->type = SQLT_INT;
 		break;
 
 	case DB_BITMAP:


### PR DESCRIPTION
From Oracle documentation https://docs.oracle.com/cd/B19306_01/appdev.102/b14250/oci03typ.htm
"NUMBER
You should not need to use NUMBER as an external datatype. If you do use it, Oracle returns numeric values in its internal 21-byte binary format and will expect this format on input."