### PR TITLE
Fix parse_qop_value() to not access memory outside of the qop value region

### DIFF
--- a/parser/parse_authenticate.h
+++ b/parser/parse_authenticate.h
@@ -55,7 +55,7 @@ int parse_proxy_authenticate_header( struct sip_msg *msg );
 int parse_www_authenticate_header( struct sip_msg *msg );
 int parse_authenticate_header(struct hdr_field *authenticate);
 
-int parse_qop_value(str *val, struct authenticate_body *auth);
+int parse_qop_value(str val, struct authenticate_body *auth);
 
 void free_authenticate(struct authenticate_body *authenticate_b);
 

--- a/parser/test/test_oob.c
+++ b/parser/test/test_oob.c
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2020 Maksym Sobolyev
+ *
+ * This file is part of opensips, a free SIP server.
+ *
+ * opensips is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version
+ *
+ * opensips is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301,USA
+ */
+
+#include <sys/mman.h>
+#include <assert.h>
+#include <unistd.h>
+
+#include "../../str.h"
+#include "test_oob.h"
+
+void test_oob(const str *sarg, void (*tfunc)(const str *, void *), void *param)
+{
+	char *mpages[3];
+	str targ;
+	long page_size = sysconf(_SC_PAGESIZE);
+
+	mpages[0] = mmap(NULL, page_size * 3, PROT_NONE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+	assert(mpages[0] != NULL);
+	mpages[1] = mpages[0] + page_size;
+	mpages[2] = mpages[1] + page_size;
+	for (targ.len = 0; targ.len <= sarg->len; targ.len++) {
+		targ.s = mpages[1] - targ.len;
+		assert(mprotect(mpages[0], page_size, PROT_WRITE) == 0);
+		memcpy(targ.s, sarg->s, targ.len);
+		assert(mprotect(mpages[0], page_size, PROT_READ) == 0);
+		tfunc(&targ, param);
+
+		targ.s = mpages[2];
+		assert(mprotect(mpages[2], page_size, PROT_WRITE) == 0);
+		memcpy(targ.s, sarg->s, targ.len);
+		assert(mprotect(mpages[2], page_size, PROT_READ) == 0);
+		tfunc(&targ, param);
+    }
+    munmap(mpages[0], page_size * 3);
+    return;
+}

--- a/parser/test/test_oob.h
+++ b/parser/test/test_oob.h
@@ -1,0 +1,21 @@
+/*
+ * Copyright (C) 2020 Maksym Sobolyev
+ *
+ * This file is part of opensips, a free SIP server.
+ *
+ * opensips is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version
+ *
+ * opensips is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301,USA
+ */
+
+void test_oob(const str *, void (*)(const str *, void *), void *);

--- a/parser/test/test_parse_qop.c
+++ b/parser/test/test_parse_qop.c
@@ -25,33 +25,50 @@
 
 #include "../../parser/parse_authenticate.h"
 
+#include "test_oob.h"
+
+void test_parse_qop_oob(const str *, void *);
+
 void test_parse_qop_val(void)
 {
 	struct authenticate_body auth;
+	int i;
+	struct tts {
+		const str ts;
+		int tres;
+		int aflags;
+	} tset[] = {
+		{.ts = str_init("aut"), .tres = -1},
+		{.ts = str_init("auth-inti"), .tres = -1},
+		{.ts = str_init("auth,aut"), .tres = -1},
+		{.ts = str_init("auth,auth-inti"), .tres = -1},
+		{.ts = str_init("auth,,auth-int"), .tres = -1},
+		{.ts = str_init("auth-int,"), .tres = -1},
+		{.ts = str_init("auth,auth-int,"), .tres = -1},
+		{.ts = str_init("auth,auth-int,aut"), .tres = -1},
+		{.ts = str_init("auth-int  , \tauth "),  .tres = -1},
+		{.ts = str_init(" auth-int,auth"),  .tres = -1},
+		{.ts = str_init("auth "), .tres = 0, .aflags = QOP_AUTH},
+		{.ts = str_init("auth-int"), .tres = 0, .aflags = QOP_AUTH_INT},
+		{.ts = str_init("auth, auth-int"), .tres = 0, .aflags = QOP_AUTH | QOP_AUTH_INT},
+		{.ts = str_init("auth-int , auth"), .tres = 0, .aflags = QOP_AUTH | QOP_AUTH_INT},
+		{.ts = STR_NULL}
+	};
 
-	memset(&auth, 0, sizeof(struct authenticate_body));
-	ok(parse_qop_value(_str("aaa"), &auth));
-	ok(parse_qop_value(_str("auth-init"), &auth));
-	ok(parse_qop_value(_str("auth,aaa"), &auth));
-	ok(parse_qop_value(_str("auth,auth-init"), &auth));
+	for (i = 0; tset[i].ts.s != NULL; i++) {
+		memset(&auth, 0, sizeof(struct authenticate_body));
+		ok(parse_qop_value(tset[i].ts, &auth) == tset[i].tres,
+		    "parse_qop_value(\"%s\") == %d", tset[i].ts.s, tset[i].tres);
+		if (tset[i].tres == 0)
+			ok(auth.flags == tset[i].aflags, "auth.flags == %d", tset[i].aflags);
+		test_oob(&tset[i].ts, test_parse_qop_oob, &auth);
+	}
+}
 
-	memset(&auth, 0, sizeof(struct authenticate_body));
-	ok(!parse_qop_value(_str("auth "), &auth));
-	ok(auth.flags & QOP_AUTH);
-	ok(!(auth.flags & QOP_AUTH_INT));
+void test_parse_qop_oob(const str *tstr, void *farg)
+{
+	struct authenticate_body *ap = farg;
 
-	memset(&auth, 0, sizeof(struct authenticate_body));
-	ok(!parse_qop_value(_str("auth-int"), &auth));
-	ok(!(auth.flags & QOP_AUTH));
-	ok(auth.flags & QOP_AUTH_INT);
-
-	memset(&auth, 0, sizeof(struct authenticate_body));
-	ok(!parse_qop_value(_str("auth, auth-int"), &auth));
-	ok(auth.flags & QOP_AUTH);
-	ok(auth.flags & QOP_AUTH_INT);
-
-	memset(&auth, 0, sizeof(struct authenticate_body));
-	ok(!parse_qop_value(_str("auth-int , auth"), &auth));
-	ok(auth.flags & QOP_AUTH);
-	ok(auth.flags & QOP_AUTH_INT);
+	parse_qop_value(*tstr, ap);
+	ok(1, "oob check: parse_qop_value(\"%.*s\")", tstr->len, tstr->s);
 }


### PR DESCRIPTION
Fix parse_qop_value() to not access memory outside of the qop value region.

Noticed by:	liviuchircu

Use is_ws(), not isspace() while I am here.

Below is the little unit test that I created. I am not sure if there any place to put it in.

```
#include <assert.h>
#include <stddef.h>
#include <stdio.h>
#include <stdlib.h>

#include "parser/parse_authenticate.h"
#include "str.h"

static struct tts {
    const str ts;
    int tres;
} tset[] = {
    {.ts = str_init("auth"), .tres = 0},
    {.ts = str_init("auth-int"), .tres = 0},
    {.ts = str_init("auth,auth-int"), .tres = 0},
    {.ts = str_init("auth, auth-int"), .tres = 0},
    {.ts = str_init("auth       , auth-int"), .tres = 0},
    {.ts = str_init("auth-int,auth"), .tres = 0},
    {.ts = str_init("auth-int  ,                auth"),  .tres = 0},
    {.ts = str_init("gargage"), .tres = -1},
    {.ts = str_init("auth,garbage"), .tres = -1},
    {.ts = str_init("auth , garbage"), .tres = -1},
    {.ts = str_init("auth,,auth-int"), .tres = -1},
    {.ts = str_init("auth-int,"), .tres = -1},
    {.ts = str_init("auth,auth-int,"), .tres = -1},
    {.ts = str_init("auth,auth-int,garbage"), .tres = -1},
    {.ts = str_init("auth-int  ,                auth "),  .tres = -1},
    {.ts = str_init(" auth-int,auth"),  .tres = -1},
    {.tres = 0}
};

int main()
{
    struct tts *tp;
    static struct authenticate_body ab;

    for (tp = tset; tp->ts.len != 0; tp++) {
        int tres = parse_qop_value(tp->ts, &ab);
        printf("parse(\"%s\") = %d\n", tp->ts.s, tres);
        assert(tp->tres == tres);
    }
    return 0;
}

```

```
[sobomax@van01 ~/projects/opensips]$ ./patest
parse("auth") = 0
parse("auth-int") = 0
parse("auth,auth-int") = 0
parse("auth, auth-int") = 0
parse("auth     , auth-int") = 0
parse("auth-int,auth") = 0
parse("auth-int  ,              auth") = 0
parse("gargage") = -1
parse("auth,garbage") = -1
parse("auth , garbage") = -1
parse("auth,,auth-int") = -1
parse("auth-int,") = -1
parse("auth,auth-int,") = -1
parse("auth,auth-int,garbage") = -1
parse("auth-int  ,              auth ") = -1
parse(" auth-int,auth") = -1
```