### PR TITLE
Fix MIPS64, add MIPS64 cross-build for travis, merge updates into fastlocks.h

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -90,10 +90,10 @@ jobs:
         - GCOV_CMD="llvm-cov-10 gcov"
       before_install:
         - sudo apt-get -y install clang-10 llvm-10-dev libc++-10-dev libc++abi-10-dev
-    - name: "Build with GCC 7 @ Ubuntu 18 (ARM)"
+    - name: "Build with GCC 7 @ Ubuntu 18 (ARM64)"
       compiler: gcc
       arch: arm64
-    - name: "Build with Clang 7 @ Ubuntu 18 (ARM)"
+    - name: "Build with Clang 7 @ Ubuntu 18 (ARM64)"
       compiler: clang
       arch: arm64
     - name: "Build Core with GCC 7 @ Ubuntu 18 (i386)"
@@ -110,3 +110,14 @@ jobs:
         - MAKE_TGT="opensips"
       before_install:
         - sudo apt-get -y install libc6-dev:i386 libstdc++6:i386 lib32gcc-7-dev
+    - name: "Build Core with GCC 7 @ Ubuntu 18 (MIPS64)"
+      compiler: gcc
+      env:
+        - CC=mips64-linux-gnuabi64-gcc AR=mips64-linux-gnuabi64-ar RANLIB=mips64-linux-gnuabi64-ranlib
+        - MAKE_TGT="opensips"
+      before_install:
+        - sudo apt-get -y install gcc-mips64-linux-gnuabi64 libc-dev-mips64-cross qemu-user-static
+        - sudo mkdir "/usr/mips64-linux-gnuabi64/etc"
+        - sudo touch "/usr/mips64-linux-gnuabi64/etc/ld.so.cache"
+        - sudo mkdir "/etc/qemu-binfmt"
+        - sudo ln -sf "/usr/mips64-linux-gnuabi64" "/etc/qemu-binfmt/mips64"

--- a/fastlock.h
+++ b/fastlock.h
@@ -189,8 +189,7 @@ inline static int tsl(volatile int* lock)
 		"    mb           \n\t"
 		"2:               \n\t"
 		:"=&r" (val), "=m"(*lock), "=r"(tmp)
-		:"1"(*lock)  /* warning on gcc 3.4: replace it with m or remove
-						it and use +m in the input line ? */
+		:"m"(*lock) 
 		: "memory"
 	);
 #else

--- a/fastlock.h
+++ b/fastlock.h
@@ -134,9 +134,8 @@ inline static int tsl(volatile int* lock)
 
 #elif defined __CPU_arm
 	asm volatile(
-			"# here \n\t"
-			"swpb %0, %1, [%2] \n\t"
-			: "=&r" (val) : "r"(1), "r" (lock) : "memory"
+			"swp %0, %2, [%3] \n\t"
+			: "=&r" (val), "=m"(*lock) : "r"(1), "r" (lock) : "memory"
 	);
 
 #elif defined(__CPU_arm6) || defined(__CPU_arm7)

--- a/fastlock.h
+++ b/fastlock.h
@@ -158,7 +158,9 @@ inline static int tsl(volatile int* lock)
 	long tmp;
 	
 	asm volatile(
+		".set push \n\t"
 		".set noreorder\n\t"
+		".set mips2 \n\t"
 		"1:  ll %1, %2   \n\t"
 		"    li %0, 1 \n\t"
 		"    sc %0, %2  \n\t"
@@ -167,7 +169,7 @@ inline static int tsl(volatile int* lock)
 #ifndef NOSMP
 		"    sync \n\t"
 #endif
-		".set reorder\n\t"
+		".set pop\n\t"
 		: "=&r" (tmp), "=&r" (val), "=m" (*lock) 
 		: "m" (*lock) 
 		: "memory"
@@ -295,12 +297,14 @@ inline static void release_lock(fl_lock_t* lock_struct)
 	*lock = 0;
 #elif defined(__CPU_mips2) || defined(__CPU_mips32) || defined(__CPU_mips64)
 	asm volatile(
+		".set push \n\t"
 		".set noreorder \n\t"
+		".set mips2 \n\t"
 #ifndef NOSMP
 		"    sync \n\t"
 #endif
 		"    sw $0, %0 \n\t"
-		".set reorder \n\t"
+		".set pop \n\t"
 		: "=m" (*lock)  : /* no input */ : "memory"
 	);
 #elif defined __CPU_alpha

--- a/fastlock.h
+++ b/fastlock.h
@@ -48,13 +48,7 @@
 #ifndef fastlock_h
 #define fastlock_h
 
-#ifdef HAVE_SCHED_YIELD
-#include <sched.h>
-#else
-#include <unistd.h>
-/** Fake sched_yield if no unistd.h include is available */
-	#define sched_yield()	sleep(0)
-#endif
+#include "sched_yield.h"
 
 
 #define SPIN_OPTIMIZE /* if defined optimize spining on the lock:

--- a/sched_yield.h
+++ b/sched_yield.h
@@ -1,0 +1,43 @@
+/*
+ * sched_yield wrapper
+ *
+ * $Id$
+ *
+ * 
+ *
+ * Copyright (C) 2001-2003 FhG Fokus
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+/*
+ *
+ *History:
+ *--------
+ *  2007-07-13  splitted from fastlock.h (andrei)
+ */
+
+
+#ifndef _sched_yield_h
+#define _sched_yield_h
+
+#ifdef HAVE_SCHED_YIELD
+#include <sched.h>
+#else
+#include <unistd.h>
+	/* fake sched_yield */
+#ifndef sched_yield()
+	#define sched_yield()	sleep(0)
+#endif
+#endif
+
+#endif /* _sched_yield_h */


### PR DESCRIPTION
o Merge in relevant improvements and fixes from OpenSER commits by
  andrei@iptel.orgi (2006-2007):

  - mips inline asm gcc 3.x warnings fixed
  - mips2 NOSMP mode (skip sync)
  - minor x86 & mips optimizations
  - fastlock: minor fixes
  - x86/x86_64 lock optimizations:  spinning on a lock should be friendlier now
    for the other cpus caches (at the extra cost of a cmp mem + jump) ; tried to
    arrange a little better the instructions to allow for some parallel
    execution.
  - x86 unlocks with xchg by default (since some x86s reorder stores, so a
    simple mov is unsafe)
  - ppc fixes (s/stw/stwx/, s/lwz/lwzx)
  - missing early clobbers added for x86, sparc*, armv6, ppc*, alpha
  - small arm/sparc optimizations.
  - moved sched_yield() wrapper into sched_yield.h at Miklos's request.