### PR TITLE
Update ip_addr.c

### DIFF
--- a/ip_addr.c
+++ b/ip_addr.c
@@ -177,7 +177,7 @@ int ip_addr_is_1918(str *s_ip)
 		{ 0x0a000000, 0xffffffffu << 24},  /* "10.0.0.0"    RFC 1918 */
 		{ 0xac100000, 0xffffffffu << 20},  /* "172.16.0.0"  RFC 1918 */
 		{ 0xc0a80000, 0xffffffffu << 16},  /* "192.168.0.0" RFC 1918 */
-		{ 0x64400000, 0xffffffffu << 22},  /* "100.64.0.0"  RFC 6598 */
+		{ 0x64400000, 0xffffffffu << 10},  /* "100.64.0.0"  RFC 6598 */
 		{ 0, 0}
 	};
 	struct ip_addr *ip;


### PR DESCRIPTION
Update RFC6598 address space

The current /22 is causing problems NAT traversal problems using space outside 100.64.0.0/22

RFC6598 para 7 defines the cgnat address space:
---------------------------------------------------------------------
7.  IANA Considerations

   IANA has recorded the allocation of an IPv4 /10 for use as Shared
   Address Space.

   The Shared Address Space address range is 100.64.0.0/10.