### PR TITLE
Fix in the residential script. Does not make sense to send a plus cha…

### DIFF
--- a/menuconfig/configs/opensips_residential.m4
+++ b/menuconfig/configs/opensips_residential.m4
@@ -411,6 +411,7 @@ ifelse(ENABLE_TCP, `yes', ifelse(ENABLE_TLS, `yes', `
 	ifelse(HAVE_OUTBOUND_PSTN,`yes',`
 	if ($rU=~"^\+[1-9][0-9]+$") {
 		ifelse(USE_DR_MODULE,`yes',`
+		strip(1);
 		if (!do_routing(0)) {
 			send_reply(500,"No PSTN Route found");
 			exit;

--- a/modules/rtpengine/README
+++ b/modules/rtpengine/README
@@ -471,7 +471,10 @@ rtpengine_offer();
             trusted. Without this flag, the RTP proxy ignores
             address in the SDP and uses source address of the SIP
             message as media address which is passed to the RTP
-            proxy.
+            proxy. From rtpengine 3.8 this is the default behaviour.
+	  + SIP-source-address - the opposite of trust-address. 
+	    Restores the old default behaviour of ignoring endpoint
+            addresses in the SDP body. 
           + replace-origin - flags that IP from the origin
             description (o=) should be also changed.
           + replace-session-connection - flags to change the

--- a/modules/rtpengine/doc/rtpengine_admin.xml
+++ b/modules/rtpengine/doc/rtpengine_admin.xml
@@ -478,7 +478,11 @@ rtpengine_offer();
 				<emphasis>trust-address</emphasis> - flags that IP address in SDP should
 				be trusted. Without this flag, the &rtp; proxy ignores address in
 				the SDP and uses source address of the SIP message as media
-				address which is passed to the RTP proxy.
+				address which is passed to the RTP proxy. From rtpengine 3.8 this is the default behaviour.
+				</para></listitem>
+				<listitem><para>
+				<emphasis>SIP-source-address</emphasis> - the opposite of trust-address. 
+				Restores the old default behaviour of ignoring endppoint of the addresses in the SDP body.
 				</para></listitem>
 				<listitem><para>
 				<emphasis>replace-origin</emphasis> - flags that IP from the origin


### PR DESCRIPTION
In the residential file it does not make sense to send a number to drouting starting with + as drouting does not support + as a prefix. 