### PR TITLE
auth: return -1 on error in auth_get_ha1()

### DIFF
--- a/modules/auth/auth_mod.c
+++ b/modules/auth/auth_mod.c
@@ -442,7 +442,7 @@ static inline int pv_authorize(struct sip_msg* msg, str *domain,
 	cred = (auth_body_t*)h->parsed;
 
 	res = auth_get_ha1(msg, &cred->digest.username, domain, ha1);
-	if (res != 0) {
+	if (res < 0) {
 		/* Error */
 		if (sigb.reply(msg, 500, &auth_500_err, NULL) == -1) {
 			LM_ERR("failed to send 500 reply\n");

--- a/modules/auth/auth_mod.c
+++ b/modules/auth/auth_mod.c
@@ -393,7 +393,7 @@ static inline int auth_get_ha1(struct sip_msg *msg, struct username* _username,
 			return 1;
 		}
 	} else {
-		return 1;
+		return -1;
 	}
 	/* get password from PV */
 	memset(&sval, 0, sizeof(pv_value_t));
@@ -406,7 +406,7 @@ static inline int auth_get_ha1(struct sip_msg *msg, struct username* _username,
 			return 1;
 		}
 	} else {
-		return 1;
+		return -1;
 	}
 	if (auth_calc_ha1) {
 		/* Only plaintext passwords are stored in database,


### PR DESCRIPTION
Revert #2024, which ignored "Username not found" cases.