### PR TITLE
Fix TCP connections load balancing to use all TCP workers evenly

### DIFF
--- a/net/net_tcp.c
+++ b/net/net_tcp.c
@@ -1283,6 +1283,8 @@ inline static int handle_tcp_worker(struct tcp_child* tcp_c, int fd_i)
 			break;
 		case ASYNC_WRITE:
 			tcp_c->busy--;
+			/* fall through*/
+		case ASYNC_WRITE2:
 			if (tcpconn->state==S_CONN_BAD){
 				sh_log(tcpconn->hist, TCP_UNREF, "tcpworker async write bad, (%d)", tcpconn->refcnt);
 				tcpconn_destroy(tcpconn);
@@ -1299,6 +1301,8 @@ inline static int handle_tcp_worker(struct tcp_child* tcp_c, int fd_i)
 		case CONN_EOF:
 			/* WARNING: this will auto-dec. refcnt! */
 			tcp_c->busy--;
+			/* fall through*/
+		case CONN_ERROR2:
 			if ((tcpconn->flags & F_CONN_REMOVED) != F_CONN_REMOVED &&
 				(tcpconn->s!=-1)){
 				reactor_del_all( tcpconn->s, -1, IO_FD_CLOSING);

--- a/net/net_tcp_proc.c
+++ b/net/net_tcp_proc.c
@@ -94,11 +94,11 @@ void tcp_conn_release(struct tcp_connection* c, int pending_data)
 	if (c->state==S_CONN_BAD) {
 		c->lifetime=0;
 		/* CONN_ERROR will auto-dec refcnt => we must not call tcpconn_put !!*/
-		tcpconn_release(c, CONN_ERROR,1);
+		tcpconn_release(c, CONN_ERROR2,1);
 		return;
 	}
 	if (pending_data) {
-		tcpconn_release(c, ASYNC_WRITE,1);
+		tcpconn_release(c, ASYNC_WRITE2,1);
 		return;
 	}
 	tcpconn_put(c);

--- a/net/tcp_conn.h
+++ b/net/tcp_conn.h
@@ -58,8 +58,8 @@
 
 
 /* fd communication commands - internal usage ONLY */
-enum conn_cmds { CONN_DESTROY=-3, CONN_ERROR=-2, CONN_EOF=-1, CONN_RELEASE,
-		CONN_GET_FD, CONN_NEW, ASYNC_CONNECT, ASYNC_WRITE, CONN_RELEASE_WRITE };
+enum conn_cmds { CONN_DESTROY=-4, CONN_ERROR=-3,CONN_ERROR2=-2, CONN_EOF=-1, CONN_RELEASE,
+		CONN_GET_FD, CONN_NEW, ASYNC_CONNECT, ASYNC_WRITE, ASYNC_WRITE2, CONN_RELEASE_WRITE };
 /* CONN_RELEASE, EOF, ERROR, DESTROY can be used by "reader" processes
  * CONN_GET_FD, NEW, ERROR only by writers */
 


### PR DESCRIPTION
When opensips calls `msg_send()` (from actions, clusterer, forward_request, forward_reply, etc..) `pi->tran.send()` of a corresponding proto module (proto_tcp,proto_bin,...) is getting executed. `proto_tcp_send` and `proto_bin_send` finds a `struct tcp_connection *c` calling `tcp_conn_get()`. This function find a connection in a hash table and gets a requests a file descriptor of a corresponding socket from TCP main if needed. When TCP main send an fd to a requestor it doesn't increment tcp_c->busy counter. After finishing its job send functions releases a connection calling `tcp_conn_release()` which is some conditions like `c->state==S_CONN_BAD` or availability of data in a sending queue returnes a tcp connection to the TCP main process which in its turn always decrements `tcp_c->busy` counter. As a result, this counter is getting decremented more often then incremented and goes below zero.
I've experienced a situation when one of the TCP workers had a very big negative value in its `busy` counter and TCP main sent all tcp connections to only one overloaded worker while the rest 99 free tcp processes were doing nothing.