### PR TITLE
Unify openssl make-foo

### DIFF
--- a/Makefile.openssl
+++ b/Makefile.openssl
@@ -1,0 +1,20 @@
+#
+# WARNING: do not run this directly, it should be included by other Makefiles
+
+ifeq ($(CROSS_COMPILE),)
+SSL_BUILDER=$(shell \
+	if pkg-config --exists libssl; then \
+		echo 'pkg-config libssl'; \
+	fi)
+endif
+
+ifneq ($(SSL_BUILDER),)
+	DEFS += $(shell $(SSL_BUILDER) --cflags)
+	LIBS += $(shell $(SSL_BUILDER) --libs)
+else
+	DEFS += -I$(LOCALBASE)/ssl/include \
+			-I$(LOCALBASE)/include
+	LIBS += -L$(LOCALBASE)/lib -L$(LOCALBASE)/ssl/lib \
+			-L$(LOCALBASE)/lib64 -L$(LOCALBASE)/ssl/lib64 \
+			-lssl -lcrypto
+endif

--- a/modules/identity/Makefile
+++ b/modules/identity/Makefile
@@ -9,23 +9,6 @@ include ../../Makefile.defs
 auto_gen=
 NAME=identity.so
 
-ifeq ($(CROSS_COMPILE),)
-SSL_BUILDER=$(shell \
-	if pkg-config --exists libssl; then \
-		echo 'pkg-config libssl'; \
-	fi)
-endif
-
-ifneq ($(SSL_BUILDER),)
-	DEFS += $(shell $(SSL_BUILDER) --cflags)
-	LIBS += $(shell $(SSL_BUILDER) --libs)
-else
-	DEFS += -I$(LOCALBASE)/ssl/include \
-			-I$(LOCALBASE)/include
-	LIBS += -L$(LOCALBASE)/lib -L$(LOCALBASE)/ssl/lib \
-			-L$(LOCALBASE)/lib64 -L$(LOCALBASE)/ssl/lib64 \
-			-lssl -lcrypto
-endif
-
+include ../../Makefile.openssl
 include ../../Makefile.modules
 

--- a/modules/osp/Makefile
+++ b/modules/osp/Makefile
@@ -7,23 +7,7 @@ include ../../Makefile.defs
 auto_gen=
 NAME=osp.so
 
-ifeq ($(CROSS_COMPILE),)
-SSL_BUILDER=$(shell \
-	if pkg-config --exists libssl; then \
-		echo 'pkg-config libssl'; \
-	fi)
-endif
-
-ifneq ($(SSL_BUILDER),)
-	DEFS += $(shell $(SSL_BUILDER) --cflags)
-	LIBS += $(shell $(SSL_BUILDER) --libs)
-else
-	DEFS += -I$(LOCALBASE)/ssl/include \
-			-I$(LOCALBASE)/include
-	LIBS += -L$(LOCALBASE)/lib -L$(LOCALBASE)/ssl/lib \
-			-L$(LOCALBASE)/lib64 -L$(LOCALBASE)/ssl/lib64 \
-			-lssl -lcrypto
-endif
+include ../../Makefile.openssl
 
 DEFS+=-D_POSIX_THREADS -I$(LOCALBASE)/include
 LIBS+=-L$(LOCALBASE)/lib -losptk -lutf8proc -lpthread -lm

--- a/modules/proto_tls/Makefile
+++ b/modules/proto_tls/Makefile
@@ -7,22 +7,5 @@ NAME=proto_tls.so
 
 ETC_DIR?=../../etc/
 
-ifeq ($(CROSS_COMPILE),)
-SSL_BUILDER=$(shell \
-	if pkg-config --exists libssl; then \
-		echo 'pkg-config libssl'; \
-	fi)
-endif
-
-ifneq ($(SSL_BUILDER),)
-	DEFS += $(shell $(SSL_BUILDER) --cflags)
-	LIBS += $(shell $(SSL_BUILDER) --libs)
-else
-	DEFS += -I$(LOCALBASE)/ssl/include \
-			-I$(LOCALBASE)/include
-	LIBS += -L$(LOCALBASE)/lib -L$(LOCALBASE)/ssl/lib \
-			-L$(LOCALBASE)/lib64 -L$(LOCALBASE)/ssl/lib64 \
-			-lssl -lcrypto
-endif
-
+include ../../Makefile.openssl
 include ../../Makefile.modules

--- a/modules/proto_wss/Makefile
+++ b/modules/proto_wss/Makefile
@@ -7,22 +7,5 @@ NAME=proto_wss.so
 
 ETC_DIR?=../../etc/
 
-ifeq ($(CROSS_COMPILE),)
-SSL_BUILDER=$(shell \
-	if pkg-config --exists libssl; then \
-		echo 'pkg-config libssl'; \
-	fi)
-endif
-
-ifneq ($(SSL_BUILDER),)
-	DEFS += $(shell $(SSL_BUILDER) --cflags)
-	LIBS += $(shell $(SSL_BUILDER) --libs)
-else
-	DEFS += -I$(LOCALBASE)/ssl/include \
-			-I$(LOCALBASE)/include
-	LIBS += -L$(LOCALBASE)/lib -L$(LOCALBASE)/ssl/lib \
-			-L$(LOCALBASE)/lib64 -L$(LOCALBASE)/ssl/lib64 \
-			-lssl -lcrypto
-endif
-
+include ../../Makefile.openssl
 include ../../Makefile.modules

--- a/modules/tls_mgm/Makefile
+++ b/modules/tls_mgm/Makefile
@@ -12,24 +12,7 @@ tls_configs=$(patsubst $(ETC_DIR)/%, %, $(wildcard $(ETC_DIR)/tls/*) \
 		$(wildcard $(ETC_DIR)/tls/rootCA/private/*) $(wildcard $(ETC_DIR)/tls/user/*))
 
 
-ifeq ($(CROSS_COMPILE),)
-SSL_BUILDER=$(shell \
-	if pkg-config --exists libssl; then \
-		echo 'pkg-config libssl'; \
-	fi)
-endif
-
-ifneq ($(SSL_BUILDER),)
-	DEFS += $(shell $(SSL_BUILDER) --cflags)
-	LIBS += $(shell $(SSL_BUILDER) --libs)
-else
-	DEFS += -I$(LOCALBASE)/ssl/include \
-			-I$(LOCALBASE)/include
-	LIBS += -L$(LOCALBASE)/lib -L$(LOCALBASE)/ssl/lib \
-			-L$(LOCALBASE)/lib64 -L$(LOCALBASE)/ssl/lib64 \
-			-lssl -lcrypto
-endif
-
+include ../../Makefile.openssl
 include ../../Makefile.modules
 
 install_module_custom: 


### PR DESCRIPTION
Move the same openssl make-foo code that has been copied and pasted around into a central location and include it from there.