### PR TITLE
revised timeout value information

### DIFF
--- a/modules/tls_mgm/doc/tls_mgm_admin.xml
+++ b/modules/tls_mgm/doc/tls_mgm_admin.xml
@@ -504,21 +504,46 @@ modparam("tls_mgm", "verify_cert", "[dom]1")
 		</section>
 
 		<section id="param_tls_handshake_timeout" xreflabel="tls_handshake_timeout">
-			<title><varname>tls_handshake_timeout</varname> (integer) and
-				<varname>tls_send_timeout</varname> (integer)</title>
+			<title><varname>tls_handshake_timeout</varname> (integer)</title>
 			<para>
-			Timeouts ... advanced users only
+			Sets the timeout (in milliseconds) for the handshake sequence to complete.
+				It may be necessary to increase this value when using a CPU intensive cipher
+				for the connection to allow time for keys to be generated and processed.
+			</para>
+			<para>
+			The timeout is invoked during acceptance of a new connection (inbound) and
+				during the wait period when a new session is being initiated (outbound).
 			</para>
 			<para><emphasis>
-				Default value for both is 30.
+				Default value is 100.
 			</emphasis></para>
 			<example>
-				<title>Set <varname>tls_handshake_timeout &amp;
-					tls_send_timeout </varname> variable</title>
+				<title>Set <varname>tls_handshake_timeout</varname> variable</title>
 				<programlisting format="linespecific">
 ...
-modparam("tls_mgm", "tls_handshake_timeout", 119) # number of seconds
-modparam("tls_mgm", "tls_send_timeout", 121) # number of seconds
+modparam("tls_mgm", "tls_handshake_timeout", 200) # number of milliseconds
+...
+				</programlisting>
+			</example>
+		</section>
+
+		<section id="param_tls_send_timeout" xreflabel="tls_send_timeout">
+			<title><varname>tls_send_timeout</varname> (integer)</title>
+			<para>
+				Sets the timeout (in milliseconds) for the send operations to complete
+			</para>
+			<para>
+				The send timeout is invoked for all TLS write operations, excluding
+				the handshake process (see: tls_handshake_timeout)
+			</para>
+			<para><emphasis>
+				Default value is 100.
+			</emphasis></para>
+			<example>
+				<title>Set <varname>tls_send_timeout</varname> variable</title>
+				<programlisting format="linespecific">
+...
+modparam("tls_mgm", "tls_send_timeout", 200) # number of milliseconds
 ...
 				</programlisting>
 			</example>


### PR DESCRIPTION
Updated tls_mgm documentation following discovery or a unit error in the settings (s->ms)

Note that Liviu also asks "How do they relate to "tcp_connect_timeout" (core param) and "tcp_send_timeout" (proto_tcp module)" so this information could be added for additional clarity.