### PR TITLE
xsnprintf.c: fix excessive expression

### DIFF
--- a/modules/jabber/xsnprintf.c
+++ b/modules/jabber/xsnprintf.c
@@ -193,7 +193,7 @@ ap_gcvt(double number, int ndigit, char *buf)
     for (i = ndigit - 1; i > 0 && p1[i] == '0'; i--)
         ndigit--;
     if ((decpt >= 0 && decpt - ndigit > 4)
-            || (decpt < 0 && decpt < -3)) {     /* use E-style */
+            || decpt < -3) {     /* use E-style */
         decpt--;
         *p2++ = *p1++;
         *p2++ = '.';

--- a/modules/xmpp/xsnprintf.c
+++ b/modules/xmpp/xsnprintf.c
@@ -193,7 +193,7 @@ ap_gcvt(double number, int ndigit, char *buf)
     for (i = ndigit - 1; i > 0 && p1[i] == '0'; i--)
         ndigit--;
     if ((decpt >= 0 && decpt - ndigit > 4)
-            || (decpt < 0 && decpt < -3)) {     /* use E-style */
+            || decpt < -3) {     /* use E-style */
         decpt--;
         *p2++ = *p1++;
         *p2++ = '.';


### PR DESCRIPTION
I have no idea what I'm doing, but smart compilers would do the same thing...

I'm wondering if it's a bug / typo.