### PR TITLE
A crash in stir_shaken module.

### DIFF
--- a/modules/stir_shaken/stir_shaken.c
+++ b/modules/stir_shaken/stir_shaken.c
@@ -747,6 +747,7 @@ static int add_identity_hf(struct sip_msg *msg, EVP_PKEY *pkey,
 	}
 
 	EVP_MD_CTX_destroy(mdctx);
+	mdctx = NULL;
 
 	/* convert from DER format to the internal structure in order to extract
 	 * the R and S values */


### PR DESCRIPTION
The opensips may dump core when the private key or certificate for the stir_shaken module has an issue.