### PR TITLE
Fix crash in db_timer_udomain() when the database has little work

### DIFF
--- a/modules/usrloc/udomain.c
+++ b/modules/usrloc/udomain.c
@@ -1040,24 +1040,24 @@ int db_timer_udomain(udomain_t* _d)
 	db_op_t  ops[2];
 	db_val_t vals[2];
 
-	if (my_ps==NULL) {
-		keys[0] = &expires_col;
-		ops[0] = "<";
-		keys[1] = &expires_col;
-		ops[1] = "!=";
+	if (ul_dbf.use_table(ul_dbh, _d->name) < 0) {
+		LM_ERR("failed to change table\n");
+		return -1;
 	}
 
 	memset(vals, 0, sizeof vals);
 
+	keys[0] = &expires_col;
+	ops[0] = "<";
 	vals[0].type = DB_INT;
 	vals[0].val.int_val = act_time + 1;
 
+	keys[1] = &expires_col;
+	ops[1] = "!=";
 	vals[1].type = DB_INT;
 	vals[1].val.int_val = 0;
 
 	CON_PS_REFERENCE(ul_dbh) = &my_ps;
-	ul_dbf.use_table(ul_dbh, _d->name);
-
 	if (ul_dbf.delete(ul_dbh, keys, ops, vals, 2) < 0) {
 		LM_ERR("failed to delete from table %s\n",_d->name->s);
 		return -1;


### PR DESCRIPTION
The previous code, added in 1f0be8f02 but mostly fixed by 0d0909fc1, added this interesting erroneous pattern:
```c
    static db_ps_t my_ps = NULL;
    db_key_t keys[2];
    db_op_t  ops[2];

    if (my_ps == NULL) {
        keys[0] = &expires_col;
        ops[0] = "<";
        ...
```
That is: the initialisation of the stack depended on a global (local static). Once it was set, the initialisation would be skipped, causing keys and ops to contain undefined values.

Due to the way the CON_PS_REFERENCE() prepared statement handle code has become, my_ps would always be reset to NULL after use, hiding this bug.

However, if you have a flaky database connection (for instance an auto-closing socket on a machine with little traffic) then the
following happens:

    CRITICAL:db_mysql:wrapper_single_mysql_stmt_execute: driver error
      (2003): Lost connection to backend server.
    ERROR:usrloc:db_timer_udomain: failed to delete from table location
    ERROR:usrloc:synchronize_all_udomains: synchronizing cache failed

When this happens, my_ps is _not_ reset to NULL, and the next time this function is invoked, keys and ops are undefined, causing a segfault down the road.

This changeset adds an if around use_table() because all the other code in this module does so. The actual fix is the removal of if(my_ps==NULL).

(An alternative fix could have been to explicitly reset the prepared statement handle to NULL like 57caa6c03 does. Or to make keys and ops static too and set them only once.)

----

**DEBUG**

So, looks like this bug has existed for quite a while (2009?), or at least until the prepared statement code started resetting the handle after each query. 3.1 and 2.4 should both be affected, although we have only experiences this with 3.1 so far.

```
Program terminated with signal SIGSEGV, Segmentation fault.
#0  __strlen_sse2 () at ../sysdeps/x86_64/multiarch/../strlen.S:120
120	../sysdeps/x86_64/multiarch/../strlen.S: No such file or directory.
```
```
(gdb) bt
#0  __strlen_sse2 () at ../sysdeps/x86_64/multiarch/../strlen.S:120
#1  0x00007fb0439369ef in _IO_vfprintf_internal (s=s@entry=0x7ffda9c4f0a0, format=format@entry=0x558cda72103a "%.*s%s", ap=ap@entry=0x7ffda9c4f220) at vfprintf.c:1638
#2  0x00007fb0439ed219 in ___vsnprintf_chk (s=0x558cda877a42 <sql_buf+34> "", maxlen=<optimized out>, flags=1, slen=<optimized out>, format=0x558cda72103a "%.*s%s", 
    args=args@entry=0x7ffda9c4f220) at vsnprintf_chk.c:63
#3  0x00007fb0439ed145 in ___snprintf_chk (s=s@entry=0x558cda877a42 <sql_buf+34> "", maxlen=maxlen@entry=65502, flags=flags@entry=1, slen=slen@entry=18446744073709551615, 
    format=format@entry=0x558cda72103a "%.*s%s") at snprintf_chk.c:34
#4  0x0000558cda65a94c in snprintf (__fmt=0x558cda72103a "%.*s%s", __n=65502, __s=0x558cda877a42 <sql_buf+34> "") at /usr/include/x86_64-linux-gnu/bits/stdio2.h:67
#5  db_print_where (_c=_c@entry=0x7fb043287fa0, _b=_b@entry=0x558cda877a42 <sql_buf+34> "", _l=_l@entry=65502, _k=_k@entry=0x7ffda9c4f470, _o=_o@entry=0x7ffda9c4f480, 
    _v=_v@entry=0x7ffda9c4f490, _n=2, val2str=0x7fafc2fc9730 <db_mysql_val2str>) at db/db_ut.c:335
#6  0x0000558cda64f6c8 in db_do_delete (_h=_h@entry=0x7fb043287fa0, _k=_k@entry=0x7ffda9c4f470, _o=_o@entry=0x7ffda9c4f480, _v=_v@entry=0x7ffda9c4f490, _n=_n@entry=2, 
    val2str=0x7fafc2fc9730 <db_mysql_val2str>, submit_query=0x7fafc2fcbb80 <db_mysql_submit_dummy_query>) at db/db_query.c:323
#7  0x00007fafc2fd4a4f in db_mysql_delete (_h=0x7fb043287fa0, _k=0x7ffda9c4f470, _o=0x7ffda9c4f480, _v=0x7ffda9c4f490, _n=2) at dbase.c:1325
#8  0x00007fafc23d7879 in db_timer_udomain (_d=0x7fafc35f39d8) at udomain.c:1060
#9  0x00007fafc23fc111 in _synchronize_all_udomains () at dlist.c:1077
#10 0x00007fafc23e42d4 in synchronize_all_udomains (ticks=<optimized out>, param=<optimized out>) at ul_timer.c:81
#11 0x0000558cda57e4ca in handle_timer_job () at timer.c:868
#12 0x0000558cda673d55 in handle_io (idx=<optimized out>, event_type=<optimized out>, fm=<optimized out>) at net/net_udp.c:276
#13 io_wait_loop_epoll (repeat=0, t=1, h=<optimized out>) at net/../io_wait_loop.h:311
#14 0x0000558cda679066 in udp_start_processes (chd_rank=chd_rank@entry=0x558cda872328 <chd_rank>, startup_done=startup_done@entry=0x0) at net/net_udp.c:497
#15 0x0000558cda50e80f in main_loop () at main.c:804
#16 main (argc=<optimized out>, argv=<optimized out>) at main.c:1491
```
```
(gdb) up 5
#5  db_print_where (_c=_c@entry=0x7fb043287fa0, _b=_b@entry=0x558cda877a42 <sql_buf+34> "", _l=_l@entry=65502, _k=_k@entry=0x7ffda9c4f470, _o=_o@entry=0x7ffda9c4f480, 
    _v=_v@entry=0x7ffda9c4f490, _n=2, val2str=0x7fafc2fc9730 <db_mysql_val2str>) at db/db_ut.c:335
```
```c
        for(i = 0; i < _n; i++) {
                if (_o) {
                        ret = snprintf(_b + len, _l - len, "%.*s%s",
                                _k[i]->len, _k[i]->s, _o[i]);    // <-- crash
                        if (ret < 0 || ret >= (_l - len)) goto error;
                        len += ret;
```
```
(gdb) info args
_c = 0x7fb043287fa0
_b = 0x558cda877a42 <sql_buf+34> ""
_l = 65502
_k = 0x7ffda9c4f470
_o = 0x7ffda9c4f480
_v = 0x7ffda9c4f490
_n = 2
```
```
(gdb) info locals
i = 0
l = 0
ret = <optimized out>
len = 0
```
```
(gdb) print _o[0]
$1 = (const db_op_t) 0x4 <error: Cannot access memory at address 0x4>
```
```
(gdb) up 3
#8  0x00007fafc23d7879 in db_timer_udomain (_d=0x7fafc35f39d8) at udomain.c:1060
1060	udomain.c: No such file or directory.
(gdb) print keys
$2 = {0x7fafc36b1880, 0x7ffda9c4f4f8}
(gdb) print ops
$3 = {0x4 <error: Cannot access memory at address 0x4>, 0x1 <error: Cannot access memory at address 0x1>}
```