### PR TITLE
Bugfix/fix corefile generation

### DIFF
--- a/config.h
+++ b/config.h
@@ -52,6 +52,15 @@
 
 #define CHILD_NO    8		/*!< default number of child processes started */
 
+/*! \brief maximum allowed execution time of a high-priority, graceful
+ *    shutdown job broadcast before the attendant process SIGKILLs any
+ *    remaining workers
+ */
+#define GRACEFUL_SHUTDOWN_TIMEOUT    5 /* sec */
+
+/*! \brief overall maximum shutdown time (graceful shutdown + all cleanups) */
+#define SHUTDOWN_TIMEOUT    60 /* sec */
+
 #define RT_NO 100 		/*!< routing tables number */
 #define FAILURE_RT_NO RT_NO	/*!< on_failure routing tables number */
 #define ONREPLY_RT_NO RT_NO	/*!< on_reply routing tables number */

--- a/packaging/debian/opensips.service
+++ b/packaging/debian/opensips.service
@@ -15,6 +15,7 @@ PermissionsStartOnly=yes
 PIDFile=%t/opensips/opensips.pid
 ExecStart=/usr/sbin/opensips -P %t/opensips/opensips.pid -f /etc/opensips/opensips.cfg -m $S_MEMORY -M $P_MEMORY $OPTIONS
 ExecStartPre=/usr/sbin/opensips-m4cfg
+ExecStop=/usr/bin/pkill --pidfile %t/opensips/opensips.pid
 Restart=always
 TimeoutStopSec=30s
 LimitNOFILE=262144

--- a/packaging/redhat_fedora/opensips.service
+++ b/packaging/redhat_fedora/opensips.service
@@ -15,6 +15,7 @@ PermissionsStartOnly=yes
 PIDFile=%t/opensips/opensips.pid
 ExecStart=/usr/sbin/opensips -P %t/opensips/opensips.pid -f /etc/opensips/opensips.cfg -m $S_MEMORY -M $P_MEMORY $OPTIONS
 ExecStartPre=/usr/sbin/opensips-m4cfg
+ExecStop=/usr/bin/pkill --pidfile %t/opensips/opensips.pid
 Restart=always
 TimeoutStopSec=30s
 LimitNOFILE=262144

--- a/pt.h
+++ b/pt.h
@@ -76,6 +76,7 @@ int   count_init_children(int flags);
 #define OSS_FORK_NO_IPC        (1<<0)
 #define OSS_FORK_NO_LOAD       (1<<1)
 #define OSS_FORK_IS_EXTRA      (1<<2)
+#define OSS_TAKING_A_DUMP      (1<<3) /* this process is writing a corefile */
 
 pid_t internal_fork(char *proc_desc, unsigned int flags);
 


### PR DESCRIPTION
A set of patches which:

* improves `SIGKILL`-based shutdown code (do not skip final `cleanup()` on a `SIGKILL` broadcast)
* avoid truncated corefiles on OpenSIPS `2.4+` versions
* fix `systemd` service files, so `restart` commands don't deadlock OpenSIPS