### PR TITLE
Re-use alg_t from "digest/digest_parser.h"

### DIFF
--- a/modules/uac_auth/auth.c
+++ b/modules/uac_auth/auth.c
@@ -285,7 +285,7 @@ void uac_calc_HA1( struct uac_credential *crd,
 	MD5Update(&Md5Ctx, crd->passwd.s, crd->passwd.len);
 	MD5Final(HA1, &Md5Ctx);
 
-	if ( auth->flags& AUTHENTICATE_MD5SESS )
+	if ( auth->algorithm == ALG_MD5SESS )
 	{
 		MD5Init(&Md5Ctx);
 		MD5Update(&Md5Ctx, HA1, HASHLEN);

--- a/parser/parse_authenticate.c
+++ b/parser/parse_authenticate.c
@@ -33,10 +33,6 @@
 #include "parse_authenticate.h"
 
 
-#define AUTHENTICATE_MD5         (1<<0)
-#define AUTHENTICATE_MD5SESS     (1<<1)
-#define AUTHENTICATE_STALE       (1<<2)
-
 #define AUTHENTICATE_DIGEST_S    "Digest"
 #define AUTHENTICATE_DIGEST_LEN  (sizeof(AUTHENTICATE_DIGEST_S)-1)
 
@@ -290,7 +286,7 @@ int parse_authenticate_body( str body, struct authenticate_body *auth)
 				if (val.len==3)
 				{
 					if ( LOWER4B(GET3B(val.s))==0x6d6435ff) /*MD5*/
-						auth->flags |= AUTHENTICATE_MD5;
+						auth->algorithm = ALG_MD5;
 				} else {
 					LM_ERR("unsupported algorithm \"%.*s\"\n",val.len,val.s);
 					goto error;

--- a/parser/parse_authenticate.h
+++ b/parser/parse_authenticate.h
@@ -28,14 +28,14 @@
 
 
 #include "msg_parser.h"
+#include "digest/digest_parser.h"
 
-#define AUTHENTICATE_MD5	(1<<0)
-#define AUTHENTICATE_MD5SESS	(1<<1)
-#define AUTHENTICATE_STALE	(1<<2)
-#define QOP_AUTH		(1<<3)
-#define QOP_AUTH_INT		(1<<4)
+#define AUTHENTICATE_STALE	(1<<0)
+#define QOP_AUTH		(1<<1)
+#define QOP_AUTH_INT		(1<<2)
 
 struct authenticate_body {
+	alg_t algorithm;
 	int flags;
 	str realm;
 	str domain;

--- a/parser/test/test_parse_authenticate_body.c
+++ b/parser/test/test_parse_authenticate_body.c
@@ -37,6 +37,7 @@ static const struct tts {
 	const char *anonce;
 	const char *aopaque;
 	const char *arealm;
+	alg_t aalg;
 } tset[] = {
 	{
 	/* Case #1 */
@@ -53,14 +54,14 @@ static const struct tts {
 		.ts = str_init("Digest stale=false,realm=\"[::1]\",nonce=\"esWk1wFa4bUBKzkmfKId++Y83eWzD9edBCGTwLV4Juk\","
                                "qop=auth,algorithm=MD5"),
 		.tres = 0,
-		.aflags = QOP_AUTH | AUTHENTICATE_MD5, .anonce = "esWk1wFa4bUBKzkmfKId++Y83eWzD9edBCGTwLV4Juk",
+		.aflags = QOP_AUTH, .aalg = ALG_MD5, .anonce = "esWk1wFa4bUBKzkmfKId++Y83eWzD9edBCGTwLV4Juk",
 		.arealm = "[::1]"
 	}, {
 	/* Case #4 */
 		.ts = str_init("Digest realm=\"sip.test.com\",qop=\"auth\",opaque=\"1234567890abcedef\","
 		               "nonce=\"145f5ca9aac6f0b9f93433188d446ae0d9f91a6ff80\",algorithm=MD5,stale=true"),
 		.tres = 0,
-		.aflags = QOP_AUTH | AUTHENTICATE_MD5 | AUTHENTICATE_STALE,
+		.aflags = QOP_AUTH | AUTHENTICATE_STALE, .aalg = ALG_MD5,
 		.anonce = "145f5ca9aac6f0b9f93433188d446ae0d9f91a6ff80", .aopaque = "1234567890abcedef",
 		.arealm = "sip.test.com"
 	}, {
@@ -68,7 +69,7 @@ static const struct tts {
 		.ts = str_init("DiGeSt\r\n\trealm=\"a\",\r\n\tqop=\"auth-int, auth\",\r\n\tnonce=\"n\",\r\n\topaque=\"0\",\r\n\t"
                                "algoriTHm=md5"),
 		.tres = 0,
-		.aflags = QOP_AUTH | AUTHENTICATE_MD5 | QOP_AUTH_INT,
+		.aflags = QOP_AUTH | QOP_AUTH_INT, .aalg = ALG_MD5,
 		.anonce = "n", .aopaque = "0", .arealm = "a"
 	}, {
 		.ts = STR_NULL
@@ -88,6 +89,7 @@ void test_parse_authenticate_body(void)
 		if (tset[i].tres == 0) {
 			printf("auth.flags = %d\n", auth.flags);
 			ok(auth.flags == tset[i].aflags, "auth.flags == %d", tset[i].aflags);
+			ok(auth.algorithm == tset[i].aalg, "auth.algorithm == %d", tset[i].aalg);
 			ok(auth.nonce.len == strlen(tset[i].anonce) &&
 			    memcmp(auth.nonce.s, tset[i].anonce, auth.nonce.len) == 0,
 			    "verify nonce");


### PR DESCRIPTION
Re-use alg_t from "digest/digest_parser.h" and get rid of the duplicate AUTHENTICATE_MD5 and AUTHENTICATE_MD5SESS definitions.