### PR TITLE
Disable Expect: 100-continue behavior for large posts

### DIFF
--- a/modules/db_http/db_http.c
+++ b/modules/db_http/db_http.c
@@ -46,6 +46,7 @@ int cap_id = 0;
 int cap_replace = 0;
 int cap_insert_update = 0;
 int use_ssl = 0 ;
+int disable_expect = 0;
 
 unsigned int db_http_timeout = 30000; /* Default is 30 seconds */
 
@@ -73,6 +74,7 @@ static param_export_t params[] = {
 	{"quote_delimiter", STR_PARAM | USE_FUNC_PARAM ,set_quote_delim},
 	{"value_delimiter", STR_PARAM | USE_FUNC_PARAM ,set_value_delim},
 	{"timeout", INT_PARAM,&db_http_timeout},
+	{"disable_expect", INT_PARAM,&disable_expect},
 	{0, 0, 0}
 };
 

--- a/modules/db_http/db_http.h
+++ b/modules/db_http/db_http.h
@@ -26,6 +26,7 @@
 #ifndef DB_HTTP_H
 #define DB_HTTP_H
 
+extern int disable_expect;
 extern unsigned int db_http_timeout;
 
 #endif /* DB_HTTP_H */

--- a/modules/db_http/doc/db_http_admin.xml
+++ b/modules/db_http/doc/db_http_admin.xml
@@ -261,6 +261,27 @@ modparam("db_http", "timeout",5000)
 		</example>
 	</section>
 
+	<section id="param_disable_expect" xreflabel="disable_expect">
+		<title><varname>disable_expect</varname> (int)</title>
+		<para>
+		Disables automatic 'Expect: 100-continue' behavior in libcurl for requests over 1024 bytes in size.
+		This can help reduce latency by saving a network round-trip for large records.
+		For more information on this behavior please seee rfc2616 section 8.2.3.
+		</para>
+		<para>
+		<emphasis>Default value is <quote>0 (off)</quote>
+		</emphasis>
+		</para>
+		<example>
+		<title>Set <varname>disable_expect</varname> parameter</title>
+		<programlisting format="linespecific">
+...
+modparam("db_http", "disable_expect",1)
+...
+</programlisting>
+		</example>
+	</section>
+
 
 </section>
 

--- a/modules/db_http/http_dbase.c
+++ b/modules/db_http/http_dbase.c
@@ -1040,10 +1040,13 @@ db_con_t* db_http_init(const str* url)
 
 	curl->handle = curl_easy_init();
 
-	//Disable Expect: 100-continue
 	curl->headers = NULL;
-	curl->headers = curl_slist_append(curl->headers, "Expect:");
-	curl_easy_setopt(curl->handle,CURLOPT_HTTPHEADER,curl->headers);
+
+	//Disable Expect: 100-continue behavior
+	if (disable_expect) {
+		curl->headers = curl_slist_append(curl->headers, "Expect:");
+		curl_easy_setopt(curl->handle,CURLOPT_HTTPHEADER,curl->headers);
+	}
 
 	curl_easy_setopt(curl->handle,CURLOPT_SSL_VERIFYPEER,0);
 	curl_easy_setopt(curl->handle,CURLOPT_SSL_VERIFYHOST,0);


### PR DESCRIPTION
By default on large posts the libcurl library will send the headers with a 'Expect: 100-continue' header, then wait for a 100 response from the server before sending the actual body. This gives the server a chance to reject large requests before receiving the entire body.

This is good client behaviour for a client talking to random web servers, but creates an extra network round-trip.

Since any server that is interacting with db_http should be tested and tightly coupled, this patch removes Expect behavior, and causes the client to fully post the body with the headers immediately.