### PR TITLE
Remove quotes breaking default config

### DIFF
--- a/etc/opensips.cfg
+++ b/etc/opensips.cfg
@@ -155,7 +155,7 @@ route{
 			# if caller is not local, then called number must be local
 			
 			if (!is_myself("$rd")) {
-				send_reply("403","Relay Forbidden");
+				send_reply(403,"Relay Forbidden");
 				exit;
 			}
 		}


### PR DESCRIPTION
Startup with default configuration results in an error about parameters for `send_reply`

```
 Apr 30 10:09:24 [1398] DBG:core:fix_actions: fixing send_reply, etc/opensips/opensips.cfg:158
 Apr 30 10:09:24 [1398] ERROR:core:fix_cmd: Param [1] expected to be an integer or variable
 Apr 30 10:09:24 [1398] ERROR:core:fix_actions: Failed to fix command <send_reply>
 Apr 30 10:09:24 [1398] ERROR:core:fix_actions: fixing failed (code=-6) at etc/opensips/opensips.cfg:158
 Apr 30 10:09:24 [1398] ERROR:core:main: failed to fix configuration with err code -6
```