### PR TITLE
Fix issues found while compiling with GCC 10 (-fno-common)

### DIFF
--- a/mem/hp_malloc.c
+++ b/mem/hp_malloc.c
@@ -116,9 +116,6 @@ int mem_warming_enabled;
 int mem_warming_percentage = MEM_WARMING_DEFAULT_PERCENTAGE;
 
 #if defined(HP_MALLOC)
-stat_var *rpm_used;
-stat_var *rpm_rused;
-stat_var *rpm_frags;
 #if !defined(HP_MALLOC_FAST_STATS)
 stat_var *shm_used;
 stat_var *shm_rused;

--- a/mi/mi_trace.c
+++ b/mi/mi_trace.c
@@ -39,6 +39,9 @@ int mi_message_id;
 static char* correlation_name = "correlation_id";
 str correlation_value;
 int correlation_id=-1, correlation_vendor=-1;
+str mi_trpl;
+struct mi_trace_req mi_treq;
+struct mi_trace_param mi_tparam;
 
 
 void try_load_trace_api(void)

--- a/mi/mi_trace.h
+++ b/mi/mi_trace.h
@@ -37,18 +37,21 @@ struct mi_trace_req {
 	str cmd;
 	str backend;
 	char params[MAX_TRACE_FIELD];
-} mi_treq;
+};
 
-str mi_trpl;
+extern str mi_trpl;
 
 enum mi_trace_type { MI_TRACE_REQ, MI_TRACE_RPL};
+
 struct mi_trace_param {
 	enum mi_trace_type type;
 	union {
 		struct mi_trace_req* req;
 		str *rpl;
 	} d;
-} mi_tparam;
+};
+
+extern struct mi_trace_param mi_tparam;
 
 void try_load_trace_api(void);
 

--- a/modules/b2b_entities/b2b_entities.c
+++ b/modules/b2b_entities/b2b_entities.c
@@ -71,6 +71,8 @@ static int b2b_update_period = 100;
 int uac_auth_loaded;
 str b2b_key_prefix = str_init("B2B");
 int b2be_db_mode = WRITE_BACK;
+b2b_table server_htable = NULL;
+b2b_table client_htable = NULL;
 
 #define DB_COLS_NO  26
 

--- a/modules/b2b_entities/dlg.h
+++ b/modules/b2b_entities/dlg.h
@@ -178,8 +178,8 @@ typedef struct b2b_rpl_data
 
 
 /** Hash table declaration: for client and server dialogs */
-b2b_table server_htable;
-b2b_table client_htable;
+extern b2b_table server_htable;
+extern b2b_table client_htable;
 
 
 void print_b2b_dlg(b2b_dlg_t *dlg);

--- a/modules/b2b_logic/b2b_logic.h
+++ b/modules/b2b_logic/b2b_logic.h
@@ -111,7 +111,7 @@ extern b2b_scenario_t* extern_scenaries;
 
 extern str custom_headers_lst[HDR_LST_LEN];
 extern regex_t* custom_headers_re;
-int custom_headers_lst_len;
+extern int custom_headers_lst_len;
 extern int use_init_sdp;
 extern str server_address;
 extern unsigned int max_duration;

--- a/modules/cachedb_local/cachedb_local_replication.h
+++ b/modules/cachedb_local/cachedb_local_replication.h
@@ -34,10 +34,10 @@ extern struct clusterer_binds clusterer_api;
 extern str cache_repl_cap;
 extern int cluster_id;
 
-enum cachedb_rr_persist {
+typedef enum cachedb_rr_persist {
 	RRP_NONE,
 	RRP_SYNC_FROM_CLUSTER,
-} rr_persist_t;
+} cachedb_rr_persist_t;
 
 void receive_binary_packet(bin_packet_t *packet);
 void receive_cluster_event(enum clusterer_event ev, int node_id);

--- a/modules/dispatcher/dispatch.h
+++ b/modules/dispatcher/dispatch.h
@@ -177,7 +177,7 @@ extern str ds_setid_pvname;
 extern pv_spec_t ds_setid_pv;
 
 /* Structure containing pointers to TM-functions */
-struct tm_binds tmb;
+extern struct tm_binds tmb;
 
 extern struct fs_binds fs_api;
 extern str ds_ping_method;

--- a/modules/emergency/emergency_methods.c
+++ b/modules/emergency/emergency_methods.c
@@ -50,7 +50,28 @@ static void mod_destroy(void);
 struct dlg_binds dlgb;
 struct rr_binds rr_api;
 
+struct tm_binds eme_tm;
+
+str db_url;
+str *db_table = NULL;
+db_func_t db_funcs;
+db_con_t *db_con = NULL;
+
+struct esrn_routing **db_esrn_esgwri = NULL;
+struct service_provider **db_service_provider = NULL;
+
 str callid_aux;
+char* url_vpc;
+
+int emet_size = 0;
+int subst_size = 0;
+
+char *empty = NULL;
+
+char* mandatory_parm = NULL;
+
+struct call_htable* call_htable = NULL;
+struct subs_htable* subs_htable = NULL;
 
 /*
  * Exported functions

--- a/modules/emergency/emergency_methods.h
+++ b/modules/emergency/emergency_methods.h
@@ -140,7 +140,7 @@ struct code_number *codes = NULL;
 
 struct multi_body *mbody;
 struct esct *call_cell;
-struct lump *l;
+extern struct lump *l;
 
 int timer_interval=10;
 str table_name=str_init("emergency_routing");

--- a/modules/emergency/http_emergency.h
+++ b/modules/emergency/http_emergency.h
@@ -59,15 +59,15 @@
 
 #include "post_curl.h"
 
-struct call_htable* call_htable;
-struct subs_htable* subs_htable;
+extern struct call_htable* call_htable;
+extern struct subs_htable* subs_htable;
 
-char *url_vpc;
-str db_url;
-str *db_table;
+extern char *url_vpc;
+extern str db_url;
+extern str *db_table;
 
-int emet_size;
-int subst_size;
+extern int emet_size;
+extern int subst_size;
 
 int send_esct(struct sip_msg *msg, str callid_ori, str from_tag);
 int treat_parse_esrResponse(struct sip_msg *msg, ESCT *call_cell, PARSED *parsed, int proxy_role);

--- a/modules/emergency/report_emergency.h
+++ b/modules/emergency/report_emergency.h
@@ -57,8 +57,8 @@
 
 #include "sip_emergency.h"
 
-db_func_t db_funcs;
-db_con_t *db_con;
+extern db_func_t db_funcs;
+extern db_con_t *db_con;
 
 struct emergency_report {
 	str callid;
@@ -83,7 +83,7 @@ struct esrn_routing {
 	struct esrn_routing *next;
 };
 
-struct esrn_routing **db_esrn_esgwri;
+extern struct esrn_routing **db_esrn_esgwri;
 
 struct service_provider {
 	str nodeIP;
@@ -97,9 +97,9 @@ struct service_provider {
 	struct service_provider *next;
 };
 
-struct service_provider **db_service_provider;
+extern struct service_provider **db_service_provider;
 
-char* mandatory_parm;
+extern char* mandatory_parm;
 
 #define ACK_TIME 				 3
 #define BYE_TIME 				 10

--- a/modules/emergency/sip_emergency.c
+++ b/modules/emergency/sip_emergency.c
@@ -74,7 +74,7 @@ const char *FROMTAG_PARAM = ";from-tag=";
 
 
 struct lump *l;
-struct rr_binds rr_api;
+//struct rr_binds rr_api;
 
 /* verify if the INVITE has the header Geolocation-Routing with the value "yes"
 */

--- a/modules/emergency/subscriber_emergency.h
+++ b/modules/emergency/subscriber_emergency.h
@@ -61,7 +61,7 @@
 #define TIMER_N				132  // Timer N = 64*T1      T1 = (0,5s)
 #define MAXNUMBERLEN 			31
 
-struct tm_binds eme_tm;
+extern struct tm_binds eme_tm;
 
 struct parms_cb{
 	str callid_ori;

--- a/modules/emergency/xml_parser.h
+++ b/modules/emergency/xml_parser.h
@@ -56,7 +56,7 @@
 #include "../rr/api.h"
 #include "../tm/tm_load.h" /*load_tm_api*/
 
-char *empty;
+extern char *empty;
 #define MAX_TIME_SIZE            80
 #define MAX_DISPOSITION_SIZE     20
 

--- a/modules/event_rabbitmq/rabbitmq_send.c
+++ b/modules/event_rabbitmq/rabbitmq_send.c
@@ -43,7 +43,6 @@
 #endif
 
 unsigned rmq_sync_mode = 0;
-struct timeval conn_timeout_tv;
 
 /* used to communicate with the sending process */
 static int rmq_pipe[2];

--- a/modules/mangler/mangler.c
+++ b/modules/mangler/mangler.c
@@ -52,9 +52,8 @@ struct tm_binds tmb;
 
 #endif
 
-
-
-
+regex_t *portExpression = NULL;
+regex_t *ipExpression = NULL;
 
 /*
  * Module destroy function prototype

--- a/modules/mangler/sdp_mangler.h
+++ b/modules/mangler/sdp_mangler.h
@@ -63,8 +63,8 @@ from the last group
 
 
 
-regex_t *portExpression;
-regex_t *ipExpression;
+extern regex_t *portExpression;
+extern regex_t *ipExpression;
 
 
 

--- a/modules/permissions/permissions.h
+++ b/modules/permissions/permissions.h
@@ -66,7 +66,7 @@ typedef struct int_or_pvar {
 #define DISABLE_CACHE 0
 #define ENABLE_CACHE 1
 
-char *allow_suffix;
+extern char *allow_suffix;
 int allow_test(char *file, char *uri, char *contact);
 
 #endif

--- a/modules/pua_dialoginfo/pua_dialoginfo.c
+++ b/modules/pua_dialoginfo/pua_dialoginfo.c
@@ -83,6 +83,7 @@ static int osips_ps = 1;
 static int publish_on_trying = 0;
 static int nopublish_flag = -1;
 static char *nopublish_flag_str = 0;
+send_publish_t pua_send_publish = NULL;
 
 
 

--- a/modules/pua_dialoginfo/pua_dialoginfo.h
+++ b/modules/pua_dialoginfo/pua_dialoginfo.h
@@ -30,8 +30,7 @@ struct dlginfo_part {
 	str display;
 };
 
-
-send_publish_t pua_send_publish;
+extern send_publish_t pua_send_publish;
 
 void dialog_publish(char *state,
 		struct dlginfo_part* entity, struct dlginfo_part *peer,

--- a/modules/pua_usrloc/pua_usrloc.c
+++ b/modules/pua_usrloc/pua_usrloc.c
@@ -44,7 +44,8 @@
 #include "../pua/pua_bind.h"
 #include "pua_usrloc.h"
 
-
+send_publish_t pua_send_publish = NULL;
+send_subscribe_t pua_send_subscribe = NULL;
 
 str default_domain= {NULL, 0};
 pua_api_t pua;

--- a/modules/pua_usrloc/pua_usrloc.h
+++ b/modules/pua_usrloc/pua_usrloc.h
@@ -24,8 +24,8 @@
 #define _PUA_UL_
 #include "../pua/pua_bind.h"
 
-send_publish_t pua_send_publish;
-send_subscribe_t pua_send_subscribe;
+extern send_publish_t pua_send_publish;
+extern send_subscribe_t pua_send_subscribe;
 void ul_contact_publish(void *binding, ul_cb_type type);
 int pua_set_publish(struct sip_msg* , char*, char*);
 

--- a/modules/ratelimit/ratelimit_helper.c
+++ b/modules/ratelimit/ratelimit_helper.c
@@ -55,9 +55,6 @@ static rl_algo_t get_rl_algo(str);
 /* big hash table */
 rl_big_htable rl_htable;
 
-/* feedback algorithm */
-int *rl_feedback_limit;
-
 static cachedb_funcs cdbf;
 static cachedb_con *cdbc = 0;
 

--- a/modules/registrar/reg_mod.c
+++ b/modules/registrar/reg_mod.c
@@ -114,6 +114,7 @@ char* attr_avp_param = 0;
 unsigned short attr_avp_type = 0;
 int attr_avp_name;
 
+usrloc_api_t ul;
 
 int reg_use_domain = 0;
 /*!< Realm prefix to be removed */

--- a/modules/registrar/reg_mod.h
+++ b/modules/registrar/reg_mod.h
@@ -67,7 +67,7 @@ extern int max_aor_len;
 extern int retry_after;
 extern str sock_hdr_name;
 
-usrloc_api_t ul;  /*!< Structure containing pointers to usrloc functions */
+extern usrloc_api_t ul;  /*!< Structure containing pointers to usrloc functions */
 
 extern struct sig_binds sigb;
 extern struct tm_binds tmb;

--- a/modules/usrloc/ul_mod.h
+++ b/modules/usrloc/ul_mod.h
@@ -44,7 +44,7 @@ extern enum ul_sql_write_mode sql_wmode;
 extern enum ul_pinging_mode pinging_mode;
 
 /* manner in which node data should be restored (or not) following a restart */
-enum ul_rr_persist {
+typedef enum ul_rr_persist {
 	RRP_NONE,
 	RRP_LOAD_FROM_SQL,
 	RRP_SYNC_FROM_CLUSTER,
@@ -53,14 +53,14 @@ enum ul_rr_persist {
 
 /* if using SQL for restart persistency,
  * should runtime SQL blocking writes be performed eagerly or lazily? */
-enum ul_sql_write_mode {
+typedef enum ul_sql_write_mode {
 	SQL_NO_WRITE,
 	SQL_WRITE_THROUGH,
 	SQL_WRITE_BACK,
 } ul_sql_write_mode_t;
 #define bad_sql_write_mode(wm) ((wm) < SQL_NO_WRITE || (wm) > SQL_WRITE_BACK)
 
-enum ul_pinging_mode {
+typedef enum ul_pinging_mode {
 	PMD_OWNERSHIP,
 	PMD_COOPERATION,
 } ul_pinging_mode_t;

--- a/modules/usrloc/usrloc.h
+++ b/modules/usrloc/usrloc.h
@@ -36,7 +36,7 @@
 #include "ul_callback.h"
 #include "ul_dbg.h"
 
-enum ul_cluster_mode {
+typedef enum ul_cluster_mode {
 	CM_NONE,
 	CM_FEDERATION,
 	CM_FEDERATION_CACHEDB,

--- a/obsolete_modules/sms/libsms_modem.c
+++ b/obsolete_modules/sms/libsms_modem.c
@@ -35,7 +35,6 @@ mailto:s.frings@mail.isis.de
 #define optz(_n,_l)     (buf+buf_len-(((_n)+(_l)>buf_len)?buf_len:(_n)+(_l)))
 
 /* global variables */
-int         sms_report_type;
 cds_report  cds_report_func;
 
 

--- a/obsolete_modules/sms/libsms_putsms.c
+++ b/obsolete_modules/sms/libsms_putsms.c
@@ -25,8 +25,6 @@ mailto:s.frings@mail.isis.de
 #include "libsms_modem.h"
 
 
-int  sms_report_type;
-
 static char hexa[16] = {
 	'0','1','2','3','4','5','6','7',
 	'8','9','A','B','C','D','E','F'

--- a/obsolete_modules/sms/sms_funcs.c
+++ b/obsolete_modules/sms/sms_funcs.c
@@ -55,10 +55,6 @@ struct network networks[MAX_NETWORKS];
 int net_pipes_in[MAX_NETWORKS];
 int nr_of_networks;
 int nr_of_modems;
-int *queued_msgs;
-int use_contact;
-int sms_report_type;
-struct tm_binds tmb;
 
 
 #define ERR_NUMBER_TEXT " is an invalid number! Please resend your SMS "\

--- a/sr_module.h
+++ b/sr_module.h
@@ -191,7 +191,7 @@ struct module_exports{
 
 void set_mpath(const char *new_mpath);
 
-struct sr_module* modules; /*!< global module list*/
+extern struct sr_module* modules; /*!< global module list*/
 
 int register_builtin_modules();
 int register_module(struct module_exports*, char*,  void*);

--- a/ut.c
+++ b/ut.c
@@ -32,6 +32,10 @@
 
 char int2str_buf[INT2STR_BUF_NO][INT2STR_MAX_LEN];
 
+int tcp_timeout_con_get = 0;
+int tcp_timeout_receive_fd = 0;
+int tcp_timeout_send = 0;
+
 /* make a null-termianted copy of the given string (in STR format) into
  * a static local buffer
  * !!IMPORTANT!! sequential calls do overwrite the previous values.

--- a/ut.h
+++ b/ut.h
@@ -1098,10 +1098,9 @@ static inline int str_strcasecmp(const str *stra, const str *strb)
 			inc_stat(total); \
 	} while (0)
 
-
-int tcp_timeout_con_get;
-int tcp_timeout_receive_fd;
-int tcp_timeout_send;
+extern int tcp_timeout_con_get;
+extern int tcp_timeout_receive_fd;
+extern int tcp_timeout_send;
 
 #define reset_tcp_vars(threshold) \
 	do { \


### PR DESCRIPTION
There is a more strict check about global variables definitions in header flags w/o extern keyword in  GCC 10.

* https://gcc.gnu.org/gcc-10/porting_to.html#common

It let us to catch a few potential issues (missing typedef keyword, globals declated in header files).