### PR TITLE
Cleanup digest_parser code a bit.

### DIFF
--- a/parser/digest/digest_parser.c
+++ b/parser/digest/digest_parser.c
@@ -115,15 +115,10 @@ static inline int parse_token(str* _s, str* _r)
 	      */
 	for(i = 0; i < _s->len; i++) {
 
-		     /* All these characters
+		     /* All LWS characters + ','
 		      * mark end of the token
 		      */
-		switch(_s->s[i]) {
-		case ' ':
-		case '\t':
-		case '\r':
-		case '\n':
-		case ',':
+		if (is_ws(_s->s[i]) || _s->s[i] == ',') {
 			     /* So if you find
 			      * any of them
 			      * stop iterating
@@ -306,16 +301,16 @@ static inline int parse_digest_params(str* _s, dig_cred_t* _c)
 	} while(comma); /* Repeat while there are next parameters */
 
 	     /* Parse QOP body if the parameter was present */
-	if (_c->qop.qop_str.s != 0) {
+	if (_c->qop.qop_str.len > 0) {
 		parse_qop(&_c->qop);
 	}
 
 	     /* Parse algorithm body if the parameter was present */
-	if (_c->alg.alg_str.s != 0) {
+	if (_c->alg.alg_str.len > 0) {
 		parse_algorithm(&_c->alg);
 	}
 
-	if (_c->username.whole.s != 0) {
+	if (_c->username.whole.len > 0) {
 		parse_username(&_c->username);
 	}
 


### PR DESCRIPTION
 o replace another implementation of is_ws() with a is_ws call;

 o use str.len as the primary and the only way to see if string
   has zero lengh. Depending on how algorithm works, str.s might
   be non-NULL even if str.len == 0.