### PR TITLE
Fixes for db raw_query

### DIFF
--- a/db/db_async.h
+++ b/db/db_async.h
@@ -34,6 +34,12 @@
 
 #include "db_con.h"
 
+/**
+ * Used to indicate when an async trasferrer connection is not available.
+ * ie. max transferres exceeded.
+ */
+#define ASYNC_CON_UNAVAILABLE -128
+
 typedef int (*get_con_fd_f) (void *con);
 
 /**

--- a/modules/avpops/avpops_db.h
+++ b/modules/avpops/avpops_db.h
@@ -29,6 +29,7 @@
 #define _AVP_OPS_DB_H_
 
 #include "../../db/db.h"
+#include "../../db/db_async.h"
 #include "../../parser/msg_parser.h"
 #include "../../str.h"
 #include "../../sr_module.h"

--- a/modules/db_postgres/dbase.c
+++ b/modules/db_postgres/dbase.c
@@ -215,6 +215,8 @@ static int db_postgres_submit_query(const db_con_t* _con, const str* _s)
 		return(-1);
 	}
 
+	submit_func_called = 1;
+
 	for (i=0; i<max_db_queries && !successful_query; i++) {
 		failed_query = 0;
 		/* free any previous query that is laying about */
@@ -294,8 +296,6 @@ static int db_postgres_submit_async_query(const db_con_t* _con, const str* _s)
 		LM_ERR("invalid parameter value\n");
 		return(-1);
 	}
-
-	submit_func_called = 1;
 
 	for (i=0;i<max_db_queries;i++) {
 		if ( db_postgres_conn_ok(_con) < 0 ) {


### PR DESCRIPTION
- db_postgres when executing a SQL query with multiple statements, only the last PGresult was free'd resulting in a memory leak.

- db_postgres: When multiple statements are executed in a single query, return the last PGresult which had result tuples.
    That is desired behaviour when executing somthing like the following
    ```
    BEGIN;
    UPDATE tbl SET col = 'blah';
    SELECT col FROM tbl;
    COMMIT;
    ```
    so that we get the result of the last SELECT instead of the COMMIT statement.

- db_postgres: Do not resubmit a multi statement query if any of the statements succeeded.
    Otherwise, a statement like `UPDATE tbl SET col = col + 1` would be incorectly executed twise.

- db_mysql/db_postgres: When `db_init_async` does not return a async connection (ie, max transferres exceeded.)
    no results were set, and to the user it appeared as if the query failed, because
    `db_mysql_store_result` and `db_postgres_store_result` where not called by async_resume function.
    So instead of executing the query synchronously, return an negative number `ASYNC_CON_UNAVAILABLE`
    and let `ops_async_dbquery()` fallback to sync connection.

    This bug also effected db_virtual async where the same query could theoretically be executed on all nodes
    since the sync query had returned negative result..