### PR TITLE
add $var() support for timeout to notify_on_event & wait_for_event

### DIFF
--- a/modules/event_routing/doc/event_routing_admin.xml
+++ b/modules/event_routing/doc/event_routing_admin.xml
@@ -160,6 +160,7 @@
 			<emphasis>timeout</emphasis> - for how long the subscription is
 			active before expiring (integer in seconds). Note: during its 
 			lifetime, a subscription may be notified several or zero times.
+			This can be a pseudo-variable.
 			</para></listitem>
 		</itemizedlist>
 		<example>

--- a/modules/event_routing/event_routing.c
+++ b/modules/event_routing/event_routing.c
@@ -289,9 +289,9 @@ static int notify_on_event(struct sip_msg *msg, void *ev, void *avp_filter,
 									void *route, void *timeout)
 {
 	int t = 0;
+	gparam_p gp;
 
 	if (timeout) {
-		gparam_p gp;
 		gp = (gparam_p)timeout;
 		if (fixup_get_ivalue(msg, gp, &t) < 0) {
 			LM_ERR("can't get timeout!\n");
@@ -325,9 +325,9 @@ static int wait_for_event(struct sip_msg* msg, async_ctx *ctx,
 								char *ev, char* avp_filter, char* timeout)
 {
 	int t = 0; /* timeout */
+	gparam_p gp;
 
 	if (timeout) {
-		gparam_p gp;
 		gp = (gparam_p)timeout;
 		if (fixup_get_ivalue(msg, gp, &t) < 0) {
 			LM_ERR("can't get timeout!\n");


### PR DESCRIPTION
We have the need to use a variable timeout in notify_on_event like 

```
$var(timeout) = 12;

notify_on_event("E_UL_CONTACT_INSERT","$avp(filter)", "fork_call", "$var(timeout)");

```

If you have any annotations, please let me know.