### PR TITLE
compression: remove redundant check

### DIFF
--- a/modules/compression/gz_helpers.c
+++ b/modules/compression/gz_helpers.c
@@ -175,11 +175,6 @@ int gzip_uncompress(unsigned char* in, unsigned long ilen, str* out, unsigned lo
 		}
 	} while (rc != Z_STREAM_END);
 
-	if (rc != Z_STREAM_END) {
-		deflateEnd(&zlibStream);
-		return rc;
-	}
-
 	deflateEnd(&zlibStream);
 	return Z_OK;
 memerr:


### PR DESCRIPTION
`do ... while` without `break` ensures that rc is `Z_STREAM_END`.