### PR TITLE
Restore registrar 'f' flag behaviour for "sql-only" db_mode

### DIFF
--- a/modules/usrloc/ul_mod.c
+++ b/modules/usrloc/ul_mod.c
@@ -908,7 +908,7 @@ int ul_check_db(void)
 			return -1;
 		}
 
-		if (rr_persist == RRP_LOAD_FROM_SQL) {
+		if (cluster_mode != CM_NONE || rr_persist == RRP_LOAD_FROM_SQL) {
 			if (!(sync_lock = lock_init_rw())) {
 				LM_ERR("cannot init rw lock\n");
 				return -1;


### PR DESCRIPTION
On 2020-05-25 fix 3a1f9c1e2 for #2118 was introduced into opensips 3.1.
This change also modified things so cid_keys and cid_vals would *not*
be allocated when the database was in "sql-only" mode.

When "sql-only" mode is used, all usrloc records are saved to the DB
immediately, and are loaded from DB immediately.

The relevant settings:

    modparam("usrloc", "working_mode_preset", "sql-only")

Which equals the deprecated db_mode setting 3:

    modparam("usrloc", "db_mode", 3)  # 3 = "sql-only", DEPRECATED

Or, as three separate settings:

    modparam("usrloc", "cluster_mode", "sql-only")     # CM_SQL_ONLY
    modparam("usrloc", "restart_persistency", "none")  # RRP_NONE
    modparam("usrloc", "sql_write_mode", "none")       # SQL_NO_WRITE
    # This last option is slightly awkwardly named, but it refers
    # to *additional* SQL writing which is not performed. Because,
    # the is only *direct* SQL reading/writing.

In any case: the changeset removed the access to temporary storage of
cid_keys/cid_vals for the CM_SQL_ONLY case, under the assumption that
it was not needed:
```patch
       if (rr_persist == RRP_LOAD_FROM_SQL) {
          if (!(sync_lock = lock_init_rw())) {
             LM_ERR("cannot init rw lock\n");
             return -1;
          }
-      }
-   }

-   if (cluster_mode != CM_NONE || rr_persist == RRP_LOAD_FROM_SQL) {
-      cid_keys = pkg_malloc(max_contact_delete *
-            (sizeof(db_key_t) + sizeof(db_val_t)));
-      if (!cid_keys) {
-         LM_ERR("oom\n");
-         return -1;
-      }
+         /* initialize the "merged contact deletes" array */
+         cid_keys = pkg_malloc(max_contact_delete *
+               (sizeof(db_key_t) + sizeof(db_val_t)));
+         if (!cid_keys) {
+            LM_ERR("oom\n");
+            return -1;
+         }
```
However, those "merged contact deletes" were still needed when the
registrar save() function tries to limit the number of Contacts (using
the 'f' force overwrite flag).

registrar:add_contacts() calls usrloc:release_urecord() with the
contacts that should be removed (from the database). This calls
usrloc:db_only_timer() (and wb_timer) and finally
usrloc:db_multiple_ucontact_delete().

The wb_timer was supposed to populate the cid_keys/cid_vals with the
database IDs passed along from the registrar module. But because that
temporary cid_vals storage was not available, that bit would be skipped:
```c
            /* Should we remove the contact from the database ? */
            if (cid_vals && st_expired_ucontact(t) == 1
```
The result: usrloc:db_multiple_ucontact_delete() had nothing to
delete; the max contacts save settings would be ignored.

This changeset restores the `cluster_mode != CM_NONE` alternative that
initialises cid_keys/cid_vals, restoring the force/max_contacts
behaviour.

(Closes #2372. @liviuchircu: care to take a look?)