### PR TITLE
Schema extension: registrant.xml

### DIFF
--- a/db/schema/registrant.xml
+++ b/db/schema/registrant.xml
@@ -44,6 +44,14 @@
 		<description>URI pointing to the outbond proxy.</description>
 	</column>
 
+	<column id="registrar_mode">
+		<name>registrar_mode</name>
+		<type>string</type>
+		<size>64</size>
+		<default/>
+		<description>Mode used to register the address of record.</description>
+	</column>
+
 	<column id="aor">
 		<name>aor</name>
 		<type>string</type>

--- a/scripts/db_berkeley/opensips/registrant
+++ b/scripts/db_berkeley/opensips/registrant
@@ -1,5 +1,5 @@
 METADATA_COLUMNS
-id(int) registrar(str) proxy(str) aor(str) third_party_registrant(str) username(str) password(str) binding_URI(str) binding_params(str) expiry(int) forced_socket(str) cluster_shtag(str)
+id(int) registrar(str) proxy(str) registrar_mode(str) aor(str) third_party_registrant(str) username(str) password(str) binding_URI(str) binding_params(str) expiry(int) forced_socket(str) cluster_shtag(str)
 METADATA_KEY
 
 METADATA_READONLY
@@ -7,4 +7,4 @@ METADATA_READONLY
 METADATA_LOGFLAGS
 0
 METADATA_DEFAULTS
-NIL|''|NULL|''|NULL|NULL|NULL|''|NULL|NULL|NULL|NULL
+NIL|''|NULL|''|''|NULL|NULL|NULL|''|NULL|NULL|NULL|NULL

--- a/scripts/dbtext/opensips/registrant
+++ b/scripts/dbtext/opensips/registrant
@@ -1,1 +1,1 @@
-id(int,auto) registrar(string) proxy(string,null) aor(string) third_party_registrant(string,null) username(string,null) password(string,null) binding_URI(string) binding_params(string,null) expiry(int,null) forced_socket(string,null) cluster_shtag(string,null) 
+id(int,auto) registrar(string) proxy(string,null) registrar_mode(string) aor(string) third_party_registrant(string,null) username(string,null) password(string,null) binding_URI(string) binding_params(string,null) expiry(int,null) forced_socket(string,null) cluster_shtag(string,null) 

--- a/scripts/mysql/registrant-create.sql
+++ b/scripts/mysql/registrant-create.sql
@@ -3,6 +3,7 @@ CREATE TABLE registrant (
     id INT(10) UNSIGNED AUTO_INCREMENT PRIMARY KEY NOT NULL,
     registrar CHAR(255) DEFAULT '' NOT NULL,
     proxy CHAR(255) DEFAULT NULL,
+    registrar_mode CHAR(64) DEFAULT '' NOT NULL,
     aor CHAR(255) DEFAULT '' NOT NULL,
     third_party_registrant CHAR(255) DEFAULT NULL,
     username CHAR(64) DEFAULT NULL,

--- a/scripts/oracle/registrant-create.sql
+++ b/scripts/oracle/registrant-create.sql
@@ -3,6 +3,7 @@ CREATE TABLE registrant (
     id NUMBER(10) PRIMARY KEY,
     registrar VARCHAR2(255) DEFAULT '',
     proxy VARCHAR2(255) DEFAULT NULL,
+    registrar_mode VARCHAR2(64) DEFAULT '',
     aor VARCHAR2(255) DEFAULT '',
     third_party_registrant VARCHAR2(255) DEFAULT NULL,
     username VARCHAR2(64) DEFAULT NULL,

--- a/scripts/pi_http/pi_framework.xml
+++ b/scripts/pi_http/pi_framework.xml
@@ -107,6 +107,64 @@
 		<column><field>value</field><type>DB_STR</type></column>
 		<column><field>last_modified</field><type>DB_DATETIME</type></column>
 	</db_table>
+	<!-- Declaration of b2b_sca table-->
+	<db_table id="b2b_sca">
+		<table_name>b2b_sca</table_name>
+		<db_url_id>mysql</db_url_id>
+		<column><field>id</field><type>DB_INT</type></column>
+		<column><field>shared_line</field><type>DB_STR</type></column>
+		<column><field>watchers</field><type>DB_STR</type></column>
+		<column><field>app1_shared_entity</field><type>DB_INT</type></column>
+		<column><field>app1_call_state</field><type>DB_INT</type></column>
+		<column><field>app1_call_info_uri</field><type>DB_STR</type></column>
+		<column><field>app1_call_info_appearance_uri</field><type>DB_STR</type></column>
+		<column><field>app1_b2bl_key</field><type>DB_STR</type></column>
+		<column><field>app2_shared_entity</field><type>DB_INT</type></column>
+		<column><field>app2_call_state</field><type>DB_INT</type></column>
+		<column><field>app2_call_info_uri</field><type>DB_STR</type></column>
+		<column><field>app2_call_info_appearance_uri</field><type>DB_STR</type></column>
+		<column><field>app2_b2bl_key</field><type>DB_STR</type></column>
+		<column><field>app3_shared_entity</field><type>DB_INT</type></column>
+		<column><field>app3_call_state</field><type>DB_INT</type></column>
+		<column><field>app3_call_info_uri</field><type>DB_STR</type></column>
+		<column><field>app3_call_info_appearance_uri</field><type>DB_STR</type></column>
+		<column><field>app3_b2bl_key</field><type>DB_STR</type></column>
+		<column><field>app4_shared_entity</field><type>DB_INT</type></column>
+		<column><field>app4_call_state</field><type>DB_INT</type></column>
+		<column><field>app4_call_info_uri</field><type>DB_STR</type></column>
+		<column><field>app4_call_info_appearance_uri</field><type>DB_STR</type></column>
+		<column><field>app4_b2bl_key</field><type>DB_STR</type></column>
+		<column><field>app5_shared_entity</field><type>DB_INT</type></column>
+		<column><field>app5_call_state</field><type>DB_INT</type></column>
+		<column><field>app5_call_info_uri</field><type>DB_STR</type></column>
+		<column><field>app5_call_info_appearance_uri</field><type>DB_STR</type></column>
+		<column><field>app5_b2bl_key</field><type>DB_STR</type></column>
+		<column><field>app6_shared_entity</field><type>DB_INT</type></column>
+		<column><field>app6_call_state</field><type>DB_INT</type></column>
+		<column><field>app6_call_info_uri</field><type>DB_STR</type></column>
+		<column><field>app6_call_info_appearance_uri</field><type>DB_STR</type></column>
+		<column><field>app6_b2bl_key</field><type>DB_STR</type></column>
+		<column><field>app7_shared_entity</field><type>DB_INT</type></column>
+		<column><field>app7_call_state</field><type>DB_INT</type></column>
+		<column><field>app7_call_info_uri</field><type>DB_STR</type></column>
+		<column><field>app7_call_info_appearance_uri</field><type>DB_STR</type></column>
+		<column><field>app7_b2bl_key</field><type>DB_STR</type></column>
+		<column><field>app8_shared_entity</field><type>DB_INT</type></column>
+		<column><field>app8_call_state</field><type>DB_INT</type></column>
+		<column><field>app8_call_info_uri</field><type>DB_STR</type></column>
+		<column><field>app8_call_info_appearance_uri</field><type>DB_STR</type></column>
+		<column><field>app8_b2bl_key</field><type>DB_STR</type></column>
+		<column><field>app9_shared_entity</field><type>DB_INT</type></column>
+		<column><field>app9_call_state</field><type>DB_INT</type></column>
+		<column><field>app9_call_info_uri</field><type>DB_STR</type></column>
+		<column><field>app9_call_info_appearance_uri</field><type>DB_STR</type></column>
+		<column><field>app9_b2bl_key</field><type>DB_STR</type></column>
+		<column><field>app10_shared_entity</field><type>DB_INT</type></column>
+		<column><field>app10_call_state</field><type>DB_INT</type></column>
+		<column><field>app10_call_info_uri</field><type>DB_STR</type></column>
+		<column><field>app10_call_info_appearance_uri</field><type>DB_STR</type></column>
+		<column><field>app10_b2bl_key</field><type>DB_STR</type></column>
+	</db_table>
 	<!-- Declaration of b2b_entities table-->
 	<db_table id="b2b_entities">
 		<table_name>b2b_entities</table_name>
@@ -170,64 +228,6 @@
 		<column><field>e3_from</field><type>DB_STR</type></column>
 		<column><field>e3_to</field><type>DB_STR</type></column>
 		<column><field>e3_key</field><type>DB_STR</type></column>
-	</db_table>
-	<!-- Declaration of b2b_sca table-->
-	<db_table id="b2b_sca">
-		<table_name>b2b_sca</table_name>
-		<db_url_id>mysql</db_url_id>
-		<column><field>id</field><type>DB_INT</type></column>
-		<column><field>shared_line</field><type>DB_STR</type></column>
-		<column><field>watchers</field><type>DB_STR</type></column>
-		<column><field>app1_shared_entity</field><type>DB_INT</type></column>
-		<column><field>app1_call_state</field><type>DB_INT</type></column>
-		<column><field>app1_call_info_uri</field><type>DB_STR</type></column>
-		<column><field>app1_call_info_appearance_uri</field><type>DB_STR</type></column>
-		<column><field>app1_b2bl_key</field><type>DB_STR</type></column>
-		<column><field>app2_shared_entity</field><type>DB_INT</type></column>
-		<column><field>app2_call_state</field><type>DB_INT</type></column>
-		<column><field>app2_call_info_uri</field><type>DB_STR</type></column>
-		<column><field>app2_call_info_appearance_uri</field><type>DB_STR</type></column>
-		<column><field>app2_b2bl_key</field><type>DB_STR</type></column>
-		<column><field>app3_shared_entity</field><type>DB_INT</type></column>
-		<column><field>app3_call_state</field><type>DB_INT</type></column>
-		<column><field>app3_call_info_uri</field><type>DB_STR</type></column>
-		<column><field>app3_call_info_appearance_uri</field><type>DB_STR</type></column>
-		<column><field>app3_b2bl_key</field><type>DB_STR</type></column>
-		<column><field>app4_shared_entity</field><type>DB_INT</type></column>
-		<column><field>app4_call_state</field><type>DB_INT</type></column>
-		<column><field>app4_call_info_uri</field><type>DB_STR</type></column>
-		<column><field>app4_call_info_appearance_uri</field><type>DB_STR</type></column>
-		<column><field>app4_b2bl_key</field><type>DB_STR</type></column>
-		<column><field>app5_shared_entity</field><type>DB_INT</type></column>
-		<column><field>app5_call_state</field><type>DB_INT</type></column>
-		<column><field>app5_call_info_uri</field><type>DB_STR</type></column>
-		<column><field>app5_call_info_appearance_uri</field><type>DB_STR</type></column>
-		<column><field>app5_b2bl_key</field><type>DB_STR</type></column>
-		<column><field>app6_shared_entity</field><type>DB_INT</type></column>
-		<column><field>app6_call_state</field><type>DB_INT</type></column>
-		<column><field>app6_call_info_uri</field><type>DB_STR</type></column>
-		<column><field>app6_call_info_appearance_uri</field><type>DB_STR</type></column>
-		<column><field>app6_b2bl_key</field><type>DB_STR</type></column>
-		<column><field>app7_shared_entity</field><type>DB_INT</type></column>
-		<column><field>app7_call_state</field><type>DB_INT</type></column>
-		<column><field>app7_call_info_uri</field><type>DB_STR</type></column>
-		<column><field>app7_call_info_appearance_uri</field><type>DB_STR</type></column>
-		<column><field>app7_b2bl_key</field><type>DB_STR</type></column>
-		<column><field>app8_shared_entity</field><type>DB_INT</type></column>
-		<column><field>app8_call_state</field><type>DB_INT</type></column>
-		<column><field>app8_call_info_uri</field><type>DB_STR</type></column>
-		<column><field>app8_call_info_appearance_uri</field><type>DB_STR</type></column>
-		<column><field>app8_b2bl_key</field><type>DB_STR</type></column>
-		<column><field>app9_shared_entity</field><type>DB_INT</type></column>
-		<column><field>app9_call_state</field><type>DB_INT</type></column>
-		<column><field>app9_call_info_uri</field><type>DB_STR</type></column>
-		<column><field>app9_call_info_appearance_uri</field><type>DB_STR</type></column>
-		<column><field>app9_b2bl_key</field><type>DB_STR</type></column>
-		<column><field>app10_shared_entity</field><type>DB_INT</type></column>
-		<column><field>app10_call_state</field><type>DB_INT</type></column>
-		<column><field>app10_call_info_uri</field><type>DB_STR</type></column>
-		<column><field>app10_call_info_appearance_uri</field><type>DB_STR</type></column>
-		<column><field>app10_b2bl_key</field><type>DB_STR</type></column>
 	</db_table>
 	<!-- Declaration of cachedb table-->
 	<db_table id="cachedb">
@@ -433,15 +433,6 @@
 		<column><field>attrs</field><type>DB_STR</type></column>
 		<column><field>description</field><type>DB_STR</type></column>
 	</db_table>
-	<!-- Declaration of domain table-->
-	<db_table id="domain">
-		<table_name>domain</table_name>
-		<db_url_id>mysql</db_url_id>
-		<column><field>id</field><type>DB_INT</type></column>
-		<column><field>domain</field><type>DB_STR</type></column>
-		<column><field>attrs</field><type>DB_STR</type></column>
-		<column><field>last_modified</field><type>DB_DATETIME</type></column>
-	</db_table>
 	<!-- Declaration of domainpolicy table-->
 	<db_table id="domainpolicy">
 		<table_name>domainpolicy</table_name>
@@ -452,6 +443,15 @@
 		<column><field>att</field><type>DB_STR</type></column>
 		<column><field>val</field><type>DB_STR</type></column>
 		<column><field>description</field><type>DB_STR</type></column>
+	</db_table>
+	<!-- Declaration of domain table-->
+	<db_table id="domain">
+		<table_name>domain</table_name>
+		<db_url_id>mysql</db_url_id>
+		<column><field>id</field><type>DB_INT</type></column>
+		<column><field>domain</field><type>DB_STR</type></column>
+		<column><field>attrs</field><type>DB_STR</type></column>
+		<column><field>last_modified</field><type>DB_DATETIME</type></column>
 	</db_table>
 	<!-- Declaration of dr_gateways table-->
 	<db_table id="dr_gateways">
@@ -773,6 +773,7 @@
 		<column><field>id</field><type>DB_INT</type></column>
 		<column><field>registrar</field><type>DB_STR</type></column>
 		<column><field>proxy</field><type>DB_STR</type></column>
+		<column><field>registrar_mode</field><type>DB_STR</type></column>
 		<column><field>aor</field><type>DB_STR</type></column>
 		<column><field>third_party_registrant</field><type>DB_STR</type></column>
 		<column><field>username</field><type>DB_STR</type></column>
@@ -3882,6 +3883,7 @@
 				<col><field>id</field><link_cmd>update</link_cmd></col>
 				<col><field>registrar</field></col>
 				<col><field>proxy</field></col>
+				<col><field>registrar_mode</field></col>
 				<col><field>aor</field></col>
 				<col><field>third_party_registrant</field></col>
 				<col><field>username</field></col>
@@ -3899,6 +3901,7 @@
 			<query_cols>
 				<col><field>registrar</field></col>
 				<col><field>proxy</field></col>
+				<col><field>registrar_mode</field></col>
 				<col><field>aor</field></col>
 				<col><field>third_party_registrant</field></col>
 				<col><field>username</field></col>
@@ -3919,6 +3922,7 @@
 			<query_cols>
 				<col><field>registrar</field></col>
 				<col><field>proxy</field></col>
+				<col><field>registrar_mode</field></col>
 				<col><field>aor</field></col>
 				<col><field>third_party_registrant</field></col>
 				<col><field>username</field></col>

--- a/scripts/pi_http/registrant-mod
+++ b/scripts/pi_http/registrant-mod
@@ -7,6 +7,7 @@
 				<col><field>id</field><link_cmd>update</link_cmd></col>
 				<col><field>registrar</field></col>
 				<col><field>proxy</field></col>
+				<col><field>registrar_mode</field></col>
 				<col><field>aor</field></col>
 				<col><field>third_party_registrant</field></col>
 				<col><field>username</field></col>
@@ -24,6 +25,7 @@
 			<query_cols>
 				<col><field>registrar</field></col>
 				<col><field>proxy</field></col>
+				<col><field>registrar_mode</field></col>
 				<col><field>aor</field></col>
 				<col><field>third_party_registrant</field></col>
 				<col><field>username</field></col>
@@ -44,6 +46,7 @@
 			<query_cols>
 				<col><field>registrar</field></col>
 				<col><field>proxy</field></col>
+				<col><field>registrar_mode</field></col>
 				<col><field>aor</field></col>
 				<col><field>third_party_registrant</field></col>
 				<col><field>username</field></col>

--- a/scripts/pi_http/registrant-table
+++ b/scripts/pi_http/registrant-table
@@ -5,6 +5,7 @@
 		<column><field>id</field><type>DB_INT</type></column>
 		<column><field>registrar</field><type>DB_STR</type></column>
 		<column><field>proxy</field><type>DB_STR</type></column>
+		<column><field>registrar_mode</field><type>DB_STR</type></column>
 		<column><field>aor</field><type>DB_STR</type></column>
 		<column><field>third_party_registrant</field><type>DB_STR</type></column>
 		<column><field>username</field><type>DB_STR</type></column>

--- a/scripts/postgres/registrant-create.sql
+++ b/scripts/postgres/registrant-create.sql
@@ -3,6 +3,7 @@ CREATE TABLE registrant (
     id SERIAL PRIMARY KEY NOT NULL,
     registrar VARCHAR(255) DEFAULT '' NOT NULL,
     proxy VARCHAR(255) DEFAULT NULL,
+    registrar_mode VARCHAR(64) DEFAULT '' NOT NULL,
     aor VARCHAR(255) DEFAULT '' NOT NULL,
     third_party_registrant VARCHAR(255) DEFAULT NULL,
     username VARCHAR(64) DEFAULT NULL,

--- a/scripts/sqlite/registrant-create.sql
+++ b/scripts/sqlite/registrant-create.sql
@@ -3,6 +3,7 @@ CREATE TABLE registrant (
     id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
     registrar CHAR(255) DEFAULT '' NOT NULL,
     proxy CHAR(255) DEFAULT NULL,
+    registrar_mode CHAR(64) DEFAULT '' NOT NULL,
     aor CHAR(255) DEFAULT '' NOT NULL,
     third_party_registrant CHAR(255) DEFAULT NULL,
     username CHAR(64) DEFAULT NULL,


### PR DESCRIPTION
## current status ##
In the given implementation of opensips will handle the syntax
for the aor URI hardcoded to RFC3261 (Registration Mode: sip:<PSTN>@<registar>:<port>

## Updated status ##
This patch will append the schema to introduce a new field `registartion_mode`.
This field holds a valid registration type per row.