### PR TITLE
Clean up parse_authenticate_body(), fix small bug. Add Unit Test. Improve OOB test.

### DIFF
--- a/parser/parse_authenticate.c
+++ b/parser/parse_authenticate.c
@@ -51,25 +51,25 @@
 
 #define CASE_5B(_hex4,_c5, _new_state, _quoted) \
 	case _hex4: \
-		if (p+5<end && LOWER1B(*(p+4))==_c5 ) \
+		if (body.len > 5 && LOWER1B(*(body.s+4))==_c5 ) \
 		{ \
-			p+=5; \
+			STR_ADVANCE_BY(&body, 5); \
 			state = _new_state; \
 			quoted_val = _quoted; \
 		} else { \
-			p+=4; \
+			STR_ADVANCE_BY(&body, 4); \
 		} \
 		break;
 
 #define CASE_6B(_hex4,_c5,_c6, _new_state, _quoted) \
 	case _hex4: \
-		if (p+6<end && LOWER1B(*(p+4))==_c5 && LOWER1B(*(p+5))==_c6) \
+		if (body.len > 6 && LOWER1B(*(body.s+4))==_c5 && LOWER1B(*(body.s+5))==_c6) \
 		{ \
-			p+=6; \
+			STR_ADVANCE_BY(&body, 6); \
 			state = _new_state; \
 			quoted_val = _quoted; \
 		} else { \
-			p+=4; \
+			STR_ADVANCE_BY(&body, 4); \
 		} \
 		break;
 
@@ -145,50 +145,46 @@ postcomma:
 		return -1;
 }
 
-int parse_authenticate_body( str *body, struct authenticate_body *auth)
+int parse_authenticate_body( str body, struct authenticate_body *auth)
 {
-	char *p;
-	char *end;
 	int  n;
 	int state;
 	str name;
 	str val;
 	int quoted_val;
 
-	if (body->s==0 || *body->s==0 )
+	if (body.len == 0)
 	{
 		LM_ERR("empty body\n");
 		goto error;
 	}
 
 	memset( auth, 0, sizeof(struct authenticate_body));
-	p = body->s;
-	end = body->s + body->len;
 
 	/* parse the "digest" */
-	while (p<end && is_ws(*p)) p++;
-	if (p+AUTHENTICATE_DIGEST_LEN>=end )
+	trim_leading(&body);
+	if (body.len <= AUTHENTICATE_DIGEST_LEN)
 		goto parse_error;
-	if ( LOWER4B( GET4B(p) ) != 0x64696765 /*dige*/ ||
-	LOWER1B(*(p+4))!=0x73 /*s*/ || LOWER1B(*(p+5))!=0x74 /*t*/)
+	if ( LOWER4B( GET4B(body.s) ) != 0x64696765 /*dige*/ ||
+	LOWER1B(*(body.s+4))!=0x73 /*s*/ || LOWER1B(*(body.s+5))!=0x74 /*t*/)
 		goto parse_error;
-	p += AUTHENTICATE_DIGEST_LEN;
-	if (!is_ws(*p))
+	STR_ADVANCE_BY(&body, AUTHENTICATE_DIGEST_LEN);
+	if (!is_ws(*body.s))
 		goto parse_error;
-	p++;
-	while (p<end && is_ws(*p)) p++;
-	if (p==end)
+	STR_ADVANCE(&body);
+	trim_leading(&body);
+	if (body.len == 0)
 		goto parse_error;
 
-	while (p<end)
+	while (body.len > 0)
 	{
 		state = OTHER_STATE;
 		quoted_val = 0;
 		/* get name */
-		name.s = p;
-		if (p+4<end)
+		name.s = body.s;
+		if (body.len > 4)
 		{
-			n = LOWER4B( GET4B(p) );
+			n = LOWER4B( GET4B(body.s) );
 			switch(n)
 			{
 				CASE_5B( 0x7265616c, 'm', REALM_STATE, 1); /*realm*/
@@ -197,71 +193,73 @@ int parse_authenticate_body( str *body, struct authenticate_body *auth)
 				CASE_6B( 0x646f6d62, 'i', 'n', DOMAIN_STATE, 1); /*domain*/
 				CASE_6B( 0x6f706171, 'u', 'e', OPAQUE_STATE, 1); /*opaque*/
 				case 0x616c676f: /*algo*/
-					if (p+9<end && LOWER4B(GET4B(p+4))==0x72697468
-						&& LOWER1B(*(p+8))=='m' )
+					if (body.len > 9 && LOWER4B(GET4B(body.s+4))==0x72697468
+						&& LOWER1B(*(body.s+8))=='m' )
 					{
-						p+=9;
+						STR_ADVANCE_BY(&body, 9);
 						state = ALGORITHM_STATE;
 					} else {
-						p+=4;
+						STR_ADVANCE_BY(&body, 4);
 					}
 					break;
 				default:
 					if ((n|0xff)==0x716f70ff) /*qop*/
 					{
 						state = QOP_STATE;
-						p+=3;
+						STR_ADVANCE_BY(&body, 3);
 					}
 			}
-		} else if (p+3<end) {
-			n = LOWER4B( GET3B(p) );
+		} else if (body.len > 3) {
+			n = LOWER4B( GET3B(body.s) );
 			if (n==0x716f70ff) /*qop*/
 			{
-				p+=3;
+				STR_ADVANCE_BY(&body, 3);
 				state = QOP_STATE;
 			}
 		}
 
 		/* parse to the "=" */
-		for( n=0 ; p<end&&!is_ws(*p)&&*p!='=' ; n++,p++  );
-		if (p==end)
+		for(n=0 ; body.len > 0 && !is_ws(*body.s) && *body.s != '=' ; n++)
+			STR_ADVANCE(&body);
+		if (body.len == 0)
 			goto parse_error;
 		if (n!=0)
 			state = OTHER_STATE;
-		name.len = p-name.s;
+		name.len = body.s - name.s;
 		/* get the '=' */
-		while (p<end && is_ws(*p)) p++;
-		if (p==end || *p!='=')
+		trim_leading(&body);
+		if (body.len == 0 || *body.s != '=')
 			goto parse_error;
-		p++;
+		STR_ADVANCE(&body);
 		/* get the value (quoted or not) */
-		while (p<end && is_ws(*p)) p++;
-		if (p+1>=end || (quoted_val && *p!='\"'))
+		trim_leading(&body);
+		if (body.len <= 1 || (quoted_val && *body.s != '\"'))
 			goto parse_error;
-		if (!quoted_val && *p=='\"')
+		if (!quoted_val && *body.s == '\"')
 			quoted_val = 1;
 		if (quoted_val)
 		{
-			val.s = ++p;
-			while (p<end && *p!='\"')
-				p++;
-			if (p==end)
+			STR_ADVANCE(&body);
+			val.s = body.s;
+			while (body.len > 0 && *body.s != '\"')
+				STR_ADVANCE(&body);
+			if (body.len == 0)
 				goto error;
 		} else {
-			val.s = p;
-			while (p<end && !is_ws(*p) && *p!=',')
-				p++;
+			val.s = body.s;
+			while (body.len > 0 && !is_ws(*body.s) && *body.s != ',')
+				STR_ADVANCE(&body);
 		}
-		val.len = p - val.s;
+		val.len = body.s - val.s;
 		if (val.len==0)
 			val.s = 0;
 		/* consume the closing '"' if quoted */
-		p += quoted_val;
-		while (p<end && is_ws(*p)) p++;
-		if (p<end && *p==',')
+		STR_ADVANCE_BY(&body, quoted_val);
+		trim_leading(&body);
+		if (body.len > 0 && *body.s == ',')
 		{
-			p++;
-			while (p<end && is_ws(*p)) p++;
+			STR_ADVANCE(&body);
+			trim_leading(&body);
 		}
 
 		LM_DBG("<%.*s>=\"%.*s\" state=%d\n",
@@ -323,7 +321,7 @@ int parse_authenticate_body( str *body, struct authenticate_body *auth)
 
 	return 0;
 parse_error:
-	LM_ERR("parse error in <%.*s> around %ld\n", body->len, body->s, (long)(p-body->s));
+	LM_ERR("parse error in <%.*s> around %ld\n", body.len, body.s, (long)(body.len));
 error:
 	return -1;
 }
@@ -345,7 +343,7 @@ int parse_authenticate_header(struct hdr_field *authenticate)
 	    return -1;
 	}
 
-	if (0 != parse_authenticate_body(&authenticate->body, auth_body))
+	if (0 != parse_authenticate_body(authenticate->body, auth_body))
 	    return -1;
 	*parsed = auth_body;
 

--- a/parser/parse_authenticate.h
+++ b/parser/parse_authenticate.h
@@ -56,6 +56,7 @@ int parse_www_authenticate_header( struct sip_msg *msg );
 int parse_authenticate_header(struct hdr_field *authenticate);
 
 int parse_qop_value(str val, struct authenticate_body *auth);
+int parse_authenticate_body(str body, struct authenticate_body *auth);
 
 void free_authenticate(struct authenticate_body *authenticate_b);
 

--- a/parser/test/test_oob.c
+++ b/parser/test/test_oob.c
@@ -41,13 +41,13 @@ void test_oob(const str *sarg, void (*tfunc)(const str *, enum oob_position, voi
 		assert(mprotect(mpages[0], page_size, PROT_WRITE) == 0);
 		memcpy(targ.s, sarg->s, targ.len);
 		assert(mprotect(mpages[0], page_size, PROT_READ) == 0);
-		tfunc(&targ, OOB_POST, param);
+		tfunc(&targ, OOB_OVERFLOW, param);
 
 		targ.s = mpages[2];
 		assert(mprotect(mpages[2], page_size, PROT_WRITE) == 0);
 		memcpy(targ.s, sarg->s, targ.len);
 		assert(mprotect(mpages[2], page_size, PROT_READ) == 0);
-		tfunc(&targ, OOB_PRE, param);
+		tfunc(&targ, OOB_UNDERFLOW, param);
     }
     munmap(mpages[0], page_size * 3);
     return;

--- a/parser/test/test_oob.c
+++ b/parser/test/test_oob.c
@@ -25,7 +25,8 @@
 #include "../../str.h"
 #include "test_oob.h"
 
-void test_oob(const str *sarg, void (*tfunc)(const str *, void *), void *param)
+void test_oob(const str *sarg, void (*tfunc)(const str *, enum oob_position, void *),
+    void *param)
 {
 	char *mpages[3];
 	str targ;
@@ -40,13 +41,13 @@ void test_oob(const str *sarg, void (*tfunc)(const str *, void *), void *param)
 		assert(mprotect(mpages[0], page_size, PROT_WRITE) == 0);
 		memcpy(targ.s, sarg->s, targ.len);
 		assert(mprotect(mpages[0], page_size, PROT_READ) == 0);
-		tfunc(&targ, param);
+		tfunc(&targ, OOB_POST, param);
 
 		targ.s = mpages[2];
 		assert(mprotect(mpages[2], page_size, PROT_WRITE) == 0);
 		memcpy(targ.s, sarg->s, targ.len);
 		assert(mprotect(mpages[2], page_size, PROT_READ) == 0);
-		tfunc(&targ, param);
+		tfunc(&targ, OOB_PRE, param);
     }
     munmap(mpages[0], page_size * 3);
     return;

--- a/parser/test/test_oob.h
+++ b/parser/test/test_oob.h
@@ -18,6 +18,10 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301,USA
  */
 
-enum oob_position {OOB_PRE, OOB_POST};
+enum oob_position {OOB_UNDERFLOW, OOB_OVERFLOW};
+
+#define OOB_CHECK_OK_MSG(fut, tstr, where) "oob check: %s(%s\"%.*s\"%s)", (fut), \
+    (where) == OOB_UNDERFLOW ? "->" : "", (tstr)->len, (tstr)->s, \
+    (where) == OOB_OVERFLOW ? "<-" : ""
 
 void test_oob(const str *, void (*)(const str *, enum oob_position, void *), void *);

--- a/parser/test/test_oob.h
+++ b/parser/test/test_oob.h
@@ -18,4 +18,6 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301,USA
  */
 
-void test_oob(const str *, void (*)(const str *, void *), void *);
+enum oob_position {OOB_PRE, OOB_POST};
+
+void test_oob(const str *, void (*)(const str *, enum oob_position, void *), void *);

--- a/parser/test/test_parse_authenticate_body.c
+++ b/parser/test/test_parse_authenticate_body.c
@@ -87,7 +87,5 @@ void test_parse_authenticate_body_oob(const str *tstr, enum oob_position where, 
 	struct authenticate_body *ap = farg;
 
 	parse_authenticate_body(*tstr, ap);
-	ok(1, "oob check: parse_authenticate_body(%s\"%.*s\"%s)",
-	    where == OOB_PRE ? "->" : "", tstr->len, tstr->s,
-	    where == OOB_POST ? "<-" : "");
+	ok(1, OOB_CHECK_OK_MSG("parse_authenticate_body", tstr, where));
 }

--- a/parser/test/test_parse_authenticate_body.c
+++ b/parser/test/test_parse_authenticate_body.c
@@ -30,35 +30,56 @@
 
 void test_parse_authenticate_body_oob(const str *, enum oob_position where, void *);
 
+static const struct tts {
+	const str ts;
+	int tres;
+	int aflags;
+	const char *anonce;
+	const char *aopaque;
+	const char *arealm;
+} tset[] = {
+	{
+	/* Case #1 */
+		.ts = str_init("Digest realm=\"[::1]\",nonce=\"ak/bKmGcoPPWdj0AUWv/ldViLInmkiJ2Kct5p/LapNo\","
+                               "qop=auth,algorithm=SHA-512-256"),
+		.tres = -1
+	}, {
+	/* Case #2 */
+		.ts = str_init("Digest realm=\"[::1]\",nonce=\"kp5XbciCMxVbeZm2d58YZCfaAjW/2T7XtuYwIeZoz1o\","
+                               "qop=auth,algorithm=SHA-256"),
+		.tres = -1
+	}, {
+	/* Case #3 */
+		.ts = str_init("Digest stale=false,realm=\"[::1]\",nonce=\"esWk1wFa4bUBKzkmfKId++Y83eWzD9edBCGTwLV4Juk\","
+                               "qop=auth,algorithm=MD5"),
+		.tres = 0,
+		.aflags = QOP_AUTH | AUTHENTICATE_MD5, .anonce = "esWk1wFa4bUBKzkmfKId++Y83eWzD9edBCGTwLV4Juk",
+		.arealm = "[::1]"
+	}, {
+	/* Case #4 */
+		.ts = str_init("Digest realm=\"sip.test.com\",qop=\"auth\",opaque=\"1234567890abcedef\","
+		               "nonce=\"145f5ca9aac6f0b9f93433188d446ae0d9f91a6ff80\",algorithm=MD5,stale=true"),
+		.tres = 0,
+		.aflags = QOP_AUTH | AUTHENTICATE_MD5 | AUTHENTICATE_STALE,
+		.anonce = "145f5ca9aac6f0b9f93433188d446ae0d9f91a6ff80", .aopaque = "1234567890abcedef",
+		.arealm = "sip.test.com"
+	}, {
+	/* Case #5 */
+		.ts = str_init("DiGeSt\r\n\trealm=\"a\",\r\n\tqop=\"auth-int, auth\",\r\n\tnonce=\"n\",\r\n\topaque=\"0\",\r\n\t"
+                               "algoriTHm=md5"),
+		.tres = 0,
+		.aflags = QOP_AUTH | AUTHENTICATE_MD5 | QOP_AUTH_INT,
+		.anonce = "n", .aopaque = "0", .arealm = "a"
+	}, {
+		.ts = STR_NULL
+	}
+};
+
+
 void test_parse_authenticate_body(void)
 {
 	struct authenticate_body auth;
 	int i;
-	struct tts {
-		const str ts;
-		int tres;
-		int aflags;
-		const char *anonce;
-		const char *aopaque;
-		const char *arealm;
-	} tset[] = {
-		{.ts = str_init("Digest realm=\"[::1]\",nonce=\"ak/bKmGcoPPWdj0AUWv/ldViLInmkiJ2Kct5p/LapNo\","
-		    "qop=auth,algorithm=SHA-512-256"), .tres = -1},
-		{.ts = str_init("Digest realm=\"[::1]\",nonce=\"kp5XbciCMxVbeZm2d58YZCfaAjW/2T7XtuYwIeZoz1o\","
-		    "qop=auth,algorithm=SHA-256"), .tres = -1},
-		{.ts = str_init("Digest stale=false,realm=\"[::1]\",nonce=\"esWk1wFa4bUBKzkmfKId++Y83eWzD9edBCGTwLV4Juk\","
-		    "qop=auth,algorithm=MD5"), .tres = 0, .aflags = QOP_AUTH | AUTHENTICATE_MD5,
-		    .anonce = "esWk1wFa4bUBKzkmfKId++Y83eWzD9edBCGTwLV4Juk", .arealm = "[::1]"},
-		{.ts = str_init("Digest realm=\"sip.test.com\",qop=\"auth\",opaque=\"1234567890abcedef\","
-		    "nonce=\"145f5ca9aac6f0b9f93433188d446ae0d9f91a6ff80\",algorithm=MD5,stale=true"),
-		    .tres = 0, .aflags = QOP_AUTH | AUTHENTICATE_MD5 | AUTHENTICATE_STALE,
-		    .anonce = "145f5ca9aac6f0b9f93433188d446ae0d9f91a6ff80", .aopaque = "1234567890abcedef",
-		    .arealm = "sip.test.com"},
-		{.ts = str_init("DiGeSt\r\n\trealm=\"a\",\r\n\tqop=\"auth-int, auth\",\r\n\tnonce=\"n\",\r\n\topaque=\"0\",\r\n\t"
-		    "algoriTHm=md5"), .tres = 0, .aflags = QOP_AUTH | AUTHENTICATE_MD5 | QOP_AUTH_INT,
-		    .anonce = "n", .aopaque = "0", .arealm = "a"},
-		{.ts = STR_NULL}
-	};
 
 	for (i = 0; tset[i].ts.s != NULL; i++) {
 		memset(&auth, 0, sizeof(struct authenticate_body));

--- a/parser/test/test_parse_authenticate_body.h
+++ b/parser/test/test_parse_authenticate_body.h
@@ -1,0 +1,26 @@
+/*
+ * Copyright (C) 2019 OpenSIPS Solutions
+ *
+ * This file is part of opensips, a free SIP server.
+ *
+ * opensips is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version
+ *
+ * opensips is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301,USA
+ */
+
+#ifndef __TEST_PARSE_AUTHB_H__
+#define __TEST_PARSE_AUTHB_H__
+
+void test_parse_authenticate_body(void);
+
+#endif /* __TEST_PARSE_AUTHB_H__ */

--- a/parser/test/test_parse_qop.c
+++ b/parser/test/test_parse_qop.c
@@ -70,7 +70,5 @@ void test_parse_qop_oob(const str *tstr, enum oob_position where, void *farg)
 	struct authenticate_body *ap = farg;
 
 	parse_qop_value(*tstr, ap);
-	ok(1, "oob check: parse_qop_value(%s\"%.*s\"%s)",
-	    where == OOB_PRE ? "->" : "", tstr->len, tstr->s,
-	    where == OOB_POST ? "<-" : "");
+	ok(1, OOB_CHECK_OK_MSG("parse_qop_value", tstr, where));
 }

--- a/parser/test/test_parse_qop.c
+++ b/parser/test/test_parse_qop.c
@@ -27,7 +27,7 @@
 
 #include "test_oob.h"
 
-void test_parse_qop_oob(const str *, void *);
+void test_parse_qop_oob(const str *, enum oob_position where, void *);
 
 void test_parse_qop_val(void)
 {
@@ -65,10 +65,12 @@ void test_parse_qop_val(void)
 	}
 }
 
-void test_parse_qop_oob(const str *tstr, void *farg)
+void test_parse_qop_oob(const str *tstr, enum oob_position where, void *farg)
 {
 	struct authenticate_body *ap = farg;
 
 	parse_qop_value(*tstr, ap);
-	ok(1, "oob check: parse_qop_value(\"%.*s\")", tstr->len, tstr->s);
+	ok(1, "oob check: parse_qop_value(%s\"%.*s\"%s)",
+	    where == OOB_PRE ? "->" : "", tstr->len, tstr->s,
+	    where == OOB_POST ? "<-" : "");
 }

--- a/parser/test/test_parser.c
+++ b/parser/test/test_parser.c
@@ -25,6 +25,7 @@
 #include "test_parse_qop.h"
 #include "test_parse_fcaps.h"
 #include "test_parser.h"
+#include "test_parse_authenticate_body.h"
 
 void test_parse_uri(void)
 {
@@ -114,4 +115,5 @@ void test_parser(void)
 	test_parse_qop_val();
 	test_parse_fcaps();
 	test_parse_uri();
+	test_parse_authenticate_body();
 }


### PR DESCRIPTION
This PR cleans up parse_authenticate_body() in the same way we've done with parse_qop_value(), fixes one error (accessing 1-st element of zero-lenth buf) and adds unit test.

I've also included some changes to improve OOB unit test output.