### PR TITLE
Work around a few poor compiler warnings

### DIFF
--- a/modules/b2b_logic/b2b_logic.c
+++ b/modules/b2b_logic/b2b_logic.c
@@ -1545,7 +1545,7 @@ static mi_response_t *mi_b2b_list(const mi_params_t *params,
 					if (!clients_item)
 						goto error;
 
-					if (add_mi_number(server_item, MI_SSTR("index"), index) < 0)
+					if (add_mi_number(clients_item, MI_SSTR("index"), index) < 0)
 						goto error;
 					if (internal_mi_print_b2bl_entity_id(clients_item,
 							tuple->clients[index])!=0)

--- a/modules/rabbitmq/rmq_servers.c
+++ b/modules/rabbitmq/rmq_servers.c
@@ -277,7 +277,7 @@ int rmq_server_add(modparam_t type, void * val)
 	char uri_pending = 0;
 	unsigned flags = 0;
 	char *uri;
-	int retries;
+	int retries = 0;
 	int max_frames = RMQ_DEFAULT_FRAMES;
 	int heartbeat = RMQ_DEFAULT_HEARTBEAT;
 	str exchange = {0, 0};

--- a/modules/sip_i/isup.c
+++ b/modules/sip_i/isup.c
@@ -677,14 +677,13 @@ int called_party_num_writef(int param_idx, int subfield_idx, unsigned char *para
 		isup_put_number(param_val + 2, num, &num_len, &oddeven);
 		/* also set oddeven, just in case it wasn't already */
 		param_val[0] = SET_BITS(param_val[0], 0x80, 7, oddeven);
-	} else
+		*len = num_len + 2;
+	} else {
 		param_val[idx[subfield_idx]] = SET_BITS(param_val[idx[subfield_idx]],
 										mask[subfield_idx], shift[subfield_idx], new_val);
-
-	if (subfield_idx == 4)
-		*len = num_len + 2;
-	else if (*len == 0)
-		*len = 2;
+		if (*len == 0)
+			*len = 2;
+	}
 
 	return 0;
 }
@@ -735,14 +734,13 @@ int calling_party_num_writef(int param_idx, int subfield_idx, unsigned char *par
 		isup_put_number(param_val + 2, num, &num_len, &oddeven);
 		/* also set oddeven, just in case it wasn't already */
 		param_val[0] = SET_BITS(param_val[0], 0x80, 7, oddeven);
-	} else
+		*len = num_len + 2;
+	} else {
 		param_val[idx[subfield_idx]] = SET_BITS(param_val[idx[subfield_idx]],
 										mask[subfield_idx], shift[subfield_idx], new_val);
-
-	if (subfield_idx == 6)
-		*len = num_len + 2;
-	else if (*len == 0)
-		*len = 2;
+		if (*len == 0)
+			*len = 2;
+	}
 
 	return 0;
 }
@@ -870,14 +868,13 @@ int connected_num_writef(int param_idx, int subfield_idx, unsigned char *param_v
 		isup_put_number(param_val + 2, num, &num_len, &oddeven);
 		/* also set oddeven, just in case it wasn't already */
 		param_val[0] = SET_BITS(param_val[0], 0x80, 7, oddeven);
-	} else
+		*len = num_len + 2;
+	} else {
 		param_val[idx[subfield_idx]] = SET_BITS(param_val[idx[subfield_idx]],
 										mask[subfield_idx], shift[subfield_idx], new_val);
-
-	if (subfield_idx == 5)
-		*len = num_len + 2;
-	else if (*len == 0)
-		*len = 2;
+		if (*len == 0)
+			*len = 2;
+	}
 
 	return 0;
 }
@@ -928,14 +925,13 @@ int original_called_num_writef(int param_idx, int subfield_idx,
 		isup_put_number(param_val + 2, num, &num_len, &oddeven);
 		/* also set oddeven, just in case it wasn't already */
 		param_val[0] = SET_BITS(param_val[0], 0x80, 7, oddeven);
-	} else
+		*len = num_len + 2;
+	} else {
 		param_val[idx[subfield_idx]] = SET_BITS(param_val[idx[subfield_idx]],
 								mask[subfield_idx], shift[subfield_idx], new_val);
-
-	if (subfield_idx == 4)
-		*len = num_len + 2;
-	else if (*len == 0)
-		*len = 2;
+		if (*len == 0)
+			*len = 2;
+	}
 
 	return 0;
 }

--- a/modules/tracer/tracer.c
+++ b/modules/tracer/tracer.c
@@ -561,7 +561,7 @@ static int parse_siptrace_id(str *suri)
 	str name={NULL, 0};
 	str trace_uri;
 	str param1={NULL, 0};
-	tlist_elem_p    elem;
+	tlist_elem_p elem;
 	enum types uri_type;
 
 
@@ -582,7 +582,8 @@ static int parse_siptrace_id(str *suri)
 		LM_ERR("bad format for uri {%.*s}\n", suri->len, suri->s);
 		return -1;
 	} else {
-		(suri->s++, suri->len--);                                 \
+		suri->s++;
+		suri->len--;
 	}
 
 	PARSE_NAME(suri, name); /*parse '[<name>]'*/
@@ -2369,14 +2370,17 @@ static int mi_tid_dyn_filters(tlist_dyn_elem_p tid_el, mi_item_t *dest_item)
 			case TRACE_FILTER_CALLEE:
 				msg = "callee";
 				break;
+			default:
+				/* Invalid */
+				return -1;
 		}
 		obj = add_mi_object(filters_arr, NULL, 0);
 		if (!obj) {
 			LM_ERR("could not create new MI object!\n");
 			return -1;
 		}
-        if (add_mi_string(obj, msg, strlen(msg),
-				filter->match.s, filter->match.len) < 0) {
+		if (add_mi_string(obj, msg, strlen(msg),
+					filter->match.s, filter->match.len) < 0) {
 			LM_ERR("could not create new string object!\n");
 			return -1;
 		}

--- a/modules/usrloc/dlist.c
+++ b/modules/usrloc/dlist.c
@@ -291,7 +291,7 @@ static int get_domain_db_ucontacts(udomain_t *d, void *buf, int *len,
 			/* write path */
 			memcpy(buf, &p1_len, sizeof p1_len);
 			buf += sizeof p1_len;
-			memcpy(buf, p1, p1_len);
+			memcpy(buf, p1, (unsigned)p1_len);
 			if (p1_len > 0)
 				next_hop_host = buf + next_hop_offset;
 			buf += p1_len;
@@ -654,7 +654,7 @@ get_domain_mem_ucontacts(udomain_t *d,void *buf, int *len, unsigned int flags,
 	int needed;
 	int count;
 	int i = 0;
-	char *next_hop_host;
+	char *next_hop_host = NULL;
 	int cur_node_idx = 0, nr_nodes = 0;
 
 	cp = buf;
@@ -747,7 +747,7 @@ get_domain_mem_ucontacts(udomain_t *d,void *buf, int *len, unsigned int flags,
 					memcpy(cp, &c->path.len, sizeof(c->path.len));
 					cp = (char*)cp + sizeof(c->path.len);
 					memcpy(cp, c->path.s, c->path.len);
-					if (c->path.len)
+					if (c->path.len != 0)
 						next_hop_host = cp + (c->next_hop.name.s - c->path.s);
 					cp = (char*)cp + c->path.len;
 					memcpy(cp, &c->sock, sizeof(c->sock));


### PR DESCRIPTION
Like:

    dlist.c: In function ‘get_all_ucontacts’:
    dlist.c:759:37: error: ‘next_hop_host’ may be used uninitialized in this
      function [-Werror=maybe-uninitialized]

And:

    In function ‘memcpy’,
      inlined from ‘get_domain_db_ucontacts’ at dlist.c:294:4:
    /usr/include/x86_64-linux-gnu/bits/string_fortified.h:34:10: error:
      ‘__builtin_memcpy’: specified size between 18446744071562067968 and
      18446744073709551615 exceeds maximum object size 9223372036854775807
      [-Werror=stringop-overflow=]

And one probable bug:

    b2b_logic.c: In function ‘mi_b2b_list’:
    b2b_logic.c:1548:10: error: ‘server_item’ may be used uninitialized in this
        function [-Werror=maybe-uninitialized]
    ^- should be client_item

See also #1666 