### PR TITLE
Remove dead code

### DIFF
--- a/parser/parse_list_hdr.c
+++ b/parser/parse_list_hdr.c
@@ -152,7 +152,7 @@ int list_hdr_has_option(struct hdr_field *hdr, str *opt)
 
 		/* not in this header, try the next hdr if any */
 		hdr = hdr->sibling;
-	} while (hdr!=NULL);
+	}
 
 	/* option not found in any header instaces */
 	return -1;


### PR DESCRIPTION
`while (hdr)` without `break` ensures that `hdr` will always be `NULL` afterwards, skipping the second `while`.