### PR TITLE
Add TLS support to module/httpd

### DIFF
--- a/modules/httpd/doc/httpd_admin.xml
+++ b/modules/httpd/doc/httpd_admin.xml
@@ -1,20 +1,29 @@
 <!-- Module User's Guide -->
 
 <chapter>
-	
+
 	<title>&adminguide;</title>
-	
+
 	<section id="overview" xreflabel="Overview">
 	<title>Overview</title>
 	<para>
 		This module provides an HTTP transport layer for &osips;.
 	</para>
 	<para>
-		Implementation of httpd module's http server is based on 
+		Implementation of httpd module's http server is based on
 		libmicrohttpd library.
 	</para>
 	</section>
-	
+
+	<section id="tlssupport" xreflabel="tlssupport">
+		<title>Overview</title>
+		<para>
+			TLS for the http server is enabled by setting  the <varname>tls_cert_file</varname>
+			and <varname>tls_key_file</varname> parameters. If this is enabled, support for plain
+			http is disabled.
+		</para>
+	</section>
+
 	<section id="dependencies" xreflabel="Dependencies">
 	<title>Dependencies</title>
 	<section>
@@ -125,6 +134,68 @@ modparam("httpd", "buf_size", 524288)
 		<programlisting format="linespecific">
 ...
 modparam("httpd", "post_buf_size", 4096)
+...
+</programlisting>
+		</example>
+	</section>
+	<section id="param_tls_cert_file" xreflabel="tls_cert_file">
+		<title><varname>tls_cert_file</varname> (string)</title>
+		<para>
+		Public certificate file for httpd. It will be used as server-side certificate for incoming TLS connections.
+		</para>
+		<para>
+		<emphasis> The default value is ""</emphasis>
+		</para>
+		<example>
+		<title>Set <varname>tls_cert_file</varname> parameter</title>
+		<programlisting format="linespecific">
+...
+modparam("httpd", "tls_cert_file", "/etc/opensips/tls/server.pem")
+...
+</programlisting>
+		</example>
+	</section>
+	<section id="param_tls_key_file" xreflabel="tls_key_file">
+		<title><varname>tls_key_file</varname> (string)</title>
+		<para>
+		Private key of the above certificate. I must be kept in a safe place with tight permissions!
+		</para>
+		<para>
+		<emphasis> The default value is ""</emphasis>
+		</para>
+		<example>
+		<title>Set <varname>tls_key_file</varname> parameter</title>
+		<programlisting format="linespecific">
+...
+modparam("httpd", "tls_key_file", "/etc/opensips/tls/server.key")
+...
+</programlisting>
+		</example>
+	</section>
+	<section id="param_tls_ciphers" xreflabel="tls_ciphers">
+		<title><varname>tls_ciphers</varname> (string)</title>
+		<para>
+		You can specify the list of algorithms for authentication and encryption that you allow.
+		To obtain a list of ciphers
+		and then choose, use the gnutls-cli application:
+		</para>
+		<itemizedlist>
+			<listitem>
+				<para>gnutls-cli -l</para>
+			</listitem>
+		</itemizedlist>
+		<warning><para>
+			Do not use the NULL algorithms (no encryption) ... never!!!
+		</para></warning>
+
+		<para>
+		<emphasis> The default value is  "SECURE256:+SECURE192:-VERS-ALL:+VERS-TLS1.2"</emphasis>
+		</para>
+		<example>
+		<title>Set <varname>tls_key_file</varname> parameter</title>
+		<programlisting format="linespecific">
+...
+modparam("httpd", "tls_ciphers", "SECURE256:+SECURE192:-VERS-ALL:+VERS-TLS1.2")
 ...
 </programlisting>
 		</example>

--- a/modules/httpd/httpd.c
+++ b/modules/httpd/httpd.c
@@ -59,6 +59,9 @@ static mi_response_t *mi_list_root_path(const mi_params_t *params,
 int port = 8888;
 str ip = {NULL, 0};
 str buffer = {NULL, 0};
+str tls_cert_file = {NULL, 0};
+str tls_key_file = {NULL, 0};
+str tls_ciphers = {"SECURE256:+SECURE192:-VERS-ALL:+VERS-TLS1.2", 45};
 int post_buf_size = DEFAULT_POST_BUF_SIZE;
 struct httpd_cb *httpd_cb_list = NULL;
 
@@ -75,6 +78,9 @@ static param_export_t params[] = {
 	{"ip",            STR_PARAM, &ip.s},
 	{"buf_size",      INT_PARAM, &buffer.len},
 	{"post_buf_size", INT_PARAM, &post_buf_size},
+	{"tls_cert_file", STR_PARAM, &tls_cert_file.s},
+	{"tls_key_file", STR_PARAM,  &tls_key_file.s},
+	{"tls_ciphers", STR_PARAM, &tls_ciphers.s},
 	{NULL, 0, NULL}
 };
 
@@ -261,5 +267,3 @@ error:
 	free_mi_response(resp);
 	return 0;
 }
-
-


### PR DESCRIPTION
As our policies require encrypted connections only, i enabled tls support within the httpd module,
so opensips-cli can be used from a remote instance over an encrypted channel. 

Due the limitations of the used libmicrohttpd, enabling https will disable http connections, but in our case this is fine & wanted.

A PR for opensips-cli handling with self-signed certificates will follow.