### PR TITLE
pv_print_buf_size

### DIFF
--- a/cfg.lex
+++ b/cfg.lex
@@ -206,7 +206,7 @@ XLOG_BUF_SIZE	"xlog_buf_size"
 XLOG_FORCE_COLOR	"xlog_force_color"
 XLOG_DEFAULT_LEVEL	"xlog_default_level"
 XLOG			"xlog"
-PV_PRINT_BUF_SIZE   "pv_print_buf_size"
+PV_PRINT_BUF_SIZE   	"pv_print_buf_size"
 RAISE_EVENT		"raise_event"
 SUBSCRIBE_EVENT	"subscribe_event"
 CONSTRUCT_URI	"construct_uri"
@@ -501,8 +501,8 @@ IMPORTFILE      "import_file"
 									return XLOG_FORCE_COLOR;}
 <INITIAL>{XLOG_DEFAULT_LEVEL}	{	count(); yylval.strval=yytext;
 									return XLOG_DEFAULT_LEVEL;}
-<INITIAL>{PV_PRINT_BUF_SIZE}    {   count(); yylval.strval=yytext;
-                                    return PV_PRINT_BUF_SIZE;}
+<INITIAL>{PV_PRINT_BUF_SIZE}    {   	count(); yylval.strval=yytext;
+                                    					return PV_PRINT_BUF_SIZE;}
 <INITIAL>{RAISE_EVENT}		{	count(); yylval.strval=yytext;
 									return RAISE_EVENT;}
 <INITIAL>{SUBSCRIBE_EVENT}		{	count(); yylval.strval=yytext;

--- a/cfg.lex
+++ b/cfg.lex
@@ -206,6 +206,7 @@ XLOG_BUF_SIZE	"xlog_buf_size"
 XLOG_FORCE_COLOR	"xlog_force_color"
 XLOG_DEFAULT_LEVEL	"xlog_default_level"
 XLOG			"xlog"
+PV_PRINT_BUF_SIZE   "pv_print_buf_size"
 RAISE_EVENT		"raise_event"
 SUBSCRIBE_EVENT	"subscribe_event"
 CONSTRUCT_URI	"construct_uri"
@@ -500,6 +501,8 @@ IMPORTFILE      "import_file"
 									return XLOG_FORCE_COLOR;}
 <INITIAL>{XLOG_DEFAULT_LEVEL}	{	count(); yylval.strval=yytext;
 									return XLOG_DEFAULT_LEVEL;}
+<INITIAL>{PV_PRINT_BUF_SIZE}    {   count(); yylval.strval=yytext;
+                                    return PV_PRINT_BUF_SIZE;}
 <INITIAL>{RAISE_EVENT}		{	count(); yylval.strval=yytext;
 									return RAISE_EVENT;}
 <INITIAL>{SUBSCRIBE_EVENT}		{	count(); yylval.strval=yytext;

--- a/cfg.y
+++ b/cfg.y
@@ -295,6 +295,7 @@ static struct multi_str *tmp_mod;
 %token XLOG_BUF_SIZE
 %token XLOG_FORCE_COLOR
 %token XLOG_DEFAULT_LEVEL
+%token PV_PRINT_BUF_SIZE
 %token RAISE_EVENT
 %token SUBSCRIBE_EVENT
 %token CONSTRUCT_URI
@@ -964,6 +965,8 @@ assign_stm: DEBUG EQUAL snumber
 		| XLOG_BUF_SIZE EQUAL error { yyerror("number expected"); }
 		| XLOG_FORCE_COLOR EQUAL error { yyerror("boolean value expected"); }
 		| XLOG_DEFAULT_LEVEL EQUAL error { yyerror("number expected"); }
+		| PV_PRINT_BUF_SIZE EQUAL NUMBER { pv_print_buf_size = $3; }
+        | PV_PRINT_BUF_SIZE EQUAL error { yyerror("number expected"); }
 		| LISTEN EQUAL listen_def {
 							if (add_listener($3)!=0){
 								LM_CRIT("cfg. parser: failed"

--- a/pvar.c
+++ b/pvar.c
@@ -4615,7 +4615,7 @@ void pv_value_destroy(pv_value_t *val)
 	memset(val, 0, sizeof(pv_value_t));
 }
 
-int		pv_print_buf_size = 1024;
+int	pv_print_buf_size = 1024;
 #define PV_PRINT_BUF_NO    7
 /*IMPORTANT NOTE - even if the function prints and returns a static buffer, it
  * has built-in support for 3 levels of nesting (or concurrent usage).
@@ -4624,7 +4624,7 @@ int		pv_print_buf_size = 1024;
 int pv_printf_s(struct sip_msg* msg, pv_elem_p list, str *s)
 {
 	static int buf_itr = 0;
-	static char buf[PV_PRINT_BUF_NO][pv_print_buf_size];
+	char buf[PV_PRINT_BUF_NO][pv_print_buf_size];
 
 	if (list->next==0 && list->spec.getf==0) {
 		*s = list->text;

--- a/pvar.c
+++ b/pvar.c
@@ -4615,7 +4615,7 @@ void pv_value_destroy(pv_value_t *val)
 	memset(val, 0, sizeof(pv_value_t));
 }
 
-#define PV_PRINT_BUF_SIZE  1024
+int		pv_print_buf_size = 1024;
 #define PV_PRINT_BUF_NO    7
 /*IMPORTANT NOTE - even if the function prints and returns a static buffer, it
  * has built-in support for 3 levels of nesting (or concurrent usage).
@@ -4624,14 +4624,14 @@ void pv_value_destroy(pv_value_t *val)
 int pv_printf_s(struct sip_msg* msg, pv_elem_p list, str *s)
 {
 	static int buf_itr = 0;
-	static char buf[PV_PRINT_BUF_NO][PV_PRINT_BUF_SIZE];
+	static char buf[PV_PRINT_BUF_NO][pv_print_buf_size];
 
 	if (list->next==0 && list->spec.getf==0) {
 		*s = list->text;
 		return 0;
 	} else {
 		s->s = buf[buf_itr];
-		s->len = PV_PRINT_BUF_SIZE;
+		s->len = pv_print_buf_size;
 		buf_itr = (buf_itr+1)%PV_PRINT_BUF_NO;
 		return pv_printf( msg, list, s->s, &s->len);
 	}

--- a/pvar.h
+++ b/pvar.h
@@ -222,6 +222,8 @@ typedef struct _pv_elem
 	struct _pv_elem *next;
 } pv_elem_t, *pv_elem_p;
 
+extern int pv_print_buf_size;
+
 char* pv_parse_spec(str *in, pv_spec_p sp);
 int pv_get_spec_value(struct sip_msg* msg, pv_spec_p sp, pv_value_t *value);
 int pv_print_spec(struct sip_msg* msg, pv_spec_p sp, char *buf, int *len);


### PR DESCRIPTION
Make PV_PRINT_BUF_SIZE into a global parameter: pv_print_buf_size.

For example, in opensips.cfg:

pv_print_buf_size = 1024;