### PR TITLE
* fixed msg payload content to be string rather than binary data

### DIFF
--- a/modules/sipcapture/sipcapture.c
+++ b/modules/sipcapture/sipcapture.c
@@ -5070,7 +5070,7 @@ static int report_capture(struct sip_msg* msg, str* table, str* cor_id,
 		db_vals[10].val.str_val = capture_node;
 	}
 
-	db_vals[11].type = DB_BLOB;
+	db_vals[11].type = DB_STR;
 
 
 	/* we can have other pyload than sip only for hepv3 */


### PR DESCRIPTION
According to homer db schema data type should be string for payload msg
other than sip proto

http://lists.opensips.org/pipermail/users/2018-July/039627.html