### PR TITLE
Correct presence list MI flush in OpenSIPS 2.4

### DIFF
--- a/modules/mi_datagram/mi_datagram_writer.c
+++ b/modules/mi_datagram/mi_datagram_writer.c
@@ -65,7 +65,7 @@ static inline int mi_datagram_write_node(datagram_stream * dtgram,
 
 
 	start = p = dtgram->current;
-	end = dtgram->start + dtgram->len;
+	end = dtgram->current + dtgram->len;
 	LM_DBG("writing the name <%.*s> and value <%.*s> \n",
 			node->name.len, node->name.s, node->value.len, node->value.s);
 	/* write indents */
@@ -200,12 +200,12 @@ int mi_datagram_write_tree(datagram_stream * dtgram, struct mi_root *tree)
 	if (datagram_recur_write_tree(dtgram, tree->node.kids, 0)!=0)
 		return -1;
 
-	if (dtgram->len<=0) {
+	if (dtgram->len <= 1) {
 		LM_ERR("failed to write - EOC does not fit in!!!\n");
 		return -1;
 	}
 
-	*(dtgram->current) = '\n';
+	*(dtgram->current++) = '\n';
 	dtgram->len--;
 	*(dtgram->current) = '\0';
 
@@ -297,8 +297,6 @@ int mi_datagram_flush_tree(datagram_stream * dtgram, struct mi_root *tree)
 		return -1;
 	}
 
-	*(dtgram->current) = '\n';
-	dtgram->len--;
 	*(dtgram->current) = '\0';
 
 	return 0;

--- a/modules/presence/presence.c
+++ b/modules/presence/presence.c
@@ -716,23 +716,26 @@ static struct mi_root* mi_list_phtable(struct mi_root* cmd, void* param)
 	struct mi_root *rpl_tree;
 	struct mi_node* rpl;
 	pres_entry_t* p;
-	unsigned int i;
+	unsigned int i, j;
 
 	rpl_tree = init_mi_tree( 200, MI_OK_S, MI_OK_LEN);
 	if (rpl_tree==NULL) return NULL;
 	rpl = &rpl_tree->node;
 	rpl->flags |= MI_IS_ARRAY;
 
-	for(i= 0; i<phtable_size; i++)
+	for(i = 0, j = 0; i < phtable_size; i++)
 	{
 		lock_get(&pres_htable[i].lock);
 		p = pres_htable[i].entries->next;
 		while(p)
 		{
 			if(mi_print_phtable_record(rpl, p)<0) goto error;
-			p= p->next;;
+			p = p->next;
+			if ((++j % 50) == 0)
+				flush_mi_tree(rpl_tree);
 		}
 		lock_release(&pres_htable[i].lock);
+
 	}
 	return rpl_tree;
 error:
@@ -893,12 +896,10 @@ static struct mi_root* mi_list_shtable(struct mi_root* cmd, void* param)
 
 			if (mi_print_shtable_record(rpl, s) < 0)
 				goto error;
-			j++;
+			if ((++j % 50) == 0)
+				flush_mi_tree(rpl_tree);
 		}
 		lock_release(&subs_htable[i].lock);
-
-		if ((j % 50) == 0)
-			flush_mi_tree(rpl_tree);
 	}
 
 	if (match_from.s)


### PR DESCRIPTION
Hi there!

We're still using the soon-to-be-removed mi_datagram.

Apparently it has some bytes-left counting issues which were revealed because mi_list_phtable was flushing mi-nodes irregularly.

This fixes things.