### PR TITLE
fixes #1954  - change return value if we can not add crl files

### DIFF
--- a/modules/tls_mgm/tls_mgm.c
+++ b/modules/tls_mgm/tls_mgm.c
@@ -942,7 +942,7 @@ static int load_crl(SSL_CTX * ctx, char *crl_directory, int crl_check_all)
 
 	if (!crl_added) {
 		LM_ERR("No suitable CRL files found in directory %s\n", crl_directory);
-		return -1;
+		return 0;
 	}
 
 	/*Enable CRL checking*/


### PR DESCRIPTION
This avoids the crash from #1954 - startup continues.