### PR TITLE
Remove double free on bad input

### DIFF
--- a/modules/mi_json/http_fnc.c
+++ b/modules/mi_json/http_fnc.c
@@ -278,7 +278,6 @@ struct mi_root* mi_json_run_mi_cmd(struct mi_cmd *f, const str* miCmd,
           node = &mi_cmd->node;
           if(!add_mi_node_child(node,0,NULL,0,val.s,val.len)){
             LM_ERR("cannot add the child node to the tree\n");
-            free_mi_tree(mi_cmd);
             goto error;
           }
           j = i+1;
@@ -291,7 +290,6 @@ struct mi_root* mi_json_run_mi_cmd(struct mi_cmd *f, const str* miCmd,
         node = &mi_cmd->node;
         if(!add_mi_node_child(node,0,NULL,0,val.s,val.len)){
           LM_ERR("cannot add the child node to the tree\n");
-          free_mi_tree(mi_cmd);
           goto error;
         }
       }


### PR DESCRIPTION
If bad input is passed to a mi_json command it causes a double free.
This removes the extra free.