### PR TITLE
nat_traversal: default to not saving a keep-alive file

### DIFF
--- a/modules/nat_traversal/README
+++ b/modules/nat_traversal/README
@@ -469,7 +469,7 @@ PS\r\nX-MyHeader: some_value\r\n")
    which case it will store it in the OpenSIPS working directory,
    or an absolute path.
 
-   Default value is undefined “keepalive_state”.
+   Default value is NULL, no keep-alive file will be kept.
 
    Example 1.5. Setting the keepalive_state_file parameter
 ...

--- a/modules/nat_traversal/nat_traversal.c
+++ b/modules/nat_traversal/nat_traversal.c
@@ -201,7 +201,7 @@ static Bool keepalive_disabled = False;
 
 static unsigned int keepalive_interval = 60;
 
-static char *keepalive_state_file = "keepalive_state";
+static char *keepalive_state_file = NULL;
 
 static Keepalive_Params keepalive_params = {"NOTIFY", NULL, "", "", 0, 0, ""};
 


### PR DESCRIPTION
Typically OpenSIPS will be installed in /usr/(s)bin/ and the OpenSIPS
process will have no rights to store it there. In addition, this allows
for not having a keep-alive file at all, since the code is ready to
handle that.