### PR TITLE
Fix a rather obscure copy-n-paste bug in the digest parser

### DIFF
--- a/parser/digest/digest_parser.c
+++ b/parser/digest/digest_parser.c
@@ -351,11 +351,8 @@ int parse_digest_cred(str* _s, dig_cred_t* _c)
 	      * scheme we are able to parse here
 	      */
 	if (!strncasecmp(tmp.s, DIGEST_SCHEME, DIG_LEN) &&
-	    ((tmp.s[DIG_LEN] == ' ') ||     /* Test for one of LWS chars */
-	     (tmp.s[DIG_LEN] == '\r') ||
-	     (tmp.s[DIG_LEN] == 'n') ||
-	     (tmp.s[DIG_LEN] == '\t') ||
-	     (tmp.s[DIG_LEN] == ','))) {
+	    /* Test for one of LWS chars + ',' */
+	    (is_ws(tmp.s[DIG_LEN]) || (tmp.s[DIG_LEN] == ','))) {
 		     /* Scheme is Digest */
 		tmp.s += DIG_LEN + 1;
 		tmp.len -= DIG_LEN + 1;

--- a/trim.h
+++ b/trim.h
@@ -25,7 +25,14 @@
 #include "str.h"
 
 /* whitespace */
-#define is_ws(c) ((c) == ' ' || (c) == '\r' || (c) == '\n' || (c) == '\t')
+static inline int
+is_ws(unsigned char ch)
+{
+    const unsigned int mask = (1 << (' ' - 1)) | (1 << ('\r' - 1)) |
+        (1 << ('\n' - 1)) | (1 << ('\t' - 1));
+    ch--;
+    return ch < ' ' && ((1 << ch) & mask);
+}
 
 /*
  * trim leading ws

--- a/trim.h
+++ b/trim.h
@@ -47,17 +47,7 @@
  * define characters that should be skipped
  * here.
  */
-#define TRIM_SWITCH(c) switch(c) {     \
-                       case ' ':       \
-                       case '\t':      \
-                       case '\r':      \
-                       case '\n':      \
-                               break;  \
-                                       \
-                       default:        \
-                               return; \
-                       }
-
+#define TRIM_SWITCH(c) {if (!is_ws(c)) return;}
 
 /*! \brief
  * Remove any leading whitechars, like spaces,

--- a/ut.h
+++ b/ut.h
@@ -63,8 +63,7 @@ struct sip_msg;
 #define trim_len( _len, _begin, _mystr ) \
 	do{ 	static char _c; \
 		(_len)=(_mystr).len; \
-		while ((_len) && ((_c=(_mystr).s[(_len)-1])==0 || _c=='\r' || \
-					_c=='\n' || _c==' ' || _c=='\t' )) \
+		while ((_len) && ((_c=(_mystr).s[(_len)-1])==0 || is_ws(_c))) \
 			(_len)--; \
 		(_begin)=(_mystr).s; \
 		while ((_len) && ((_c=*(_begin))==' ' || _c=='\t')) { \


### PR DESCRIPTION
Fix a rather obscure copy-n-paste bug in the digest parser causing  "Digestn" to be accepted just as well as "Digest" would, however if the header happens to overflow to the next line right after that, i.e.:

```
Authorization: Digest[LF]
 username="opensipit2020"...
```

The header would fail to be parsed at LF. Use is_ws() macro here (and in two more places), don't reinvent a wheel.