### PR TITLE
matching_mode honored in cachedbs

### DIFF
--- a/modules/usrloc/urecord.c
+++ b/modules/usrloc/urecord.c
@@ -503,40 +503,40 @@ int cdb_add_ct_update(cdb_dict_t *updates, const ucontact_t *ct, char remove)
 	cdb_key_init(&contacts_key, "contacts");
 	
 	switch (matching_mode) {
-                case CONTACT_ONLY:
-                        len = ct->c.len  ;
-                        base64len = calc_base64_encode_len(len);
-                        if (pkg_str_extend(&ctkey_pkg_buf, len) < 0) {
-                                LM_ERR("oom\n");
-                                return -1;
-                        }
+	case CONTACT_ONLY:
+		len = ct->c.len  ;
+		base64len = calc_base64_encode_len(len);
+		if (pkg_str_extend(&ctkey_pkg_buf, len) < 0) {
+			LM_ERR("oom\n");
+			return -1;
+		}
 
-                        if (pkg_str_extend(&ctkeyb64_pkg_buf, base64len) < 0) {
-                                LM_ERR("oom\n");
-                                return -1;
-                        }
-                        memcpy(ctkey_pkg_buf.s, ct->c.s, ct->c.len);
-                        break;
-                case CONTACT_CALLID:
-                        len = ct->c.len + 1 + ct->callid.len;
-                        base64len = calc_base64_encode_len(len);
-                        if (pkg_str_extend(&ctkey_pkg_buf, len) < 0) {
-                                LM_ERR("oom\n");
-                                return -1;
-                        }
+		if (pkg_str_extend(&ctkeyb64_pkg_buf, base64len) < 0) {
+			LM_ERR("oom\n");
+			return -1;
+		}
+		memcpy(ctkey_pkg_buf.s, ct->c.s, ct->c.len);
+		break;
+	case CONTACT_CALLID:
+		len = ct->c.len + 1 + ct->callid.len;
+		base64len = calc_base64_encode_len(len);
+		if (pkg_str_extend(&ctkey_pkg_buf, len) < 0) {
+			LM_ERR("oom\n");
+			return -1;
+		}
 
-                        if (pkg_str_extend(&ctkeyb64_pkg_buf, base64len) < 0) {
-                                LM_ERR("oom\n");
-                                return -1;
-                        }
-                        memcpy(ctkey_pkg_buf.s, ct->c.s, ct->c.len);
-                        ctkey_pkg_buf.s[ct->c.len] = ':';
-                        memcpy(ctkey_pkg_buf.s + ct->c.len + 1, ct->callid.s,
-                               ct->callid.len);
-                        break;
-                default:
-                        LM_CRIT("unknown matching_mode %d\n", matching_mode);
-                        return -1;
+		if (pkg_str_extend(&ctkeyb64_pkg_buf, base64len) < 0) {
+			LM_ERR("oom\n");
+			return -1;
+		}
+		memcpy(ctkey_pkg_buf.s, ct->c.s, ct->c.len);
+		ctkey_pkg_buf.s[ct->c.len] = ':';
+		memcpy(ctkey_pkg_buf.s + ct->c.len + 1, ct->callid.s,
+			ct->callid.len);
+		break;
+	default:
+		LM_CRIT("unknown matching_mode %d\n", matching_mode);
+		return -1;
         }
 	
 	base64encode((unsigned char *)ctkeyb64_pkg_buf.s,

--- a/modules/usrloc/urecord.c
+++ b/modules/usrloc/urecord.c
@@ -537,7 +537,7 @@ int cdb_add_ct_update(cdb_dict_t *updates, const ucontact_t *ct, char remove)
 	default:
 		LM_CRIT("unknown matching_mode %d\n", matching_mode);
 		return -1;
-        }
+	}
 	
 	base64encode((unsigned char *)ctkeyb64_pkg_buf.s,
 	             (unsigned char *)ctkey_pkg_buf.s, len);

--- a/modules/usrloc/urecord.c
+++ b/modules/usrloc/urecord.c
@@ -501,24 +501,44 @@ int cdb_add_ct_update(cdb_dict_t *updates, const ucontact_t *ct, char remove)
 	int len, base64len;
 
 	cdb_key_init(&contacts_key, "contacts");
-	len = ct->c.len + 1 + ct->callid.len;
-	base64len = calc_base64_encode_len(len);
+	
+	switch (matching_mode) {
+                case CONTACT_ONLY:
+                        len = ct->c.len  ;
+                        base64len = calc_base64_encode_len(len);
+                        if (pkg_str_extend(&ctkey_pkg_buf, len) < 0) {
+                                LM_ERR("oom\n");
+                                return -1;
+                        }
 
-	if (pkg_str_extend(&ctkey_pkg_buf, len) < 0) {
-		LM_ERR("oom\n");
-		return -1;
-	}
+                        if (pkg_str_extend(&ctkeyb64_pkg_buf, base64len) < 0) {
+                                LM_ERR("oom\n");
+                                return -1;
+                        }
+                        memcpy(ctkey_pkg_buf.s, ct->c.s, ct->c.len);
+                        break;
+                case CONTACT_CALLID:
+                        len = ct->c.len + 1 + ct->callid.len;
+                        base64len = calc_base64_encode_len(len);
+                        if (pkg_str_extend(&ctkey_pkg_buf, len) < 0) {
+                                LM_ERR("oom\n");
+                                return -1;
+                        }
 
-	if (pkg_str_extend(&ctkeyb64_pkg_buf, base64len) < 0) {
-		LM_ERR("oom\n");
-		return -1;
-	}
-
-	memcpy(ctkey_pkg_buf.s, ct->c.s, ct->c.len);
-	ctkey_pkg_buf.s[ct->c.len] = ':';
-	memcpy(ctkey_pkg_buf.s + ct->c.len + 1, ct->callid.s,
-	       ct->callid.len);
-
+                        if (pkg_str_extend(&ctkeyb64_pkg_buf, base64len) < 0) {
+                                LM_ERR("oom\n");
+                                return -1;
+                        }
+                        memcpy(ctkey_pkg_buf.s, ct->c.s, ct->c.len);
+                        ctkey_pkg_buf.s[ct->c.len] = ':';
+                        memcpy(ctkey_pkg_buf.s + ct->c.len + 1, ct->callid.s,
+                               ct->callid.len);
+                        break;
+                default:
+                        LM_CRIT("unknown matching_mode %d\n", matching_mode);
+                        return -1;
+        }
+	
 	base64encode((unsigned char *)ctkeyb64_pkg_buf.s,
 	             (unsigned char *)ctkey_pkg_buf.s, len);
 


### PR DESCRIPTION
This fix works for me, i set modparam("usrloc", "matching_mode", 0) on my opensips.cfg and now I have one entry only for each contact as expected.
Actually setting matching_mode at zero is useless because it's the default behaviour, however I like to state it explicitly in the configuration file.
Please consider merging it and if yes, porting this fix in the 2.4 branch since for now I am only using Opensips 2.4 series.

This fix should close #1801.
