### PR TITLE
topology_hiding: More verbose in case of error

### DIFF
--- a/modules/topology_hiding/topo_hiding_logic.c
+++ b/modules/topology_hiding/topo_hiding_logic.c
@@ -1429,7 +1429,7 @@ int topo_callid_post_raw(str *data, struct sip_msg* foo)
 	msg.buf=data->s;
 	msg.len=data->len;
 	if (dlg_th_callid_pre_parse(&msg,1) < 0) {
-		LM_ERR("could not parse resulted sip message!\n");
+		LM_ERR("could not parse resulted sip message: %.*s\n", data->len, data->s);
 		goto done;
 	}
 


### PR DESCRIPTION
Be more verbose in case of error so you'll get the idea what's going on.
Instead of a message that something went wrong you'll get more
insightful one:

Jan 22 15:38:32 li443-44 /usr/local/sbin/opensips[1278]: ERROR:topology_hiding:topo_callid_post_raw: could not parse resulted sip message: HEP3#001À

Signed-off-by: Peter Lemenkov <lemenkov@gmail.com>