### PR TITLE
LB will always to one dst when use lb_next

### DIFF
--- a/modules/load_balancer/lb_data.c
+++ b/modules/load_balancer/lb_data.c
@@ -765,6 +765,7 @@ int lb_route(struct sip_msg *req, int group, struct lb_res_str_list *rl,
 							dsts_size_cur = 0;
 						} else if( it_l < load ) {
 							/* lower availability -> new iteration */
+							if( ++j == (8 * sizeof(unsigned int)) ) { i++; j=0; }
 							continue;
 						}
 


### PR DESCRIPTION
The current dst is not a larger load. When skipping, the index of the bitmask does not move.