### PR TITLE
osp: remove obsolete callback type check

### DIFF
--- a/modules/osp/tm.c
+++ b/modules/osp/tm.c
@@ -110,8 +110,6 @@ static void ospTmcbFunc(
 {
     if (type & TMCB_RESPONSE_OUT) {
         LM_DBG("RESPONSE_OUT\n");
-    } else if (type & TMCB_ON_FAILURE) {
-        LM_DBG("FAILURE_RO\n");
     } else if (type & TMCB_RESPONSE_IN) {
         LM_DBG("RESPONSE_IN\n");
     } else if (type & TMCB_REQUEST_FWDED) {


### PR DESCRIPTION
TMCB_ON_FAILURE_RO was removed but the corresponding debug check is
kept, overriding TMCB_ON_FAILURE check on line 121/119.

See commit 2adbeacd3c7055f949048e793fa193119f3a6873.