### PR TITLE
rtpengine/rtpproxy: Remove unused defines (leftovers)

### DIFF
--- a/modules/rtpengine/rtpengine.c
+++ b/modules/rtpengine/rtpengine.c
@@ -102,8 +102,6 @@
 #define MI_RTP_ENGINE_NOT_FOUND_LEN	(sizeof(MI_RTP_ENGINE_NOT_FOUND)-1)
 #define MI_SET						"Set"
 #define MI_SET_LEN					(sizeof(MI_SET)-1)
-#define MI_NODE						"node"
-#define MI_NODE_LEN					(sizeof(MI_NODE)-1)
 #define MI_INDEX					"index"
 #define MI_INDEX_LEN				(sizeof(MI_INDEX)-1)
 #define MI_DISABLED					"disabled"

--- a/modules/rtpproxy/rtpproxy.c
+++ b/modules/rtpproxy/rtpproxy.c
@@ -209,8 +209,6 @@
 #define MI_PING_DISABLED_LEN		(sizeof(MI_PING_DISABLED)-1)
 #define MI_SET						"Set"
 #define MI_SET_LEN					(sizeof(MI_SET)-1)
-#define MI_NODE						"node"
-#define MI_NODE_LEN					(sizeof(MI_NODE)-1)
 #define MI_INDEX					"index"
 #define MI_INDEX_LEN				(sizeof(MI_INDEX)-1)
 #define MI_DISABLED					"disabled"


### PR DESCRIPTION
These defines unused since commit 39179df17cb772b04cb2d388f5754a338932f1d0 and commit c944d2fb76180efafc33a1603faeb08b91629d66.