### PR TITLE
Two minior issue which will stop compiling in unbuntu 18.04 with gcc7.3.0

### DIFF
--- a/modules/cgrates/cgrates_acc.c
+++ b/modules/cgrates/cgrates_acc.c
@@ -203,16 +203,16 @@ static int cgr_proc_start_acc_reply(struct cgr_conn *c, json_object *jobj,
 		return -1;
 
 	if (!cgre_compat_mode) {
+		json_object *jorig = jobj;
 		if (json_object_get_type(jobj) != json_type_object) {
 			LM_ERR("CGRateS did not return an object in InitiateSession reply: %d %s\n",
 					json_object_get_type(jobj), json_object_to_json_string(jobj));
 			return -4;
 		}
 		/* we are only interested in the MaxUsage token */
-		jobj = json_object_object_get(jobj, "MaxUsage");
-		if (!jobj) {
+		if (!json_object_object_get_ex(jorig, "MaxUsage", &jobj)) {
 			LM_ERR("CGRateS did not return an MaxUsage in InitiateSession reply: %d %s\n",
-					json_object_get_type(jobj), json_object_to_json_string(jobj));
+					json_object_get_type(jorig), json_object_to_json_string(jorig));
 			return -4;
 		}
 		if (json_object_get_type(jobj) != json_type_int) {

--- a/modules/permissions/address.c
+++ b/modules/permissions/address.c
@@ -74,7 +74,7 @@ int reload_address_table(struct pm_part_struct *part_struct)
 	struct address_list **new_hash_table;
 	struct subnet *new_subnet_table;
 	int i, mask, proto, group, port, id;
-    struct ip_addr *ip_addr;
+	struct ip_addr *ip_addr;
 	struct net *subnet;
 	str str_pattern = {NULL,0}, str_info={NULL,0};
 	str str_src_ip, str_proto;
@@ -714,7 +714,7 @@ int check_src_addr_1(struct sip_msg* msg,
 int get_source_group(struct sip_msg* msg, char *arg) {
 	int group = -1;
 	struct ip_addr *ip;
-	str str_ip, partition;
+	str partition;
 	pv_value_t pvt;
 	struct part_pvar *ppv;
 	struct pm_part_struct *ps;
@@ -759,8 +759,8 @@ int get_source_group(struct sip_msg* msg, char *arg) {
 				ip,
 				msg->rcv.src_port);
 		if (group == -1) {
-			LM_DBG("IP <%.*s:%u> not found in any group\n",
-					str_ip.len, str_ip.s, msg->rcv.src_port);
+			LM_DBG("IP <%s:%u> not found in any group\n",
+					ip_addr2a(ip), msg->rcv.src_port);
 			return -1;
 		}
 	}


### PR DESCRIPTION
I want to use opensips in ubuntu 18.04 for future usage.
I found that the wrong usage of json_object_object_get. 
It is deprecated and even it is not, there is a BUG which jobj is nullified and use it in DEBUG info.

The other issue is that str_ip is not accually used and it block the comping too. (And some typo in the same file.)

I fix these two.

Also there is a sugguestion:
Can we make ip_addr2a A MACRO that allocate string on stack? 
It is not thread-safe.
I don't know whether it concerns.

