### PR TITLE
dispatcher: added database column type checks on reload

### DIFF
--- a/db/db_val.h
+++ b/db/db_val.h
@@ -194,6 +194,29 @@ static inline void db_print_val(db_val_t *v)
  */
 #define VAL_BITMAP(dv) ((dv)->val.bitmap_val)
 
+#define get_int_from_dbval(_col_name, _val, _not_null, _not_zero,  _int,  _error_label) \
+        do{\
+                if ((_val)->nul) { \
+                        if(_not_null) { \
+                                LM_ERR("value in column %s cannot be null\n", _col_name); \
+                                goto _error_label; \
+                        } else { \
+				_int = 0; \
+			} \
+                } \
+		if ((_val)->type == DB_INT || (_val)->type == DB_BIGINT) { \
+			if (VAL_INT(_val) == 0 && _not_zero) { \
+			        LM_ERR("value in column %s cannot be zero\n", _col_name); \
+                                goto _error_label;\
+			} else { \
+				_int = VAL_INT(_val); \
+			} \
+		} else { \
+			LM_ERR("column %s does not have a int or bigint type (found %d)\n",\
+                                _col_name,(_val)->type); \
+                        goto _error_label;\
+		} \
+        }while(0);
 
 #define get_str_from_dbval( _col_name, _val, _not_null, _not_empty, _str, _error_label) \
 	do{\

--- a/modules/dispatcher/dispatch.c
+++ b/modules/dispatcher/dispatch.c
@@ -1025,19 +1025,13 @@ static ds_data_t* ds_load_data(ds_partition_t *partition, int use_state_col)
 		}
 
 		weight = 1;
-
-		/* weight */
-		if (VAL_TYPE(values+3) == DB_INT || VAL_TYPE(values+3) == DB_BIGINT) {
-			weight = VAL_INT(values+3);
-			memset(&weight_st, 0, sizeof weight_st);
-		} else {
-			/* dynamic weight, given as a communication socket string */
-			get_str_from_dbval("WEIGHT", values+3,
-			                   0/*not_null*/, 0/*not_empty*/, weight_st, error2);
-			if (!is_fs_url(&weight_st)) {
-				str2int(&weight_st, (unsigned int *)&weight);
-				memset(&weight_st, 0, sizeof weight_st);
-			}
+                /* weight */
+		/* dynamic weight, given as a communication socket string or a static weight*/
+		get_str_from_dbval("WEIGHT", values+3,
+		    0/*not_null*/, 0/*not_empty*/, weight_st, error2);
+		if (!is_fs_url(&weight_st)) {
+		    str2int(&weight_st, (unsigned int *)&weight);
+		    memset(&weight_st, 0, sizeof weight_st);
 		}
 
 		/* attrs */

--- a/modules/dispatcher/dispatch.c
+++ b/modules/dispatcher/dispatch.c
@@ -1052,6 +1052,7 @@ static ds_data_t* ds_load_data(ds_partition_t *partition, int use_state_col)
 		if(use_state_col) {
 			get_int_from_dbval("STATE",values+7,
                                 0/*not_null*/, 0/*not_zero*/, state, error2);
+                /*active state*/
 		} else {
 			state = 0;
 		}

--- a/modules/dispatcher/dispatch.c
+++ b/modules/dispatcher/dispatch.c
@@ -997,11 +997,8 @@ static ds_data_t* ds_load_data(ds_partition_t *partition, int use_state_col)
 		values = ROW_VALUES(rows+i);
 
 		/* id */
-		if (VAL_NULL(values)) {
-			LM_ERR("ds ID column cannot be NULL -> skipping\n");
-			continue;
-		}
-		id = VAL_INT(values);
+		get_int_from_dbval("ID",values,
+		        1/*not_null*/, 0/*not_zero*/, id, error2);
 
 		/* uri */
 		get_str_from_dbval( "URI", values+1,
@@ -1030,7 +1027,7 @@ static ds_data_t* ds_load_data(ds_partition_t *partition, int use_state_col)
 		weight = 1;
 
 		/* weight */
-		if (values[3].type == DB_INT) {
+		if (VAL_TYPE(values+3) == DB_INT || VAL_TYPE(values+3) == DB_BIGINT) {
 			weight = VAL_INT(values+3);
 			memset(&weight_st, 0, sizeof weight_st);
 		} else {
@@ -1048,18 +1045,18 @@ static ds_data_t* ds_load_data(ds_partition_t *partition, int use_state_col)
 			0/*not_null*/, 0/*not_empty*/, attrs, error2);
 
 		/* priority */
-		if (VAL_NULL(values+5))
-			prio = 0;
-		else
-			prio = VAL_INT(values+5);
+		get_int_from_dbval("PRIORITY", values+5,
+                        0/*not_null*/, 0/*not_zero*/, prio, error2);
 
 		/* state */
-		if (!use_state_col || VAL_NULL(values+7))
-			/* active state */
+		if(use_state_col) {
+			get_int_from_dbval("STATE",values+7,
+                                0/*not_null*/, 0/*not_zero*/, state, error2);
+		} else {
 			state = 0;
-		else
-			state = VAL_INT(values+7);
+		}
 
+		/* description */
 		get_str_from_dbval( "DESCRIPTION", values+6,
 			0/*not_null*/, 0/*not_empty*/, description, error2);
 


### PR DESCRIPTION
Added some database column checks while reloading dispatcher data from database to OpenSIPS cache. It strictly checks database values and user has to follow the table version strictly otherwise dispatcher module will not load and return error.