### PR TITLE
rtpengine: Use standart ALL_ROUTES macro

### DIFF
--- a/modules/rtpengine/README
+++ b/modules/rtpengine/README
@@ -547,7 +547,7 @@ rtpengine_offer();
        the rtpengine_* function. If this parameter is missing the
        body of the current message is used.
 
-   This function can be used from ANY_ROUTE.
+   This function can be used from ALL_ROUTES.
 
    Example 1.12. rtpengine_offer usage
 route {
@@ -643,7 +643,7 @@ rtpengine_offer("... codec-mask-PCMA codec-strip-opus transcode-opus ...
    meaning of the parameters. Note that not all flags make sense
    for a “delete”.
 
-   This function can be used from ANY_ROUTE.
+   This function can be used from ALL_ROUTES.
 
    Example 1.17. rtpengine_delete usage
 ...
@@ -674,7 +674,7 @@ rtpengine_delete();
        do rtpengine_answer() if the request had SDP or tm is not
        loaded, otherwise do rtpengine_offer()
 
-   This function can be used from ANY_ROUTE.
+   This function can be used from ALL_ROUTES.
 
    Example 1.18. rtpengine_manage usage
 ...

--- a/modules/rtpengine/doc/rtpengine_admin.xml
+++ b/modules/rtpengine/doc/rtpengine_admin.xml
@@ -599,7 +599,7 @@ rtpengine_offer();
 		</para></listitem>
 		</itemizedlist>
 		<para>
-		This function can be used from ANY_ROUTE.
+		This function can be used from ALL_ROUTES.
 		</para>
 		<example>
 		<title><function>rtpengine_offer</function> usage</title>
@@ -720,7 +720,7 @@ rtpengine_offer("... codec-mask-PCMA codec-strip-opus transcode-opus ...");
 		parameters. Note that not all flags make sense for a <quote>delete</quote>.
 		</para>
 		<para>
-		This function can be used from ANY_ROUTE.
+		This function can be used from ALL_ROUTES.
 		</para>
 		<example>
 		<title><function>rtpengine_delete</function> usage</title>
@@ -787,7 +787,7 @@ rtpengine_delete();
 	</itemizedlist>
 
 		<para>
-		This function can be used from ANY_ROUTE.
+		This function can be used from ALL_ROUTES.
 		</para>
 		<example>
 		 <title><function>rtpengine_manage</function> usage</title>

--- a/modules/rtpengine/rtpengine.c
+++ b/modules/rtpengine/rtpengine.c
@@ -336,73 +336,71 @@ static struct tm_binds tmb;
 
 static pv_elem_t *extra_id_pv = NULL;
 
-#define ANY_ROUTE     (REQUEST_ROUTE|ONREPLY_ROUTE|FAILURE_ROUTE|BRANCH_ROUTE|LOCAL_ROUTE)
-
 static cmd_export_t cmds[] = {
 	{"rtpengine_use_set", (cmd_function)set_rtpengine_set_f, {
 		{CMD_PARAM_INT, fixup_set_id, fixup_free_set_id}, {0,0,0}},
-		ANY_ROUTE},
+		ALL_ROUTES},
 	{"rtpengine_start_recording", (cmd_function)start_recording_f, {
 		{CMD_PARAM_STR | CMD_PARAM_OPT, 0, 0},
 		{CMD_PARAM_VAR | CMD_PARAM_OPT, 0, 0}, {0,0,0}},
-		ANY_ROUTE},
+		ALL_ROUTES},
 	{"rtpengine_stop_recording", (cmd_function)stop_recording_f, {
 		{CMD_PARAM_STR | CMD_PARAM_OPT, 0, 0},
 		{CMD_PARAM_VAR | CMD_PARAM_OPT, 0, 0}, {0,0,0}},
-		ANY_ROUTE},
+		ALL_ROUTES},
 	{"rtpengine_offer",	(cmd_function)rtpengine_offer_f, {
 		{CMD_PARAM_STR | CMD_PARAM_OPT, 0, 0},
 		{CMD_PARAM_VAR | CMD_PARAM_OPT, 0, 0},
 		{CMD_PARAM_VAR | CMD_PARAM_OPT, 0, 0},
 		{CMD_PARAM_STR | CMD_PARAM_OPT, 0, 0}, {0,0,0}},
-		ANY_ROUTE},
+		ALL_ROUTES},
 	{"rtpengine_answer", (cmd_function)rtpengine_answer_f, {
 		{CMD_PARAM_STR | CMD_PARAM_OPT, 0, 0},
 		{CMD_PARAM_VAR | CMD_PARAM_OPT, 0, 0},
 		{CMD_PARAM_VAR | CMD_PARAM_OPT, 0, 0},
 		{CMD_PARAM_STR | CMD_PARAM_OPT, 0, 0}, {0,0,0}},
-		ANY_ROUTE},
+		ALL_ROUTES},
 	{"rtpengine_manage", (cmd_function)rtpengine_manage_f, {
 		{CMD_PARAM_STR | CMD_PARAM_OPT, 0, 0},
 		{CMD_PARAM_VAR | CMD_PARAM_OPT, 0, 0},
 		{CMD_PARAM_VAR | CMD_PARAM_OPT, 0, 0},
 		{CMD_PARAM_STR | CMD_PARAM_OPT, 0, 0}, {0,0,0}},
-		ANY_ROUTE},
+		ALL_ROUTES},
 	{"rtpengine_delete", (cmd_function)rtpengine_delete_f, {
 		{CMD_PARAM_STR | CMD_PARAM_OPT, 0, 0},
 		{CMD_PARAM_VAR | CMD_PARAM_OPT, 0, 0}, {0,0,0}},
-		ANY_ROUTE},
+		ALL_ROUTES},
 	{"rtpengine_play_media", (cmd_function)rtpengine_playmedia_f, {
 		{CMD_PARAM_STR, 0, 0},
 		{CMD_PARAM_VAR | CMD_PARAM_OPT, 0, 0},
 		{CMD_PARAM_VAR | CMD_PARAM_OPT, 0, 0},
 		{0,0,0}},
-		ANY_ROUTE},
+		ALL_ROUTES},
 	{"rtpengine_stop_media", (cmd_function)rtpengine_stopmedia_f, {
 		{CMD_PARAM_STR | CMD_PARAM_OPT, 0, 0},
 		{CMD_PARAM_VAR | CMD_PARAM_OPT, 0, 0},
 		{0,0,0}},
-		ANY_ROUTE},
+		ALL_ROUTES},
 	{"rtpengine_block_media", (cmd_function)rtpengine_blockmedia_f, {
 		{CMD_PARAM_STR | CMD_PARAM_OPT, 0, 0},
 		{CMD_PARAM_VAR | CMD_PARAM_OPT, 0, 0},
 		{0,0,0}},
-		ANY_ROUTE},
+		ALL_ROUTES},
 	{"rtpengine_unblock_media", (cmd_function)rtpengine_unblockmedia_f, {
 		{CMD_PARAM_STR | CMD_PARAM_OPT, 0, 0},
 		{CMD_PARAM_VAR | CMD_PARAM_OPT, 0, 0},
 		{0,0,0}},
-		ANY_ROUTE},
+		ALL_ROUTES},
 	{"rtpengine_block_dtmf", (cmd_function)rtpengine_blockdtmf_f, {
 		{CMD_PARAM_STR | CMD_PARAM_OPT, 0, 0},
 		{CMD_PARAM_VAR | CMD_PARAM_OPT, 0, 0},
 		{0,0,0}},
-		ANY_ROUTE},
+		ALL_ROUTES},
 	{"rtpengine_unblock_dtmf", (cmd_function)rtpengine_unblockdtmf_f, {
 		{CMD_PARAM_STR | CMD_PARAM_OPT, 0, 0},
 		{CMD_PARAM_VAR | CMD_PARAM_OPT, 0, 0},
 		{0,0,0}},
-		ANY_ROUTE},
+		ALL_ROUTES},
 	{0,0,{{0,0,0}},0}
 };
 


### PR DESCRIPTION
ALL_ROUTES macro was introduced in commit
85413735093b55f64390c0284ec4c2f63fad3526. Let's use it instead of
hand-made non-standart ANY_ROUTE.

Signed-off-by: Peter Lemenkov <lemenkov@gmail.com>