### PR TITLE
Flexible s.substr transformation

### DIFF
--- a/transformations.c
+++ b/transformations.c
@@ -478,45 +478,30 @@ int tr_eval_string(struct sip_msg *msg, tr_param_t *tp, int subtype,
 				j = v.ri;
 			}
 			LM_DBG("i=%d j=%d\n", i, j);
-			if(j<0)
+
+			if (i < 0)
 			{
-				LM_ERR("substr negative offset\n");
-				goto error;
+				if (i*-1 >= val->rs.len)
+				{
+					i = 0;
+				} else {
+					i = val->rs.len + i;
+				}
 			}
+			if (j < 1) j = val->rs.len + j - i;
+			if (i+j >= val->rs.len) j = val->rs.len-i; // cut if length > string
+
 			val->flags = PV_VAL_STR;
 			val->ri = 0;
-			if(i>=0)
+
+			if (i >= val->rs.len) // out of range
 			{
-				if(i>=val->rs.len)
-				{
-					LM_ERR("substr out of range\n");
-					goto error;
-				}
-				if(i+j>=val->rs.len) j=0;
-				if(j==0)
-				{ /* to end */
-					val->rs.s += i;
-					val->rs.len -= i;
-					break;
-				}
-				val->rs.s += i;
-				val->rs.len = j;
+				val->rs.s += val->rs.len;
+				val->rs.len = 0;
 				break;
 			}
-			i = -i;
-			if(i>val->rs.len)
-			{
-				LM_ERR("substr out of range\n");
-				goto error;
-			}
-			if(i<j) j=0;
-			if(j==0)
-			{ /* to end */
-				val->rs.s += val->rs.len-i;
-				val->rs.len = i;
-				break;
-			}
-			val->rs.s += val->rs.len-i;
+
+			val->rs.s += i;
 			val->rs.len = j;
 			break;
 
@@ -2764,11 +2749,6 @@ int tr_parse_string(str* in, trans_t *t)
 		p++;
 		if (tr_parse_nparam(p, in, &tp) == NULL)
 			goto error;
-		if(tp->type==TR_PARAM_NUMBER && tp->v.n<0)
-		{
-			LM_ERR("substr negative offset\n");
-			goto error;
-		}
 		t->params->next = tp;
 		tp = 0;
 


### PR DESCRIPTION
{s.substr,offset,length}

Return substring starting at offset having size of 'length'.
If offset is negative, then it is counted from the end of the value, -1 being the last char.
In case of positive value, 0 is first char.

Length can be positive or negative.
In case length is negative, it is counted from the end of the value, 0 means last character.

Example:
$var(x) = "abcdefghijk";

$(var(x){s.substr,3,4}) = "defg"
$(var(x){s.substr,1,0}) = "bcdefghijk"
$(var(x){s.substr,2,-2}) = "cdbcdefghi"
$(var(x){s.substr,-5,-3}) = "gh"
$(var(x){s.substr,-5,0}) = "ghijk"
$(var(x){s.substr,-100,0}) = "abcdefghijk"
$(var(x){s.substr,2,100}) = "cdefghijk"
$(var(x){s.substr,100,5}) = ""
