### PR TITLE
add clusterer replication capabilty to cachedb_local

### DIFF
--- a/modules/cachedb_local/cachedb_local.c
+++ b/modules/cachedb_local/cachedb_local.c
@@ -37,8 +37,10 @@
 #include "../../mem/shm_mem.h"
 #include "../../mod_fix.h"
 #include "../../mi/tree.h"
+#include "../clusterer/api.h"
 
 #include "cachedb_local.h"
+#include "cachedb_local_replication.h"
 #include "hash.h"
 
 #include <fnmatch.h>
@@ -55,6 +57,10 @@ int local_exec_threshold = 0;
 lcache_col_t* lcache_collection = NULL;
 url_lst_t* url_list=NULL;
 
+str cache_repl_cap = str_init("cachedb-local-repl");
+int replication_cluster = 0;
+enum cachedb_rr_persist rr_persist = RRP_SYNC_FROM_CLUSTER;
+char *restart_persist;
 
 static int w_remove_chunk_1(struct sip_msg* msg, char* glob);
 static int w_remove_chunk_2(struct sip_msg* msg, char* collection, char* glob);
@@ -69,6 +75,8 @@ static param_export_t params[]={
 	{ "exec_threshold",     INT_PARAM, &local_exec_threshold },
 	{ "cache_collections",  STR_PARAM|USE_FUNC_PARAM, (void *)parse_collections },
 	{ "cachedb_url",        STR_PARAM|USE_FUNC_PARAM, (void *)store_urls },
+	{ "replication_cluster",INT_PARAM, &replication_cluster },
+	{ "restart_persistency",STR_PARAM, &restart_persist },
 	{0,0,0}
 };
 
@@ -87,13 +95,22 @@ static mi_export_t mi_cmds[] = {
 	{ 0, 0, 0, 0, 0, 0}
 };
 
+static dep_export_t deps = {
+	{ /* OpenSIPS module dependencies */
+		{ MOD_TYPE_NULL, NULL, 0},
+	},
+	{ /* modparam dependencies */
+		{"replication_cluster", get_deps_clusterer},
+	},
+};
+
 /** module exports */
 struct module_exports exports= {
 	"cachedb_local",               /* module name */
 	MOD_TYPE_CACHEDB,/* class of this module */
 	MODULE_VERSION,
 	DEFAULT_DLFLAGS,            /* dlopen flags */
-	NULL,            /* OpenSIPS module dependencies */
+	&deps,            /* OpenSIPS module dependencies */
 	cmds,                       /* exported functions */
 	0,                          /* exported async functions */
 	params,                     /* exported parameters */
@@ -432,6 +449,37 @@ static int mod_init(void)
 	register_timer("localcache-expire",localcache_clean, 0,
 		cache_clean_period, TIMER_FLAG_DELAY_ON_DELAY);
 
+	/* register clusterer module */
+	if (replication_cluster) {
+		if (restart_persist) {
+			if (!strcasecmp(restart_persist, "none"))
+				rr_persist = RRP_NONE;
+			else if (!strcasecmp(restart_persist, "sync-from-cluster"))
+				rr_persist = RRP_SYNC_FROM_CLUSTER;
+			else
+				LM_ERR("unknown 'restart_persistency' value: %s, "
+				       "using 'sync-from-cluster'\n", restart_persist);
+		}
+
+		if (load_clusterer_api(&clusterer_api) < 0) {
+			LM_DBG("failed to load clusterer API - is clusterer module loaded?\n");
+			return -1;
+		}
+
+		if (clusterer_api.register_capability(&cache_repl_cap, receive_binary_packet,
+		    receive_cluster_event, replication_cluster,
+		    rr_persist == RRP_SYNC_FROM_CLUSTER? 1 : 0,
+		    NODE_CMP_ANY) < 0 ) {
+			LM_ERR("Cannot register clusterer callback for cache replication!\n");
+			return -1;
+		}
+
+		if (rr_persist == RRP_SYNC_FROM_CLUSTER &&
+		    clusterer_api.request_sync(&cache_repl_cap, replication_cluster, 0) < 0)
+			LM_ERR("cachedb sync request failed\n");
+
+	}
+
 	return 0;
 }
 
@@ -662,4 +710,3 @@ static int store_urls(unsigned int type, void *val)
 
 	return 0;
 }
-

--- a/modules/cachedb_local/cachedb_local_replication.c
+++ b/modules/cachedb_local/cachedb_local_replication.c
@@ -1,0 +1,256 @@
+/*
+ * memory cache system replication
+ *
+ * Copyright (C) 2018 Fabian Gast
+ *
+ * This file is part of opensips, a free SIP server.
+ *
+ * opensips is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version
+ *
+ * opensips is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301  USA
+ *
+ * History:
+ * --------
+ *  2018-12-06  initial version (Fabian Gast)
+ */
+
+#include "../../cachedb/cachedb.h"
+#include "../../cachedb/cachedb_con.h"
+#include "hash.h"
+#include "cachedb_local.h"
+#include "cachedb_local_replication.h"
+
+struct clusterer_binds clusterer_api;
+extern cachedb_engine* lookup_cachedb(str *name);
+extern cachedb_con *cachedb_get_connection(cachedb_engine *cde,str *group_name);
+
+int cache_replicated_insert(bin_packet_t *packet)
+{
+        int expires;
+        str attr, value, col;
+        str name = str_init("local");
+        cachedb_engine * cde;
+        cachedb_con * con;
+
+        LM_DBG("Received replicated cache entry\n");
+        if (bin_pop_str(packet, &col) < 0)
+                goto error;
+        if (bin_pop_str(packet, &attr) < 0)
+                goto error;
+        if (bin_pop_str(packet, &value) < 0)
+                goto error;
+
+        if (bin_pop_int(packet, &expires) < 0)
+                expires = 0;
+
+        if ((cde = lookup_cachedb(&name)) == 0) {
+                LM_ERR("Failed to get cache engine\n");
+                return -1;
+        }
+        if (strncasecmp(col.s, DEFAULT_COLLECTION_NAME, col.len) == 0 ){
+                col.s = NULL;
+                col.len = 0;
+        }
+        if ((con = cachedb_get_connection(cde, &col)) == NULL) {
+                LM_ERR("Failed to get cachedb connection\n");
+                return -1;
+        }
+
+        if ((_lcache_htable_insert(con, &attr, &value, expires, 1)) < 0) {
+                LM_ERR("Can not insert...\n");
+                return -1;
+        }
+
+        return 0;
+error:
+        LM_ERR("Failed to pop data from bin packet\n");
+        return -1;
+}
+
+int cache_replicated_remove(bin_packet_t *packet)
+{
+        str attr, col;
+        str name = str_init("local");
+        cachedb_engine * cde;
+        cachedb_con * con;
+
+        LM_DBG("Received replicated cache remove\n");
+        if (bin_pop_str(packet, &col) < 0)
+                goto error;
+        if (bin_pop_str(packet, &attr) < 0)
+                goto error;
+
+        if ((cde = lookup_cachedb(&name)) == 0) {
+                LM_ERR("Failed to get cache engine\n");
+                return -1;
+        }
+        if (strncasecmp(col.s, DEFAULT_COLLECTION_NAME, col.len) == 0 ){
+                col.s = NULL;
+                col.len = 0;
+        }
+        if ((con = cachedb_get_connection(cde, &col)) == NULL) {
+                LM_ERR("Failed to get cachedb connection\n");
+                return -1;
+        }
+
+        if ((_lcache_htable_remove(con, &attr, 1)) < 0) {
+                LM_ERR("Can not remove from cache\n");
+                return -1;
+        }
+        return 0;
+error:
+        LM_ERR("Failed to pop data from bin packet\n");
+        return -1;
+}
+
+void replicate_cache_insert(str* col, str* attr, str* value, int expires)
+{
+        int rc;
+        bin_packet_t packet;
+
+        if (bin_init(&packet, &cache_repl_cap, REPL_CACHE_INSERT, BIN_VERSION, 1024) != 0) {
+                LM_ERR("failed to replicate this event\n");
+                return;
+        }
+
+        bin_push_str(&packet, col);
+        bin_push_str(&packet, attr);
+        bin_push_str(&packet, value);
+        bin_push_int(&packet, expires);
+
+        rc = clusterer_api.send_all(&packet, replication_cluster);
+        switch (rc) {
+                case CLUSTERER_CURR_DISABLED:
+                        LM_INFO("Current node is disabled in cluster: %d\n", replication_cluster);
+                        goto error;
+                case CLUSTERER_DEST_DOWN:
+                	LM_INFO("All destinations in cluster: %d are down or probing\n",
+                	replication_cluster);
+                	goto error;
+                case CLUSTERER_SEND_ERR:
+                	LM_ERR("Error sending in cluster: %d\n", replication_cluster);
+                	goto error;
+        }
+        bin_free_packet(&packet);
+        return;
+
+error:
+        LM_ERR("replicate local cache insert failed (%d)\n", rc);
+        bin_free_packet(&packet);
+}
+
+void replicate_cache_remove(str* col, str *attr)
+{
+        int rc;
+        bin_packet_t packet;
+
+        if (bin_init(&packet, &cache_repl_cap, REPL_CACHE_REMOVE, BIN_VERSION, 1024) != 0) {
+                LM_ERR("failed to replicate this event\n");
+                return;
+        }
+
+        bin_push_str(&packet, col);
+        bin_push_str(&packet, attr);
+
+        rc = clusterer_api.send_all(&packet, replication_cluster);
+        switch (rc) {
+                case CLUSTERER_CURR_DISABLED:
+                        LM_INFO("Current node is disabled in cluster: %d\n", replication_cluster);
+                        goto error;
+                case CLUSTERER_DEST_DOWN:
+                	LM_INFO("All destinations in cluster: %d are down or probing\n",
+                	replication_cluster);
+                	goto error;
+                case CLUSTERER_SEND_ERR:
+                	LM_ERR("Error sending in cluster: %d\n", replication_cluster);
+                	goto error;
+        }
+        bin_free_packet(&packet);
+        return;
+
+error:
+        LM_ERR("replicate local cache insert failed (%d)\n", rc);
+        bin_free_packet(&packet);
+}
+
+int receive_sync_request(int node_id)
+{
+        int i;
+        lcache_col_t *col;
+        lcache_entry_t *data;
+        bin_packet_t *sync_packet;
+
+        for ( col=lcache_collection; col; col=col->next ) {
+                LM_ERR("Found collection %.*s\n", col->col_name.len, col->col_name.s);
+
+                for (i =0; i < col->size; i++) {
+                        lock_get(&col->col_htable[i].lock);
+                        data = col->col_htable[i].entries;
+                        while(data) {
+                                if (data->expires == 0 || data->expires > get_ticks()) {
+                                        sync_packet = clusterer_api.sync_chunk_start(&cache_repl_cap,
+                                                                                      replication_cluster, node_id);
+                                        if (!sync_packet) {
+                                                LM_ERR("Can not create sync packet!\n");
+                                                return -1;
+                                        }
+                                        bin_push_str(sync_packet, &col->col_name);
+                                        bin_push_str(sync_packet, &data->attr);
+                                        bin_push_str(sync_packet, &data->value);
+                                        bin_push_int(sync_packet, data->expires);
+                                }
+                                data = data->next;
+                        }
+                        lock_release(&col->col_htable[i].lock);
+                }
+        }
+
+        return 0;
+}
+
+void receive_cluster_event(enum clusterer_event ev, int node_id)
+{
+	if (ev == SYNC_REQ_RCV && receive_sync_request(node_id) < 0)
+		LM_ERR("Failed to send sync data to node: %d\n", node_id);
+}
+
+void receive_binary_packet(bin_packet_t *packet)
+{
+        int rc = 0;
+        bin_packet_t * pkt;
+        for (pkt = packet; pkt; pkt = pkt->next) {
+                LM_DBG("Got cache replication packet %d\n", pkt->type);
+                switch(pkt->type) {
+                        case REPL_CACHE_INSERT:
+                        rc = cache_replicated_insert(pkt);
+                        break;
+                        case REPL_CACHE_REMOVE:
+                        rc = cache_replicated_remove(pkt);
+                        break;
+                        case SYNC_PACKET_TYPE:
+        			while (clusterer_api.sync_chunk_iter(pkt))
+        				if (cache_replicated_insert(pkt) < 0) {
+        					LM_ERR("Failed to process sync packet\n");
+        					return;
+        				}
+        			break;
+                default:
+                        rc = -1;
+                        LM_WARN("Invalid cache binary packet command: %d "
+                                "(from node: %d in cluster: %d)\n", pkt->type, pkt->src_id,
+                                replication_cluster);
+                }
+                if (rc != 0)
+			LM_ERR("Failed to process a binary packet!\n");
+        }
+}

--- a/modules/cachedb_local/cachedb_local_replication.c
+++ b/modules/cachedb_local/cachedb_local_replication.c
@@ -22,6 +22,7 @@
 
 #include "../../cachedb/cachedb.h"
 #include "../../cachedb/cachedb_con.h"
+#include "../../timer.h"
 #include "hash.h"
 #include "cachedb_local.h"
 #include "cachedb_local_replication.h"

--- a/modules/cachedb_local/cachedb_local_replication.h
+++ b/modules/cachedb_local/cachedb_local_replication.h
@@ -1,0 +1,52 @@
+/*
+ * memory cache system module
+ *
+ Copyright (C) 2018 Fabian Gast
+ *
+ * This file is part of opensips, a free SIP server.
+ *
+ * opensips is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version
+ *
+ * opensips is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301  USA
+ *
+ * History:
+ * --------
+ *  2018-12-06  initial version (Fabian Gast)
+ */
+
+#include "../../bin_interface.h"
+#include "../clusterer/api.h"
+
+#ifndef __CACHEDB_LOCAL_REPLICATION_H_
+#define __CACHEDB_LOCAL_REPLICATION_H_
+
+#define REPL_CACHE_INSERT 1
+#define REPL_CACHE_REMOVE 2
+#define BIN_VERSION 1
+
+extern struct clusterer_binds clusterer_api;
+extern str cache_repl_cap;
+extern int replication_cluster;
+
+enum cachedb_rr_persist {
+	RRP_NONE,
+	RRP_SYNC_FROM_CLUSTER,
+} rr_persist_t;
+
+void receive_binary_packet(bin_packet_t *packet);
+void receive_cluster_event(enum clusterer_event ev, int node_id);
+
+void replicate_cache_insert(str * col, str* attr, str* value, int expires);
+void replicate_cache_remove(str* col, str *attr);
+
+#endif /* __CACHEDB_LOCAL_REPLICATION_H_ */

--- a/modules/cachedb_local/cachedb_local_replication.h
+++ b/modules/cachedb_local/cachedb_local_replication.h
@@ -18,10 +18,6 @@
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301  USA
- *
- * History:
- * --------
- *  2018-12-06  initial version (Fabian Gast)
  */
 
 #include "../../bin_interface.h"
@@ -36,7 +32,7 @@
 
 extern struct clusterer_binds clusterer_api;
 extern str cache_repl_cap;
-extern int replication_cluster;
+extern int cluster_id;
 
 enum cachedb_rr_persist {
 	RRP_NONE,

--- a/modules/cachedb_local/doc/cachedb_local_admin.xml
+++ b/modules/cachedb_local/doc/cachedb_local_admin.xml
@@ -16,6 +16,41 @@
 	<para>
 	</para>
 	</section>
+	<section id="clustering" xreflabel="clustering">
+		<title>Clustering</title>
+		<para>
+			Cachedb_local clustering is a mechanism used to mirror local cache changes
+			taking place in one OpenSIPS instance to one or multiple other instances without
+			the need of third party dependencies.
+			The process is simplified by using the clusterer module which facilitates the
+			management of a cluster of OpenSIPS noeds and the sending of replication-related
+			BIN packets (binary-encoded, using proto_bin). This might be usefull for implementing
+			a hot stand-by system, where the stand-by instance can take over without the need
+			of filling the cache by its own.
+		</para>
+		<para>
+			The following cache operations will be distributet within the cluster:
+			<itemizedlist>
+				<listitem><para>cache_store</para></listitem>
+				<listitem><para>cache_remove</para></listitem>
+				<listitem><para>cache_add</para></listitem>
+				<listitem><para>cache_sub</para></listitem>
+			<itemizedlist>
+		</para>
+		<para>
+			In addition to the event-driven replication, an OpenSIPS instance will first
+			try to learn all the local cache information from antoher node in the cluster at startup.
+			The data synchronization mechanism requires defining one of the nodes in the cluster
+			as a "<emphasis role='bold'>seed</emphasis>" node.
+			See the <ulink url="http://www.opensips.org/html/docs/modules/3.0.x/clusterer.html#capabilities">clusterer</ulink>
+			module for details on how to do this and why is it needed.
+		</para>
+		<para>
+			<emphasis role='bold'>Limitations:</emphasis> The clustering operations are not atomic
+			and constistency over the cluster nodes is not guaranteed.
+		</para>
+
+	</section>
 
 	<section id="dependencies" xreflabel="Dependencies">
 	<title>Dependencies</title>
@@ -26,7 +61,7 @@
 			<itemizedlist>
 				<listitem>
 				<para>
-					<emphasis>clusterer, if <xref linkend="replication_cluster"/>
+					<emphasis>clusterer, if <xref linkend="cluster_id"/>
 					is set.</emphasis>
 				</para>
 				</listitem>
@@ -140,8 +175,8 @@ modparam("cachedb_local", "cache_clean_period", 1200)
 		</example>
 	</section>
 
-	<section id="param_replication_cluster" xreflabel="replication_cluster">
-		<title><varname>replication_cluster</varname> (int)</title>
+	<section id="param_cluster_id" xreflabel="cluster_id">
+		<title><varname>cluster_id</varname> (int)</title>
 		<para>
 		Specifies the cluster ID which this instance will send to and receive
 		cache data.
@@ -150,16 +185,16 @@ modparam("cachedb_local", "cache_clean_period", 1200)
 			Default value is 0 (replication disabled).
 		</para>
 		<example>
-		<title>Setting the <varname>replication_cluster</varname> parameter</title>
+		<title>Setting the <varname>cluster_id</varname> parameter</title>
 		<programlisting format="linespecific">
 ...
-modparam("cachedb_local", "replication_cluster", 1)
+modparam("cachedb_local", "cluster_id", 1)
 ...
 		</programlisting>
 		</example>
 	</section>
-	<section id="param_restart_persistency" xreflabel="restart_persistency">
-		<title><varname>restart_persistency</varname> (string)</title>
+	<section id="param_cluster_persistency" xreflabel="cluster_persistency">
+		<title><varname>cluster_persistency</varname> (string)</title>
 		<para>
 		Controls the behavior of the OpenSIPS local cachedb clustering following a restart.
 		</para>
@@ -190,10 +225,10 @@ modparam("cachedb_local", "replication_cluster", 1)
 			</emphasis>
 		</para>
 		<example>
-			title>Set <varname>restart_persistency</varname> parameter</title>
+			title>Set <varname>cluster_persistency</varname> parameter</title>
 		<programlisting format="linespecific">
 ...
-modparam("cachedb_local", "restart_persistency", "sync-from-cluster")
+modparam("cachedb_local", "cluster_persistency", "sync-from-cluster")
 ...
 		</example>
 	</section>

--- a/modules/cachedb_local/doc/cachedb_local_admin.xml
+++ b/modules/cachedb_local/doc/cachedb_local_admin.xml
@@ -22,7 +22,15 @@
 	<section>
 		<title>&osips; Modules</title>
 		<para>
-		None.
+		The following modules must be loaded before this module:
+			<itemizedlist>
+				<listitem>
+				<para>
+					<emphasis>clusterer, if <xref linkend="replication_cluster"/>
+					is set.</emphasis>
+				</para>
+				</listitem>
+			</itemizedlist>
 		</para>
 	</section>
 
@@ -131,6 +139,64 @@ modparam("cachedb_local", "cache_clean_period", 1200)
 	</programlisting>
 		</example>
 	</section>
+
+	<section id="param_replication_cluster" xreflabel="replication_cluster">
+		<title><varname>replication_cluster</varname> (int)</title>
+		<para>
+		Specifies the cluster ID which this instance will send to and receive
+		cache data.
+		</para>
+		<para>
+			Default value is 0 (replication disabled).
+		</para>
+		<example>
+		<title>Setting the <varname>replication_cluster</varname> parameter</title>
+		<programlisting format="linespecific">
+...
+modparam("cachedb_local", "replication_cluster", 1)
+...
+		</programlisting>
+		</example>
+	</section>
+	<section id="param_restart_persistency" xreflabel="restart_persistency">
+		<title><varname>restart_persistency</varname> (string)</title>
+		<para>
+		Controls the behavior of the OpenSIPS local cachedb clustering following a restart.
+		</para>
+		<para>
+		This parameter may take the following values:
+		</para>
+		<itemizedlist>
+			<listitem>
+				<para><emphasis>"none"</emphasis> - no explicit data
+				synchronization following a restart. The node starts empty.
+				</para>
+			</listitem>
+			<listitem>
+				<para><emphasis>"sync-from-cluster"</emphasis> - enable
+				cluster-based restart persistency. Following a restart,
+				an OpenSIPS cluster node will search for a healthy "donor" node
+				from which to mirror the entire user location dataset via
+				direct cluster sync (TCP-based, binary-encoded data transfer).
+				This will require the configuration of one or multiple "seed"
+				nodes in the cluster.
+				</para>
+			</listitem>
+		</itemizedlist>
+		<para>
+			<emphasis>
+				Default value is
+				<emphasis>"sync-from-cluster"</emphasis>.
+			</emphasis>
+		</para>
+		<example>
+			title>Set <varname>restart_persistency</varname> parameter</title>
+		<programlisting format="linespecific">
+...
+modparam("cachedb_local", "restart_persistency", "sync-from-cluster")
+...
+		</example>
+	</section>
 	</section>
 
 	<section id="exported_functions" xreflabel="exported_functions">
@@ -197,4 +263,3 @@ modparam("cachedb_local", "cache_clean_period", 1200)
 	</section>
 
 </chapter>
-

--- a/modules/cachedb_local/hash.c
+++ b/modules/cachedb_local/hash.c
@@ -33,6 +33,7 @@
 #include "../../mem/mem.h"
 #include "../../mem/shm_mem.h"
 #include "cachedb_local.h"
+#include "cachedb_local_replication.h"
 #include "hash.h"
 
 void lcache_htable_remove_safe(str attr, lcache_entry_t** it);
@@ -104,6 +105,11 @@ void lcache_htable_destroy(lcache_t** cache_htable_p, int size)
 
 int lcache_htable_insert(cachedb_con *con,str* attr, str* value, int expires)
 {
+	return _lcache_htable_insert(con, attr, value, expires, 0);
+}
+
+int _lcache_htable_insert(cachedb_con *con,str* attr, str* value, int expires, int isrepl)
+{
 	lcache_entry_t* me, *it;
 	int hash_code;
 	int size;
@@ -158,6 +164,11 @@ int lcache_htable_insert(cachedb_con *con,str* attr, str* value, int expires)
 
 	stop_expire_timer(start,local_exec_threshold,
 	"cachedb_local insert",attr->s,attr->len,0);
+
+	/* replicate */
+	if (replication_cluster && isrepl != 1)
+		replicate_cache_insert(&cache_col->col_name, attr, value, expires);
+
 	return 1;
 }
 
@@ -188,6 +199,11 @@ void lcache_htable_remove_safe(str attr, lcache_entry_t** it_p)
 
 int lcache_htable_remove(cachedb_con *con,str* attr)
 {
+	return _lcache_htable_remove(con, attr, 0);
+}
+
+int _lcache_htable_remove(cachedb_con *con,str* attr, int isrepl)
+{
 	int hash_code;
 	struct timeval start;
 
@@ -215,6 +231,9 @@ int lcache_htable_remove(cachedb_con *con,str* attr)
 
 	stop_expire_timer(start,local_exec_threshold,
 	"cachedb_local remove",attr->s,attr->len,0);
+
+	if (replication_cluster && isrepl != 1)
+		replicate_cache_remove(&cache_col->col_name, attr);
 
 	return 0;
 }

--- a/modules/cachedb_local/hash.c
+++ b/modules/cachedb_local/hash.c
@@ -166,7 +166,7 @@ int _lcache_htable_insert(cachedb_con *con,str* attr, str* value, int expires, i
 	"cachedb_local insert",attr->s,attr->len,0);
 
 	/* replicate */
-	if (replication_cluster && isrepl != 1)
+	if (cluster_id && isrepl != 1)
 		replicate_cache_insert(&cache_col->col_name, attr, value, expires);
 
 	return 1;
@@ -232,7 +232,7 @@ int _lcache_htable_remove(cachedb_con *con,str* attr, int isrepl)
 	stop_expire_timer(start,local_exec_threshold,
 	"cachedb_local remove",attr->s,attr->len,0);
 
-	if (replication_cluster && isrepl != 1)
+	if (cluster_id && isrepl != 1)
 		replicate_cache_remove(&cache_col->col_name, attr);
 
 	return 0;

--- a/modules/cachedb_local/hash.h
+++ b/modules/cachedb_local/hash.h
@@ -50,8 +50,10 @@ typedef struct lcache
 
 int lcache_htable_init(lcache_t** cache_htable_p, int size);
 void lcache_htable_destroy();
-int lcache_htable_insert(cachedb_con *con,str* attr, str* value,int expires);
+int lcache_htable_insert(cachedb_con *con,str* attr, str* value, int expires);
+int _lcache_htable_insert(cachedb_con *con,str* attr, str* value, int expires, int isrepl);
 int lcache_htable_remove(cachedb_con *con,str* attr);
+int _lcache_htable_remove(cachedb_con *con,str* attr, int isrepl);
 int lcache_htable_fetch(cachedb_con *con,str* attr, str* val);
 int lcache_htable_add(cachedb_con *con,str *attr,int val,int expires,int *new_val);
 int lcache_htable_sub(cachedb_con *con,str *attr,int val,int expires,int *new_val);


### PR DESCRIPTION
We make heavy use of the cachedb in our scripts, but we do not want to add a 'third party' system to distribute the cache in the cluster. 
So i came up with the idea of adding native clusterer support to the cachedb_local module.

If you have any annotations, please let me know.