### PR TITLE
tm/async: Handle ASYNC_DONE_CLOSE_FD when switching to sync

### DIFF
--- a/modules/tm/async.c
+++ b/modules/tm/async.c
@@ -354,6 +354,8 @@ sync:
 			( fd, msg, ctx->async.resume_param );
 		if (async_status == ASYNC_CHANGE_FD)
 			fd = return_code;
+		if (async_status == ASYNC_DONE_CLOSE_FD)
+			close(fd);
 	} while(async_status==ASYNC_CONTINUE||async_status==ASYNC_CHANGE_FD);
 	/* get rid of the context, useless at this point further */
 	shm_free(ctx);


### PR DESCRIPTION
One more place where we have to close file descriptor according to the
specification while doing async packet processing.

Signed-off-by: Peter Lemenkov <lemenkov@gmail.com>