### PR TITLE
Fix #1804 - mid_registrar_save() should save new contact from registe…

### DIFF
--- a/modules/usrloc/urecord.c
+++ b/modules/usrloc/urecord.c
@@ -864,7 +864,7 @@ int delete_ucontact(urecord_t* _r, struct ucontact* _c, char is_replicated)
 static inline struct ucontact* contact_match( ucontact_t* ptr, str* _c)
 {
 	while(ptr) {
-		if ((_c->len == ptr->c.len) && !memcmp(_c->s, ptr->c.s, _c->len)) {
+		if ((_c->len == ptr->c.len) && !memcmp(_c->s, ptr->c.s, _c->len) && ptr->expires != UL_EXPIRED_TIME ) {
 			return ptr;
 		}
 
@@ -881,6 +881,7 @@ static inline struct ucontact* contact_callid_match( ucontact_t* ptr,
 		if ( (_c->len==ptr->c.len) && (_callid->len==ptr->callid.len)
 		&& !memcmp(_c->s, ptr->c.s, _c->len)
 		&& !memcmp(_callid->s, ptr->callid.s, _callid->len)
+		&& ptr->expires != UL_EXPIRED_TIME
 		) {
 			return ptr;
 		}


### PR DESCRIPTION
…r following an unregister.

When using `sql_mode` is set to `SQL_WRITE_BACK` and  `rr_persist` is `RRP_LOAD_FROM_SQL` contacts are not
immediately deleted from memory, contacts are marked `expires = UL_EXPIRED_TIME`. So when a `REGISTER` request
is received following an UNREGISTER, do not return the previous contact marked for deletion.

Returning the previous contact record, could have potentially lead to a crash, if opensips would free the contact
record while mid_registrar would retreive that using `get_ucontact()`.