### PR TITLE
b2b: properly release tuples

### DIFF
--- a/modules/b2b_entities/dlg.c
+++ b/modules/b2b_entities/dlg.c
@@ -1733,6 +1733,7 @@ void b2b_delete_record(b2b_dlg_t* dlg, b2b_table htable, unsigned int hash_index
 		shm_free(dlg->ack_sdp.s);
 
 	shm_free(dlg);
+	dlg = 0;
 }
 
 void b2b_entity_delete(enum b2b_entity_type et, str* b2b_key,

--- a/modules/b2b_logic/entity_storage.c
+++ b/modules/b2b_logic/entity_storage.c
@@ -412,9 +412,12 @@ static void receive_entity_create(enum b2b_entity_type entity_type,
 
 	return;
 error:
-	lock_release(&b2bl_htable[hash_index].lock);
 	if (tuple && !old_tuple)
+	{
 		b2bl_delete(tuple, hash_index, 0, 0);
+		tuple = 0;
+	}
+	lock_release(&b2bl_htable[hash_index].lock);
 	if (entity) {
 		if (entity->dlginfo)
 			shm_free(entity->dlginfo);
@@ -609,8 +612,11 @@ static void receive_entity_delete(enum b2b_entity_type entity_type,
 
 	for (i = 0; i < MAX_BRIDGE_ENT && !tuple->bridge_entities[i]; i++) ;
 	if (i == MAX_BRIDGE_ENT)
+	{
 		/* no other bridge entities remaining, delete the tuple */
 		b2bl_delete(tuple, hash_index, 1, 0);
+		tuple = 0;
+	}
 
 	lock_release(&b2bl_htable[hash_index].lock);
 }

--- a/modules/b2b_logic/logic.c
+++ b/modules/b2b_logic/logic.c
@@ -3383,6 +3383,7 @@ error:
 	if(tuple)
 	{
 		b2bl_delete(tuple, hash_index, 1, 1);
+		tuple = 0;
 		lock_release(&b2bl_htable[hash_index].lock);
 	}
 	if(to_uri.s)
@@ -4131,6 +4132,7 @@ int b2bl_bridge_2calls(str* key1, str* key2)
 		goto error;
 	}
 	b2bl_delete(tuple, hash_index, 1, 1);
+	tuple = 0;
 
 	lock_release(&b2bl_htable[hash_index].lock);
 


### PR DESCRIPTION
Release b2b tuples properly which prevents corrupted data usage.