### PR TITLE
Fix for Makefile.defs

### DIFF
--- a/Makefile.defs
+++ b/Makefile.defs
@@ -823,13 +823,13 @@ ifeq	($(CC_NAME), clang)
 	CC_OPTIMIZE_FLAG?=-O3
 endif
 
+ifeq ($(mode), release)
 ifeq (,$(CFLAGS))
 
 #common stuff
 CFLAGS+=$(DEBUGSYM)
 
 # setting more CFLAGS
-ifeq ($(mode), release)
 
 #if i386
 ifeq	($(ARCH), i386)

--- a/Makefile.defs
+++ b/Makefile.defs
@@ -462,11 +462,11 @@ endif
 
 INSTALL_TOUCH = touch          # used to create the file first (good to
                                #  make solaris install work)
-INSTALL_CFG = $(INSTALL) -m 644
-INSTALL_BIN = $(INSTALL) -m 755
-INSTALL_MODULES = $(INSTALL) -m 755
-INSTALL_DOC = $(INSTALL) -m 644
-INSTALL_MAN = $(INSTALL) -m 644
+INSTALL_CFG ?= $(INSTALL) -m 644
+INSTALL_BIN ?= $(INSTALL) -m 755
+INSTALL_MODULES ?= $(INSTALL) -m 755
+INSTALL_DOC ?= $(INSTALL) -m 644
+INSTALL_MAN ?= $(INSTALL) -m 644
 
 
 ifeq ($(VERSIONTYPE),)


### PR DESCRIPTION
I was working on a new FreeBSD port for opensips and found a bug in the Makefile.defs which prevented LDFLAGS from including additional library search directory. The current order of the ifeq/else/endif is:

ifeq (,$(CFLAGS)) : line 826
ifeq ($(mode), release) : line 832
endif   # CFLAGS not set : line 1330
else    #mode,release : line 1362
endif #mode=release : line 1389

so I've changed the order of ifeqs and my build succeeded.

Another important feature which is needed by FreeBSD port is ability to override variables INSTALL_BIN, INSTALL_MODULES, etc so it is possible to be able to strip binaries of debug symbols if needed.