### PR TITLE
Fixed bug where any addr get positive match in config if cluster_id i…

### DIFF
--- a/modules/clusterer/clusterer.c
+++ b/modules/clusterer/clusterer.c
@@ -910,7 +910,7 @@ static int ip_check(cluster_info_t *cluster, union sockaddr_union *su, str *ip_s
 				return 1;
 		} else {
 			LM_ERR("No address to check\n");
-			return -1;
+			return 0;
 		}
 
 	return 0;
@@ -928,7 +928,7 @@ int clusterer_check_addr(int cluster_id, str *ip_str,
 	cluster = get_cluster_by_id(cluster_id);
 	if (!cluster) {
 		LM_WARN("Unknown cluster id [%d]\n", cluster_id);
-		return -1;
+		return 0;
 	}
 
 	if (check_type == NODE_BIN_ADDR) {
@@ -936,20 +936,21 @@ int clusterer_check_addr(int cluster_id, str *ip_str,
 		ip.len = 16;
 		if (inet_pton(AF_INET, ip_str->s, ip.u.addr) <= 0) {
 			LM_ERR("Invalid IP address\n");
-			return -1;
+			return 0;
 		}
 		ip_addr2su(&su, &ip, 0);
 
 		rc = ip_check(cluster, &su, NULL);
+		
 	} else if (check_type == NODE_SIP_ADDR) {
 		rc = ip_check(cluster, NULL, ip_str);
 	} else {
 		LM_ERR("Bad address type\n");
-		rc = -1;
+		rc = 0;
 	}
 
 	lock_stop_read(cl_list_lock);
-
+	/* return 1 if addr matched, 0 for ALL other cases, unless return codes implemented */
 	return rc;
 }
 


### PR DESCRIPTION
Fixed bug where any addr get positive match in config if cluster_id is invalid or Invalid IP addr is given to cluster_check_addr()

Example, start a cluster with cluster_id = 1 but when checking a source address belonging to list of clustered nodes provide different cluster ID. (cluster_id should be loadable into an avp to avoid such mismatches in future) Atleast the function should never return a positive match for erroneous cases.

opensips.cfg 
```
$var(cl_id) = 2;
if (cluster_check_addr("$var(cl_id)", "1.2.3.4")) {
        xlog("L_INFO"," Yes the provided IP is a connected cluster node\n");         
}
```

