### PR TITLE
Accept single \r as EOH in multipart

### DIFF
--- a/parser/parse_body.c
+++ b/parser/parse_body.c
@@ -168,7 +168,7 @@ static int parse_single_part(struct body_part *part, char * start, char * end)
 	if (*(end-1)=='\n') {
 		end--;
 		if (*(end-1)=='\r') end--;
-	} else if (*(end-1)=='\n') {
+	} else if (*(end-1)=='\r') {
 		end--;
 	} else {
 		LM_ERR("invalid separator between body and boundry [%x/%x]\n",


### PR DESCRIPTION
This completes commit 3ec9d1b25430715f2b800c455c8518104a243f49.

> OpenSIPS accepts (for hdrs) a single \n or \r as EOH