### PR TITLE
python: Explicitly mark include as system-wide one (minor, almost cosmetic)

### DIFF
--- a/modules/python/python_msgobj.c
+++ b/modules/python/python_msgobj.c
@@ -21,7 +21,7 @@
 
 #include <Python.h>
 #include "python_compat.h"
-#include "structmember.h"
+#include <structmember.h>
 
 #include "../../action.h"
 #include "../../mem/mem.h"


### PR DESCRIPTION
Let's explicitly state that we're using a system-wide header instead of a some local one.
