### PR TITLE
Fix 2 compilation warnings.

### DIFF
--- a/cfg.y
+++ b/cfg.y
@@ -123,6 +123,8 @@
  with no built in alloca, like icc*/
 #undef _ALLOCA_H
 
+#undef MIN
+#undef MAX
 
 extern int yylex();
 static void yyerror(char* s);

--- a/cfg_pp.c
+++ b/cfg_pp.c
@@ -20,6 +20,8 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301,USA
  */
 
+#define _WITH_GETLINE
+
 #include <stdlib.h>
 #include <stdio.h>
 #include <fcntl.h>


### PR DESCRIPTION
[sobomax@van01 ~/projects/opensips]$ gmake CC=clang
Generating parser
yacc: 2 shift/reduce conflicts.
Generating lexer
Compiling cfg_pp.c
cfg_pp.c:325:14: warning: implicit declaration of function 'getline' is invalid in C99 [-Wimplicit-function-declaration]
                line_len = getline(&line, (size_t*)&line_buf_sz, cfg);
                           ^
1 warning generated.
New git revision: 8e391c2f8
Compiling main.c
Compiling lex.yy.c
Compiling cfg.tab.c
cfg.tab.c:437:9: warning: 'MAX' macro redefined [-Wmacro-redefined]
#define MAX 482
        ^
/usr/include/sys/param.h:304:9: note: previous definition is here
#define MAX(a,b) (((a)>(b))?(a):(b))
        ^
cfg.tab.c:438:9: warning: 'MIN' macro redefined [-Wmacro-redefined]
#define MIN 483
        ^
/usr/include/sys/param.h:303:9: note: previous definition is here
#define MIN(a,b) (((a)<(b))?(a):(b))
        ^
2 warnings generated.
Linking opensips
