### PR TITLE
redhat_fedora: specify cfg_target when installing

### DIFF
--- a/packaging/redhat_fedora/opensips.spec
+++ b/packaging/redhat_fedora/opensips.spec
@@ -778,6 +778,7 @@ rm -rf $RPM_BUILD_ROOT
   exclude_modules="%EXCLUDE_MODULES" \
   basedir=%{buildroot} prefix=%{_prefix} \
   cfg_prefix=%{buildroot} \
+  cfg_target=%{_sysconfdir}/opensips/ \
   modules_prefix=%{buildroot}/%{_prefix} \
   modules_dir=%{_lib}/%{name}/modules \
   DBTEXTON=yes # fixed dbtext documentation installation


### PR DESCRIPTION
When installing osipsconsole, we need to know the `cfg_target` to be
able to retrieve it later, otherwise it will default to
`/usr/etc/opensips.cfg`, which is broken.

This addresses #1676