### PR TITLE
Correct example in docs for t_add_cancel_reason

### DIFF
--- a/modules/tm/doc/tm_admin.xml
+++ b/modules/tm/doc/tm_admin.xml
@@ -1715,7 +1715,7 @@ t_add_hdrs("X-origin: 1.1.1.1\r\n");
 		<title><function>t_add_cancel_reason</function> usage</title>
 		<programlisting format="linespecific">
 ...
-t_add_cancel_reason('Reason: SIP ;cause=200;text="Call completed elsewhere"\r\n');
+t_add_cancel_reason("Reason: SIP ;cause=200 ;text=\"Call completed elsewhere\"\r\n");
 t_relay();
 ...
 </programlisting>


### PR DESCRIPTION
If we use command like in original docs, we'll have such  header fianly:
```
Max-Forwards: 70
Reason: SIP ;cause=487 ;text="ha ha ha"\r\nUser-Agent: SIP Proxy
Content-Length: 0
```
so there must be double quotes. And escaped double quotes for text:
`t_add_cancel_reason("Reason: SIP ;cause=200 ;text=\"Call completed elsewhere\"\r\n");`
