### PR TITLE
Add support for set id substitution for dispatcher algorithm 9

### DIFF
--- a/modules/dispatcher/dispatch.h
+++ b/modules/dispatcher/dispatch.h
@@ -42,9 +42,9 @@
 #define DS_RESET_FAIL_DST	4  /* Reset-Failure-Counter */
 #define DS_STATE_DIRTY_DST	8  /* STATE is dirty */
 
-#define DS_PV_ALGO_MARKER	"%u"	/* Marker to indicate where the URI should
-									   be inserted in the pvar */
-#define DS_PV_ALGO_MARKER_LEN (sizeof(DS_PV_ALGO_MARKER) - 1)
+#define DS_PV_ALGO_ID_MARKER   "%i"  /* Marker to indicate where the Set ID should be inserted in the pvar */
+#define DS_PV_ALGO_URI_MARKER  "%u"  /* Marker to indicate where the URI should be inserted in the pvar */
+#define DS_PV_ALGO_MARKER_LEN  2
 
 #define DS_MAX_IPS  32
 

--- a/modules/dispatcher/doc/dispatcher_admin.xml
+++ b/modules/dispatcher/doc/dispatcher_admin.xml
@@ -617,7 +617,9 @@ modparam("dispatcher", "sock_avp", "$avp(275)")
 		pseudovariable pattern used to detect the load of each destination. The
 		name of the pseudovariable should contain the string <quote>%u</quote>,
 		which will be internally replaced by the module with the uri of the
-		destination.
+		destination. The string <quote>%i</quote> can also be used and will be
+		replaced with the set ID of the destination (useful in cases where same
+		uri exists in multiple sets).
 		</para>
 		<para>
 		</para>


### PR DESCRIPTION
This PR adds support for replacing `%i` with the selected dispatcher set ID when using algorithm 9.  Currently, only support for URI substitution exists via `%u` string. However, if using the same URI in multiple sets then weighting can lead to unexpected behaviors as the same `$stat(...)` will be referenced/updated by multiple sets. By allowing use of `%i`, multiple sets with same URI(s) can be weighted independently.

Example usage:
```
modparam("dispatcher", "pvar_algo_pattern", "$stat(weight_%i_%u)")
...
...
$var(setid) = 1;
ds_select_domain($var(setid),9);

#prefer local dispatch
if ($(rd{ip.matches,MY_PUBLIC_IP/24}))
    update_stat("weight_$var(setid)_sip:$rd:$rp",1);
else
    update_stat("weight_$var(setid)_sip:$rd:$rp"",10);
```

The same type of weighting logic can be achieved by using algorithm 10, however, for large dispatcher sets algo 9 has the advantage of only calling weighting logic 1x per request as opposed to Nx per request with algo 10.