### PR TITLE
Use DBG level for per-connection nominal log messages

### DIFF
--- a/net/net_tcp.c
+++ b/net/net_tcp.c
@@ -169,7 +169,7 @@ static inline int init_sock_keepalive(int s)
 				strerror(errno));
 			return -1;
 		}
-		LM_INFO("TCP keepalive enabled on socket %d\n",s);
+		LM_DBG("TCP keepalive enabled on socket %d\n",s);
 	}
 #endif
 #ifdef HAVE_TCP_KEEPINTVL

--- a/socket_info.c
+++ b/socket_info.c
@@ -1297,7 +1297,7 @@ int probe_max_sock_buff(int sock,int buff_choice,int buff_max,int buff_increment
 		LM_ERR("getsockopt: %s\n", strerror(errno));
 		return -1;
 	}
-	LM_INFO("using %s buffer of %d kb\n",info, (foptval/1024));
+	LM_DBG("using %s buffer of %d kb\n",info, (foptval/1024));
 
 	return 0;
 }


### PR DESCRIPTION
AWS health checks open a TCP connection very frequently to check on the status of the server. The per-connection INFO logs get spammed. This commit changes these messages to debug messages since that log level may be more appropriate for them anyway.