### PR TITLE
Fix NULL values for str params in EVI API

### DIFF
--- a/evi/evi_transport.c
+++ b/evi/evi_transport.c
@@ -176,7 +176,10 @@ static int payload_add_params(cJSON *ret_obj, evi_params_t *params,
 				return -1;
 			}
 		} else {
-			tmp = cJSON_CreateStr(param->val.s.s, param->val.s.len);
+			if (param->val.s.s)
+				tmp = cJSON_CreateStr(param->val.s.s, param->val.s.len);
+			else
+				tmp = cJSON_CreateNull();
 			if (!tmp) {
 				LM_ERR("Failed to create JSON string %.*s\n", param->name.len, param->name.s);
 				return -1;

--- a/evi/evi_transport.c
+++ b/evi/evi_transport.c
@@ -178,7 +178,7 @@ static int payload_add_params(cJSON *ret_obj, evi_params_t *params,
 		} else {
 			tmp = cJSON_CreateStr(param->val.s.s, param->val.s.len);
 			if (!tmp) {
-				LM_ERR("Failed to create JSON string\n");
+				LM_ERR("Failed to create JSON string %.*s\n", param->name.len, param->name.s);
 				return -1;
 			}
 		}

--- a/modules/event_datagram/event_datagram.c
+++ b/modules/event_datagram/event_datagram.c
@@ -314,7 +314,7 @@ static int datagram_raise(struct sip_msg *msg, str* ev_name,
 
 	buf.s = evi_build_payload(params, ev_name, 0, NULL, NULL);
 	if (!buf.s) {
-		LM_ERR("Failed to build event payload\n");
+		LM_ERR("Failed to build event payload %.*s\n", ev_name->len, ev_name->s);
 		return -1;
 	}
 	buf.len = strlen(buf.s);

--- a/modules/event_rabbitmq/event_rabbitmq.c
+++ b/modules/event_rabbitmq/event_rabbitmq.c
@@ -476,7 +476,7 @@ static int rmq_raise(struct sip_msg *msg, str* ev_name,
 
 	buf.s = evi_build_payload(params, ev_name, 0, NULL, NULL);
 	if (!buf.s) {
-		LM_ERR("Failed to build event payload\n");
+		LM_ERR("Failed to build event payload %.*s\n", ev_name->len, ev_name->s);
 		return -1;
 	}
 	buf.len = strlen(buf.s);

--- a/modules/event_stream/stream_send.c
+++ b/modules/event_stream/stream_send.c
@@ -254,7 +254,7 @@ int stream_build_buffer(str *event_name, evi_reply_sock *sock,
 	s = evi_build_payload(params, method, stream_sync_mode ? id : 0,
 		extra_param.s ? &extra_param : NULL, extra_param.s ? event_name : NULL);
 	if (!s) {
-		LM_ERR("Failed to build event payload\n");
+		LM_ERR("Failed to build event payload %.*s\n", event_name->len, event_name->s);
 		return -1;
 	}
 


### PR DESCRIPTION
NULL value as a str param is totally fine according to JSON
specification. So let's not crash when adding str parameter with NULL
value.

Also make  error messages more verbose.