### PR TITLE
replace /usr/local/lib/opensips to /usr/local/lib64/opensips in all files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -543,7 +543,7 @@ install-bin: $(bin_prefix)/$(bin_dir) opensipsmc utils
 		# install opensipsctl (and family) tool
 		cat scripts/opensipsctl | \
 		sed -e "s#/usr/local/sbin#$(bin-target)#g" | \
-		sed -e "s#/usr/local/lib/opensips#$(lib-target)#g" | \
+		sed -e "s#/usr/local/lib64/opensips#$(lib-target)#g" | \
 		sed -e "s#/usr/local/etc/opensips#$(cfg_target)#g"  >/tmp/opensipsctl
 		$(INSTALL_TOUCH) $(bin_prefix)/$(bin_dir)/opensipsctl
 		$(INSTALL_BIN) /tmp/opensipsctl $(bin_prefix)/$(bin_dir)
@@ -586,7 +586,7 @@ install-bin: $(bin_prefix)/$(bin_dir) opensipsmc utils
 		rm -fr /tmp/opensipsdbctl.base
 		cat scripts/opensipsdbctl | \
 		sed -e "s#/usr/local/sbin#$(bin-target)#g" | \
-		sed -e "s#/usr/local/lib/opensips#$(lib-target)#g" | \
+		sed -e "s#/usr/local/lib64/opensips#$(lib-target)#g" | \
 		sed -e "s#/usr/local/etc/opensips#$(cfg_target)#g"  >/tmp/opensipsdbctl
 		$(INSTALL_TOUCH) $(bin_prefix)/$(bin_dir)/opensipsdbctl
 		$(INSTALL_BIN) /tmp/opensipsdbctl $(bin_prefix)/$(bin_dir)

--- a/etc/opensips.cfg
+++ b/etc/opensips.cfg
@@ -43,7 +43,7 @@ listen=udp:127.0.0.1:5060   # CUSTOMIZE ME
 ####### Modules Section ########
 
 #set module path
-mpath="/usr/local/lib/opensips/modules/"
+mpath="/usr/local/lib64/opensips/modules/"
 
 #### SIGNALING module
 loadmodule "signaling.so"

--- a/examples/acc-mysql.cfg
+++ b/examples/acc-mysql.cfg
@@ -73,7 +73,7 @@ children=4
 # ------------------ module loading ----------------------------------
 
 # set module path
-mpath="/usr/local/lib/opensips/modules/"
+mpath="/usr/local/lib64/opensips/modules/"
 
 # Uncomment this if you want to use SQL database
 # - MySQL loaded for accounting as well

--- a/examples/acc.cfg
+++ b/examples/acc.cfg
@@ -7,7 +7,7 @@
 # ------------------ module loading ----------------------------------
 
 #set module path
-mpath="/usr/local/lib/opensips/modules/"
+mpath="/usr/local/lib64/opensips/modules/"
 
 loadmodule "tm.so"
 loadmodule "acc.so"

--- a/examples/exec_s3.cfg
+++ b/examples/exec_s3.cfg
@@ -7,7 +7,7 @@
 # ------------------ module loading ----------------------------------
 
 #set module path
-mpath="/usr/local/lib/opensips/modules/"
+mpath="/usr/local/lib64/opensips/modules/"
 loadmodule "exec.so"
 loadmodule "sl.so"
 

--- a/examples/exec_s4.cfg
+++ b/examples/exec_s4.cfg
@@ -7,7 +7,7 @@
 # ------------------ module loading ----------------------------------
 
 #set module path
-mpath="/usr/local/lib/opensips/modules/"
+mpath="/usr/local/lib64/opensips/modules/"
 loadmodule "exec.so"
 loadmodule "sl.so"
 loadmodule "tm.so"

--- a/examples/exec_s5.cfg
+++ b/examples/exec_s5.cfg
@@ -7,7 +7,7 @@
 # ----------- global configuration parameters ------------------------
 
 #set module path
-mpath="/usr/local/lib/opensips/modules/"
+mpath="/usr/local/lib64/opensips/modules/"
 loadmodule "sl.so"
 loadmodule "tm.so"
 loadmodule "usrloc.so"

--- a/examples/flag_reply.cfg
+++ b/examples/flag_reply.cfg
@@ -17,7 +17,7 @@ port=5060
 # ------------------ module loading ----------------------------------
 
 #set module path
-mpath="/usr/local/lib/opensips/modules/"
+mpath="/usr/local/lib64/opensips/modules/"
 
 
 # Uncomment this if you want to use SQL database

--- a/examples/fork.cfg
+++ b/examples/fork.cfg
@@ -11,7 +11,7 @@
 # ------------------ module loading ----------------------------------
 
 #set module path
-mpath="/usr/local/lib/opensips/modules/"
+mpath="/usr/local/lib64/opensips/modules/"
 loadmodule "sl.so"
 loadmodule "tm.so"
 

--- a/examples/msilo.cfg
+++ b/examples/msilo.cfg
@@ -14,7 +14,7 @@ rev_dns=off       # (cmd. line: -R)
 
 # ------------------ module loading ----------------------------------
 #set module path
-mpath="/usr/local/lib/opensips/modules/"
+mpath="/usr/local/lib64/opensips/modules/"
 loadmodule "textops.so"
 loadmodule "sl.so"
 loadmodule "db_mysql.so"

--- a/examples/nathelper.cfg
+++ b/examples/nathelper.cfg
@@ -32,7 +32,7 @@ children=4
 # ------------------ module loading ----------------------------------
 
 #set module path
-mpath="/usr/local/lib/opensips/modules/"
+mpath="/usr/local/lib64/opensips/modules/"
 
 # Uncomment this if you want to use SQL database
 #loadmodule "db_mysql.so"

--- a/examples/pstn.cfg
+++ b/examples/pstn.cfg
@@ -8,7 +8,7 @@
 # ------------------ module loading ----------------------------------
 
 #set module path
-mpath="/usr/local/lib/opensips/modules/"
+mpath="/usr/local/lib64/opensips/modules/"
 
 loadmodule "sl.so"
 loadmodule "tm.so"

--- a/examples/redirect.cfg
+++ b/examples/redirect.cfg
@@ -7,7 +7,7 @@
 # ------------------ module loading ----------------------------------
 
 #set module path
-mpath="/usr/local/lib/opensips/modules/"
+mpath="/usr/local/lib64/opensips/modules/"
 
 loadmodule "sl.so"
 

--- a/examples/replicate.cfg
+++ b/examples/replicate.cfg
@@ -10,7 +10,7 @@ log_stderror=yes # (cmd line: -E)
 # ------------------ module loading ----------------------------------
 
 #set module path
-mpath="/usr/local/lib/opensips/modules/"
+mpath="/usr/local/lib64/opensips/modules/"
 
 loadmodule "db_mysql.so"
 loadmodule "sl.so"

--- a/examples/serial_183.cfg
+++ b/examples/serial_183.cfg
@@ -9,7 +9,7 @@ listen=192.168.2.16
 # ------------------ module loading ----------------------------------
 
 #set module path
-mpath="/usr/local/lib/opensips/modules/"
+mpath="/usr/local/lib64/opensips/modules/"
 
 # Uncomment this if you want to use SQL database
 loadmodule "tm.so"

--- a/menuconfig/configs/opensips_loadbalancer.m4
+++ b/menuconfig/configs/opensips_loadbalancer.m4
@@ -47,7 +47,7 @@ ifelse(USE_HTTP_MANAGEMENT_INTERFACE,`yes',`define(`HTTPD_NEEDED',`yes')', `')
 ####### Modules Section ########
 
 #set module path
-mpath="/usr/local/lib/opensips/modules/"
+mpath="/usr/local/lib64/opensips/modules/"
 
 ifdef(`HTTPD_NEEDED',`#### HTTPD module
 loadmodule "httpd.so"

--- a/menuconfig/configs/opensips_residential.m4
+++ b/menuconfig/configs/opensips_residential.m4
@@ -45,7 +45,7 @@ ifelse(ENABLE_TLS,`yes',`listen=tls:127.0.0.1:5061  # CUSTOMIZE ME' , `')dnl
 ####### Modules Section ########
 
 #set module path
-mpath="/usr/local/lib/opensips/modules/"
+mpath="/usr/local/lib64/opensips/modules/"
 
 #### SIGNALING module
 loadmodule "signaling.so"

--- a/menuconfig/configs/opensips_trunking.m4
+++ b/menuconfig/configs/opensips_trunking.m4
@@ -47,7 +47,7 @@ ifelse(USE_HTTP_MANAGEMENT_INTERFACE,`yes',`define(`HTTPD_NEEDED',`yes')', `')
 ####### Modules Section ########
 
 #set module path
-mpath="/usr/local/lib/opensips/modules/"
+mpath="/usr/local/lib64/opensips/modules/"
 
 ifdef(`HTTPD_NEEDED',`#### HTTPD module
 loadmodule "httpd.so"

--- a/modules/db_unixodbc/README
+++ b/modules/db_unixodbc/README
@@ -116,13 +116,13 @@ modparam("db_unixodbc", "use_escape_common", 1)
 
    In the opensips.conf file, add the line:
 ....
-loadmodule "/usr/local/lib/opensips/modules/db_unixodbc.so"
+loadmodule "/usr/local/lib64/opensips/modules/db_unixodbc.so"
 ....
 
    You should also uncomment this:
 ....
-loadmodule "/usr/local/lib/opensips/modules/auth.so"
-loadmodule "/usr/local/lib/opensips/modules/auth_db.so"
+loadmodule "/usr/local/lib64/opensips/modules/auth.so"
+loadmodule "/usr/local/lib64/opensips/modules/auth_db.so"
 modparam("usrloc", "db_mode", 2)
 modparam("auth_db", "calculate_ha1", yes)
 modparam("auth_db", "password_column", "password")

--- a/modules/db_unixodbc/doc/db_unixodbc_admin.xml
+++ b/modules/db_unixodbc/doc/db_unixodbc_admin.xml
@@ -131,7 +131,7 @@ modparam("db_unixodbc", "use_escape_common", 1)
 	</para>
 	<programlisting format="linespecific">
 ....
-loadmodule "/usr/local/lib/opensips/modules/db_unixodbc.so"
+loadmodule "/usr/local/lib64/opensips/modules/db_unixodbc.so"
 ....
 </programlisting>
 	<para>
@@ -139,8 +139,8 @@ loadmodule "/usr/local/lib/opensips/modules/db_unixodbc.so"
 	</para>
 	<programlisting format="linespecific">
 ....
-loadmodule "/usr/local/lib/opensips/modules/auth.so"
-loadmodule "/usr/local/lib/opensips/modules/auth_db.so"
+loadmodule "/usr/local/lib64/opensips/modules/auth.so"
+loadmodule "/usr/local/lib64/opensips/modules/auth_db.so"
 modparam("usrloc", "db_mode", 2)
 modparam("auth_db", "calculate_ha1", yes)
 modparam("auth_db", "password_column", "password")

--- a/modules/dispatcher/README
+++ b/modules/dispatcher/README
@@ -1028,7 +1028,7 @@ port=5060
 # for more info: opensips -h
 
 # ------------------ module loading ----------------------------------
-mpath="/usr/local/lib/opensips/modules/"
+mpath="/usr/local/lib64/opensips/modules/"
 loadmodule "maxfwd.so"
 loadmodule "signaling.so"
 loadmodule "sl.so"

--- a/modules/dispatcher/doc/dispatcher.cfg
+++ b/modules/dispatcher/doc/dispatcher.cfg
@@ -13,7 +13,7 @@ port=5060
 # for more info: opensips -h
 
 # ------------------ module loading ----------------------------------
-mpath="/usr/local/lib/opensips/modules/"
+mpath="/usr/local/lib64/opensips/modules/"
 loadmodule "maxfwd.so"
 loadmodule "signaling.so"
 loadmodule "sl.so"

--- a/modules/msilo/README
+++ b/modules/msilo/README
@@ -579,7 +579,7 @@ port=5060
 listen=10.0.0.2   # listen address
 
 # ------------------ module loading ----------------------------------
-mpath="/usr/local/lib/opensips/modules/"
+mpath="/usr/local/lib64/opensips/modules/"
 
 loadmodule "textops.so"
 

--- a/modules/msilo/doc/msilo.cfg
+++ b/modules/msilo/doc/msilo.cfg
@@ -15,7 +15,7 @@ port=5060
 listen=10.0.0.2   # listen address
 
 # ------------------ module loading ----------------------------------
-mpath="/usr/local/lib/opensips/modules/"
+mpath="/usr/local/lib64/opensips/modules/"
 
 loadmodule "textops.so"
 

--- a/modules/osp/Makefile
+++ b/modules/osp/Makefile
@@ -33,7 +33,7 @@ include ../../Makefile.modules
 install_module_custom:
 	echo "OSP module overwrites the default configuration file"
 	sed  \
-		-e "s#/usr/local/lib/opensips#$(modules_prefix)/$(lib_dir)#g" \
+		-e "s#/usr/local/lib64/opensips#$(modules_prefix)/$(lib_dir)#g" \
 		< etc/sample-osp-opensips.cfg \
 		> $(cfg_prefix)/$(cfg_dir)/opensips.cfg
 

--- a/modules/osp/etc/sample-osp-opensips.cfg
+++ b/modules/osp/etc/sample-osp-opensips.cfg
@@ -14,7 +14,7 @@ listen=udp:127.0.0.1:5060
 children=64
 
 # --------- module loading -------------------------------------------
-mpath="/usr/local/lib/opensips/modules"
+mpath="/usr/local/lib64/opensips/modules"
 loadmodule "sl.so"
 loadmodule "tm.so"
 loadmodule "maxfwd.so"

--- a/modules/perl/README
+++ b/modules/perl/README
@@ -315,7 +315,7 @@ modparam("perl", "filename", "/home/john/opensips/myperl.pl")
 
    Example 1.2. Set modpath parameter
 ...
-modparam("perl", "modpath", "/usr/local/lib/opensips/perl/")
+modparam("perl", "modpath", "/usr/local/lib64/opensips/perl/")
 ...
 
 1.6. Exported Functions

--- a/modules/perl/doc/perl_admin.xml
+++ b/modules/perl/doc/perl_admin.xml
@@ -177,7 +177,7 @@ modparam("perl", "filename", "/home/john/opensips/myperl.pl")
 			<title>Set <varname>modpath</varname> parameter</title>
 			<programlisting format="linespecific">
 ...
-modparam("perl", "modpath", "/usr/local/lib/opensips/perl/")
+modparam("perl", "modpath", "/usr/local/lib64/opensips/perl/")
 ...
 </programlisting>
 			</example>

--- a/modules/seas/README
+++ b/modules/seas/README
@@ -661,15 +661,15 @@ dns=no          # (cmd. line: -r)
 rev_dns=no      # (cmd. line: -R)
 port=5060
 children=4
-loadmodule "/usr/local/lib/opensips/modules/sl.so"
-loadmodule "/usr/local/lib/opensips/modules/tm.so"
-loadmodule "/usr/local/lib/opensips/modules/rr.so"
-loadmodule "/usr/local/lib/opensips/modules/maxfwd.so"
-loadmodule "/usr/local/lib/opensips/modules/usrloc.so"
-loadmodule "/usr/local/lib/opensips/modules/registrar.so"
-loadmodule "/usr/local/lib/opensips/modules/textops.so"
-loadmodule "/usr/local/lib/opensips/modules/seas.so"
-loadmodule "/usr/local/lib/opensips/modules/mi_fifo.so"
+loadmodule "/usr/local/lib64/opensips/modules/sl.so"
+loadmodule "/usr/local/lib64/opensips/modules/tm.so"
+loadmodule "/usr/local/lib64/opensips/modules/rr.so"
+loadmodule "/usr/local/lib64/opensips/modules/maxfwd.so"
+loadmodule "/usr/local/lib64/opensips/modules/usrloc.so"
+loadmodule "/usr/local/lib64/opensips/modules/registrar.so"
+loadmodule "/usr/local/lib64/opensips/modules/textops.so"
+loadmodule "/usr/local/lib64/opensips/modules/seas.so"
+loadmodule "/usr/local/lib64/opensips/modules/mi_fifo.so"
 
 modparam("mi_fifo", "fifo_name", "/tmp/opensips_fifo")
 modparam("usrloc", "db_mode",   0)

--- a/modules/seas/doc/seas_admin.xml
+++ b/modules/seas/doc/seas_admin.xml
@@ -680,15 +680,15 @@ dns=no          # (cmd. line: -r)
 rev_dns=no      # (cmd. line: -R)
 port=5060
 children=4
-loadmodule "/usr/local/lib/opensips/modules/sl.so"
-loadmodule "/usr/local/lib/opensips/modules/tm.so"
-loadmodule "/usr/local/lib/opensips/modules/rr.so"
-loadmodule "/usr/local/lib/opensips/modules/maxfwd.so"
-loadmodule "/usr/local/lib/opensips/modules/usrloc.so"
-loadmodule "/usr/local/lib/opensips/modules/registrar.so"
-loadmodule "/usr/local/lib/opensips/modules/textops.so"
-loadmodule "/usr/local/lib/opensips/modules/seas.so"
-loadmodule "/usr/local/lib/opensips/modules/mi_fifo.so"
+loadmodule "/usr/local/lib64/opensips/modules/sl.so"
+loadmodule "/usr/local/lib64/opensips/modules/tm.so"
+loadmodule "/usr/local/lib64/opensips/modules/rr.so"
+loadmodule "/usr/local/lib64/opensips/modules/maxfwd.so"
+loadmodule "/usr/local/lib64/opensips/modules/usrloc.so"
+loadmodule "/usr/local/lib64/opensips/modules/registrar.so"
+loadmodule "/usr/local/lib64/opensips/modules/textops.so"
+loadmodule "/usr/local/lib64/opensips/modules/seas.so"
+loadmodule "/usr/local/lib64/opensips/modules/mi_fifo.so"
 
 modparam("mi_fifo", "fifo_name", "/tmp/opensips_fifo")
 modparam("usrloc", "db_mode",   0)

--- a/modules/snmpstats/README
+++ b/modules/snmpstats/README
@@ -541,7 +541,7 @@ Chapter 2. Frequently Asked Questions
 
    On some systems, you may receive the following error at stdout
    or the log files depending on the configuration.
-    ERROR: load_module: could not open module </usr/local/lib/opensips/m
+    ERROR: load_module: could not open module </usr/local/lib64/opensips/m
 odules/snmpstats.so>:
            libnetsnmpmibs.so.10: cannot open shared object file: No such
  file or directory.

--- a/modules/snmpstats/doc/snmpstats_faq.xml
+++ b/modules/snmpstats/doc/snmpstats_faq.xml
@@ -123,7 +123,7 @@
 		</para>
 
 		<programlisting format="linespecific">
-    ERROR: load_module: could not open module &lt;/usr/local/lib/opensips/modules/snmpstats.so&gt;:
+    ERROR: load_module: could not open module &lt;/usr/local/lib64/opensips/modules/snmpstats.so&gt;:
            libnetsnmpmibs.so.10: cannot open shared object file: No such file or directory.
 		</programlisting>
 

--- a/modules/speeddial/README
+++ b/modules/speeddial/README
@@ -229,7 +229,7 @@ rev_dns=no      # (cmd. line: -R)
 
 # ------------------ module loading ----------------------------------
 
-mpath="/usr/local/lib/opensips/modules"
+mpath="/usr/local/lib64/opensips/modules"
 loadmodule "sl.so"
 loadmodule "tm.so"
 loadmodule "rr.so"

--- a/modules/speeddial/doc/speeddial.cfg
+++ b/modules/speeddial/doc/speeddial.cfg
@@ -12,7 +12,7 @@ rev_dns=no      # (cmd. line: -R)
 
 # ------------------ module loading ----------------------------------
 
-mpath="/usr/local/lib/opensips/modules"
+mpath="/usr/local/lib64/opensips/modules"
 loadmodule "sl.so"
 loadmodule "tm.so"
 loadmodule "rr.so"

--- a/packaging/freebsd/files/patch-Makefile
+++ b/packaging/freebsd/files/patch-Makefile
@@ -44,7 +44,7 @@
  		fi
  		# opensipsctl config
 @@ -445,7 +432,7 @@
- 		sed -e "s#/usr/local/lib/opensips#$(lib-target)#g" | \
+ 		sed -e "s#/usr/local/lib64/opensips#$(lib-target)#g" | \
  		sed -e "s#/usr/local/etc/opensips#$(cfg-target)#g"  >/tmp/opensipsctl
  		$(INSTALL_TOUCH) $(bin-prefix)/$(bin-dir)/opensipsctl
 -		$(INSTALL_BIN) /tmp/opensipsctl $(bin-prefix)/$(bin-dir)
@@ -53,7 +53,7 @@
  		sed -e "s#/usr/local/sbin#$(bin-target)#g" \
  			< scripts/opensipsctl.base > /tmp/opensipsctl.base
 @@ -492,10 +479,10 @@
- 		sed -e "s#/usr/local/lib/opensips#$(lib-target)#g" | \
+ 		sed -e "s#/usr/local/lib64/opensips#$(lib-target)#g" | \
  		sed -e "s#/usr/local/etc/opensips#$(cfg-target)#g"  >/tmp/opensipsdbctl
  		$(INSTALL_TOUCH) $(bin-prefix)/$(bin-dir)/opensipsdbctl
 -		$(INSTALL_BIN) /tmp/opensipsdbctl $(bin-prefix)/$(bin-dir)

--- a/scripts/opensipsctl
+++ b/scripts/opensipsctl
@@ -64,7 +64,7 @@ if [ -z $MYDIR ] ; then
 fi
 
 if [ -z $MYLIBDIR ] ; then
-	MYLIBDIR="/usr/local/lib/opensips/opensipsctl"
+	MYLIBDIR="/usr/local/lib64/opensips/opensipsctl"
 	if [ ! -d $MYLIBDIR ]; then
 		MYLIBDIR=$MYDIR
 	fi

--- a/scripts/opensipsdbctl
+++ b/scripts/opensipsdbctl
@@ -54,7 +54,7 @@ if [ -z "$MYDIR" ] ; then
 fi
 
 if [ -z "$MYLIBDIR" ] ; then
-	MYLIBDIR="/usr/local/lib/opensips/opensipsctl"
+	MYLIBDIR="/usr/local/lib64/opensips/opensipsctl"
 	if [ ! -d "$MYLIBDIR" ]; then
 		MYLIBDIR=$MYDIR
 	fi


### PR DESCRIPTION
Since most new OpenSIPS is running on 64 bit OS, is it reasonable to replace '/usr/local/lib/opensips' to '/usr/local/lib64/opensips' throughout the repository?

It will avoid update default config file generated every-time.