### PR TITLE
Fixed double release of read_lock in dr_match

### DIFF
--- a/modules/drouting/drouting.c
+++ b/modules/drouting/drouting.c
@@ -4100,7 +4100,6 @@ static int dr_match(struct sip_msg* msg, int *grp, long flags, str *number,
 	rule = find_rule_by_prefix_unsafe(part->rdata->pt,
 			&part->rdata->noprefix, *number, *grp, &matched_len);
 	if (rule == NULL){
-		lock_stop_read( part->ref_lock );
 		goto failure;
 	}
 


### PR DESCRIPTION
This should be backported to 3.1.x