### PR TITLE
Make FORCE_SINGLE_REGISTRATION work again

### DIFF
--- a/modules/uac_registrant/registrant.c
+++ b/modules/uac_registrant/registrant.c
@@ -445,8 +445,8 @@ int run_reg_tm_cback(void *e_data, void *data, void *r_data)
 		}
 
 		if (rec->flags&FORCE_SINGLE_REGISTRATION &&
-			rec->state == REGISTERING_STATE &&
-			rec->state == AUTHENTICATING_STATE) {
+			(rec->state == REGISTERING_STATE ||
+			 rec->state == AUTHENTICATING_STATE)) {
 			head_contact = msg->contact;
 			contact = ((contact_body_t*)msg->contact->parsed)->contacts;
 			while (contact) {


### PR DESCRIPTION
In 5b551ba35f, an always-false expression was added. The code was probably supposed to be as follows..

(REGISTERING_STATE == 1, AUTHENTICATING_STATE == 2)

----

@rvlad-patrascu, care to take a look?