### PR TITLE
Added MI function to enable/disable gateways probing in drouting module

### DIFF
--- a/modules/drouting/doc/drouting_admin.xml
+++ b/modules/drouting/doc/drouting_admin.xml
@@ -2235,6 +2235,31 @@ Partition:: part_test Date=Tue Aug 12 12:24:13 2014
 		</programlisting>
 	</section>
 
+	<section>
+		<title>
+		<function moreinfo="none">dr_enable_probing</function>
+		</title>
+		<para>
+		Enables gateways probing if parameter value greater than 0.
+		Disables probing if parameter value is 0. With no parameter,
+		it returns the current gateways probing status.
+		</para>
+		<para>
+		The function may takean optional parameter (for set operations)
+		- a number in decimal format.
+		</para>
+		<example>
+		<title><function>dr_enable_probing</function> usage</title>
+		<programlisting  format="linespecific">
+$ opensipsctl fifo dr_enable_probing
+Status:: 1
+$ opensipsctl fifo dr_enable_probing 0
+$ opensipsctl fifo dr_enable_probing
+Status:: 0
+		</programlisting>
+		</example>
+	</section>
+
 </section>
 
 <section id="exported_events" xreflabel="Exported Events">


### PR DESCRIPTION
Fixes #1484
The command exactly like in nathelper modile to enable/disable gateways probing.
Can be useful in cluster environment. Command name of course can be changed.
Please review. Moved to master branch.