### PR TITLE
packaging: We no longer have atomic.h

### DIFF
--- a/packaging/debian/copyright
+++ b/packaging/debian/copyright
@@ -31,10 +31,6 @@ Files: async.c
 Copyright: 2011-2015, OpenSIPS Solutions
 License: GPL-2+
 
-Files: atomic.h
-Copyright: 2006, kernel.org
-License: GPL-2+
-
 Files: blacklists.c
   blacklists.h
   core_stats.c


### PR DESCRIPTION
This file was replaced by stdatomic.h in commit
18f4c3d9b34583c7464eba2e5ca8fe24f72e9fc9.

Signed-off-by: Peter Lemenkov <lemenkov@gmail.com>