### PR TITLE
Add ability to build various static supporting libraries to contain code that is shared between several modules.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *.o
 *.d
 *.so
+*.a
 *.sw?
 tags
 cscope*

--- a/Makefile
+++ b/Makefile
@@ -193,6 +193,12 @@ $(modules):
 
 .PHONY: modules
 modules: $(deps_gen)
+	@set -e; \
+	for r in $(all_misclibs); do \
+		echo  "" ; \
+		echo  "" ; \
+		$(MAKE) -j -C $$r ; \
+	done
 ifeq (,$(FASTER))
 	@set -e; \
 	for r in $(modules) "" ; do \

--- a/Makefile.defs
+++ b/Makefile.defs
@@ -57,6 +57,9 @@ else
 makefile_defs=1
 export makefile_defs
 
+_makefile_defs_path := $(lastword $(MAKEFILE_LIST))
+TOP_SRCDIR?=    $(shell realpath `dirname $(_makefile_defs_path)`)
+
 # main binary name
 MAIN_NAME=opensips
 
@@ -1675,7 +1678,7 @@ endif
 
 
 ## Unit Testing - required extensions
-ifeq (1,$(shell grep -c '^\DEFS+= -DUNIT_TESTS' Makefile.conf))
+ifeq (1,$(shell grep -c '^\DEFS+= -DUNIT_TESTS' $(TOP_SRCDIR)/Makefile.conf))
 DEFS := $(DEFS) -DUNIT_TESTS
 LIBS := $(LIBS) -ltap
 test_src := $(shell find . -wholename "*/test/*\.c" | grep -v "^./modules/")

--- a/Makefile.misclibs
+++ b/Makefile.misclibs
@@ -1,0 +1,22 @@
+#
+# Miscelanious library Makefile
+#(to be included from each library)
+#
+
+_makefile_misclibs_path := $(lastword $(MAKEFILE_LIST))
+TOP_SRCDIR?=    $(shell realpath `dirname $(_makefile_misclibs_path)`)
+
+include $(TOP_SRCDIR)/Makefile.defs
+
+NAME=	lib${LIBNAME}.a
+LD=	$(TOP_SRCDIR)/scripts/build/linkstatic.sh
+
+include $(TOP_SRCDIR)/Makefile.conf
+
+LIBS=
+TWEAK_LIBS=
+LDFLAGS=
+CFLAGS:=$(MOD_CFLAGS)
+
+include $(TOP_SRCDIR)/Makefile.sources
+include $(TOP_SRCDIR)/Makefile.rules

--- a/Makefile.rules
+++ b/Makefile.rules
@@ -18,6 +18,8 @@ all_nostatic_modules=$(filter-out $(addprefix modules/, $(static_modules)), \
 all_modules:=$(addprefix modules/, $(all_modules))
 all_modules:=$(addprefix net/, $(builtin_modules)) $(all_modules)
 all_utils:=$(addprefix utils/, $(all_utils))
+all_misclibs=reg
+all_misclibs:=$(addprefix lib/, $(all_misclibs))
 
 #implicit rules
 %.o: %.c $(ALLDEP)
@@ -147,12 +149,7 @@ dbschema-docbook-clean:
 .PHONY: clean
 clean: docbook-clean dbschema-docbook-clean
 	-@rm -f $(objs) $(NAME) $(objs:.o=.il) 2>/dev/null
-	-@for r in $(all_modules) "" ; do \
-		if [ -d "$$r" -a -f "$$r/Makefile" ]; then \
-			$(MAKE) -C $$r clean ; \
-		fi ; \
-	done
-	-@for r in $(all_utils) "" ; do \
+	-@for r in $(all_modules) $(all_utils) $(all_misclibs); do \
 		if [ -d "$$r" -a -f "$$r/Makefile" ]; then \
 			$(MAKE) -C $$r clean ; \
 		fi ; \
@@ -164,7 +161,7 @@ clean: docbook-clean dbschema-docbook-clean
 proper realclean distclean: clean
 	-@rm -f $(depends) $(deps_gen) $(auto_gen) 2>/dev/null
 	-@rm -f cfg.tab.h 2>/dev/null
-	-@for r in $(all_nostatic_modules) "" ; do \
+	-@for r in $(all_nostatic_modules) $(all_misclibs) ; do \
 		if [ -d "$$r" -a -f "$$r/Makefile" ]; then \
 			 $(MAKE) -C $$r proper ; \
 		fi ; \

--- a/lib/reg/Makefile
+++ b/lib/reg/Makefile
@@ -1,0 +1,3 @@
+LIBNAME=	reg
+
+include ../../Makefile.misclibs

--- a/modules/mid_registrar/Makefile
+++ b/modules/mid_registrar/Makefile
@@ -3,9 +3,7 @@
 include ../../Makefile.defs
 auto_gen=
 NAME=mid_registrar.so
-LIBS=
-
-# include common registrar code
-extra_sources=$(wildcard ../../lib/reg/*.c)
+# link in common registrar code
+LIBS=../../lib/reg/libreg.a
 
 include ../../Makefile.modules

--- a/modules/registrar/Makefile
+++ b/modules/registrar/Makefile
@@ -3,9 +3,7 @@
 include ../../Makefile.defs
 auto_gen=
 NAME=registrar.so
-LIBS=
-
-# include common registrar code
-extra_sources=$(wildcard ../../lib/reg/*.c)
+# link in common registrar code
+LIBS=../../lib/reg/libreg.a
 
 include ../../Makefile.modules

--- a/scripts/build/linkstatic.sh
+++ b/scripts/build/linkstatic.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+
+set -e
+
+AR=${AR:-"ar"}
+RANLIB=${RANLIB:-"ranlib"}
+
+LINKARGS=""
+ARNAME=""
+nmfollows=0
+for var in "$@"
+do
+  if [ ${nmfollows} -ne 0 ]
+  then
+    ARNAME="${var}"
+    nmfollows=0
+    continue
+  fi
+  if [ "${var}" != "-o" ]
+  then
+    LINKARGS="${LINKARGS} ${var}"
+    continue
+  fi
+  nmfollows=1
+done
+
+${AR} cr "${ARNAME}" ${LINKARGS}
+${RANLIB} "${ARNAME}"


### PR DESCRIPTION
As discussed on opensips-developers mailing list, here is the part of the RFC8760 work to add support for building static libraries for code to be shared between multiple modules.