### PR TITLE
[FEATURE] rest_client transformations (RFC3986 encode)

### DIFF
--- a/modules/rest_client/doc/rest_client_admin.xml
+++ b/modules/rest_client/doc/rest_client_admin.xml
@@ -659,5 +659,65 @@ route [resume] {
 
 	</section>
 
+    <section id="exported_transformations">
+        <title>Exported script transformations</title>
+        <para>
+            The module also provides a way for encoding and decoding parameters contained in a arbitrary script variable, in accordance with RFC3986. This is done by applying a transformation to a script variable containing the data to be encoded. The value of the original variable is not altered and a corresponding string value is returned. The transformation is performed through libcurl API method curl_easy_escape (or curl_escape for libcurl < 7.15.4).
+        </para>
+
+        <section id="tran_rest.escape" xreflabel="rest.escape">
+            <title>
+                <varname>{rest.escape}</varname>
+            </title>
+            <para>
+                The result of this transformation is to produce percent encoded string value which can be safely used in URI construction.
+            </para>
+
+            <para>There are no parameters for this transformation.</para>
+
+            <example>
+                <title><varname>rest.escape</varname> usage</title>
+                <programlisting format="linespecific">
+...
+# This example would produce log entry: "Output: call%40example.com%26safe%3Dfalse"
+$var(tmp) = "call@example.com&safe=false";
+xlog("Output: $(var(tmp){rest.escape})\n");
+
+# Encode call ID before transmission:
+$var(rc) = rest_get("https://call-info.org/?id=$(ci{rest.escape})", $var(body_pv));
+...
+                </programlisting>
+            </example>
+
+        </section>
+
+        <section id="tran_rest.unescape" xreflabel="rest.unescape">
+            <title>
+                <varname>{rest.unescape}</varname>
+            </title>
+            <para>
+                The result of this transformation is to decode percent encoded string values.
+            </para>
+
+            <para>There are no parameters for this transformation.</para>
+
+            <example>
+                <title><varname>rest.unescape</varname> usage</title>
+                <programlisting format="linespecific">
+...
+# This example would produce log entry: "Output: 1+1=2!"
+$var(tmp) = "1%2B1%3D2%21";
+xlog("Output: $(var(tmp){rest.unescape})\n");
+
+# This example would produce log entry: "OpenSIPs, tastes better with every SIP!"
+$var(tmp) = "OpenSIPs%2C%20tastes%20better%20with%20every%20SIP%21";
+xlog("$(var(tmp){rest.unescape})\n");
+...
+                </programlisting>
+            </example>
+
+        </section>
+
+    </section>
 
 </chapter>

--- a/modules/rest_client/rest_client.h
+++ b/modules/rest_client/rest_client.h
@@ -1,0 +1,33 @@
+/**
+ *
+ * Copyright (C) 2020 OpenSIPS Foundation
+ *
+ * This file is part of opensips, a free SIP server.
+ *
+ * opensips is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version
+ *
+ * opensips is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301  USA
+ *
+ * History
+ * -------
+ *  2020-01-xx  initial version (Callum Guy)
+ */
+
+#ifndef _REST_CLIENT_
+#define _REST_CLIENT_
+
+enum tr_rest_subtype {
+	TR_REST_ESCAPE, TR_REST_UNESCAPE
+};
+
+#endif /* _REST_CLIENT_ */

--- a/modules/rest_client/rest_methods.c
+++ b/modules/rest_client/rest_methods.c
@@ -54,7 +54,7 @@ static int transfers;
 static int read_fds[FD_SETSIZE];
 
 /* handle for use with synchronous reqs */
-static CURL *sync_handle;
+CURL *sync_handle;
 
 /* libcurl's reported running handles */
 static int running_handles;
@@ -180,7 +180,7 @@ int trace_rest_request_cb(CURL *handle, curl_infotype type, char *data, size_t s
 			}
 
 			/* generate a new correlation each time we send a message */
-			/* FIXME what if 2 messages are sent before recieving reply?
+			/* FIXME what if 2 messages are sent before receiving reply?
 			 * Ex: destination has 2 ip's */
 			if ( type == CURLINFO_HEADER_OUT ) {
 				tparam->correlation.s = (char *)tprot.generate_guid(REST_CORRELATION_COOKIE);

--- a/modules/rest_client/rest_methods.h
+++ b/modules/rest_client/rest_methods.h
@@ -49,6 +49,9 @@ extern int ssl_verifyhost;
 
 extern int curl_http_version;
 
+/* handle for use with synchronous reqs */
+extern CURL *sync_handle;
+
 /* Currently supported HTTP verbs */
 enum rest_client_method {
 	REST_CLIENT_GET,


### PR DESCRIPTION
Provides two new exported transformation methods from rest_client module. Actual transformations are provided via libcurl in accordance with RFC3986.

```
$var(tmp) = "call@example.com&safe=false";
xlog("$(var(tmp){rest.escape})\n");
```
Produces: `call%40example.com%26safe%3Dfalse`

```
$var(tmp) = "1%2B1%3D2%21";
xlog("$(var(tmp){rest.unescape})\n");
```
Produces: `1+1=2!`