### PR TITLE
 Add the ability to call uac_auth() without incrementing CSEQ

### DIFF
--- a/modules/uac/README
+++ b/modules/uac/README
@@ -18,6 +18,7 @@ UAC Module
               1.3.3. rr_from_store_param (string)
               1.3.4. rr_to_store_param (string)
               1.3.5. force_dialog (int)
+              1.3.6. increment_cseq (int)
 
         1.4. Exported Functions
 
@@ -161,6 +162,19 @@ modparam("uac","rr_to_store_param","my_Tparam")
    Example 1.5. Set force_dialog parameter
 ...
 modparam("uac", "force_dialog", yes)
+...
+
+1.3.6. increment_cseq (int)
+
+   Under most circumstances, SIP Authenication can fail if the
+   second INVITE (with the Authorization header) uses the same
+   CSEQ value.  The default behavior is to increment the CSEQ.
+
+   Default value is 1.
+
+   Example 1.6. Set increment_cseq parameter
+...
+modparam("uac", "increment_cseq", 1)
 ...
 
 1.4. Exported Functions

--- a/modules/uac/auth.c
+++ b/modules/uac/auth.c
@@ -48,6 +48,7 @@ extern uac_auth_api_t uac_auth_api;
 extern str rr_uac_cseq_param;
 extern struct rr_binds uac_rrb;
 extern struct dlg_binds dlg_api;
+extern int increment_cseq;
 
 static inline int apply_urihdr_changes( struct sip_msg *req,
 													str *uri, str *hdr)
@@ -120,7 +121,9 @@ int apply_cseq_op(struct sip_msg *msg,int val)
 		return -1;
 	}
 
-	cseq_no=cseq_no+val;
+	if (increment_cseq) {
+		cseq_no=cseq_no+val;
+	}
 	obuf = int2str(cseq_no,&olen);
 	if (obuf == NULL) {
 		LM_ERR("Failed to convert new integer to string \n");

--- a/modules/uac/doc/uac_admin.xml
+++ b/modules/uac/doc/uac_admin.xml
@@ -212,6 +212,24 @@ modparam("uac", "force_dialog", yes)
 				</programlisting>
 			</example>
 		</section>
+
+		<section id="param_increment_cseq" xreflabel="increment_cseq">
+			<title><varname>increment_cseq</varname> (int)</title>
+			<para>
+				Increment the CSEQ value when calling uac_auth().
+			</para>
+			<para>
+				Default value is yes.
+			</para>
+			<example>
+				<title>Set <varname>increment_cseq</varname> parameter</title>
+				<programlisting format="linespecific">
+...
+modparam("uac", "increment_cseq", 1)
+...
+				</programlisting>
+			</example>
+		</section>
 	</section>
 
 

--- a/modules/uac/uac.c
+++ b/modules/uac/uac.c
@@ -75,6 +75,7 @@ struct rr_binds uac_rrb;
 uac_auth_api_t uac_auth_api;
 int force_dialog = 0;
 struct dlg_binds dlg_api;
+int increment_cseq = 1;
 
 static int w_replace_from(struct sip_msg* msg, char* p1, char* p2);
 static int w_restore_from(struct sip_msg* msg);
@@ -124,6 +125,7 @@ static param_export_t params[] = {
 	{"restore_mode",        STR_PARAM,                &restore_mode_str      },
 	{"restore_passwd",      STR_PARAM,                &uac_passwd.s          },
 	{"force_dialog",        INT_PARAM,                &force_dialog          },
+	{"increment_cseq",      INT_PARAM,                &increment_cseq        },
 	{0, 0, 0}
 };
 


### PR DESCRIPTION
This solves a problem where a UA is known to accept SIP Authorization without requiring the CSEQ being incremented and allowing for relaying without CSEQ adjustments.