### PR TITLE
Re-introduce using stdatomics for the purposes of core stats. 

### DIFF
--- a/Makefile.defs
+++ b/Makefile.defs
@@ -245,6 +245,9 @@ ifeq ($(CC_NAME:clang=gcc),gcc)
 #if gcc use gcc arch
 predef_macros:=$(shell $(CC) -dM -E -x c $(CC_EXTRA_OPTS) $(extra_defs) \
 					$(CFLAGS) /dev/null)
+stdatomics_support:=$(shell printf '\43include <stdatomic.h>' | $(CC) -dM -E -x c $(CC_EXTRA_OPTS) $(extra_defs) \
+					$(CFLAGS) /dev/stdin >/dev/null 2>/dev/null && printf '%sDHAVE_STDATOMIC' '-')
+DEFS+=$(stdatomics_support)
 
 ifneq ($(strip $(filter $(i386_macros), $(predef_macros))),)
 CC_ARCH=i386

--- a/atomic.h
+++ b/atomic.h
@@ -32,12 +32,6 @@
  * partial support for C11, so stdatomic.h is not present.  Dropping support
  * for these OS'es would affect a significant number of OpenSIPS deployments,
  * which is undesirable, at least for now.
- *
- * FIXME: When the time is right (??), PLEASE REMOVE THIS FILE and cherry-pick
- * the following commits:
- *	- 18f4c3d9b34
- *	- 4ed5ba188a9
- *	- 9dacffd696e
  * ============================================================================
  */
 
@@ -217,5 +211,15 @@ static __inline__ void atomic_dec(atomic_t *v)
 #define NO_ATOMIC_OPS
 
 #endif
+
+/* C11 stdatomics wrappers */
+#define atomic_init(a, v) atomic_set(a, v)
+#define atomic_store(a, v) atomic_set(a, v)
+#define atomic_load(a) ((a)->counter)
+#define atomic_fetch_add(a, v) \
+	if ((long)(v) >= 0L) \
+		atomic_add(v, a);\
+	else \
+		atomic_sub(-(v), a);
 
 #endif

--- a/mem/module_info.c
+++ b/mem/module_info.c
@@ -25,7 +25,11 @@
 #ifdef SHM_EXTRA_STATS
 
 #include <dlfcn.h>
+#ifdef HAVE_STDATOMIC
 #include <stdatomic.h>
+#else
+#include "../atomic.h"
+#endif
 #include <string.h>
 
 #include "module_info.h"

--- a/mem/module_info.c
+++ b/mem/module_info.c
@@ -25,6 +25,7 @@
 #ifdef SHM_EXTRA_STATS
 
 #include <dlfcn.h>
+#include <stdatomic.h>
 #include <string.h>
 
 #include "module_info.h"
@@ -89,7 +90,7 @@ int init_new_stat(stat_var* stat) {
 #ifdef NO_ATOMIC_OPS
 		*(stat->u.val) = 0;
 #else
-		atomic_set(stat->u.val,0);
+		atomic_init(stat->u.val,0);
 #endif
 
 	return 0;

--- a/statistics.c
+++ b/statistics.c
@@ -34,7 +34,7 @@
  * \brief Statistics support
  */
 
-
+#include <stdatomic.h>
 #include <string.h>
 
 #include "mem/shm_mem.h"
@@ -46,7 +46,6 @@
 #include "core_stats.h"
 #include "statistics.h"
 #include "pt.h"
-#include "atomic.h"
 #include "globals.h"
 #include "rw_locking.h"
 
@@ -424,7 +423,7 @@ static int __register_stat(str *module, str *name, stat_var **pvar,
 #ifdef NO_ATOMIC_OPS
 		*(stat->u.val) = 0;
 #else
-		atomic_set(stat->u.val,0);
+		atomic_init(stat->u.val, 0);
 #endif
 		*pvar = stat;
 	} else {

--- a/statistics.c
+++ b/statistics.c
@@ -34,7 +34,11 @@
  * \brief Statistics support
  */
 
+#ifdef HAVE_STDATOMIC
 #include <stdatomic.h>
+#else
+#include "atomic.h"
+#endif
 #include <string.h>
 
 #include "mem/shm_mem.h"

--- a/statistics.h
+++ b/statistics.h
@@ -34,7 +34,11 @@
 #ifndef _STATISTICS_H_
 #define _STATISTICS_H_
 
+#ifdef HAVE_STDATOMIC
 #include <stdatomic.h>
+#else
+#include "atomic.h"
+#endif
 
 #include "hash_func.h"
 
@@ -53,7 +57,11 @@
 #ifdef NO_ATOMIC_OPS
 typedef unsigned int stat_val;
 #else
+# ifdef HAVE_STDATOMIC
 typedef _Atomic(unsigned long) stat_val;
+# else
+typedef atomic_t stat_val;
+# endif
 #endif
 
 typedef unsigned long (*stat_function)(void *);


### PR DESCRIPTION
This change puts back stdatomic to be used by default when compiler supports it. In case support has not been detected, the compilation fails back to the "poor-man's atomics in atomic.h".