### PR TITLE
[topology_hiding] Fix encoding $TH_callee_callid and small cleanup

### DIFF
--- a/modules/topology_hiding/topo_hiding_logic.c
+++ b/modules/topology_hiding/topo_hiding_logic.c
@@ -1246,12 +1246,7 @@ static int dlg_th_encode_callid(struct sip_msg *msg)
 	new_callid.len = word64_enc_len + topo_hiding_prefix.len;
 	new_callid.s = pkg_malloc(new_callid.len);
 	if (new_callid.s==NULL) {
-		LM_ERR("Failed to allocate callid len\n");
-		return -1;
-	}
-
-	if (new_callid.s == NULL) {
-		LM_ERR("Failed to encode callid\n");
+		LM_ERR("Failed to allocate new callid\n");
 		return -1;
 	}
 

--- a/modules/topology_hiding/topology_hiding.c
+++ b/modules/topology_hiding/topology_hiding.c
@@ -242,7 +242,6 @@ static int pv_topo_callee_callid(struct sip_msg *msg, pv_param_t *param, pv_valu
 {
 	struct dlg_cell *dlg;
 	int req_len = 0,i;
-	char *p;
 
 	if(res==NULL)
 		return -1;
@@ -253,7 +252,7 @@ static int pv_topo_callee_callid(struct sip_msg *msg, pv_param_t *param, pv_valu
 	}
 
 
-	req_len = calc_base64_encode_len(dlg->callid.len) + topo_hiding_prefix.len;
+	req_len = calc_word64_encode_len(dlg->callid.len) + topo_hiding_prefix.len;
 
 	if (req_len*2 > callid_buf_len) {
 		callid_buf = pkg_realloc(callid_buf,req_len*2);
@@ -269,14 +268,8 @@ static int pv_topo_callee_callid(struct sip_msg *msg, pv_param_t *param, pv_valu
 	for (i=0;i<dlg->callid.len;i++)
 		callid_buf[i] = dlg->callid.s[i] ^ topo_hiding_seed.s[i%topo_hiding_seed.len];
 
-	base64encode((unsigned char *)(callid_buf+topo_hiding_prefix.len+req_len),
+	word64encode((unsigned char *)(callid_buf+topo_hiding_prefix.len+req_len),
 		     (unsigned char *)(callid_buf),dlg->callid.len);
-
-	p = callid_buf+ 2*req_len - 1;
-	while (*p == '=') {
-		*p = '-';
-		p--;
-	}
 
 	res->rs.s = callid_buf+req_len;
 	res->rs.len = req_len;


### PR DESCRIPTION
Corrected that after PR #1448 pseudo-variable $TH_callee_callid were still using base64 encoding instead of word64.