### PR TITLE
mid_registrar segfault due to null callid

### DIFF
--- a/modules/mid_registrar/lookup.c
+++ b/modules/mid_registrar/lookup.c
@@ -187,6 +187,12 @@ int mid_reg_lookup(struct sip_msg* req, char* _t, char* _f, char* _s)
 	}
 
 	if (reg_mode != MID_REG_THROTTLE_AOR) {
+
+		if ( (!req->callid && parse_headers(req, HDR_CALLID_F,0)<0) || !req->callid ) {
+			LM_ERR("bad request or missing Call-ID hdr\n");
+			return -1;
+		}
+
 		if (parse_uri(uri.s, uri.len, &puri) < 0) {
 			LM_ERR("failed to parse R-URI <%.*s>, ci: %.*s\n", uri.len,
 			       uri.s, req->callid->body.len, req->callid->body.s);


### PR DESCRIPTION
If no contact_id is found, the subsequent code tries to log $ci, since the parser is lazy we don't have, yet, this header parsed unless another module/function (like xlog) forces the parse of it.

The backtrace generated was:
```log
(gdb) bt
#0  0x00007fa9282d5fac in mid_reg_lookup (req=0x7fa92bac4a48, _t=0x7fa929cf5bd8 "\330Z\317)\251\177", _f=0x0, _s=0x0) at lookup.c:223
#1  0x0000000000441254 in do_action (a=0x7fa92ba653d0, msg=0x7fa92bac4a48) at action.c:1866
#2  0x000000000043948e in run_action_list (a=0x7fa92ba653d0, msg=0x7fa92bac4a48) at action.c:172
#3  0x0000000000467366 in eval_elem (e=0x7fa92ba65500, msg=0x7fa92bac4a48, val=0x0) at route.c:1367
#4  0x00000000004683f7 in eval_expr (e=0x7fa92ba65500, msg=0x7fa92bac4a48, val=0x0) at route.c:1691
#5  0x00000000004684f3 in eval_expr (e=0x7fa92ba655a0, msg=0x7fa92bac4a48, val=0x0) at route.c:1707
#6  0x000000000046852e in eval_expr (e=0x7fa92ba65640, msg=0x7fa92bac4a48, val=0x0) at route.c:1712
#7  0x000000000043d7e2 in do_action (a=0x7fa92ba65bf8, msg=0x7fa92bac4a48) at action.c:1106
#8  0x000000000043948e in run_action_list (a=0x7fa92ba65bf8, msg=0x7fa92bac4a48) at action.c:172
#9  0x000000000043d93a in do_action (a=0x7fa92ba66768, msg=0x7fa92bac4a48) at action.c:1124
#10 0x000000000043948e in run_action_list (a=0x7fa92ba64128, msg=0x7fa92bac4a48) at action.c:172
#11 0x000000000043935b in run_actions (a=0x7fa92ba64128, msg=0x7fa92bac4a48) at action.c:137
#12 0x0000000000439615 in run_top_route (a=0x7fa92ba64128, msg=0x7fa92bac4a48) at action.c:214
#13 0x000000000042a859 in receive_msg (
    buf=0x831440 <buf> "INVITE sip:500@192.168.60.80:5060;ctid=2851060039102246806 SIP/2.0\r\nVia: SIP/2.0/UDP 192.168.60.5;rport;branch=z9hG4bKS4D1D34Xp408c\r\nMax-Forwards: 68\r\nFrom: \"400\" <sip:400@t1>;tag=S3XF7KKNFD77j\r\nTo: <"..., len=1567, rcv_info=0x7ffed5002660, existing_context=0x0, flags=0) at receive.c:209
#14 0x0000000000551699 in udp_read_req (si=0x7fa92ba5fc48, bytes_read=0x7ffed5002728) at net/proto_udp/proto_udp.c:181
#15 0x00000000005368cb in handle_io (fm=0x7fa92ba7c498, idx=0, event_type=1) at net/net_udp.c:261
#16 0x00000000005352ea in io_wait_loop_epoll (h=0x852000 <_worker_io>, t=1, repeat=0) at net/../io_wait_loop.h:280
#17 0x000000000053719b in udp_start_processes (chd_rank=0x81d638 <chd_rank>, startup_done=0x0) at net/net_udp.c:389
#18 0x00000000004a0a35 in main_loop () at main.c:771
#19 0x00000000004a3781 in main (argc=5, argv=0x7ffed5002a08) at main.c:1417
(gdb) frame 0
#0  0x00007fa9282d5fac in mid_reg_lookup (req=0x7fa92bac4a48, _t=0x7fa929cf5bd8 "\330Z\317)\251\177", _f=0x0, _s=0x0) at lookup.c:223
223				LM_ERR("no record found for %.*s, ci: %.*s\n", uri.len, uri.s,
(gdb) print req
$1 = (struct sip_msg *) 0x7fa92bac4a48
(gdb) print req->callid
$2 = (struct hdr_field *) 0x0
```

Not sure if it's the best way to handle this, and this is the first time I'm running the project :), happy to get directions on how to fix it properly if it's the case
