### PR TITLE
Feature/build speed improvements

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -151,7 +151,7 @@ Clean:
 make clean   (clean the modules too)
 make proper  (clean also the dependencies)
 make distclean (the same as proper)
-make mantainer-clean (clean everything, including auto generated files,
+make maintainer-clean (clean everything, including auto generated files,
  tags, *.dbg a.s.o)
 
 Compile:

--- a/Makefile.rules
+++ b/Makefile.rules
@@ -160,8 +160,8 @@ proper realclean distclean: clean
 	-@if [ -d utils/db_berkeley ]; then $(MAKE) -C utils/db_berkeley proper; fi
 	-@if [ -d utils/db_oracle ]; then $(MAKE) -C utils/db_oracle proper; fi
 
-.PHONY: mantainer-clean
-mantainer-clean: distclean
+.PHONY: maintainer-clean
+maintainer-clean: distclean
 	-rm -f TAGS tags *.dbg .*.swp
 	find . -type f \( -iname tags -o -name "*.dbg" -o -name "*.swp" \) -delete
 
@@ -175,7 +175,7 @@ TAGS:
 ifeq (,$(MAKECMDGOALS))
 -include $(depends)
 endif
-ifneq (,$(filter-out clean proper distclean realclean mantainer-clean \
+ifneq (,$(filter-out clean proper distclean realclean maintainer-clean \
 		bin-clean TAGS tar deb deb-orig-tar modules, $(MAKECMDGOALS)))
 -include $(depends)
 endif

--- a/Makefile.rules
+++ b/Makefile.rules
@@ -125,36 +125,27 @@ dosetrev:
 
 .PHONY: docbook-clean
 docbook-clean:
-	-@for r in $(modules) $(static_modules_path) "" ; do \
-		if [ -d "$$r" ]; then \
-			if [ -d "$$r"/doc ]; then \
-				rm -f "$$r"/doc/*.txt ; \
-				rm -f "$$r"/doc/*.html ; \
-				rm -f "$$r"/doc/*.pdf ; \
-			fi ; \
-		fi ; \
+	-@for r in $(modules) $(static_modules_path); do \
+		rm -f "$$r"/doc/*.{txt,html,pdf}; \
 	done
 
 .PHONY: dbschema-docbook-clean
 dbschema-docbook-clean:
 	-@if [ -d doc/database ] ; then \
-		rm -f doc/database/*.txt ; \
-		rm -f doc/database/*.html ; \
-		rm -f doc/database/*.pdf ; \
+		rm -f doc/database/*.{txt,html,pdf}; \
 		$(MAKE) -C db/schema docbook_clean; \
 	fi
 
+.PHONY: bin-clean
+bin-clean:
+	rm -f $(NAME)
+
 .PHONY: clean
-clean: docbook-clean dbschema-docbook-clean
-	-@rm -f $(objs) $(NAME) $(objs:.o=.il) 2>/dev/null
-	-@for r in $(all_modules) "" ; do \
-		if [ -d "$$r" -a -f "$$r/Makefile" ]; then \
-			$(MAKE) -C $$r clean ; \
-		fi ; \
-	done
+clean: docbook-clean dbschema-docbook-clean bin-clean
+	find . -type f \( -name "*.o" -o -name "*.so" \) -delete
 	-@for r in $(all_utils) "" ; do \
 		if [ -d "$$r" -a -f "$$r/Makefile" ]; then \
-			$(MAKE) -C $$r clean ; \
+			$(MAKE) -C $$r bin-clean ; \
 		fi ; \
 	done
 
@@ -162,13 +153,8 @@ clean: docbook-clean dbschema-docbook-clean
 .PHONY: distclean
 .PHONY: realclean
 proper realclean distclean: clean
-	-@rm -f $(depends) $(deps_gen) $(auto_gen) 2>/dev/null
-	-@rm -f cfg.tab.h 2>/dev/null
-	-@for r in $(all_nostatic_modules) "" ; do \
-		if [ -d "$$r" -a -f "$$r/Makefile" ]; then \
-			 $(MAKE) -C $$r proper ; \
-		fi ; \
-	done
+	rm -f $(deps_gen) $(auto_gen) cfg.tab.h 2>/dev/null
+	find . -type f \( -name "*.d" \) -delete
 	-@if [ -d menuconfig ]; then $(MAKE) -C menuconfig proper; fi
 	-@if [ -d utils/opensipsunix ]; then $(MAKE) -C utils/opensipsunix proper; fi
 	-@if [ -d utils/db_berkeley ]; then $(MAKE) -C utils/db_berkeley proper; fi
@@ -177,13 +163,7 @@ proper realclean distclean: clean
 .PHONY: mantainer-clean
 mantainer-clean: distclean
 	-rm -f TAGS tags *.dbg .*.swp
-	-@for r in $(modules) "" ; do \
-		if [ -d "$$r" ]; then \
-			$(MAKE) -C $$r mantainer-clean; \
-		fi ; \
-	 done
-	-@if [ -d utils/opensipsunix ]; then $(MAKE) -C utils/opensipsunix mantainer-clean; fi
-
+	find . -type f \( -iname tags -o -name "*.dbg" -o -name "*.swp" \) -delete
 
 .PHONY: install_module_custom
 
@@ -195,7 +175,7 @@ TAGS:
 ifeq (,$(MAKECMDGOALS))
 -include $(depends)
 endif
-ifneq (,$(filter-out clean proper distclean realclean mantainer-clean TAGS \
-		tar modules, $(MAKECMDGOALS)))
+ifneq (,$(filter-out clean proper distclean realclean mantainer-clean \
+		bin-clean TAGS tar deb deb-orig-tar modules, $(MAKECMDGOALS)))
 -include $(depends)
 endif

--- a/modules/seas/event_dispatcher.c
+++ b/modules/seas/event_dispatcher.c
@@ -728,7 +728,7 @@ again:
  * which says the length of the following message (header and payload).
  * This way, we avoid multiple small reads() to the socket, which (as we know), consumes
  * far more processor because of the kernel read(2) system call. The drawback
- * is the added complexity of mantaining a buffer, the bytes read, and looking
+ * is the added complexity of maintaining a buffer, the bytes read, and looking
  * if there is a complete message already prepared.
  *
  * Actions are supposed to be small, that's why BUF_SIZE is 2000 bytes length.


### PR DESCRIPTION
This PR **dramatically** speeds up the following:

    make clean
    make proper
    make maintainer-clean

Before:

```
$ time make proper
make[1]: Entering directory '/home/liviu/src/opensips/db/schema'
make[1]: Leaving directory '/home/liviu/src/opensips/db/schema'
make[1]: Entering directory '/home/liviu/src/opensips/modules/aaa_radius'
...
make[1]: Entering directory '/home/liviu/src/opensips/utils/db_oracle'
make[1]: Leaving directory '/home/liviu/src/opensips/utils/db_oracle'

real	0m20,773s
user	0m14,564s
sys	0m9,672s
```

After:

```
$ time make proper
rm -f opensips
find . -type f \( -name "*.o" -o -name "*.so" \) -delete
make[1]: Entering directory '/home/liviu/src/opensips-liviuchircu/utils/db_berkeley'
rm -f bdb_recover
make[1]: Leaving directory '/home/liviu/src/opensips-liviuchircu/utils/db_berkeley'
make[1]: Entering directory '/home/liviu/src/opensips-liviuchircu/utils/db_oracle'
...
make[1]: Leaving directory '/home/liviu/src/opensips-liviuchircu/utils/db_oracle'

real	0m0,575s
user	0m0,435s
sys	0m0,275s
```

... and visibly speeds up:

    make deb-orig-tar
    make deb