### PR TITLE
Fix missing column in subscriber table

### DIFF
--- a/db/schema/subscriber.xml
+++ b/db/schema/subscriber.xml
@@ -77,6 +77,14 @@
     </column>
 
     <column>
+        <name>uri_user</name>
+        <type>string</type>
+        <size>&user_len;</size>
+        <default/>
+        <description>URI user</description>
+    </column>
+
+    <column>
         <name>rpid</name>
         <type>string</type>
         <size>&domain_len;</size>

--- a/scripts/db_berkeley/opensips/subscriber
+++ b/scripts/db_berkeley/opensips/subscriber
@@ -1,5 +1,5 @@
 METADATA_COLUMNS
-id(int) username(str) domain(str) password(str) email_address(str) ha1(str) ha1b(str) rpid(str)
+id(int) username(str) domain(str) password(str) email_address(str) ha1(str) ha1b(str) uri_user(str) rpid(str)
 METADATA_KEY
 1 2 
 METADATA_READONLY
@@ -7,4 +7,4 @@ METADATA_READONLY
 METADATA_LOGFLAGS
 0
 METADATA_DEFAULTS
-NIL|''|''|''|''|''|''|NULL
+NIL|''|''|''|''|''|''|''|NULL

--- a/scripts/dbtext/opensips/subscriber
+++ b/scripts/dbtext/opensips/subscriber
@@ -1,1 +1,1 @@
-id(int,auto) username(string) domain(string) password(string) email_address(string) ha1(string) ha1b(string) rpid(string,null) 
+id(int,auto) username(string) domain(string) password(string) email_address(string) ha1(string) ha1b(string) uri_user(string) rpid(string,null) 

--- a/scripts/mysql/auth_db-create.sql
+++ b/scripts/mysql/auth_db-create.sql
@@ -7,6 +7,7 @@ CREATE TABLE subscriber (
     email_address CHAR(64) DEFAULT '' NOT NULL,
     ha1 CHAR(64) DEFAULT '' NOT NULL,
     ha1b CHAR(64) DEFAULT '' NOT NULL,
+    uri_user CHAR(64) DEFAULT '' NOT NULL,
     rpid CHAR(64) DEFAULT NULL,
     CONSTRAINT account_idx UNIQUE (username, domain)
 ) ENGINE=InnoDB;

--- a/scripts/oracle/auth_db-create.sql
+++ b/scripts/oracle/auth_db-create.sql
@@ -7,6 +7,7 @@ CREATE TABLE subscriber (
     email_address VARCHAR2(64) DEFAULT '',
     ha1 VARCHAR2(64) DEFAULT '',
     ha1b VARCHAR2(64) DEFAULT '',
+    uri_user VARCHAR2(64) DEFAULT '',
     rpid VARCHAR2(64) DEFAULT NULL,
     CONSTRAINT subscriber_account_idx  UNIQUE (username, domain)
 );

--- a/scripts/pi_http/auth_db-mod
+++ b/scripts/pi_http/auth_db-mod
@@ -11,6 +11,7 @@
 				<col><field>email_address</field></col>
 				<col><field>ha1</field></col>
 				<col><field>ha1b</field></col>
+				<col><field>uri_user</field></col>
 				<col><field>rpid</field></col>
 			</query_cols>
 		</cmd>
@@ -24,6 +25,7 @@
 				<col><field>email_address</field></col>
 				<col><field>ha1</field></col>
 				<col><field>ha1b</field></col>
+				<col><field>uri_user</field></col>
 				<col><field>rpid</field></col>
 			</query_cols>
 		</cmd>
@@ -40,6 +42,7 @@
 				<col><field>email_address</field></col>
 				<col><field>ha1</field></col>
 				<col><field>ha1b</field></col>
+				<col><field>uri_user</field></col>
 				<col><field>rpid</field></col>
 			</query_cols>
 		</cmd>

--- a/scripts/pi_http/auth_db-table
+++ b/scripts/pi_http/auth_db-table
@@ -9,6 +9,7 @@
 		<column><field>email_address</field><type>DB_STR</type></column>
 		<column><field>ha1</field><type>DB_STR</type></column>
 		<column><field>ha1b</field><type>DB_STR</type></column>
+		<column><field>uri_user</field><type>DB_STR</type></column>
 		<column><field>rpid</field><type>DB_STR</type></column>
 	</db_table>
 	<!-- Declaration of uri table-->

--- a/scripts/pi_http/pi_framework.xml
+++ b/scripts/pi_http/pi_framework.xml
@@ -82,6 +82,7 @@
 		<column><field>email_address</field><type>DB_STR</type></column>
 		<column><field>ha1</field><type>DB_STR</type></column>
 		<column><field>ha1b</field><type>DB_STR</type></column>
+		<column><field>uri_user</field><type>DB_STR</type></column>
 		<column><field>rpid</field><type>DB_STR</type></column>
 	</db_table>
 	<!-- Declaration of uri table-->

--- a/scripts/postgres/auth_db-create.sql
+++ b/scripts/postgres/auth_db-create.sql
@@ -7,6 +7,7 @@ CREATE TABLE subscriber (
     email_address VARCHAR(64) DEFAULT '' NOT NULL,
     ha1 VARCHAR(64) DEFAULT '' NOT NULL,
     ha1b VARCHAR(64) DEFAULT '' NOT NULL,
+    uri_user VARCHAR(64) DEFAULT '' NOT NULL,
     rpid VARCHAR(64) DEFAULT NULL,
     CONSTRAINT subscriber_account_idx UNIQUE (username, domain)
 );

--- a/scripts/sqlite/auth_db-create.sql
+++ b/scripts/sqlite/auth_db-create.sql
@@ -7,6 +7,7 @@ CREATE TABLE subscriber (
     email_address CHAR(64) DEFAULT '' NOT NULL,
     ha1 CHAR(64) DEFAULT '' NOT NULL,
     ha1b CHAR(64) DEFAULT '' NOT NULL,
+    uri_user CHAR(64) DEFAULT '' NOT NULL,
     rpid CHAR(64) DEFAULT NULL,
     CONSTRAINT subscriber_account_idx  UNIQUE (username, domain)
 );


### PR DESCRIPTION
I found another problem in DB schema configuration. Now it is "subscriber" table.
In current version if you try register SIP-account based on auth_db module you will catch error (if PostgreSQL backend):
```
Jun  3 16:26:07 os1 /usr/local/sbin/opensips[16659]: ERROR:db_postgres:db_postgres_submit_query: 0x7f4b4a61ffe0 PQsendQuery Error: ERROR:  column "uri_user" does not exist#012LINE 1: ...rname='101' AND domain='example.local' AND uri_user='...#012
^#012 Query: select username from subscriber where username='101' AND domain='example.local' AND uri_user='101'
Jun  3 16:26:07 os1 /usr/local/sbin/opensips[16659]: ERROR:core:db_do_query: error while submitting query - [select username from subscriber where username='101' AND domain='example.local' AND uri_user='101']
Jun  3 16:26:07 os1 /usr/local/sbin/opensips[16659]: ERROR:auth_db:check_username: Error while querying database
```