### PR TITLE
Fix build with modern compilers by properly defining inline functions

### DIFF
--- a/parser/parse_sst.c
+++ b/parser/parse_sst.c
@@ -30,17 +30,17 @@
 #include "../mem/mem.h"
 
 
-inline int/*bool*/  is_space( char c ) { return (c == ' ' || c == '\t'); }
-inline int/*bool*/  is_num( char c ) { return (c >= '0' && c <= '9'); }
+static inline int/*bool*/  is_space( char c ) { return (c == ' ' || c == '\t'); }
+static inline int/*bool*/  is_num( char c ) { return (c >= '0' && c <= '9'); }
 
-inline unsigned  lower_byte( char b ) { return b | 0x20; }
-inline unsigned  lower_4bytes( unsigned d ) { return d | 0x20202020; }
-inline unsigned  lower_3bytes( unsigned d ) { return d |   0x202020; }
-inline unsigned  read_4bytes( char *val ) {
+static inline unsigned  lower_byte( char b ) { return b | 0x20; }
+static inline unsigned  lower_4bytes( unsigned d ) { return d | 0x20202020; }
+static inline unsigned  lower_3bytes( unsigned d ) { return d |   0x202020; }
+static inline unsigned  read_4bytes( char *val ) {
 	return (*(val + 0) + (*(val + 1) << 8)
 		+ (*(val + 2) << 16) + (*(val + 3) << 24));
 }
-inline unsigned  read_3bytes( char *val ) {
+static inline unsigned  read_3bytes( char *val ) {
 	return (*(val + 0) + (*(val + 1) << 8) + (*(val + 2) << 16));
 }
 

--- a/resolve.c
+++ b/resolve.c
@@ -123,14 +123,14 @@ typedef union {
 		(s) = ntohl (*t_cp); \
 	} while (0)
 
-inline unsigned int dns_get16(const u_char *src) {
+static inline unsigned int dns_get16(const u_char *src) {
 	unsigned int dst;
 
 	DNS_GET16(dst, src);
 	return dst;
 }
 
-inline unsigned int dns_get32(const u_char *src) {
+static inline unsigned int dns_get32(const u_char *src) {
 	unsigned int dst;
 
 	DNS_GET32(dst, src);


### PR DESCRIPTION
Fix build with modern compilers by properly defining functions as "static inline" instead of just "inline". For some reason 2.1 is the only branch affected, 1.x and 2.[234] are fine.

This popped up after we moved our travis test base to xenial. It's been pretty painful to keep relevant with ancient gcc 4.8 otherwise. Please see 2.1* stand out below:

https://travis-ci.org/sippy/voiptests/builds/508412647