### PR TITLE
Fix empty body check in the parse_authenticate_body().

### DIFF
--- a/parser/parse_authenticate.c
+++ b/parser/parse_authenticate.c
@@ -155,7 +155,7 @@ int parse_authenticate_body( str *body, struct authenticate_body *auth)
 	str val;
 	int quoted_val;
 
-	if (body->s==0 || *body->s==0 )
+	if (body->len == 0)
 	{
 		LM_ERR("empty body\n");
 		goto error;


### PR DESCRIPTION
Use body->len as the only authoritative way to check if the provided body is empty or not. Split out of the PR#2260.