### PR TITLE
Dialog rr_param should have ;did=

### DIFF
--- a/modules/dialog/dlg_handlers.c
+++ b/modules/dialog/dlg_handlers.c
@@ -156,14 +156,13 @@ static inline int add_dlg_rr_param(struct sip_msg *req, struct dlg_cell *dlg)
 	char *p;
 	str id;
 
-	p = buf;
+	id.s = p = buf;
 
 	*(p++) = ';';
 	memcpy(p, rr_param.s, rr_param.len);
 	p += rr_param.len;
 	*(p++) = '=';
 
-	id.s = p;
 	id.len = RR_DLG_PARAM_SIZE - (p-buf);
 	if (dlg_get_did_buf(dlg, &id) < 0)
 		return -1;


### PR DESCRIPTION
While testing opensips-3.1-beta, The record_route parameter not adding the dialogid properly. 

Record-Route: <sip:10.201.17.76;r2=on;lr6b91.9064b111>

it should be  : Record-Route: <sip:10.201.17.76;r2=on;lr;did=6b91.9064b111>

Hope this patch will fix this issue. 