### PR TITLE
Do not simply link the buffered lumps, but better clone them -> this …

### DIFF
--- a/modules/rr/record.c
+++ b/modules/rr/record.c
@@ -427,10 +427,7 @@ int record_route_preset(struct sip_msg* _m, str* _data)
 		&& ap->before->u.cond==COND_FALSE) {
 			/* found our phony anchor lump */
 			/* jump over the anchor and conditional lumps */
-			lp = ap->before->before;
-			/* unlink it */
-			ap->before->before = NULL;
-			ap->type = 0;
+			lp = dup_lump_list(ap->before->before);
 			/* link the pending buffered params and go at the end of the list*/
 			for ( l2->before = lp ; l2 && l2->before ; l2=l2->before);
 			break;


### PR DESCRIPTION
…will avoid a mixage of lump types (shm versus pkg) when using async()

This fix is already present for record_route function and missed to add for record_route_preset function. Getting the crash when i tested with 2.4.6 for record_route_preset. This fix is tested and it is working fine. 

Reference : https://github.com/OpenSIPS/opensips/issues/1683 