### PR TITLE
rtpengine: fix single-bit field type

### DIFF
--- a/modules/rtpengine/bencode.h
+++ b/modules/rtpengine/bencode.h
@@ -71,7 +71,7 @@ struct bencode_item {
 struct bencode_buffer {
 	struct __bencode_buffer_piece *pieces;
 	struct __bencode_free_list *free_list;
-	int error:1;		/* set to !0 if allocation failed at any point */
+	unsigned int error:1;		/* set to !0 if allocation failed at any point */
 };
 
 


### PR DESCRIPTION
`signed int` of a single bit has no value bits and one sign bit, so in theory it can't be assigned 1.