### PR TITLE
presence/clustering: Keep presence state on all nodes without shared DB

### DIFF
--- a/modules/presence/README
+++ b/modules/presence/README
@@ -228,10 +228,23 @@ modparam("presence", "cluster_id", 2)
 1.4.4. cluster_federation_mode (int)
 
    When enabling the federation mode, the node inside the presence
-   cluster will start partitioning the data (each node will keep
-   its own data set) and exchange the minimimum of needed
-   information via the clustering support. A non-zero value means
-   enabled.
+   cluster will start broadcasting the data to other nodes in the
+   cluster via the clustering support. Each node will keep its own
+   data set. A non-zero value means enabled.
+
+   Possible values for mode:
+     * 0 (default) - no federation/partitioning.
+     * 1 - the minimum needed information is broadcast/kept.
+     * 2 - published state is kept on all presence nodes on all
+       presence nodes, even when there aren't any subscribers.
+
+   If you don't want to use a shared database using fallback2db,
+   but still want a complete data set everywhere, you may choose
+   mode 2.
+
+   This mode allows you to switch PUBLISH endpoints, even for
+   already published Event States, thus allowing you to add and
+   remove presence servers without losing state.
 
    For more on presence clustering see the Section 1.2, “Presence
    clustering” chapter.

--- a/modules/presence/clustering.h
+++ b/modules/presence/clustering.h
@@ -31,6 +31,11 @@
 #define is_cluster_federation_enabled() \
 	(is_presence_cluster_enabled() && cluster_federation>0)
 
+/* Discard broadcast presentity state when there are no local
+ * subscribers */
+#define discard_unused_cluster_federation_data() \
+	(cluster_federation == 1)
+
 /* The ID of the presence cluster */
 extern int pres_cluster_id;
 

--- a/modules/presence/doc/presence_admin.xml
+++ b/modules/presence/doc/presence_admin.xml
@@ -159,10 +159,48 @@ modparam("presence", "cluster_id", 2)
 	<section id="param_cluster_federation_mode" xreflabel="cluster_federation_mode">
 		<title><varname>cluster_federation_mode</varname> (int)</title>
 		<para>
-		When enabling the federation mode, the node inside the presence cluster
-		will start partitioning the data (each node will keep its own data
-		set) and exchange the minimimum of needed information via the
-		clustering support. A non-zero value means enabled.
+		When enabling the federation mode, the node inside the presence
+		cluster will start broadcasting the data to other nodes in the
+		cluster via the clustering support. Each node will keep its own
+		data set. A non-zero value means enabled.
+		</para>
+		<para>
+		<emphasis>Possible values for mode:</emphasis>
+		<itemizedlist>
+			<listitem>
+			<para>
+				<emphasis>0 (default) - no federation/partitioning.</emphasis>
+			</para>
+			</listitem>
+			<listitem>
+			<para>
+				<emphasis>1 - the minimum needed information is
+				broadcast/kept.</emphasis>
+			</para>
+			</listitem>
+			<listitem>
+			<para>
+				<emphasis>2 - published state is kept on all
+				presence nodes on all presence nodes, even when
+				there aren't any subscribers.</emphasis>
+			</para>
+			</listitem>
+		</itemizedlist>
+		</para>
+		<para>
+		<emphasis>
+			If you don't want to use a shared database using
+			<xref linkend="param_fallback2db"/>, but still want a
+			complete data set everywhere, you may choose mode 2.
+		</emphasis>
+		</para>
+		<para>
+		<emphasis>
+			This mode allows you to switch PUBLISH endpoints,
+			even for already published Event States, thus allowing
+			you to add and remove presence servers without losing
+			state.
+		</emphasis>
 		</para>
 		<para>
 		For more on presence clustering see the 


### PR DESCRIPTION
Add the option to set cluster_federation_mode = 2, which does the
following:

- All PUBLISH/presence state is recorded on the presence node, even when
  no one is subscribed. PUBLISH is now accepted on any node for updated
  state.

This means that you can round-robin your PUBLISH instead of having to
choose a single presence endpoint. And it also means you can switch to
other nodes and get up-to-date state from there, when a node dies.

This is achieved without using a shared DB (which has its own
limitations obviously).