### PR TITLE
Only report status if in forking daemon mode

### DIFF
--- a/net/net_tcp.c
+++ b/net/net_tcp.c
@@ -2071,7 +2071,7 @@ int tcp_start_processes(int *chd_rank, int *startup_done)
 				*startup_done = 1;
 			}
 
-			report_conditional_status( 1, 0);
+			report_conditional_status( (!no_daemon_mode), 0);
 
 			tcp_worker_proc_loop();
 		}

--- a/timer.c
+++ b/timer.c
@@ -812,7 +812,7 @@ int start_timer_extra_processes(int *chd_rank)
 					goto error;
 				}
 
-				report_conditional_status( 1, 0);
+				report_conditional_status( (!no_daemon_mode), 0);
 
 				/* launch the reactor */
 				reactor_main_loop( 1/*timeout in sec*/, error , );


### PR DESCRIPTION
I've been experimenting running opensips with the -F option under systemd.

Everything seemed to run fine, but some errors where being logged on startup ("failed to send 0 status code"). This fixes the errors.

My testing has been under 2.4.x. I know that 3.x changed a bunch of stuff with auto-scaling, but I think this still applies.