### PR TITLE
Fix for TCP socket selection

### DIFF
--- a/modules/proto_bin/proto_bin.c
+++ b/modules/proto_bin/proto_bin.c
@@ -522,9 +522,9 @@ static int proto_bin_send(struct socket_info* send_sock,
 	if (to){
 		su2ip_addr(&ip, to);
 		port=su_getport(to);
-		n = tcp_conn_get(id, &ip, port, PROTO_BIN, &c, &fd);
+		n = tcp_conn_get(id, &ip, port, PROTO_BIN, &c, &fd, send_sock);
 	}else if (id){
-		n = tcp_conn_get(id, 0, 0, PROTO_NONE, &c, &fd);
+		n = tcp_conn_get(id, 0, 0, PROTO_NONE, &c, &fd, send_sock);
 	}else{
 		LM_CRIT("tcp_send called with null id & to\n");
 		return -1;

--- a/modules/proto_hep/proto_hep.c
+++ b/modules/proto_hep/proto_hep.c
@@ -693,9 +693,9 @@ static int hep_tcp_send (struct socket_info* send_sock,
 	if (to) {
 		su2ip_addr(&ip, to);
 		port=su_getport(to);
-		n = tcp_conn_get(id,&ip, port, PROTO_HEP_TCP, &c, &fd);
+		n = tcp_conn_get(id,&ip, port, PROTO_HEP_TCP, &c, &fd, send_sock);
 	} else if (id) {
-		n = tcp_conn_get(id, 0, 0, PROTO_NONE, &c, &fd);
+		n = tcp_conn_get(id, 0, 0, PROTO_NONE, &c, &fd, send_sock);
 	} else {
 		LM_CRIT("tcp_send called with null id & to\n");
 		return -1;

--- a/modules/proto_tls/proto_tls.c
+++ b/modules/proto_tls/proto_tls.c
@@ -432,9 +432,9 @@ static int proto_tls_send(struct socket_info* send_sock,
 	if (to){
 		su2ip_addr(&ip, to);
 		port=su_getport(to);
-		n = tcp_conn_get(id, &ip, port, PROTO_TLS, &c, &fd);
+		n = tcp_conn_get(id, &ip, port, PROTO_TLS, &c, &fd, send_sock);
 	}else if (id){
-		n = tcp_conn_get(id, 0, 0, PROTO_NONE, &c, &fd);
+		n = tcp_conn_get(id, 0, 0, PROTO_NONE, &c, &fd, send_sock);
 	}else{
 		LM_CRIT("prot_tls_send called with null id & to\n");
 		return -1;

--- a/modules/proto_ws/proto_ws.c
+++ b/modules/proto_ws/proto_ws.c
@@ -412,9 +412,9 @@ static int proto_ws_send(struct socket_info* send_sock,
 	if (to){
 		su2ip_addr(&ip, to);
 		port=su_getport(to);
-		n = tcp_conn_get(id, &ip, port, PROTO_WS, &c, &fd);
+		n = tcp_conn_get(id, &ip, port, PROTO_WS, &c, &fd, send_sock);
 	}else if (id){
-		n = tcp_conn_get(id, 0, 0, PROTO_NONE, &c, &fd);
+		n = tcp_conn_get(id, 0, 0, PROTO_NONE, &c, &fd, send_sock);
 	}else{
 		LM_CRIT("prot_tls_send called with null id & to\n");
 		get_time_difference(get,tcpthreshold,tcp_timeout_con_get);

--- a/modules/proto_wss/proto_wss.c
+++ b/modules/proto_wss/proto_wss.c
@@ -440,9 +440,9 @@ static int proto_wss_send(struct socket_info* send_sock,
 	if (to){
 		su2ip_addr(&ip, to);
 		port=su_getport(to);
-		n = tcp_conn_get(id, &ip, port, PROTO_WSS, &c, &fd);
+		n = tcp_conn_get(id, &ip, port, PROTO_WSS, &c, &fd, send_sock);
 	}else if (id){
-		n = tcp_conn_get(id, 0, 0, PROTO_NONE, &c, &fd);
+		n = tcp_conn_get(id, 0, 0, PROTO_NONE, &c, &fd, send_sock);
 	}else{
 		LM_CRIT("prot_tls_send called with null id & to\n");
 		get_time_difference(get,tcpthreshold,tcp_timeout_con_get);

--- a/modules/tls_mgm/tls_select.c
+++ b/modules/tls_mgm/tls_select.c
@@ -54,7 +54,7 @@ struct tcp_connection* get_cur_connection(struct sip_msg* msg)
 		return 0;
 	}
 
-	tcp_conn_get(msg->rcv.proto_reserved1, 0, 0, PROTO_NONE, &c, NULL/*fd*/);
+	tcp_conn_get(msg->rcv.proto_reserved1, 0, 0, PROTO_NONE, &c, NULL/*fd*/, NULL/*send_sock*/);
 	if (c && c->type != PROTO_TLS && c->type != PROTO_WSS) {
 		LM_ERR("connection found but is not TLS (bug in config)\n");
 		tcp_conn_release(c, 0);

--- a/net/net_tcp.h
+++ b/net/net_tcp.h
@@ -83,7 +83,7 @@ int tcp_connect_blocking_timeout(int s, const struct sockaddr *servaddr,
 
 /* returns the connection identified by either the id or the destination to */
 int tcp_conn_get(int id, struct ip_addr* ip, int port, enum sip_protos proto,
-		struct tcp_connection** conn, int* conn_fd);
+		struct tcp_connection** conn, int* conn_fd, struct socket_info* send_sock);
 
 /* creates a new tcp conn around a newly connected socket
  * and sends it to the master */

--- a/net/proto_tcp/proto_tcp.c
+++ b/net/proto_tcp/proto_tcp.c
@@ -769,9 +769,9 @@ static int proto_tcp_send(struct socket_info* send_sock,
 	if (to){
 		su2ip_addr(&ip, to);
 		port=su_getport(to);
-		n = tcp_conn_get(id, &ip, port, PROTO_TCP, &c, &fd);
+		n = tcp_conn_get(id, &ip, port, PROTO_TCP, &c, &fd, send_sock);
 	}else if (id){
-		n = tcp_conn_get(id, 0, 0, PROTO_NONE, &c, &fd);
+		n = tcp_conn_get(id, 0, 0, PROTO_NONE, &c, &fd, send_sock);
 	}else{
 		LM_CRIT("tcp_send called with null id & to\n");
 		get_time_difference(get,tcpthreshold,tcp_timeout_con_get);


### PR DESCRIPTION
Issue #2083:

Fix for TCP socket selection in tcp_conn_get() when client connections to opensips share the same ephemeral port on the client side.  This can happen when opensips is listening on more than one port, and a given client host/ip connects to that opensips on more than one of its listening ports.  Under these circumstances the client TCP stack will allow client connections to share a local port as long as the destination ip:port are different.

In opensips, when searching for a TCP socket to send over, the general search algorithm in tcp_conn_get only considers the destination ip:port and not the source ip:port.  What can happen as a result is, for example, if the same client host/ip registers two UAs on different opensips listening ports, when it comes time to send a call to one of the UAs, opensips will randomly send to the UA using the first TCP connection that it finds based on the destination ip:port search which will be the wrong connection half the time.

This patch causes "send_sock" to be passed to tcp_conn_get() from all of the modules that call it which contains the desired local ip:port to use.  This is used in the search algorithm in tcp_conn_get to prefer connections that match both source and destination ip:port first, and falls back to just destination ip:port matching as before if a more specific match can not be made.
Note that this search algorithm was implemented using an additional pass for the primary source and destination ip:port match.  This could be optimized by a more sophisticated check for both cases in a single pass but that would involve much care with locks and reference counters by a person more familiar with their implementation.

Below is an excerpt of extra debug logs after this patch showing correct socket selection in a scenario like that described above.  Prior to patch the first socket on the wrong port would have been selected, but after the patch that socket is skipped and the second (correct c=0x7f98e14342a0) socket is selected instead.

```
DBG:core:tcp_conn_get: 0  port 5555
DBG:core:print_ip: tcpconn_find: ip 2.2.2.2
DBG:core:tcp_conn_get: p1 a=0x7f98e1433d90, c=0x7f98e1433cc0, c->id=1848113304, alias port= 5555 src_port=5555 dst_port=5060
DBG:core:print_ip: src_ip=2.2.2.2
DBG:core:print_ip: dst_ip=1.1.1.1
DBG:core:tcp_conn_get: p1 a=0x7f98e1434370, c=0x7f98e14342a0, c->id=1848113305, alias port= 5555 src_port=5555 dst_port=7080
DBG:core:print_ip: src_ip=2.2.2.2
DBG:core:print_ip: dst_ip=1.1.1.1
DBG:core:tcp_conn_get: con found in state 0
DBG:core:tcp_conn_get: tcp connection found (0x7f98e14342a0), acquiring fd
```