### PR TITLE
b2b_logic: fix use of uninitialized pointer

### DIFF
--- a/modules/b2b_logic/logic.c
+++ b/modules/b2b_logic/logic.c
@@ -2977,7 +2977,7 @@ str *b2b_scenario_hdrs(struct b2bl_new_entity *entity)
 	unsigned int len;
 	char *tmp_buf;
 	int_str name_value, body_value;
-	struct usr_avp *avp_hdrs = NULL, *avp_hdr_vals;
+	struct usr_avp *avp_hdrs = NULL, *avp_hdr_vals = NULL;
 
 	/* reset the buffer to fill in with new information */
 	b2b_hdrs_buf.len = 0;


### PR DESCRIPTION
`search_first_avp()` checks if avp_hdr_vals is NULL.