### PR TITLE
Fix last reference to atomic_set() (replace with atomic_init).

### DIFF
--- a/mem/module_info.c
+++ b/mem/module_info.c
@@ -25,6 +25,7 @@
 #ifdef SHM_EXTRA_STATS
 
 #include <dlfcn.h>
+#include <stdatomic.h>
 #include <string.h>
 
 #include "module_info.h"
@@ -89,7 +90,7 @@ int init_new_stat(stat_var* stat) {
 #ifdef NO_ATOMIC_OPS
 		*(stat->u.val) = 0;
 #else
-		atomic_set(stat->u.val,0);
+		atomic_init(stat->u.val,0);
 #endif
 
 	return 0;


### PR DESCRIPTION
This one got missed from the PR#2289. It's conditional on SHM_EXTRA_STATS, that is not set  by default.