### PR TITLE
Memory leak fix for mongodb module-reply not freed

### DIFF
--- a/modules/cachedb_mongodb/cachedb_mongodb_dbase.c
+++ b/modules/cachedb_mongodb/cachedb_mongodb_dbase.c
@@ -1008,6 +1008,7 @@ int mongo_con_add(cachedb_con *con, str *attr, int val, int expires, int *new_va
 	}
 
 out:
+	bson_destroy(&reply);
 	bson_destroy(cmd);
 	return ret;
 }


### PR DESCRIPTION
mongoc_collection_command_simple() takes &reply as output parameters but probably it needs to be freed.
From the mongodb documentation at http://mongoc.org/libmongoc/1.14.0/mongoc_collection_command_simple.html

```
#include <bson/bson.h>
#include <mongoc/mongoc.h>
#include <stdio.h>

static void
print_collection_stats (mongoc_collection_t *collection)
{
   ...
   bson_t reply;

   ....

   if (mongoc_collection_command_simple (
          collection, cmd, NULL, &reply, &error)) {
          ...
   }
   ...

   bson_destroy (&reply);
   bson_destroy (cmd);
}
```