### PR TITLE
Prefer CON_SET_CURR_PS over CON_PS_REFERENCE

### DIFF
--- a/db/db_insertq.c
+++ b/db/db_insertq.c
@@ -131,7 +131,7 @@ void flush_query_list(void)
 			//Reset prepared statement between query lists/connections
 			my_ps = NULL;
 
-			CON_PS_REFERENCE(it->conn[process_no]) = &my_ps;
+			CON_SET_CURR_PS(it->conn[process_no], &my_ps);
 
 			/* and let's insert the rows */
 			for (i=0;i<it->no_rows;i++)

--- a/db/db_ps.h
+++ b/db/db_ps.h
@@ -26,18 +26,17 @@ typedef void * db_ps_t;
 /** Is any prepared statement provided for the next query? */
 #define CON_HAS_PS(cn)  ((cn)->curr_ps)
 
-/** Does the connection has attached an uninitialized prepared statemen? */
+/** Does the connection has attached an uninitialized prepared statement? */
 #define CON_HAS_UNINIT_PS(cn)  (*((cn)->curr_ps)==NULL)
 
-
-/** Pointer to the current used prepared statment */
+/** Pointer to the currently used prepared statement */
 #define CON_CURR_PS(cn)      (*(cn)->curr_ps)
 
-/** Pointer to the address of the current used prepared statment */
-#define CON_PS_REFERENCE(cn)      ((cn)->curr_ps)
+/** Wipe the address of the currently used prepared statement */
+#define CON_RESET_CURR_PS(cn)    *((void***)&(cn)->curr_ps)=NULL
 
-#define CON_RESET_CURR_PS(cn)    *((void***)&cn->curr_ps)=NULL
-#define CON_SET_CURR_PS(cn, ptr)    *((void***)&cn->curr_ps)=ptr
+/** Set the address of the currently used prepared statement */
+#define CON_SET_CURR_PS(cn, ptr)    *((void***)&(cn)->curr_ps)=ptr
 
 #endif
 

--- a/modules/acc/acc.c
+++ b/modules/acc/acc.c
@@ -595,7 +595,7 @@ int acc_db_request( struct sip_msg *rq, struct sip_msg *rpl,
 			ps = &my_ps3;
 	}
 
-	CON_PS_REFERENCE(db_handle) = ps;
+	CON_SET_CURR_PS(db_handle, ps);
 
 
 	/* multi-leg columns */
@@ -691,7 +691,7 @@ int acc_db_cdrs(struct dlg_cell *dlg, struct sip_msg *msg, acc_ctx_t* ctx)
 
 	total = ret + 5;
 	acc_dbf.use_table(db_handle, &table);
-	CON_PS_REFERENCE(db_handle) = &my_ps;
+	CON_SET_CURR_PS(db_handle, &my_ps);
 
 
 	/* prevent acces for setting variable */

--- a/modules/alias_db/alookup.c
+++ b/modules/alias_db/alookup.c
@@ -104,7 +104,7 @@ static int alias_db_query(struct sip_msg* _msg, str* table_s,
 
 	adbf.use_table(db_handle, table_s);
 	if (!ald_append_branches)
-		CON_PS_REFERENCE(db_handle) = my_ps[ps_idx];
+		CON_SET_CURR_PS(db_handle, my_ps[ps_idx]);
 
 	if(adbf.query( db_handle, db_keys, NULL, db_vals, db_cols,
 		(flags&ALIAS_NO_DOMAIN_FLAG)?1:2 /*no keys*/, 2 /*no cols*/,

--- a/modules/auth_db/authorize.c
+++ b/modules/auth_db/authorize.c
@@ -61,7 +61,7 @@ static str *get_cred_column(alg_t alg)
 
 	if (calc_ha1) {
 		rval = &pass_column;
-		CON_PS_REFERENCE(auth_db_handle) = &auth_ha1_ps;
+		CON_SET_CURR_PS(auth_db_handle, &auth_ha1_ps);
 		return rval;
 	}
 	switch(alg) {
@@ -69,17 +69,17 @@ static str *get_cred_column(alg_t alg)
 	case ALG_MD5:
 	case ALG_MD5SESS:
 		rval = &pass_column;
-		CON_PS_REFERENCE(auth_db_handle) = &auth_ha1_ps;
+		CON_SET_CURR_PS(auth_db_handle, &auth_ha1_ps);
 		break;
 	case ALG_SHA256:
 	case ALG_SHA256SESS:
 		rval = &hash_column_sha256;
-		CON_PS_REFERENCE(auth_db_handle) = &auth_ha1_sha256_ps;
+		CON_SET_CURR_PS(auth_db_handle, &auth_ha1_sha256_ps);
 		break;
 	case ALG_SHA512_256:
 	case ALG_SHA512_256SESS:
 		rval = &hash_column_sha512t256;
-		CON_PS_REFERENCE(auth_db_handle) = &auth_ha1_sha512t256_ps;
+		CON_SET_CURR_PS(auth_db_handle, &auth_ha1_sha512t256_ps);
 		break;
 	default:
 		rval = NULL;

--- a/modules/auth_db/checks.c
+++ b/modules/auth_db/checks.c
@@ -117,7 +117,7 @@ static inline int check_username(struct sip_msg* _m, str* _table,
 	VAL_STR(vals + 2) = _uri->user;
 
 	auth_dbf.use_table(auth_db_handle, _table);
-	CON_PS_REFERENCE(auth_db_handle) = &my_ps;
+	CON_SET_CURR_PS(auth_db_handle, &my_ps);
 
 	if (auth_dbf.query(auth_db_handle, keys, 0, vals, cols, 3, 1, 0, &res) < 0)
 	{
@@ -212,7 +212,7 @@ int does_uri_exist(struct sip_msg* _msg, str* uri, str* _table)
 	VAL_STR(vals) = p_uri.user;
 	VAL_STR(vals + 1) = p_uri.host;
 
-	CON_PS_REFERENCE(auth_db_handle) = &my_ps;
+	CON_SET_CURR_PS(auth_db_handle, &my_ps);
 
 	if (auth_dbf.query(auth_db_handle, keys, 0, vals, cols, (use_domain ? 2 : 1),
 				1, 0, &res) < 0) {
@@ -315,7 +315,7 @@ int get_auth_id(struct sip_msg* _msg, str *_table, str* uri,
 	VAL_NULL(vals + 1) = 0;
 	VAL_STR(vals + 1) = sip_uri.host;
 
-	CON_PS_REFERENCE(auth_db_handle) = &my_ps;
+	CON_SET_CURR_PS(auth_db_handle, &my_ps);
 
 	/* if use_domain is set also the domain column of the database table will
 	   be honoured in the following query (see sixth parameter) */

--- a/modules/call_center/cc_db.c
+++ b/modules/call_center/cc_db.c
@@ -914,7 +914,7 @@ int cc_write_cdr( str *un, str *fid, str *aid, int type, int rt, int wt, int tt,
 	vals[10].type = DB_INT;
 	vals[10].val.int_val = cid;
 
-	CON_PS_REFERENCE(cc_acc_db_handle) = &my_ps;
+	CON_SET_CURR_PS(cc_acc_db_handle, &my_ps);
 
 	if (cc_acc_dbf.insert( cc_acc_db_handle, columns, vals, 11) < 0) {
 		LM_ERR("CDR insert failed\n");

--- a/modules/dialog/dlg_db_handler.c
+++ b/modules/dialog/dlg_db_handler.c
@@ -518,7 +518,7 @@ int remove_ended_dlgs_from_db(void)
 
 	VAL_INT(values) = DLG_STATE_DELETED ;
 
-	CON_PS_REFERENCE(dialog_db_handle) = &my_ps;
+	CON_SET_CURR_PS(dialog_db_handle, &my_ps);
 
 	if(dialog_dbf.delete(dialog_db_handle, match_keys, 0, values, 1) < 0) {
 		LM_ERR("failed to delete database information\n");
@@ -884,7 +884,7 @@ int dlg_timer_remove_from_db(struct dlg_cell *cell)
 	if (dlg_del_curr_no == dlg_bulk_del_no) {
 		LM_DBG("triggering delete for %d dialogs\n",dlg_del_curr_no);
 
-		CON_PS_REFERENCE(dialog_db_handle) = &my_ps;
+		CON_SET_CURR_PS(dialog_db_handle, &my_ps);
 		CON_USE_OR_OP(dialog_db_handle);
 		if(dialog_dbf.delete(dialog_db_handle, dlg_del_keys,
 					0, dlg_del_values, dlg_bulk_del_no) < 0)
@@ -949,7 +949,7 @@ int remove_dialog_from_db(struct dlg_cell * cell)
 
 	VAL_BIGINT(values) = dlg_get_db_id(cell);
 
-	CON_PS_REFERENCE(dialog_db_handle) = &my_ps;
+	CON_SET_CURR_PS(dialog_db_handle, &my_ps);
 
 	if(dialog_dbf.delete(dialog_db_handle, match_keys, 0, values, 1) < 0) {
 		LM_ERR("failed to delete database information\n");
@@ -991,7 +991,7 @@ int update_dialog_timeout_info(struct dlg_cell * cell)
 	SET_INT_VALUE(values+1, (unsigned int)( (unsigned int)time(0) +
 			 cell->tl.timeout - get_ticks()) );
 
-	CON_PS_REFERENCE(dialog_db_handle) = &my_ps_update;
+	CON_SET_CURR_PS(dialog_db_handle, &my_ps_update);
 
 	if((dialog_dbf.update(dialog_db_handle, (insert_keys), 0,
 					(values), (insert_keys+1), (values+1), 1, 1)) !=0){
@@ -1103,7 +1103,7 @@ int update_dialog_dbinfo(struct dlg_cell * cell)
 		SET_ROUTE_VALUE(values+27, cell->rt_on_timeout);
 		SET_ROUTE_VALUE(values+28, cell->rt_on_hangup);
 
-		CON_PS_REFERENCE(dialog_db_handle) = &my_ps_insert;
+		CON_SET_CURR_PS(dialog_db_handle, &my_ps_insert);
 
 		if((dialog_dbf.insert(dialog_db_handle, insert_keys, values,
 								DIALOG_TABLE_TOTAL_COL_NO)) !=0){
@@ -1147,7 +1147,7 @@ int update_dialog_dbinfo(struct dlg_cell * cell)
 		SET_STR_VALUE(values+22, cell->legs[DLG_CALLER_LEG].contact);
 		SET_STR_VALUE(values+23, cell->legs[callee_leg].contact);
 
-		CON_PS_REFERENCE(dialog_db_handle) = &my_ps_update;
+		CON_SET_CURR_PS(dialog_db_handle, &my_ps_update);
 
 		if((dialog_dbf.update(dialog_db_handle, (insert_keys), 0,
 						(values), (insert_keys+11), (values+11), 1, 13)) !=0){
@@ -1174,7 +1174,7 @@ int update_dialog_dbinfo(struct dlg_cell * cell)
 
 		set_final_update_cols(values+18, cell, 0);
 
-		CON_PS_REFERENCE(dialog_db_handle) = &my_ps_update_vp;
+		CON_SET_CURR_PS(dialog_db_handle, &my_ps_update_vp);
 
 		if((dialog_dbf.update(dialog_db_handle, (insert_keys), 0,
 						(values), (insert_keys+18), (values+18), 1, 4)) !=0){
@@ -1643,7 +1643,7 @@ void dialog_update_db(unsigned int ticks, void *do_lock)
 				SET_ROUTE_VALUE(values+27, cell->rt_on_timeout);
 				SET_ROUTE_VALUE(values+28, cell->rt_on_hangup);
 
-				CON_PS_REFERENCE(dialog_db_handle) = &my_ps_insert;
+				CON_SET_CURR_PS(dialog_db_handle, &my_ps_insert);
 				if (con_set_inslist(&dialog_dbf,dialog_db_handle,
 				&ins_list,insert_keys,DIALOG_TABLE_TOTAL_COL_NO) < 0 )
 					CON_RESET_INSLIST(dialog_db_handle);
@@ -1693,7 +1693,7 @@ void dialog_update_db(unsigned int ticks, void *do_lock)
 				set_final_update_cols(values+21, cell, on_shutdown);
 				SET_INT_VALUE(values+25, cell->flags);
 
-				CON_PS_REFERENCE(dialog_db_handle) = &my_ps_update;
+				CON_SET_CURR_PS(dialog_db_handle, &my_ps_update);
 
 				if((dialog_dbf.update(dialog_db_handle, (insert_keys), 0,
 				(values), (insert_keys+13), (values+13), 1, 13)) !=0) {
@@ -1714,7 +1714,7 @@ void dialog_update_db(unsigned int ticks, void *do_lock)
 
 				set_final_update_cols(values+21, cell, on_shutdown);
 
-				CON_PS_REFERENCE(dialog_db_handle) = &my_ps_update_vp;
+				CON_SET_CURR_PS(dialog_db_handle, &my_ps_update_vp);
 
 				if((dialog_dbf.update(dialog_db_handle, (insert_keys), 0,
 				(values), (insert_keys+21), (values+21), 1, 4)) !=0) {
@@ -2334,7 +2334,7 @@ static int restore_dlg_db(void)
 			SET_ROUTE_VALUE(values+27, cell->rt_on_timeout);
 			SET_ROUTE_VALUE(values+28, cell->rt_on_hangup);
 
-			CON_PS_REFERENCE(dialog_db_handle) = &my_ps_insert;
+			CON_SET_CURR_PS(dialog_db_handle, &my_ps_insert);
 			if (con_set_inslist(&dialog_dbf,dialog_db_handle,
 			&ins_list,insert_keys,DIALOG_TABLE_TOTAL_COL_NO) < 0 )
 				CON_RESET_INSLIST(dialog_db_handle);

--- a/modules/drouting/drouting.c
+++ b/modules/drouting/drouting.c
@@ -933,7 +933,7 @@ static void dr_state_flusher(struct head_db* hd)
 		LM_DBG("updating the state of gw <%.*s> to %d\n",
 				gw->id.len, gw->id.s, val_set.val.int_val);
 
-		CON_PS_REFERENCE(*hd->db_con) = gw_ps;
+		CON_SET_CURR_PS(*hd->db_con, gw_ps);
 		if ( (hd->db_funcs).update(*hd->db_con,&key_cmp,0,&val_cmp,&key_set,&val_set,1,1)<0 ) {
 			LM_ERR("DB update failed\n");
 		} else {
@@ -971,7 +971,7 @@ static void dr_state_flusher(struct head_db* hd)
 		LM_DBG("updating the state of cr <%.*s> to %d\n",
 				cr->id.len, cr->id.s, val_set.val.int_val);
 
-		CON_PS_REFERENCE(*hd->db_con) = cr_ps;
+		CON_SET_CURR_PS(*hd->db_con, cr_ps);
 		if ( (hd->db_funcs).update(*hd->db_con,&key_cmp,0,&val_cmp,&key_set,&val_set,1,1)<0 ) {
 			LM_ERR("DB update failed\n");
 		} else {

--- a/modules/emergency/report_emergency.c
+++ b/modules/emergency/report_emergency.c
@@ -175,7 +175,7 @@ int report(struct emergency_report *report, str db_url, str table_report) {
 
 	if (con_set_inslist(&db_funcs, db_con, &ins_list, db_keys, NR_KEYS) < 0)
 		CON_RESET_INSLIST(db_con);
-	CON_PS_REFERENCE(db_con) = &emergency_ps;
+	CON_SET_CURR_PS(db_con, &emergency_ps);
 
 	if (db_funcs.insert(db_con, db_keys, db_vals, NR_KEYS) < 0) {
 		LM_ERR("failed to insert into database\n");

--- a/modules/group/group.c
+++ b/modules/group/group.c
@@ -146,7 +146,7 @@ int db_is_user_in(struct sip_msg* _msg, str* hf_s, str* grp_s)
 	VAL_STR(vals + 1) = *grp_s;
 
 	group_dbf.use_table(group_dbh, &table);
-	CON_PS_REFERENCE(group_dbh) = &my_ps;
+	CON_SET_CURR_PS(group_dbh, &my_ps);
 
 	if (group_dbf.query(group_dbh, keys, 0, vals, col, (use_domain) ? (3): (2),
 				1, 0, &res) < 0) {

--- a/modules/presence/notify.c
+++ b/modules/presence/notify.c
@@ -280,7 +280,7 @@ int get_wi_subs_db(subs_t* subs, watcher_t* watchers)
 		goto error;
 	}
 
-//	CON_PS_REFERENCE(pa_db) = &my_ps;
+//	CON_SET_CURR_PS(pa_db, &my_ps);
 	if (pa_dbf.query (pa_db, query_cols, query_ops, query_vals,
 		 result_cols, n_query_cols, n_result_cols, 0,  &result) < 0)
 	{
@@ -563,7 +563,7 @@ int add_waiting_watchers(watcher_t* watchers, str pres_uri, str event)
 		return -1;
 	}
 
-//	CON_PS_REFERENCE(pa_db) = &my_ps;
+//	CON_SET_CURR_PS(pa_db, &my_ps);
 
 	if (pa_dbf.query (pa_db, query_cols, 0, query_vals,
 		 result_cols, n_query_cols, n_result_cols, 0, &result) < 0)
@@ -795,7 +795,7 @@ db_res_t* pres_search_db(struct sip_uri* uri,str* ev_name, int* body_col,
 				query_vals[i].val.str_val.s);
 	}
 
-/*	CON_PS_REFERENCE(pa_db) = &my_ps; */
+/*	CON_SET_CURR_PS(pa_db, &my_ps); */
 	if (pa_dbf.query (pa_db, query_cols, 0, query_vals,
 		 result_cols, n_query_cols, n_result_cols, &query_str, &result) < 0)
 	{
@@ -1505,7 +1505,7 @@ int get_subs_db(str* pres_uri, pres_ev_t* event, str* sender,
 		if (sh_tags)
 			query_vals[n_query_cols-1].val.str_val = *sh_tags[tag_no];
 
-		//CON_PS_REFERENCE(pa_db) = &my_ps;
+		//CON_SET_CURR_PS(pa_db, &my_ps);
 		if (pa_dbf.query(pa_db, query_cols, query_ops, query_vals,result_cols,
 				n_query_cols, n_result_cols, 0, &result) < 0)
 		{
@@ -1731,7 +1731,7 @@ int presentity_has_subscribers(str* pres_uri, pres_ev_t* event)
 		LM_ERR("in use_table\n");
 		goto error;
 	}
-	CON_PS_REFERENCE(pa_db) = ps;
+	CON_SET_CURR_PS(pa_db, ps);
 
 	if ( pa_dbf.query(pa_db, keys, 0, vals, cols, 3, 1, 0, &res) < 0) {
 		LM_ERR("DB query failed\n");

--- a/modules/presence/presence.c
+++ b/modules/presence/presence.c
@@ -999,7 +999,7 @@ int pres_update_status(subs_t *subs, str reason, db_key_t* query_cols,
 		if(subs->status == TERMINATED_STATUS && subs->reason.len==11 &&
 				strncmp(subs->reason.s, "deactivated", 11)==0)
 		{
-			CON_PS_REFERENCE(pa_db) = &my_del_ps;
+			CON_SET_CURR_PS(pa_db, &my_del_ps);
 			if(pa_dbf.delete(pa_db, query_cols, 0, query_vals, n_query_cols)<0)
 			{
 				LM_ERR( "in sql delete\n");
@@ -1008,7 +1008,7 @@ int pres_update_status(subs_t *subs, str reason, db_key_t* query_cols,
 		}
 		else
 		{
-			CON_PS_REFERENCE(pa_db) = &my_upd_ps;
+			CON_SET_CURR_PS(pa_db, &my_upd_ps);
 			if(pa_dbf.update(pa_db, query_cols, 0, query_vals, update_cols,
 						update_vals, n_query_cols, n_update_cols)< 0)
 			{
@@ -1068,7 +1068,7 @@ int pres_db_delete_status(subs_t* s)
 	query_vals[n_query_cols].val.str_val= s->from_domain;
 	n_query_cols++;
 
-	CON_PS_REFERENCE(pa_db) = &my_ps;
+	CON_SET_CURR_PS(pa_db, &my_ps);
 
 	if(pa_dbf.delete(pa_db, query_cols, 0, query_vals, n_query_cols)< 0)
 	{
@@ -1176,7 +1176,7 @@ int update_watchers_status(str pres_uri, pres_ev_t* ev, str* rules_doc)
 		goto done;
 	}
 
-//	CON_PS_REFERENCE(pa_db) = &my_ps;
+//	CON_SET_CURR_PS(pa_db, &my_ps);
 	if(pa_dbf.query(pa_db, query_cols, 0, query_vals, result_cols,n_query_cols,
 				n_result_cols, 0, &result)< 0)
 	{

--- a/modules/presence/presentity.c
+++ b/modules/presence/presentity.c
@@ -534,7 +534,7 @@ int update_presentity(struct sip_msg* msg, presentity_t* presentity,
 
 		LM_DBG("inserting %d cols into table\n",n_query_cols);
 
-		//CON_PS_REFERENCE(pa_db) = &my_ps_insert;
+		//CON_SET_CURR_PS(pa_db, &my_ps_insert);
 		if (pa_dbf.insert(pa_db, query_cols, query_vals, n_query_cols) < 0)
 		{
 			LM_ERR("inserting new record in database\n");
@@ -642,7 +642,7 @@ int update_presentity(struct sip_msg* msg, presentity_t* presentity,
 				LM_ERR("unsuccessful sql use table\n");
 				goto error;
 			}
-			//CON_PS_REFERENCE(pa_db) = &my_ps_delete;
+			//CON_SET_CURR_PS(pa_db, &my_ps_delete);
 			if(pa_dbf.delete(pa_db,query_cols,0,query_vals,n_query_cols)<0)
 			{
 				LM_ERR("unsuccessful sql delete operation");
@@ -775,11 +775,11 @@ int update_presentity(struct sip_msg* msg, presentity_t* presentity,
 					goto error;
 				}
 			}
-			//CON_PS_REFERENCE(pa_db) = &my_ps_update_body;
+			//CON_SET_CURR_PS(pa_db, &my_ps_update_body);
 		}
 		else
 		{
-			//CON_PS_REFERENCE(pa_db) = &my_ps_update_no_body;
+			//CON_SET_CURR_PS(pa_db, &my_ps_update_no_body);
 		}
 
 		if (pa_dbf.use_table(pa_db, &presentity_table) < 0)
@@ -1354,7 +1354,7 @@ char* get_sphere(str* pres_uri)
 		return NULL;
 	}
 
-	// CON_PS_REFERENCE(pa_db) = &my_ps;
+	// CON_SET_CURR_PS(pa_db, &my_ps);
 	if (pa_dbf.query (pa_db, query_cols, 0, query_vals,
 		 result_cols, n_query_cols, n_result_cols, &query_str ,  &result) < 0)
 	{

--- a/modules/presence/publish.c
+++ b/modules/presence/publish.c
@@ -222,7 +222,7 @@ void msg_presentity_clean(unsigned int ticks,void *interval)
 	result_cols[etag_col=n_result_cols++] = &str_etag_col;
 	result_cols[event_col=n_result_cols++] = &str_event_col;
 
-	//CON_PS_REFERENCE(pa_db) = &my_ps_select;
+	//CON_SET_CURR_PS(pa_db, &my_ps_select);
 	if(pa_dbf.query(pa_db, db_keys, db_ops, db_vals, result_cols,
 						2, n_result_cols, &query_str, &result )< 0)
 	{
@@ -366,7 +366,7 @@ void msg_presentity_clean(unsigned int ticks,void *interval)
 	{
 		LM_ERR("in use_table\n");
 	} else {
-		CON_PS_REFERENCE(pa_db) = &my_ps_delete;
+		CON_SET_CURR_PS(pa_db, &my_ps_delete);
 		if (pa_dbf.delete(pa_db, db_keys+1, db_ops+1, db_vals+1, 1) < 0)
 			LM_ERR("cleaning expired messages\n");
 	}

--- a/modules/presence/subscribe.c
+++ b/modules/presence/subscribe.c
@@ -145,7 +145,7 @@ int delete_db_subs(str pres_uri, str ev_stored_name, str to_tag)
 		return -1;
 	}
 
-	CON_PS_REFERENCE(pa_db) = &my_ps;
+	CON_SET_CURR_PS(pa_db, &my_ps);
 	LM_DBG("delete subs \n");
 	if(pa_dbf.delete(pa_db, query_cols, 0, query_vals,
 				n_query_cols)< 0 )
@@ -248,7 +248,7 @@ int update_subs_db(subs_t* subs, int type)
 		update_vals[n_update_cols].val.str_val = subs->contact;
 		n_update_cols++;
 
-		CON_PS_REFERENCE(pa_db) = &my_ps_remote;
+		CON_SET_CURR_PS(pa_db, &my_ps_remote);
 	}
 	else
 	{
@@ -264,7 +264,7 @@ int update_subs_db(subs_t* subs, int type)
 		update_vals[n_update_cols].val.int_val = subs->version+ 1;
 		n_update_cols++;
 
-		CON_PS_REFERENCE(pa_db) = &my_ps_local;
+		CON_SET_CURR_PS(pa_db, &my_ps_local);
 	}
 
 	update_keys[n_update_cols] = &str_status_col;
@@ -1200,7 +1200,7 @@ int get_database_info(struct sip_msg* msg, subs_t* subs, int* reply_code, str* r
 		return -1;
 	}
 
-	CON_PS_REFERENCE(pa_db) = &my_ps;
+	CON_SET_CURR_PS(pa_db, &my_ps);
 
 	if (pa_dbf.query (pa_db, query_cols, 0, query_vals,
 		 result_cols, n_query_cols, n_result_cols, 0,  &result) < 0)
@@ -1596,7 +1596,7 @@ void update_db_subs(db_con_t *db,db_func_t *dbf, shtable_t hash_table,
 						update_vals[u_reason_col].val.str_val= s->reason;
 						update_vals[u_contact_col].val.str_val= s->contact;
 
-						CON_PS_REFERENCE(db) = &my_ps_update;
+						CON_SET_CURR_PS(db, &my_ps_update);
 						if(dbf->update(db, query_cols, 0, query_vals,
 						update_cols, update_vals, n_query_update,
 						n_update_cols)< 0)
@@ -1640,7 +1640,7 @@ void update_db_subs(db_con_t *db,db_func_t *dbf, shtable_t hash_table,
 							query_vals[socket_info_col].val.str_val.len = 0;
 						}
 
-						CON_PS_REFERENCE(db) = &my_ps_insert;
+						CON_SET_CURR_PS(db, &my_ps_insert);
 						if (dbf->insert( db, query_cols, query_vals,
 						n_query_cols) < 0)
 						{
@@ -1668,7 +1668,7 @@ void update_db_subs(db_con_t *db,db_func_t *dbf, shtable_t hash_table,
 	update_vals[0].val.int_val = (int)time(NULL);
 	update_ops[0] = OP_LT;
 
-	CON_PS_REFERENCE(db) = &my_ps_delete;
+	CON_SET_CURR_PS(db, &my_ps_delete);
 	if (dbf->use_table(db, &active_watchers_table) < 0) {
 		LM_ERR("deleting expired information from database\n");
 		CON_RESET_CURR_PS(db);
@@ -1859,7 +1859,7 @@ int insert_subs_db(subs_t* s)
 		return -1;
 	}
 
-	CON_PS_REFERENCE(pa_db) = &my_ps;
+	CON_SET_CURR_PS(pa_db, &my_ps);
 	if(pa_dbf.insert(pa_db,query_cols,query_vals,n_query_cols )<0)
 	{
 		LM_ERR("unsuccessful sql insert\n");
@@ -2247,7 +2247,7 @@ int get_db_subs_auth(subs_t* subs, int* found)
 		return -1;
 	}
 
-	CON_PS_REFERENCE(pa_db) = &my_ps;
+	CON_SET_CURR_PS(pa_db, &my_ps);
 	if(pa_dbf.query(pa_db, db_keys, 0, db_vals, result_cols,
 					n_query_cols, 2, 0, &result )< 0)
 	{
@@ -2361,7 +2361,7 @@ int insert_db_subs_auth(subs_t* subs)
 		return -1;
 	}
 
-	CON_PS_REFERENCE(pa_db) = &my_ps;
+	CON_SET_CURR_PS(pa_db, &my_ps);
 	if(pa_dbf.insert(pa_db, db_keys, db_vals, n_query_cols )< 0)
 	{
 		LM_ERR("in sql insert\n");

--- a/modules/sipcapture/sipcapture.c
+++ b/modules/sipcapture/sipcapture.c
@@ -2737,7 +2737,7 @@ static int sip_capture_store(struct _sipcapture_object *sco,
 	/* each query has it's own parameters for the prepared statements */
 	if (con_set_inslist(&db_funcs,db_con,&sc_ins_list,db_keys+1,NR_KEYS-1) < 0)
 	               CON_RESET_INSLIST(db_con);
-	CON_PS_REFERENCE(db_con) = &sc_ps;
+	CON_SET_CURR_PS(db_con, &sc_ps);
 
 	if (!actx && db_sync_store(db_vals+1, db_keys+1, NR_KEYS-1) != 1) {
 		LM_ERR("failed to insert into database\n");
@@ -4689,7 +4689,7 @@ static int report_capture(struct sip_msg* msg, str* table, str* cor_id,
 	/* each query has it's own parameters for the prepared statements */
 	if (con_set_inslist(&db_funcs,db_con,&rc_ins_list,db_keys,NR_KEYS) < 0 )
 	               CON_RESET_INSLIST(db_con);
-	CON_PS_REFERENCE(db_con) = &rc_ps;
+	CON_SET_CURR_PS(db_con, &rc_ps);
 
 	if (!actx && db_sync_store(db_vals, rtcp_db_keys, rtp_keys_no) != 1) {
 		LM_ERR("failed to insert into database\n");

--- a/modules/speeddial/sdlookup.c
+++ b/modules/speeddial/sdlookup.c
@@ -136,7 +136,7 @@ int sd_lookup(struct sip_msg* _msg, str* table_s, str* uri_s)
 	}
 
 	db_funcs.use_table(db_handle, table_s);
-	CON_PS_REFERENCE(db_handle) = &my_ps;
+	CON_SET_CURR_PS(db_handle, &my_ps);
 
 	if(db_funcs.query(db_handle, db_keys, NULL, db_vals, db_cols,
 		nr_keys /*no keys*/, 1 /*no cols*/, NULL, &db_res)!=0)

--- a/modules/sql_cacher/sql_cacher.c
+++ b/modules/sql_cacher/sql_cacher.c
@@ -965,7 +965,7 @@ static int load_key(cache_entry_t *c_entry, db_handlers_t *db_hdls, str key,
 		goto out_error;
 	}
 
-	CON_PS_REFERENCE(db_hdls->db_con) = &db_hdls->query_ps;
+	CON_SET_CURR_PS(db_hdls->db_con, &db_hdls->query_ps);
 	if (db_hdls->db_funcs.query(db_hdls->db_con,
 		&key_col, 0, &key_val, c_entry->columns, 1,
 		c_entry->nr_columns, 0, sql_res) != 0) {

--- a/modules/tracer/tracer.c
+++ b/modules/tracer/tracer.c
@@ -1040,7 +1040,7 @@ static inline int insert_siptrace(st_db_struct_t *st_db,
 		db_vals[13].val.str_val.len = 0;
 	}
 
-	CON_PS_REFERENCE(st_db->con) = &siptrace_ps;
+	CON_SET_CURR_PS(st_db->con, &siptrace_ps);
 	if (con_set_inslist(&st_db->funcs,st_db->con,
 						&st_db->ins_list,keys,NR_KEYS) < 0 )
 		CON_RESET_INSLIST(st_db->con);

--- a/modules/usrloc/ucontact.c
+++ b/modules/usrloc/ucontact.c
@@ -677,7 +677,7 @@ int db_insert_ucontact(ucontact_t* _c,query_list_t **ins_list, int update)
 
 	if ( !update ) {
 		/* do simple insert */
-		CON_PS_REFERENCE(ul_dbh) = &myI_ps;
+		CON_SET_CURR_PS(ul_dbh, &myI_ps);
 		if (ins_list) {
 			if (con_set_inslist(&ul_dbf,ul_dbh,ins_list,keys + start,
 						nr_vals) < 0 )
@@ -690,7 +690,7 @@ int db_insert_ucontact(ucontact_t* _c,query_list_t **ins_list, int update)
 		}
 	} else {
 		/* do insert-update / replace */
-		CON_PS_REFERENCE(ul_dbh) = &myR_ps;
+		CON_SET_CURR_PS(ul_dbh, &myR_ps);
 		if (ul_dbf.insert_update(ul_dbh, keys + start, vals + start, nr_vals) < 0) {
 			LM_ERR("inserting contact in db failed\n");
 			goto out_err;
@@ -823,7 +823,7 @@ int db_update_ucontact(ucontact_t* _c)
 		goto out_err;
 	}
 
-	CON_PS_REFERENCE(ul_dbh) = &my_ps;
+	CON_SET_CURR_PS(ul_dbh, &my_ps);
 
 	if (ul_dbf.update(ul_dbh, keys1, 0, vals1, keys2, vals2, 1, 15)<0) {
 		LM_ERR("updating database failed\n");
@@ -863,7 +863,7 @@ int db_delete_ucontact(ucontact_t* _c)
 		return -1;
 	}
 
-	CON_PS_REFERENCE(ul_dbh) = &my_ps;
+	CON_SET_CURR_PS(ul_dbh, &my_ps);
 
 	if (ul_dbf.delete(ul_dbh, keys, 0, vals, 1) < 0) {
 		LM_ERR("deleting from database failed\n");

--- a/modules/usrloc/udomain.c
+++ b/modules/usrloc/udomain.c
@@ -793,7 +793,7 @@ urecord_t* db_load_urecord(db_con_t* _c, udomain_t* _d, str *_aor)
 		return 0;
 	}
 
-	/* CON_PS_REFERENCE(_c) = &my_ps; - this is still dangerous with STMT */
+	/* CON_SET_CURR_PS(_c, &my_ps); - this is still dangerous with STMT */
 
 	if (ul_dbf.query(_c, keys, 0, vals, columns, use_domain ? 2:1, UL_COLS - 2,
 	                 order, &res) < 0) {
@@ -1055,7 +1055,7 @@ int db_timer_udomain(udomain_t* _d)
 	vals[1].type = DB_INT;
 	vals[1].val.int_val = 0;
 
-	CON_PS_REFERENCE(ul_dbh) = &my_ps;
+	CON_SET_CURR_PS(ul_dbh, &my_ps);
 	ul_dbf.use_table(ul_dbh, _d->name);
 
 	if (ul_dbf.delete(ul_dbh, keys, ops, vals, 2) < 0) {

--- a/modules/usrloc/ul_mi.c
+++ b/modules/usrloc/ul_mi.c
@@ -649,7 +649,7 @@ static mi_response_t *mi_sync_domain(udomain_t *dom)
 		return 0;
 	}
 
-	CON_PS_REFERENCE(ul_dbh) = &my_ps;
+	CON_SET_CURR_PS(ul_dbh, &my_ps);
 
 	if (ul_dbf.delete(ul_dbh, 0, 0, 0, 0) < 0) {
 		LM_ERR("failed to delete from database\n");

--- a/modules/usrloc/urecord.c
+++ b/modules/usrloc/urecord.c
@@ -484,7 +484,7 @@ int db_delete_urecord(urecord_t* _r)
 		return -1;
 	}
 
-	CON_PS_REFERENCE(ul_dbh) = &my_ps;
+	CON_SET_CURR_PS(ul_dbh, &my_ps);
 
 	if (ul_dbf.delete(ul_dbh, keys, 0, vals, (use_domain) ? (2) : (1)) < 0) {
 		LM_ERR("failed to delete from database\n");


### PR DESCRIPTION
They were used in the same fashion. And as the Zen of Python teaches us:

> There should be one-- and preferably only one --obvious way to do it.

(See also discussion at 57caa6c03.)