### PR TITLE
shm_free(NULL) has no effect 

### DIFF
--- a/modules/acc/acc_logic.c
+++ b/modules/acc/acc_logic.c
@@ -177,8 +177,7 @@ void free_extra_array(extra_value_t* array, int array_len)
 	int i;
 
 	for (i=0; i < array_len; i++) {
-		if (array[i].value.s)
-			shm_free(array[i].value.s);
+		shm_free(array[i].value.s);
 	}
 	shm_free(array);
 }
@@ -197,8 +196,7 @@ static inline void free_acc_ctx(acc_ctx_t* ctx)
 		}
 		shm_free(ctx->leg_values);
 	}
-	if (ctx->acc_table.s)
-		shm_free(ctx->acc_table.s);
+	shm_free(ctx->acc_table.s);
 
 	/* also cleanup dialog */
 	dlg = dlg_api.get_dlg ? dlg_api.get_dlg() : NULL;

--- a/modules/acc/acc_vars.c
+++ b/modules/acc/acc_vars.c
@@ -139,9 +139,7 @@ int set_value_shm(pv_value_t* pvt, extra_value_t* extra)
 	if (pvt == NULL || pvt->flags&PV_VAL_NULL
 	    || (pvt->flags & PV_VAL_STR && pvt->rs.len == 0)) {
 		/* also treat empty strings as NULL */
-		if (extra->value.s) {
-			shm_free(extra->value.s);
-		}
+		shm_free(extra->value.s);
 		extra->shm_buf_len = ACC_CTX_VAL_DELETED;
 		extra->value.s = NULL;
 		extra->value.len = 0;

--- a/modules/auth/auth_mod.c
+++ b/modules/auth/auth_mod.c
@@ -358,14 +358,10 @@ static void destroy(void)
 			lock_dealloc(nonce_lock);
 		}
 
-		if(nonce_buf)
-			shm_free(nonce_buf);
-		if(second)
-			shm_free(second);
-		if(sec_monit)
-			shm_free(sec_monit);
-		if(next_index)
-			shm_free(next_index);
+		shm_free(nonce_buf);
+		shm_free(second);
+		shm_free(sec_monit);
+		shm_free(next_index);
 	}
 }
 

--- a/modules/xmpp/xmpp.c
+++ b/modules/xmpp/xmpp.c
@@ -316,14 +316,10 @@ int xmpp_send_sip_msg(char *from, char *to, char *msg)
 
 void xmpp_free_pipe_cmd(struct xmpp_pipe_cmd *cmd)
 {
-	if (cmd->from)
-		shm_free(cmd->from);
-	if (cmd->to)
-		shm_free(cmd->to);
-	if (cmd->body)
-		shm_free(cmd->body);
-	if (cmd->id)
-		shm_free(cmd->id);
+	shm_free(cmd->from);
+	shm_free(cmd->to);
+	shm_free(cmd->body);
+	shm_free(cmd->id);
 	shm_free(cmd);
 }
 


### PR DESCRIPTION
shm_free(NULL) has no effect so we can simplify `if(foo) shm_free(foo)` to `shm_free(foo)`.