### PR TITLE
Build on Arch Linux (v3.0.0), bugfix

### DIFF
--- a/Makefile.defs
+++ b/Makefile.defs
@@ -524,6 +524,7 @@ REGENERATE_MEM_STATS=remove-mem-stats
 endif
 endif
 
+DBXHTMLXSL ?= /usr/bin/xsltproc
 ifeq ($(DBXML2HTML),)
 DBXML2HTML = $(shell which xsltproc)
 endif
@@ -535,6 +536,9 @@ endif
 #DBHTMLXSL = /usr/share/xml/docbook/stylesheet/nwalsh/html/docbook.xsl
 # On CentOS, this is the right path:
 #DBHTMLXSL = /usr/share/sgml/docbook/xsl-stylesheets/xhtml/docbook.xsl
+
+DBHTMLXSL ?= /usr/share/xml/docbook/xsl-stylesheets-1.79.2-nons/xhtml/docbook.xsl
+ifeq ($(DBHTMLCSS),)
 DBHTMLXSL=$(shell \
 	if [ -e /usr/share/xml/docbook/stylesheet/nwalsh/html/docbook.xsl ]; then \
 		echo "/usr/share/xml/docbook/stylesheet/nwalsh/html/docbook.xsl"; \
@@ -543,6 +547,7 @@ DBHTMLXSL=$(shell \
 	elif [ -e /usr/share/xml/docbook/xsl-stylesheets*/xhtml/docbook.xsl ]; then \
 		ls -1 /usr/share/xml/docbook/xsl-stylesheets*/xhtml/docbook.xsl; \
 	fi)
+endif
 DBXML2HTMLPARAMS = --stringparam section.autolabel 1
 DBXML2HTMLPARAMS += --stringparam section.label.includes.component.label 1
 DBXML2HTMLPARAMS += --stringparam generate.toc "book toc,title,figure,table,example"

--- a/doc/doxygen/opensips-doxygen
+++ b/doc/doxygen/opensips-doxygen
@@ -154,12 +154,13 @@ QT_AUTOBRIEF           = NO
 
 MULTILINE_CPP_IS_BRIEF = NO
 
+### Has become obsolete
 # If the DETAILS_AT_TOP tag is set to YES then Doxygen 
 # will output the detailed description near the top, like JavaDoc.
 # If set to NO, the detailed description appears after the member 
 # documentation.
 
-DETAILS_AT_TOP         = NO
+# DETAILS_AT_TOP         = NO
 
 # If the INHERIT_DOCS tag is set to YES (the default) then an undocumented 
 # member inherits the documentation from any documented member that it 
@@ -401,11 +402,12 @@ MAX_INITIALIZER_LINES  = 5
 
 SHOW_USED_FILES        = YES
 
+### has become obsolete
 # If the sources in your project are distributed over multiple directories 
 # then setting the SHOW_DIRECTORIES tag to YES will show the directory hierarchy 
 # in the documentation. The default is NO.
 
-SHOW_DIRECTORIES       = YES
+#SHOW_DIRECTORIES       = YES
 
 # The FILE_VERSION_FILTER tag can be used to specify a program or script that 
 # doxygen should invoke to get the current version for each file (typically from the 
@@ -478,86 +480,193 @@ WARN_LOGFILE           =
 # with spaces.
 
 INPUT                  = ./ \
+                         aaa \
+			 cachedb \
+			 cachedb/example \
+			 cachedb/test \
                          db \
+			 db/schema \
+			 db/example \
+			 evi \
+			 lib \
+			 lib/dbg \
+			 lib/json \
+			 lib/reg \
                          mem \
+			 menuconfig \
                          mi \
-                         modules/acc \
+                         modules/aaa_radius \
+			 modules/acc \
                          modules/alias_db \
                          modules/auth \
+                         modules/auth_aaa \
                          modules/auth_db \
-                         modules/auth_diameter \
-                         modules/auth_radius \
                          modules/avpops \
-                         modules/avp_radius \
+                         modules/b2b_entities \
+                         modules/b2b_logic \
+                         modules/b2b_sca \
                          modules/benchmark \
-                         modules/cfgutils \
-                         modules/cpl_c \
+                         modules/cachedb_cassandra \
+                         modules/cachedb_couchbase \
+                         modules/cachedb_local \
+                         modules/cachedb_memcached \
+                         modules/cachedb_mongodb \
+                         modules/cachedb_redis \
+			 modules/cachedb_sql \
+                         modules/call_center \
+                         modules/call_control \
                          modules/carrierroute \
+                         modules/cfgutils \
+                         modules/cgrates \
+                         modules/clusterer \
+                         modules/compression \
+                         modules/cpl_c \
                          modules/db_berkeley \
+                         modules/db_cachedb \
+                         modules/db_flatstore \
+                         modules/db_http \
+                         modules/db_mysql \
+                         modules/db_oracle \
+                         modules/db_perlvdb \
+                         modules/db_postgres \
+                         modules/db_sqlite \
                          modules/db_text \
+                         modules/db_unixodbc \
+                         modules/db_virtual \
                          modules/dialog \
                          modules/dispatcher \
                          modules/diversion \
                          modules/domain \
                          modules/domainpolicy \
+                         modules/drouting \
+                         modules/emergency \
                          modules/enum \
+                         modules/event_datagram \
+                         modules/event_flatstore \
+                         modules/event_jsonrpc \
+                         modules/event_rabbitmq \
+                         modules/event_route \
+                         modules/event_routing \
+                         modules/event_virtual \
+                         modules/event_xmlrpc \
                          modules/exec \
-                         modules/db_flatstore \
+                         modules/fraud_detection \
+                         modules/freeswitch \
+                         modules/freeswitch_scripting \
                          modules/gflags \
                          modules/group \
-                         modules/group_radius \
                          modules/h350 \
+                         modules/httpd \
+                         modules/identity \
                          modules/imc \
                          modules/jabber \
+                         modules/json \
+                         modules/jsonrpc \
                          modules/ldap \
+                         modules/load_balancer \
+                         modules/lua \
                          modules/mangler \
+                         modules/mathops \
                          modules/maxfwd \
                          modules/mediaproxy \
-                         modules/mi_fifo \
-                         modules/mi_xmlrpc \
                          modules/mi_datagram \
+                         modules/mid_registrar \
+                         modules/mi_fifo \
+                         modules/mi_html \
+                         modules/mi_http \
+                         modules/mi_xmlrpc_ng \
+                         modules/mi_datagram \
+                         modules/mmgeoip \
                          modules/msilo \
-                         modules/db_mysql \
                          modules/nathelper \
                          modules/options \
                          modules/osp \
                          modules/path \
+                         modules/peering \
                          modules/perl \
-                         modules/perlvdb \
+                         modules/permissions \
+                         modules/pi_http \
+                         modules/pike \
                          modules/permissions \
                          modules/pike \
-                         modules/db_postgres \
                          modules/presence \
+                         modules/permissions \
+                         modules/pike \
+                         modules/presence \
+                         modules/presence_callinfo \
+                         modules/presence_dialoginfo \
+                         modules/presence_mwi \
+                         modules/presence_xcapdiff \
+                         modules/presence_xml \
+                         modules/proto_bin \
+                         modules/proto_hep \
+                         modules/proto_sctp \
+                         modules/proto_smpp \
+                         modules/proto_tls \
+                         modules/proto_ws \
+                         modules/proto_wss \
                          modules/pua \
+                         modules/pua_bla \
+                         modules/pua_dialoginfo \
                          modules/pua_mi \
                          modules/pua_usrloc \
+                         modules/pua_xmpp \
+                         modules/python \
+                         modules/qos \
+                         modules/rabbitmq \
+                         modules/rabbitmq_consumer \
+                         modules/ratelimit \
+                         modules/regex \
                          modules/registrar \
+                         modules/rest_client \
+                         modules/rls \
                          modules/rr \
+                         modules/rtpengine \
+                         modules/rtpproxy \
+                         modules/script_helper \
                          modules/seas \
-                         modules/tracer \
+                         modules/signaling \
+                         modules/sipcapture \
+                         modules/sip_i \
+                         modules/sipmsgops \
+                         modules/siprec \
                          modules/sl \
-                         modules/sms \
+                         modules/sngtc \
                          modules/snmpstats \
                          modules/speeddial \
+                         modules/sql_cacher \
                          modules/sst \
                          modules/statistics \
+                         modules/stun \
                          modules/textops \
-                         modules/tlsops \
+                         modules/tls_mgm \
                          modules/tm \
+                         modules/topology_hiding \
+                         modules/tracer \
                          modules/uac \
+                         modules/uac_auth \
                          modules/uac_redirect \
-                         modules/db_unixodbc \
-                         modules/uri \
-                         modules/uri_db \
-                         modules/uri_radius \
+                         modules/uac_registrant \
+                         modules/userblacklist \
                          modules/usrloc \
-                         modules/xlog \
+                         modules/xcap \
+                         modules/xcap_client \
+                         modules/xml \
                          modules/xmpp \
+			 net \
+			 net/proto_tcp \
+			 net/proto_udp \
                          parser \
                          parser/contact \
                          parser/digest \
-                         tls \
-                         utils
+                         parser/sdp \
+                         utils \
+			 utils/coverity \
+			 utils/db_berkeley \
+			 utils/db_oracle \
+			 utils/fifo_relay \
+			 utils/opensipsunix \
+			 utils/vim
 
 # This tag can be used to specify the character encoding of the source files that 
 # doxygen parses. Internally doxygen uses the UTF-8 encoding, which is also the default 
@@ -786,11 +895,12 @@ HTML_FOOTER            =
 
 HTML_STYLESHEET        = 
 
+### has become obsolete
 # If the HTML_ALIGN_MEMBERS tag is set to YES, the members of classes, 
 # files or namespaces will be aligned in HTML using tables. If set to 
 # NO a bullet list will be used.
 
-HTML_ALIGN_MEMBERS     = YES
+#HTML_ALIGN_MEMBERS     = YES
 
 # If the GENERATE_HTMLHELP tag is set to YES, additional index files 
 # will be generated that can be used as input for tools like the 
@@ -1026,17 +1136,19 @@ GENERATE_XML           = NO
 
 XML_OUTPUT             = xml
 
+### has become obsolete
 # The XML_SCHEMA tag can be used to specify an XML schema, 
 # which can be used by a validating XML parser to check the 
 # syntax of the XML files.
 
-XML_SCHEMA             = 
+#XML_SCHEMA             = 
 
+### has become obsolete
 # The XML_DTD tag can be used to specify an XML DTD, 
 # which can be used by a validating XML parser to check the 
 # syntax of the XML files.
 
-XML_DTD                = 
+#XML_DTD                = 
 
 # If the XML_PROGRAMLISTING tag is set to YES Doxygen will 
 # dump the program listings (including syntax highlighting 
@@ -1122,14 +1234,14 @@ SEARCH_INCLUDES        = YES
 # contain include files that are not input files but should be processed by 
 # the preprocessor.
 
-INCLUDE_PATH           = 
+INCLUDE_PATH           = /usr/include /usr/include/linux /usr/include/c++/9.1.0/tr1
 
 # You can use the INCLUDE_FILE_PATTERNS tag to specify one or more wildcard 
 # patterns (like *.h and *.hpp) to filter out the header-files in the 
 # directories. If left blank, the patterns specified with FILE_PATTERNS will 
 # be used.
 
-INCLUDE_FILE_PATTERNS  = 
+INCLUDE_FILE_PATTERNS  = *.h
 
 # The PREDEFINED tag can be used to specify one or more macro names that 
 # are defined before the preprocessor is started (similar to the -D option of 
@@ -1330,7 +1442,7 @@ DOTFILE_DIRS           =
 # MAX_DOT_GRAPH_NOTES then the graph will not be shown at all. Also note 
 # that the size of a graph can be further restricted by MAX_DOT_GRAPH_DEPTH.
 
-DOT_GRAPH_MAX_NODES    = 50
+DOT_GRAPH_MAX_NODES    = 80
 
 # The MAX_DOT_GRAPH_DEPTH tag can be used to set the maximum depth of the 
 # graphs generated by dot. A depth value of 3 means that only nodes reachable 

--- a/lib/json/opensips_json_c_helper.h
+++ b/lib/json/opensips_json_c_helper.h
@@ -44,8 +44,11 @@
 #endif
 
 /* json.h automatically includes json_c_version.h, if available. */
+#ifdef __amd64__
+#include <json-c/json.h>
+#else
 #include <json.h>
-
+#endif
 /*
  * We prefer JSON_C_VERSION_NUM defined in json_c_version.h.  If it is
  * not defined, we construct it the same way from our JSON_PKG_* defines.

--- a/mod_fix.h
+++ b/mod_fix.h
@@ -25,6 +25,7 @@
 #include <regex.h>
 #include "mem/mem.h"
 #include "pvar.h"
+#include "route_struct.h"
 
 #define GPARAM_TYPE_VAL		0
 #define GPARAM_TYPE_PVS		1

--- a/modules/osp/osp_mod.c
+++ b/modules/osp/osp_mod.c
@@ -176,7 +176,7 @@ static cmd_export_t cmds[]={
         {CMD_PARAM_STR,0,0}, {0,0,0}},
         REQUEST_ROUTE},
     {0,0,{{0,0,0}},0}
-}
+};
 
 static param_export_t params[]={
     { "enable_crypto_hardware_support",   INT_PARAM, &_osp_crypto_hw },

--- a/packaging/arch/Makefile.conf.template
+++ b/packaging/arch/Makefile.conf.template
@@ -1,0 +1,108 @@
+#aaa_radius= Radius implementation for the AAA API from the core | Radius client development library, tipically radiusclient-ng 0.5.0 or higher
+#b2b_logic= Logic engine of B2BUA, responsible of actually implementing the B2BUA services | xml parsing development library, typically libxml2-dev
+#cachedb_cassandra= Implementation of a cache system designed to work with Cassandra servers | thrift 0.6.1
+#cachedb_couchbase= Implementation of a cache system designed to work with CouchBase servers | libcouchbase >= 2.0
+#cachedb_memcached= Implementation of a cache system designed to work with a memcached server. | Memcached client library, tipically libmemcached
+#cachedb_mongodb= Implementation of a cache system designed to work with a MongoDB server. | libjson and the mongo-c-driver
+#cachedb_redis= Implementation of a cache system designed to work with Redis servers | Redis client library, hiredis
+#carrierroute= Provides routing, balancing and blacklisting capabilities. | libconfuse, a configuration file parser library
+#cgrates= Provides integration with the CGRateS billing/rating engine. | JSON library, libjson
+#compression= Implements SIP message compression/decompression and base64 encoding | zlib dev library, tipically zlib1g-dev
+#cpl_c= Implements a CPL (Call Processing Language) interpreter | library for parsing XML files, tipically libxml2 and libxml2-devel
+#db_berkeley= Integrates the Berkeley DB into OpenSIPS | Berkeley embedded database
+#db_http= Provides access to a database that is implemented as a HTTP server. | CURL library - libcurl
+#db_mysql= Provides MySQL connectivity for OpenSIPS | development libraries of mysql-client , tipically libmysqlclient-dev
+#db_oracle= Provides Oracle connectivity for OpenSIPS. | Development library of OCI, tipically instantclient-sdk-10.2.0.3
+#db_perlvdb= Provides a virtualization framework for OpenSIPS's database access. | Perl library development files, tipically libperl-dev
+#db_postgres= Provides Postgres connectivity for OpenSIPS | PostgreSQL library and development library - tipically libpq5 and libpq-dev
+#db_sqlite= Provides SQLite connectivity for OpenSIPS | SQLite library and development library - tipically libsqlite3 and libsqlite3-dev
+#db_unixodbc= Allows to use the unixodbc package with OpenSIPS | ODBC library and ODBC development library
+#dialplan= Implements generic string translations based on matching and replacement rules | PCRE development library, tipically libpcre-dev
+#emergency= Provides emergency call treatment for OpenSIPS | CURL dev library - tipically libcurl4-openssl-dev
+#event_rabbitmq= Provides the implementation of a RabbitMQ client for the Event Interface | RabbitMQ development library, librabbitmq-dev
+#h350= Enables access to SIP account data stored in an LDAP [RFC4510] directory containing H.350 commObjects | OpenLDAP library & development files, tipically libldap and libldap-dev
+#regex= Offers matching operations against regular expressions using the powerful PCRE library. | Development library for PCRE, tipically libpcre-dev
+#identity= Adds support for SIP Identity (see RFC 4474). | SSL library, tipically libssl
+#jabber= Integrates XODE XML parser for parsing Jabber messages | Expat library.
+#json= Introduces a new type of variable that provides both serialization and de-serialization from JSON format. | JSON library, libjson
+#ldap= Implements an LDAP search interface for OpenSIPS | OpenLDAP library & development files, tipically libldap and libldap-dev
+#lua= Easily implement your own OpenSIPS extensions in Lua | liblua5.1-0-dev, libmemcache-dev and libmysqlclient-dev
+#httpd= Provides an HTTP transport layer implementation for OpenSIPS. | libmicrohttpd
+#mi_xmlrpc_ng= New version of the xmlrpc server that handles xmlrpc requests and generates xmlrpc responses. | parsing/building XML library, tipically libxml
+#mmgeoip= Lightweight wrapper for the MaxMind GeoIP API | libGeoIP
+#osp= Enables OpenSIPS to support secure, multi-lateral peering using the OSP standard | OSP development kit, tipically osptoolkit
+#perl= Easily implement your own OpenSIPS extensions in Perl | Perl library development files, tipically libperl-dev
+#pi_http= Provides a simple web database provisioning interface | XML parsing & building library, tipically libxml-dev
+#rabbitmq= Provides functions to publish messages to a RabbitMQ server | RabbitMQ development library, librabbitmq-dev
+#proto_sctp= Provides support for SCTP listeners in OpenSIPS | SCTP development library, tipically libsctp-dev
+#proto_tls= Provides support for TLS listeners in OpenSIPS | SSL development library, tipically libssl-dev
+#proto_wss= Provides support for Secure WebSocket listeners in OpenSIPS | SSL development library, tipically libssl-dev
+#presence= Handles PUBLISH and SUBSCRIBE messages and generates NOTIFY messages in a general, event independent way | XML parsing & Building library, tipically libxml-dev
+#presence_dialoginfo= Enables the handling of "Event: dialog" (as defined in RFC 4235) |  XML parsing & building library, tipically libxml-dev
+#presence_mwi= Does specific handling for notify-subscribe message-summary (message waiting indication) events as specified in RFC 3842 | XML parsing & building library, tipically libxml-dev
+#presence_xml= Does specific handling for notify-subscribe events using xml bodies. | XML parsing & building library, tipically libxml-dev
+#pua= Offers the functionality of a presence user agent client, sending Subscribe and Publish messages. | XML parsing & building library, tipically libxml-dev
+#pua_bla= Enables Bridged Line Appearances support according | XML parsing & building library, tipically libxml-dev
+#pua_dialoginfo= Retrieves dialog state information from the dialog module and PUBLISHes the dialog-information using the pua module. | XML parsing & building library,tipically libxml-dev
+#pua_mi= Offers the possibility to publish presence information and subscribe to presence information via MI transports. | XML parsing & building library,tipically libxml-dev
+#pua_usrloc= Connector between usrloc and pua modules. | XML parsing & building library,tipically libxml-dev
+#pua_xmpp= Gateway for presence between SIP and XMPP. | XML parsing & building library,tipically libxml-dev
+#python= Easily implement your own OpenSIPS extensions in Python | Shared Python runtime library, libpython
+#rest_client= Simple HTTP client | CURL library - libcurl
+#rls= Resource List Server implementation following the specification in RFC 4662 and RFC 4826 | parsing/building XML library, tipically libxml-dev
+#sngtc= Voice Transcoding using the D-series Sangoma transcoding cards | libsngtc_node
+#siprec= SIP Call Recording to an external/passive recorder | uuid-dev
+#snmpstats= Provides an SNMP management interface to OpenSIPS | NetSNMP v5.3
+#tls_mgm= Provides a TLS interface to manage certificates for OpenSIPS | SSL development library, tipically libssl-dev
+#xcap= XCAP utility functions for OpenSIPS. | libxml-dev
+#xcap_client= XCAP client for OpenSIPS.It fetches XCAP elements, either documents or part of them, by sending HTTP GET requests | libxml-dev and libcurl-dev
+#xml= Introduces a new type of variable that provides both serialization and de-serialization from XML format. | XML library, libxml2-dev
+#xmpp= Gateway between OpenSIPS and a jabber server. It enables the exchange of IMs between SIP clients and XMPP(jabber) clients. | parsing/building XML files, tipically libexpat1-devel
+
+#exclude_modules?= aaa_radius b2b_logic cachedb_cassandra cachedb_couchbase cachedb_memcached cachedb_mongodb cachedb_redis carrierroute cgrates compression cpl_c db_berkeley db_http db_mysql db_oracle db_perlvdb db_postgres db_sqlite db_unixodbc dialplan emergency event_rabbitmq h350 httpd identity jabber json ldap lua mi_xmlrpc_ng mmgeoip osp perl pi_http presence presence_dialoginfo presence_mwi presence_xml proto_sctp proto_tls proto_wss pua pua_bla pua_dialoginfo pua_mi pua_usrloc pua_xmpp python regex rabbitmq rest_client rls siprec sngtc snmpstats tls_mgm xcap xcap_client xml xmpp
+###
+# Arch Linux specific
+###
+# Couchbase: needs to be build from aur
+# Oracle: not supported as open-source package
+# Sangoma: can't test Voice Transcoding with D-series Sangoma transcoding cards
+exclude_modules?= cachedb_couchbase db_oracle sngtc
+
+include_modules?=
+
+#DEFS_GROUP_START
+DEFS+= -DPKG_MALLOC #Uses a faster malloc
+#DEFS+= -DUSE_SHM_MEM #All PKG allocations are mapped to SHM
+#DEFS_GROUP_END
+DEFS+= -DSHM_MMAP #Use mmap instead of SYSV shared memory
+DEFS+= -DUSE_MCAST #Compile in support for IP Multicast
+DEFS+= -DDISABLE_NAGLE #Disabled the TCP NAgle Algorithm ( lower delay )
+DEFS+= -DSTATISTICS #Enables the statistics manager
+DEFS+= -DHAVE_RESOLV_RES #Support for changing some of the resolver parameters
+#DEFS_GROUP_START
+##DEFS+= -DVQ_MALLOC #Very quick & wasteful mem allocator (currently disabled)
+#DEFS+= -DQM_MALLOC #Quality assurance memory allocator with runtime safety checks
+DEFS+= -DF_MALLOC #Fast memory allocator with minimal runtime overhead
+#DEFS+= -DHP_MALLOC #High performance allocator with fine-grained locking
+#DEFS_GROUP_END
+#DEFS+= -DDBG_MALLOC #Enables debugging for memory allocators
+DEFS+= -DF_MALLOC_OPTIMIZATIONS #Remove all safety checks in F_MALLOC
+#DEFS+= -DNO_DEBUG #Turns off all debug messages
+#DEFS+= -DNO_LOG #Completely turns off all the logging
+#DEFS+= -DFAST_LOCK #Uses fast architecture specific locking
+DEFS+= -DUSE_FUTEX #Uses linux futexs with fast architecture specific locking
+#DEFS+= -DUSE_SYSV_SEM #Uses SYSV sems for locking ( slower & limited number of locks
+#DEFS+= -DUSE_PTHREAD_MUTEX #Uses pthread mutexes for locking
+#DEFS+= -DUSE_UMUTEX #Uses FreeBSD-specific low-level mutexes for locking
+#DEFS+= -DUSE_POSIX_SEM #Uses POSIX sems for locking
+#DEFS+= -DBUSY_WAIT #Uses busy waiting on the lock
+#DEFS+= -DDBG_LOCK #Attach debug info to all lock structures
+#DEFS+= -DDBG_STRUCT_HIST #Include support for struct history logging
+#DEFS+= -DDBG_TCPCON #Attach struct history info to all TCP connections
+#DEFS+= -DNOSMP #Do not use SMP sompliant locking. Faster but won't work on SMP machines
+#DEFS+= -DEXTRA_DEBUG #Compiles in some extra debugging code
+#DEFS+= -DORACLE_USRLOC #Uses Oracle compatible queries for USRLOC
+DEFS+= -DSHM_EXTRA_STATS #Provides tools to get extra statistics for the shared memory used
+DEFS+= -DUNIT_TESTS #Include unit testing code into opensips and modules
+
+PREFIX ?= /usr/

--- a/packaging/arch/PKGBUILD.git
+++ b/packaging/arch/PKGBUILD.git
@@ -1,0 +1,234 @@
+# vim:set ts=8 sw=8 et:
+# Maintainer: Ralf Zerres <ralf.zerres@networkx.de>
+
+pkgbase=opensips-git
+_pkgname=opensips
+_branch=master
+pkgname=('opensips-git' 'opensips-git-modules' 'opensips-git-documentation')
+pkgver=0.r13459.g2e6e3f9a6
+pkgrel=1
+pkgdesc="An Open Source SIP Server able to act as a SIP proxy, registrar, location server, redirect server ..."
+url="https://www.opensips.org"
+depends=('openssl' 'db' 'attr' 'libxml2')
+makedepends=(
+	'confuse' 'cassandra-cpp-driver'
+	'doxygen' 'docbook-sgml' 'docbook-utils'
+	'expat'
+	'hiredis'
+	'geoip'
+	'json-c'
+	'freeradius'
+	'libldap>=2.4.18' 'libmariadbclient' 'libmemcached' 'libmicrohttpd'
+	'librabbitmq-c' 'libtap-git' 'libuv' 'libxslt'
+	'lksctp-tools'
+	'lua51'
+	'lynx'
+	'mongo-c-driver'
+	'net-snmp'
+	'openssl' 
+	'osptoolkit'
+	'postgresql-libs>=8.4.1'
+	'radcli'
+	'thrift' 'unixodbc' 'xmlrpc-c' 'zlib')
+backup=("etc/opensips/opensips.cfg"
+	"etc/opensips/regex_groups.cfg"
+	"etc/opensips/osipsconsolerc"
+	"etc/opensips/opensipsctlrc")
+arch=('x86_64' 'armv7')
+license=('GPL')
+options=('!emptydirs' 'zipman' '!makeflags' 'docs')
+source=("${pkgname}::git+https://github.com/OpenSIPS/$_pkgname.git#branch=$_branch"
+	Makefile.conf.template)
+sha256sums=('SKIP'
+            '2eefae7d8d40259d9a0a4a6554574cf94418ea033d3a69936e928a52bcfcca63')
+
+prepare() {
+	cd "$srcdir"/${pkgbase}
+
+	if [ -h "$srcdir"/Makefile.conf.devel.template ]; then
+		msg2 "preset Makefile.conf template"
+		test ! -f Makefile.conf.devel.template.orig  &&
+		mv Makefile.conf.template Makefile.conf.template.orig
+		cp "$srcdir"/Makefile.conf.devel.template Makefile.conf.template
+	fi
+
+	# patching
+	if [ ! -f .makepkg-patched ]; then
+		echo "  -> patching: "
+		git am --signoff ../../patches-git/0000-packaging-support-arch-linux.patch
+		git am --signoff ../../patches-git/0001-osp-Fix-module-compilation.patch
+		git am --signoff ../../patches-git/0002-opensips_json_c_helper.h-fix-preprocessor-definition.patch
+		git am --signoff ../../patches-git/0003-Makefile.defs-adapt-default-settings-for-XSL-parser.patch
+		git am --signoff ../../patches-git/0004-doxygen-update-element-list.patch
+		echo "  -> patching [done]"
+		touch .makepkg-patched
+		#echo "  -> no patches for branch '${_branch}' needed"
+	fi
+
+	msg2 "ensure python2 usage"
+	for file in $(find . -name '*.py' -print); do
+		sed -i 's_^#!.*/usr/bin/python_#!/usr/bin/python2_' $file
+		sed -i 's_^#!.*/usr/bin/env.*python_#!/usr/bin/env python2_' $file
+	done
+
+	msg2 "ensure binaries live in /bin and /usr/bin"
+	sed -i 's|sbin|bin|g' Makefile
+	sed -i 's|bin-dir = sbin/|bin-dir = bin/|' Makefile.defs
+}
+
+pkgver() {
+	cd "${srcdir}/${pkgname}"
+	echo "0.r$(git rev-list --count $_branch).g$(git log -1 --format="%h")"
+}
+
+build() {
+	cd "$srcdir"/${pkgbase}
+
+	# create binary targets
+	#FASTER=1
+	#make -j$(nproc) \
+	make \
+		LIBDIR=lib PREFIX=/usr
+
+	# create documentation targets
+	make \
+		BASEDIR="$pkgdir" PREFIX=/usr LIBDIR=lib \
+		doxygen \
+		modules-docbook-html \
+		modules-readme
+		# dbschema-docbook-html
+		# dbschema-docbook-pdf \
+		# modules-docbook-pdf \
+}
+
+package_opensips-git() {
+	pkgdesc="OpenSIPS an open source SIP Server (git version)"
+
+	depends=(
+		'confuse' 'geoip' 'json-c'
+		'libtap-git' 'libuv' 'libxslt'
+		'lksctp-tools')
+	optdepends=(
+		'cassandra-cpp-driver: cassandra C++ support'
+		'curl: curl support'
+		'confuse: confuse support'
+		'lksctp-tools: sctp support'
+		'lynx: text browser support'
+		'hiredis: HiRedis support'
+		'libldap: LDAP support'
+		'libmariadbclient: Maria DB support'
+		'libmaxminddb: MaxMin DB support'
+		'libmemcached: Memory caching support'
+		'libmicrohttpd: Inline HTTPD support'
+		'librabbitmq-c: Rabbitmq C support'
+		'libsasl: SASL authentication support'
+		'libutf8proc: UTF8 processing support'
+		'lua: LUA scripting support'
+		'mariadb-libs: Maria-DB support'
+		'mongo-c-driver: C-Interface for Mongo-DB support'
+		'net-snmp: SNMP support'
+		'osptoolkit: OSP Toolkit support'
+		'pcre: Perl Regular-Expression support'
+		'perl: Perl support'
+		'postgresql-libs: PostgreSQL-DB support'
+		'python2: Python v2 support'
+		'radcli: RAD commandline support'
+		'rabbitmq: Rabbit CacheMemory support'
+		'thrift: Thrift support'
+		'unixodbc: UNIX ODBC support')
+	checkdepends=('expat' 'libtap-git')
+	install=opensips.install
+
+	provides=("opensips=${pkgver}")
+	conflicts=('opensips')
+
+	_components=('opensips')
+
+	cd "$srcdir"/${pkgbase}
+
+	# install app only, excluding console, modules and modules docs
+	for _cmp in ${_components[@]}; do
+		make \
+		      BASEDIR="$pkgdir" PREFIX=/usr LIBDIR=lib install-app
+
+		# Conforms to the arch packaging standards (https://wiki.archlinux.org/index.php/Arch_Packaging_Standards)
+		mkdir -p "$pkgdir"/etc/
+		mv "$pkgdir"/usr/etc/opensips/ "$pkgdir"/etc/
+		sed -i 's#mpath=".*lib/opensips/modules/"#mpath="/usr/lib/opensips/modules/"#' "$pkgdir"/etc/opensips/opensips.cfg
+
+		# fix bad paths
+		cd "$pkgdir"/usr/share
+		find -type f -exec sed -i "s#"$pkgdir"##" {} \;
+
+		mv "$pkgdir"/usr/sbin "$pkgdir"/usr/bin
+
+		cd "$pkgdir"/etc
+		find -type f -exec sed -i "s#"$pkgdir"##" {} \;
+
+		# python2 is being used
+		cd "$pkgdir"
+		grep -lR '#!.*python' * | while read file; do sed -s 's/\(#!.*python\)/\12/g' -i "$file"; done
+
+		# Systemd files
+		install -Dm0644 "${srcdir}/${pkgbase}/packaging/arch/${_pkgname}.service" "$pkgdir"/usr/lib/systemd/system/${_pkgname}.service
+		install -Dm0644 "${srcdir}/${pkgbase}/packaging/arch/${_pkgname}.tmpfiles.conf" "$pkgdir"/usr/lib/tmpfiles.d/${_pkgname}.conf
+
+	done
+}
+
+package_opensips-git-modules() {
+	pkgdesc="OpenSIPS modules (git version)"
+	depends=('opensips-git')
+	provides=("opensips-modules=${pkgver}")
+	conflicts=('opensips-modules')
+
+	cd "$srcdir"/${pkgbase}
+
+	make \
+		BASEDIR="$pkgdir" PREFIX=/usr LIBDIR=lib install-modules
+
+	msg2 "ensure binaries live in /bin and /usr/bin"
+	mv "$pkgdir"/usr/sbin "$pkgdir"/usr/bin
+
+}
+
+package_opensips-git-documentation() {
+	pkgdesc="OpenSIPS modules (git version)"
+	suggests=('opensips-git')
+	provides=("opensips-documentation=${pkgver}")
+	conflicts=('opensips-documentation')
+
+  	cd "$srcdir"/${pkgbase}
+
+	msg2 "install documentation targets"
+	make \
+		BASEDIR="$pkgdir" PREFIX=/usr LIBDIR=lib install-doc install-modules-docbook
+
+	DOC_DIR="$pkgdir/usr/share/doc/${_pkgname}"
+
+	msg2 "install README documentation"
+	if [ ! -d "$DOC_DIR/txt" ]; then
+		mkdir -p "$DOC_DIR/txt"
+		chmod 0755 "$DOC_DIR/txt"
+	fi
+	mv $DOC_DIR/README.* "$DOC_DIR/txt"
+	chmod --recursive 0644 "$DOC_DIR/txt"
+
+	msg2 "install doxygen documentation"
+	if [ ! -d "$DOC_DIR/doxygen" ]; then
+		mkdir -p "$DOC_DIR/doxygen"
+		chmod 0755 "$DOC_DIR/doxygen"
+	fi
+	find $pkgdir/usr/share/doc/${_pkgname}/html  -print0 | xargs -0 -I '{}' cp -r '{}' "$DOC_DIR/doxygen/"
+	chmod --recursive 0644 "$DOC_DIR/doxygen"
+
+	msg2 "install example configurations"
+	if [ ! -d $DOC_DIR/examples ]; then
+		mkdir -p "$DOC_DIR/examples"
+		chmod 0755 "$DOC_DIR/examples"
+	fi
+	if [ -d ./examples ]; then
+		mv ./examples "$DOC_DIR"
+		chmod --recursive 0644 "$DOC_DIR/examples"
+	fi
+}

--- a/packaging/arch/opensips.install
+++ b/packaging/arch/opensips.install
@@ -1,0 +1,20 @@
+post_install() {
+	echo "OpenSIPS suite is build as a modular system."
+	echo "This packages "opensips" just includes the core functionality and the parser."
+	echo "All sophisticated SIP packet handling is provided through dedicated modules and usage will vary,"
+	echo "Please install "opensips-modules" and adapt the configuration to your individual needs."
+	echo "The documentation is provided via the "opensips-documentation" package in different formats."
+	echo "Beside html-, and text files you will find example configurations explaining the integration of available modules." 
+	echo ""
+	echo "You are encouraged to make use of a database module."
+	echo "Thus you needed to install the relevant database package in combination with the corresponding"
+	echo "opensips module package:
+	echo "1) 'pacman -S opensips-modules'"
+	echo "2) To create the opensips specific tables make use of 'opensipsdbctl create'"
+	echo "   eg for MySQL:      'pacman -S mariadb mariadb-clients' -> 'opensipsdbctl create'"
+	echo "   eg for PostgreSQL: 'pacman -S postgresql postgresql-client' -> 'opensipsdbctl create'"
+
+	useradd --system --group \
+		--shell /bin/false --comment "OpenSIPS" \
+		--home-dir $HOMEDIR --no-create-home opensips || true
+}

--- a/packaging/arch/opensips.service
+++ b/packaging/arch/opensips.service
@@ -1,0 +1,23 @@
+[Unit]
+Description=OpenSIPS is a very fast and flexible SIP (RFC3261) server
+Documentation=man:opensips
+After=network.target mysqld.service postgresql.service rtpproxy.service
+
+[Service]
+Type=forking
+User=opensips
+Group=opensips
+RuntimeDirectory=opensips
+RuntimeDirectoryMode=775
+Environment=P_MEMORY=32 S_MEMORY=32
+EnvironmentFile=-/etc/sysconfig/opensips
+PermissionsStartOnly=yes
+PIDFile=%t/opensips/opensips.pid
+ExecStart=/usr/sbin/opensips -P %t/opensips/opensips.pid -f /etc/opensips/opensips.cfg -m $S_MEMORY -M $P_MEMORY $OPTIONS
+ExecStop=/usr/bin/pkill --pidfile %t/opensips/opensips.pid
+Restart=always
+TimeoutStopSec=30s
+LimitNOFILE=262144
+
+[Install]
+WantedBy=multi-user.target

--- a/packaging/arch/opensips.tmpfiles.conf
+++ b/packaging/arch/opensips.tmpfiles.conf
@@ -1,0 +1,1 @@
+d /var/run/opensips 0755 opensips opensips


### PR DESCRIPTION
With this patch series the OpenSIPS codebase can be compiled on Arch Linux.

The code will create shared libraries for all supported modules. I couln't test the modules "db_oracle", "cachedb_couchbase" and "sngtc" (lagging the needed sources, hardware is missing).
If needed, I did created the arch-specific dependency packages. If accepted, this stuff should go to AUR or to the contrib repro.

## packaging ##

a new subfolder with arch-linux specific packaging files is included. All files need to be copied to your build-root directory.
PKGBUILD.git is the shell script containing the build information required for OpenSIPS Arch Linux packages.
The build process is initiated when calling "makepkg -m -p PKGBUILD.git

## bugfix osp-module compilation ##

just a typo correction and inclusion of missing header (route_struct.h)


## json-c (v0.13.1) ##

if compiling with json-c support, the provided headers are located in a subdir <json-c/...> (tested on arch shipped versions).
this patch incorporates a preprocessor fix for opensips_json_c_helper.h

## doxygen support ##

the patch does update the include entities for given modules (orderd lexically ascending). Using the shipped doxygen (v1.8.15) from arch-linux will produce the html files, including the graphs if support for "dot"-binary is enabled (install-modules-docbook). The parser will spit out quite a huge amount of warning, since the source code is missing e.g. variable definitions for the documentation. This can be improved.
For Arch-Linux, I did adapt the Makefile.defs to assign needed XSLT definitions.

greetings from Köln
Ralf