### PR TITLE
Clean up UAS auth code a bit before I dive into RFC8760 rework.

### DIFF
--- a/modules/auth/challenge.c
+++ b/modules/auth/challenge.c
@@ -42,8 +42,6 @@
 #include "index.h"
 #include "api.h"
 
-static str auth_400_err = str_init(MESSAGE_400);
-
 
 /*
  * proxy_challenge function sends this reply
@@ -58,34 +56,26 @@ static str auth_400_err = str_init(MESSAGE_400);
 #define MESSAGE_401        "Unauthorized"
 #define WWW_AUTH_CHALLENGE "WWW-Authenticate"
 
-
-#define QOP_AUTH	      ", qop=\"auth\""
-#define QOP_AUTH_LEN	  (sizeof(QOP_AUTH)-1)
+#define QOP_AUTH	  ", qop=\"auth\""
 #define QOP_AUTH_INT	  ", qop=\"auth-int\""
-#define QOP_AUTH_INT_LEN  (sizeof(QOP_AUTH_INT)-1)
 #define QOP_AUTH_BOTH	  ", qop=\"auth,auth-int\""
-#define QOP_AUTH_BOTH_LEN  (sizeof(QOP_AUTH_BOTH)-1)
 #define STALE_PARAM	  ", stale=true"
-#define STALE_PARAM_LEN	  (sizeof(STALE_PARAM)-1)
 #define DIGEST_REALM	  ": Digest realm=\""
-#define DIGEST_REALM_LEN  (sizeof(DIGEST_REALM)-1)
 #define DIGEST_NONCE	  "\", nonce=\""
-#define DIGEST_NONCE_LEN  (sizeof(DIGEST_NONCE)-1)
-#define DIGEST_MD5	  ", algorithm=MD5"
-#define DIGEST_MD5_LEN	  (sizeof(DIGEST_MD5)-1)
 
 
 /*
  * Create {WWW,Proxy}-Authenticate header field
  */
 static inline char *build_auth_hf(int _retries, int _stale, str* _realm,
-				  int* _len, int _qop, char* _hf_name)
+    int* _len, int _qop, const str* _hf_name)
 {
-	int hf_name_len;
 	char *hf, *p;
 	int index = 0;
-	int qop_len = 0;
-	const char *qop_param;
+	str qop_param = STR_NULL;
+	str stale_param = STR_NULL;
+	const str digest_realm = str_init(DIGEST_REALM);
+	const str nonce_param = str_init(DIGEST_NONCE);
 
 	if(!disable_nonce_check) {
 		/* get the nonce index and mark it as used */
@@ -100,29 +90,25 @@ static inline char *build_auth_hf(int _retries, int _stale, str* _realm,
 
 	if (_qop) {
 		if (_qop == QOP_TYPE_AUTH) {
-			qop_len = QOP_AUTH_LEN;
-			qop_param = QOP_AUTH;
+			qop_param = str_init(QOP_AUTH);
 		} else if (_qop == QOP_TYPE_AUTH_INT) {
-			qop_len = QOP_AUTH_INT_LEN;
-			qop_param = QOP_AUTH_INT;
+			qop_param = str_init(QOP_AUTH_INT);
 		} else {
-			qop_len = QOP_AUTH_BOTH_LEN;
-			qop_param = QOP_AUTH_BOTH;
+			qop_param = str_init(QOP_AUTH_BOTH);
 		}
 	}
+	if (_stale)
+		stale_param = str_init(STALE_PARAM);
 
 	/* length calculation */
-	*_len=hf_name_len=strlen(_hf_name);
-	*_len+=DIGEST_REALM_LEN
+	*_len=_hf_name->len;
+	*_len+=digest_realm.len
 		+_realm->len
-		+DIGEST_NONCE_LEN
+		+nonce_param.len
 		+((!disable_nonce_check)?NONCE_LEN:NONCE_LEN-8)
 		+1 /* '"' */
-		+qop_len
-		+((_stale)? STALE_PARAM_LEN : 0)
-#ifdef _PRINT_MD5
-		+DIGEST_MD5_LEN
-#endif
+		+stale_param.len
+		+qop_param.len
 		+CRLF_LEN ;
 
 	p=hf=pkg_malloc(*_len+1);
@@ -132,24 +118,21 @@ static inline char *build_auth_hf(int _retries, int _stale, str* _realm,
 		return 0;
 	}
 
-	memcpy(p, _hf_name, hf_name_len); p+=hf_name_len;
-	memcpy(p, DIGEST_REALM, DIGEST_REALM_LEN);p+=DIGEST_REALM_LEN;
+	memcpy(p, _hf_name->s, _hf_name->len); p+=_hf_name->len;
+	memcpy(p, digest_realm.s, digest_realm.len);p+=digest_realm.len;
 	memcpy(p, _realm->s, _realm->len);p+=_realm->len;
-	memcpy(p, DIGEST_NONCE, DIGEST_NONCE_LEN);p+=DIGEST_NONCE_LEN;
+	memcpy(p, nonce_param.s, nonce_param.len);p+=nonce_param.len;
 	calc_nonce(p, time(0) + nonce_expire, index, &secret);
 	p+=((!disable_nonce_check)?NONCE_LEN:NONCE_LEN-8);
 	*p='"';p++;
 	if (_qop) {
-		memcpy(p, qop_param, qop_len);
-		p+=qop_len;
+		memcpy(p, qop_param.s, qop_param.len);
+		p+=qop_param.len;
 	}
 	if (_stale) {
-		memcpy(p, STALE_PARAM, STALE_PARAM_LEN);
-		p+=STALE_PARAM_LEN;
+		memcpy(p, stale_param.s, stale_param.len);
+		p+=stale_param.len;
 	}
-#ifdef _PRINT_MD5
-	memcpy(p, DIGEST_MD5, DIGEST_MD5_LEN ); p+=DIGEST_MD5_LEN;
-#endif
 	memcpy(p, CRLF, CRLF_LEN ); p+=CRLF_LEN;
 	*p=0; /* zero terminator, just in case */
 
@@ -161,7 +144,7 @@ static inline char *build_auth_hf(int _retries, int _stale, str* _realm,
  * Create and send a challenge
  */
 static inline int challenge(struct sip_msg* _msg, str *realm, int _qop,
-						int _code, char* _message, char* _challenge_msg)
+    int _code, const str *reason, const str* _challenge_msg)
 {
 	int auth_hf_len;
 	struct hdr_field* h = NULL;
@@ -170,7 +153,6 @@ static inline int challenge(struct sip_msg* _msg, str *realm, int _qop,
 	int ret;
 	hdr_types_t hftype = 0; /* Makes gcc happy */
 	struct sip_uri *uri;
-	str reason;
 
 	switch(_code) {
 	case 401:
@@ -188,7 +170,7 @@ static inline int challenge(struct sip_msg* _msg, str *realm, int _qop,
 	if (realm->len == 0) {
 		if (get_realm(_msg, hftype, &uri) < 0) {
 			LM_ERR("failed to extract URI\n");
-			if (send_resp(_msg, 400, &auth_400_err, 0, 0) == -1) {
+			if (send_resp(_msg, 400, &str_init(MESSAGE_400), 0, 0) == -1) {
 				LM_ERR("failed to send the response\n");
 				return -1;
 			}
@@ -206,9 +188,7 @@ static inline int challenge(struct sip_msg* _msg, str *realm, int _qop,
 		return -1;
 	}
 
-	reason.s = _message;
-	reason.len = strlen(_message);
-	ret = send_resp(_msg, _code, &reason, auth_hf, auth_hf_len);
+	ret = send_resp(_msg, _code, reason, auth_hf, auth_hf_len);
 	if (auth_hf) pkg_free(auth_hf);
 	if (ret == -1) {
 		LM_ERR("failed to send the response\n");
@@ -258,7 +238,7 @@ int fixup_qop(void** param)
 int www_challenge(struct sip_msg* _msg, str* _realm, void* _qop)
 {
 	return challenge(_msg, _realm, (int)(long)_qop, 401,
-			MESSAGE_401, WWW_AUTH_CHALLENGE);
+		&str_init(MESSAGE_401), &str_init(WWW_AUTH_CHALLENGE));
 }
 
 
@@ -268,7 +248,7 @@ int www_challenge(struct sip_msg* _msg, str* _realm, void* _qop)
 int proxy_challenge(struct sip_msg* _msg, str* _realm, void* _qop)
 {
 	return challenge(_msg, _realm, (int)(long)_qop, 407,
-			MESSAGE_407, PROXY_AUTH_CHALLENGE);
+		&str_init(MESSAGE_407), &str_init(PROXY_AUTH_CHALLENGE));
 }
 
 

--- a/modules/auth/common.c
+++ b/modules/auth/common.c
@@ -75,7 +75,7 @@ int get_realm(struct sip_msg* _m, hdr_types_t _hftype, struct sip_uri** _u)
  * Create a response with given code and reason phrase
  * Optionally add new headers specified in _hdr
  */
-int send_resp(struct sip_msg* _m, int _code, str* _reason,
+int send_resp(struct sip_msg* _m, int _code, const str* _reason,
 					char* _hdr, int _hdr_len)
 {
 	/* Add new headers if there are any */

--- a/modules/auth/common.h
+++ b/modules/auth/common.h
@@ -39,7 +39,7 @@ int get_realm(struct sip_msg* _m, hdr_types_t _hftype, struct sip_uri** _u);
  * Create a response with given code and reason phrase
  * Optionally add new headers specified in _hdr
  */
-int send_resp(struct sip_msg* _m, int _code, str* _reason,
+int send_resp(struct sip_msg* _m, int _code, const str* _reason,
 	char* _hdr, int _hdr_len);
 
 #endif /* COMMON_H */

--- a/modules/signaling/signaling.c
+++ b/modules/signaling/signaling.c
@@ -45,8 +45,9 @@ struct sl_binds slb;
 int sl_loaded = 0;
 int tm_loaded = 0;
 
-int sig_send_reply(struct sip_msg* msg, int* code_i, str* code_s);
-int sig_send_reply_mod(struct sip_msg* msg, int code, str* reason, str* to_tag);
+int sig_send_reply(struct sip_msg* msg, int* code_i, const str* code_s);
+int sig_send_reply_mod(struct sip_msg* msg, int code, const str* reason,
+    str* to_tag);
 static int fixup_sig_send_reply(void** param);
 static int mod_init(void);
 
@@ -151,7 +152,7 @@ static int mod_init(void)
  * sig_send_reply - function to be called from script to send appropiate
  * replies (statefull or stateless)
  * */
-int sig_send_reply(struct sip_msg* msg, int* code_i, str* code_s)
+int sig_send_reply(struct sip_msg* msg, int* code_i, const str* code_s)
 {
 	return sig_send_reply_mod(msg, *code_i, code_s, 0);
 }
@@ -160,7 +161,8 @@ int sig_send_reply(struct sip_msg* msg, int* code_i, str* code_s)
  * sig_send_reply_mod function - sends stateless or staefull reply depending on
  * whether a transaction was created and on which modules are loaded( tm, sl).
  * */
-int sig_send_reply_mod(struct sip_msg* msg, int code, str* reason, str* to_tag)
+int sig_send_reply_mod(struct sip_msg* msg, int code,
+    const str* reason, str* to_tag)
 {
 	struct cell * t;
 

--- a/modules/signaling/signaling.h
+++ b/modules/signaling/signaling.h
@@ -30,7 +30,7 @@
 #include "../../sr_module.h"
 #include "../../parser/msg_parser.h"
 
-typedef int (*sig_send_reply_f)(struct sip_msg *msg, int code, str *reason,
+typedef int (*sig_send_reply_f)(struct sip_msg *msg, int code, const str *reason,
 		str *tag);
 typedef int (*sig_gen_totag_f)(struct sip_msg *msg, str *tag);
 

--- a/modules/sl/sl_api.h
+++ b/modules/sl/sl_api.h
@@ -26,8 +26,8 @@
 #include "../../dprint.h"
 #include "../../str.h"
 
-typedef int (*sl_send_reply_f)(struct sip_msg *msg, int code, str *reason,
-		str *tag);
+typedef int (*sl_send_reply_f)(struct sip_msg *msg, int code,
+    const str *reason, str *tag);
 typedef int (*sl_gen_totag_f)(struct sip_msg *msg, str *totag);
 
 struct sl_binds {

--- a/modules/sl/sl_funcs.c
+++ b/modules/sl/sl_funcs.c
@@ -141,7 +141,7 @@ static inline void update_sl_reply_stat(int code)
 }
 
 
-int sl_send_reply_helper(struct sip_msg *msg ,int code, str *text)
+int sl_send_reply_helper(struct sip_msg *msg ,int code, const str *text)
 {
 	str buf;
 	union sockaddr_union to;
@@ -209,7 +209,7 @@ error:
 	return -1;
 }
 
-int sl_send_reply(struct sip_msg *msg ,int code, str *text, str *totag)
+int sl_send_reply(struct sip_msg *msg ,int code, const str *text, str *totag)
 {
 	int ret;
 

--- a/modules/sl/sl_funcs.h
+++ b/modules/sl/sl_funcs.h
@@ -31,7 +31,7 @@
 
 int sl_startup();
 int sl_shutdown();
-int sl_send_reply( struct sip_msg *msg, int code, str *reason, str *totag);
+int sl_send_reply( struct sip_msg *msg, int code, const str *reason, str *totag);
 int sl_filter_ACK( struct sip_msg *msg, void *foo);
 int sl_reply_error( struct sip_msg *msg );
 int sl_gen_totag( struct sip_msg *msg, str *totag);

--- a/modules/tm/t_reply.c
+++ b/modules/tm/t_reply.c
@@ -479,7 +479,7 @@ error:
  * returns 1 if everything was OK or -1 for error
  */
 static int _reply( struct cell *trans, struct sip_msg* p_msg,
-									unsigned int code, str *text, int lock )
+    unsigned int code, const str *text, int lock )
 {
 	unsigned int len;
 	char * buf, *dset;
@@ -1112,7 +1112,7 @@ error:
 
 
 int t_reply( struct cell *t, struct sip_msg* p_msg, unsigned int code,
-	str * text )
+	const str * text )
 {
 	return _reply( t, p_msg, code, text, 1 /* lock replies */ );
 }

--- a/modules/tm/t_reply.h
+++ b/modules/tm/t_reply.h
@@ -65,7 +65,7 @@ int unmatched_totag(struct cell *t, struct sip_msg *ack);
 typedef unsigned int branch_bm_t;
 
 /* reply export types */
-typedef int (*treply_f)(struct sip_msg * , unsigned int , str * );
+typedef int (*treply_f)(struct sip_msg * , unsigned int , const str * );
 typedef int (*treply_wb_f)( struct cell* trans, unsigned int code, str *text,
 	str *body, str *new_header, str *to_tag);
 typedef int (*tgen_totag_f)(struct sip_msg * , str * );
@@ -99,7 +99,7 @@ int t_reply_with_body( struct cell *trans, unsigned int code,
 /* send a UAS reply
  * returns 1 if everything was OK or -1 for error
  */
-int t_reply( struct cell *t, struct sip_msg * , unsigned int , str * );
+int t_reply( struct cell *t, struct sip_msg * , unsigned int , const str * );
 /* the same as t_reply, except it does not claim
    REPLY_LOCK -- useful to be called within reply
    processing

--- a/msg_translator.c
+++ b/msg_translator.c
@@ -2436,7 +2436,7 @@ error:
 }
 
 
-char * build_res_buf_from_sip_req( unsigned int code, str *text ,str *new_tag,
+char * build_res_buf_from_sip_req( unsigned int code, const str *text ,str *new_tag,
 		struct sip_msg* msg, unsigned int *returned_len, struct bookmark *bmark)
 {
 	char *buf, *p, *received_buf, *rport_buf, *warning_buf;

--- a/msg_translator.h
+++ b/msg_translator.h
@@ -143,7 +143,7 @@ char * build_res_buf_from_sip_res(	struct sip_msg* msg,
 
 
 char * build_res_buf_from_sip_req( unsigned int code,
-				str *text,
+				const str *text,
 				str *new_tag,
 				struct sip_msg* msg,
 				unsigned int *returned_len,

--- a/str.h
+++ b/str.h
@@ -59,8 +59,8 @@ struct __str {
 typedef struct __str str;
 
 /* str initialization */
-#define STR_NULL {NULL, 0}
-#define str_init(_string)  {_string, sizeof(_string) - 1}
+#define STR_NULL (str){NULL, 0}
+#define str_init(_string)  (str){_string, sizeof(_string) - 1}
 static inline void init_str(str *dest, const char *src)
 {
 	dest->s = (char *)src;


### PR DESCRIPTION
o Extend STR_NULL and str_init() to set a type explicitly. This allows those macros to be used elsewhere in the function body,
not only in variable declaration(s);

o Get rid of the XYZ_LEN constants;

o normalize parameters to not pass char * + len, pass str * instead;

o add const where appropriate;

o GC stale _PRINT_MD5 section, it's going to be replaced with the
  new code really soon;

o avoid calling strlen() when the string lenth is well known.

No functional changes (I hope). Tested here: https://travis-ci.com/github/sippy/voiptests/builds/188456499