### PR TITLE
rtpengine: Remove unused struct fields

### DIFF
--- a/modules/rtpengine/rtpengine.h
+++ b/modules/rtpengine/rtpengine.h
@@ -37,8 +37,6 @@ struct rtpe_node {
 	int					rn_disabled;	/* found unaccessible? */
 	unsigned			rn_weight;		/* for load balancing */
 	unsigned int		rn_recheck_ticks;
-	int                     rn_rep_supported;
-	int                     rn_ptl_supported;
 	struct rtpe_node	*rn_next;
 };
 


### PR DESCRIPTION
These two fields were copied directly from rtpproxy module but never
used by this module.

Signed-off-by: Peter Lemenkov <lemenkov@gmail.com>