### PR TITLE
event_routing: wait_for_event() timeout support

### DIFF
--- a/modules/event_routing/ebr_data.h
+++ b/modules/event_routing/ebr_data.h
@@ -74,6 +74,8 @@ int add_ebr_subscription( struct sip_msg *msg, ebr_event *ev,
 
 int notify_ebr_subscriptions( ebr_event *ev, evi_params_t *params);
 
+void expire_ebr_subscriptions(void);
+
 void handle_ebr_ipc(int sender, void *payload);
 
 int ebr_resume_from_wait(int *fd, struct sip_msg *msg, void *param);

--- a/modules/event_routing/event_routing.c
+++ b/modules/event_routing/event_routing.c
@@ -22,6 +22,7 @@
 #include "../../ut.h"
 #include "../../ipc.h"
 #include "../../mod_fix.h"
+#include "../../timer.h"
 #include "../../evi/evi_transport.h"
 #include "../../evi/evi_modules.h"
 #include "../tm/tm_load.h"
@@ -36,6 +37,7 @@ static int fixup_notify(void** param, int param_no);
 static int fixup_wait(void** param, int param_no);
 
 static int mod_init(void);
+static void _ebr_timer(unsigned int ticks, void* param);
 static int notify_on_event(struct sip_msg *msg, void *ev, void *avp_filter,
 	void *route, void *timeout);
 static int wait_for_event(struct sip_msg* msg, async_ctx *ctx,
@@ -174,9 +176,16 @@ static int mod_init(void)
 		}
 	}
 
+	register_timer("ev-routing", _ebr_timer, 0, 10, TIMER_FLAG_DELAY_ON_DELAY);
+
 	return 0;
 }
 
+/* Timer function */
+static void _ebr_timer(unsigned int ticks, void* param)
+{
+	expire_ebr_subscriptions();
+}
 
 /* Fixes an EBR event (given by name) by coverting to an internal
  * structure (if not already found)


### PR DESCRIPTION
wait_for_event() resumes a transaction after timeout expires