### PR TITLE
Add Session-Expires header to compact_form_hdrs

### DIFF
--- a/modules/compression/compression.c
+++ b/modules/compression/compression.c
@@ -212,6 +212,7 @@ int compact_form_hdrs[]={
 	HDR_TO_T,
 	HDR_VIA_T,
 	HDR_SUPPORTED_T,
+	HDR_SESSION_EXPIRES_T,
 	HDR_OTHER_T
 };
 


### PR DESCRIPTION
Even though the docs said it was supported, Session-Expires was missing from the list used to generate the mask for checking if a compact form was available. It wasn't actually being made into short form on calls to mc_compact().

This just adds it to the list so it will can be changed to short form by mc_compact().