### PR TITLE
tm: Use shm_malloc(_bulk) consistently with free.

### DIFF
--- a/modules/tm/t_reply.c
+++ b/modules/tm/t_reply.c
@@ -268,8 +268,8 @@ inline static int update_totag_set(struct cell *t, struct sip_msg *ok)
 
 	if (!s || !n) {
 		LM_ERR("no more share memory \n");
-		if (n) shm_free(n);
-		if (s) shm_free(s);
+		if (n) shm_free_bulk(n);
+		if (s) shm_free_bulk(s);
 		return 0;
 	}
 	memset(n, 0, sizeof(struct totag_elem));


### PR DESCRIPTION
Let's be consistent here. If we use shm_malloc(_bulk) then let's call
shm_free(_bulk) consistently. Even it's the same fuctions which differs
only in locking.

Signed-off-by: Peter Lemenkov <lemenkov@gmail.com>