### PR TITLE
b2b_logic: support for rfc3515 NOTIFY and rollback after failed transfer

### DIFF
--- a/modules/b2b_logic/b2b_logic.h
+++ b/modules/b2b_logic/b2b_logic.h
@@ -53,6 +53,10 @@
 #define		B2BL_FLAG_TRANSPARENT_TO	0x02
 #define		B2BL_FLAG_USE_INIT_SDP		0x04
 
+/* B2BL_BR_FLAGS constants */
+#define B2BL_BR_FLAG_NOTIFY			0x01
+#define B2BL_BR_FLAG_RETURN_AFTER_FAILURE	0x02
+
 /* modes to write in db */
 #define NO_DB         0
 #define WRITE_THROUGH 1
@@ -82,6 +86,12 @@ struct b2b_params
 	str *id;
 	str *init_body;
 	str *init_body_type;
+};
+
+struct b2b_bridge_params
+{
+	unsigned int flags;
+	unsigned int lifetime;
 };
 
 enum pv_entity_field {

--- a/modules/b2b_logic/b2b_logic.h
+++ b/modules/b2b_logic/b2b_logic.h
@@ -51,7 +51,7 @@
 /* B2BL_FLAGS constants */
 #define		B2BL_FLAG_TRANSPARENT_AUTH	0x01
 #define		B2BL_FLAG_TRANSPARENT_TO	0x02
-#define		B2BL_FLAG_USE_INIT_SDP		0x03
+#define		B2BL_FLAG_USE_INIT_SDP		0x04
 
 /* modes to write in db */
 #define NO_DB         0

--- a/modules/b2b_logic/doc/b2b_logic_admin.xml
+++ b/modules/b2b_logic/doc/b2b_logic_admin.xml
@@ -635,7 +635,7 @@ b2b_client_new("client1", "sip:alice@opensips.org");
 
 	<section id="func_b2b_bridge" xreflabel="b2b_bridge()">
 		<title>
-		<function moreinfo="none">b2b_bridge(entity1, entity2, [provmedia_uri], [lifetime])</function>
+		<function moreinfo="none">b2b_bridge(entity1, entity2, [provmedia_uri], [flags])</function>
 		</title>
 		<para>
 			This function bridges two entities, in the context of an existing B2B session
@@ -660,9 +660,23 @@ b2b_client_new("client1", "sip:alice@opensips.org");
 				media server to be connected with the caller while the callee answers.
 			</para></listitem>
 			<listitem><para>
-				<emphasis>lifetime (int, optional)</emphasis> - maximum duration of the B2B
-				session. If the lifetime expires, the B2BUA will send BYE messages to both
-				ends and delete the record.
+				<emphasis>flags (string, optional)</emphasis> - meanings of the flags is as follows:
+				<itemizedlist>
+					<listitem><para>
+					<emphasis>t[nn]</emphasis> - Maximum duration of the B2B
+					session. If the lifetime expires, the B2BUA will send BYE messages to both
+					ends and delete the record.
+					Example: t300.
+					</para></listitem>
+					<listitem><para>
+					<emphasis>n</emphasis> - Enable rfc3515 NOTIFY to inform the agent sending the
+					REFER of the status of the reference.
+					</para></listitem>
+					<listitem><para>
+					<emphasis>f</emphasis> - Rollback call to state before bridging in case of transfer
+					failed, don't hangup the call (default behaviour).
+					</para></listitem>
+				</itemizedlist>
 			</para></listitem>
 		</itemizedlist>
 		<para>

--- a/modules/b2b_logic/records.c
+++ b/modules/b2b_logic/records.c
@@ -283,7 +283,7 @@ b2bl_tuple_t* b2bl_insert_new(struct sip_msg* msg, unsigned int hash_index,
 	LM_DBG("hash index [%d]:\n", hash_index);
 	for(it = b2bl_htable[hash_index].first; it; it=it->next)
 	{
-		LM_DBG("id [%d]", it->id);
+		LM_DBG("id [%d]\n", it->id);
 	}
 
 	b2bl_key = b2bl_generate_key(hash_index, tuple->id);

--- a/modules/b2b_logic/records.h
+++ b/modules/b2b_logic/records.h
@@ -100,6 +100,7 @@ typedef struct b2bl_tuple
 	b2bl_entity_id_t* servers[MAX_B2BL_ENT];
 	b2bl_entity_id_t* clients[MAX_B2BL_ENT];
 	b2bl_entity_id_t* bridge_entities[MAX_BRIDGE_ENT];
+	int bridge_flags;
 	int to_del;
 	str* extra_headers;
 	struct b2bl_tuple* next;

--- a/modules/b2b_logic/records.h
+++ b/modules/b2b_logic/records.h
@@ -100,6 +100,7 @@ typedef struct b2bl_tuple
 	b2bl_entity_id_t* servers[MAX_B2BL_ENT];
 	b2bl_entity_id_t* clients[MAX_B2BL_ENT];
 	b2bl_entity_id_t* bridge_entities[MAX_BRIDGE_ENT];
+	b2bl_entity_id_t* bridge_initiator;
 	int bridge_flags;
 	int to_del;
 	str* extra_headers;


### PR DESCRIPTION
Adds possibility to generate rfc3515 NOTIFY and not hangup call in case of failed transfer.

Instead of lifetime parameter there is flags parameter in b2b_bridge() function which can have next values:
`t` - set lifetime
`n` - enable NOTIFY
`f` - in case of negative reply during transfer, rollback the transfer attempt
