### PR TITLE
Clean up UAS auth code a bit before I dive into RFC8760 rework.

### DIFF
--- a/modules/auth/common.c
+++ b/modules/auth/common.c
@@ -75,7 +75,7 @@ int get_realm(struct sip_msg* _m, hdr_types_t _hftype, struct sip_uri** _u)
  * Create a response with given code and reason phrase
  * Optionally add new headers specified in _hdr
  */
-int send_resp(struct sip_msg* _m, int _code, str* _reason,
+int send_resp(struct sip_msg* _m, int _code, const str* _reason,
 					char* _hdr, int _hdr_len)
 {
 	/* Add new headers if there are any */

--- a/modules/auth/common.h
+++ b/modules/auth/common.h
@@ -39,7 +39,7 @@ int get_realm(struct sip_msg* _m, hdr_types_t _hftype, struct sip_uri** _u);
  * Create a response with given code and reason phrase
  * Optionally add new headers specified in _hdr
  */
-int send_resp(struct sip_msg* _m, int _code, str* _reason,
+int send_resp(struct sip_msg* _m, int _code, const str* _reason,
 	char* _hdr, int _hdr_len);
 
 #endif /* COMMON_H */


### PR DESCRIPTION
Changes:

o Get rid of the most XYZ_LEN constants;

o normalize parameters to not pass char * + len, pass str * instead;

o add const where appropriate;

o GC stale _PRINT_MD5 section, it's going to be replaced with the
  new code really soon;

o avoid calling strlen() when the string lenth is well known.

No functional changes (I hope).