### PR TITLE
Don't process HEP messages before sending out

### DIFF
--- a/forward.h
+++ b/forward.h
@@ -114,7 +114,7 @@ static inline int msg_send( struct socket_info* send_sock, int proto,
 	/* the raw processing callbacks are free to change whatever inside
 	 * the buffer further use out_buff.s and at the end try to free out_buff.s
 	 * if changed by callbacks */
-	if (proto != PROTO_BIN)
+	if ((proto != PROTO_BIN) && (proto != PROTO_HEP_TCP) && (proto != PROTO_HEP_UDP))
 		run_post_raw_processing_cb(POST_RAW_PROCESSING,&out_buff, msg);
 
 	/* update the length for further processing */


### PR DESCRIPTION
These mesages are not intended for any further processing so don't even
try changing anything.

Fixes #2251, fixes #2273.

Signed-off-by: Peter Lemenkov <lemenkov@gmail.com>