### PR TITLE
Refactor structure(s) packing code to do not put C structures at random unaligned offsets

### DIFF
--- a/modules/event_route/route_send.c
+++ b/modules/event_route/route_send.c
@@ -36,13 +36,16 @@
 int route_build_buffer(str *event_name, evi_reply_sock *sock,
 		evi_params_t *params, route_send_t **msg)
 {
-	route_send_t *buf;
+	struct {
+		route_send_t rt;
+		evi_param_t eps[0];
+	} *buf;
 	evi_param_p param, buf_param;
 	int len, params_len=0;
 	unsigned int param_no = 0;
 	char *s;
 
-	len = sizeof(route_send_t) + event_name->len;
+	len = sizeof(*buf) + event_name->len;
 	if (params) {
 		for (param = params->first; param; param = param->next) {
 			if (param->flags & EVI_INT_VAL) {
@@ -58,7 +61,7 @@ int route_build_buffer(str *event_name, evi_reply_sock *sock,
 		}
 	}
 
-	len += sizeof(evi_params_t) + param_no*sizeof(evi_param_t) + params_len;
+	len += param_no*sizeof(evi_param_t) + params_len;
 	buf = shm_malloc(len);
 	if (!buf) {
 		LM_ERR("oom\n");
@@ -66,15 +69,15 @@ int route_build_buffer(str *event_name, evi_reply_sock *sock,
 	}
 	memset(buf, 0, len);
 
-	/* First,is event */
-	buf->event.s = (char*)(buf + 1);
-	buf->event.len = event_name->len;
-	memcpy(buf->event.s, event_name->s, event_name->len);
+	/* Stick the event name at the end */
+	buf->rt.event.s = (char*)(buf) + len - event_name->len;
+	buf->rt.event.len = event_name->len;
+	memcpy(buf->rt.event.s, event_name->s, event_name->len);
 
 	if (params) {
-		buf_param = (evi_param_p)(buf->event.s + buf->event.len);
-		buf->params.first = buf_param;
-		s = (char*)(buf_param + param_no);
+		buf_param = &buf->eps[0];
+		buf->rt.params.first = buf_param;
+		s = (char*)(&buf->eps[param_no]);
 		for (param = params->first; param; param = param->next) {
 			if (param->flags & EVI_INT_VAL) {
 				buf_param->flags = EVI_INT_VAL;
@@ -104,10 +107,10 @@ int route_build_buffer(str *event_name, evi_reply_sock *sock,
 		}
 		buf_param--;
 		buf_param->next = NULL;
-		buf->params.last = buf_param;
+		buf->rt.params.last = buf_param;
 	}
 
-	*msg = buf;
+	*msg = &buf->rt;
 	return 0;
 }
 


### PR DESCRIPTION
One things that people often don't realize about heap management routines (malloc() etc), is that memory returned is ALWAYS aligned to provide memory that is suitable for placing C structures onto it. As such, one should not just allocate chunk of data and place structure at random offset within, at least if the data is then to be accessed without memcpy to a local variable. On some architectures such access is not allowed at all, on others just penalized performance-wise. Moreover, if memory is shared across cores, placing critical data, such as pointers, across cache line boundaries could also lead to broken value to be obtained by the core that reads the data shortly after another core has updated it.