### PR TITLE
Change CON_SET_CURR_PS pattern to always call it _directly_ before db call

### DIFF
--- a/db/db_insertq.c
+++ b/db/db_insertq.c
@@ -131,11 +131,10 @@ void flush_query_list(void)
 			//Reset prepared statement between query lists/connections
 			my_ps = NULL;
 
-			CON_SET_CURR_PS(it->conn[process_no], &my_ps);
-
 			/* and let's insert the rows */
 			for (i=0;i<it->no_rows;i++)
 			{
+				CON_SET_CURR_PS(it->conn[process_no], &my_ps);
 				if (it->dbf.insert(it->conn[process_no],it->cols,it->rows[i],
 							it->col_no) < 0)
 					LM_ERR("failed to insert into DB\n");

--- a/modules/acc/acc.c
+++ b/modules/acc/acc.c
@@ -595,9 +595,6 @@ int acc_db_request( struct sip_msg *rq, struct sip_msg *rpl,
 			ps = &my_ps3;
 	}
 
-	CON_SET_CURR_PS(db_handle, ps);
-
-
 	/* multi-leg columns */
 	if (ctx) {
 		/* prevent acces for setting variable */
@@ -612,8 +609,10 @@ int acc_db_request( struct sip_msg *rq, struct sip_msg *rpl,
 
 		if ( !ctx->leg_values ) {
 			accX_unlock(&ctx->lock);
-			if (con_set_inslist(&acc_dbf,db_handle,ins_list,db_keys,n) < 0 )
+			if (con_set_inslist(&acc_dbf, db_handle, ins_list, db_keys, n) < 0) {
 				CON_RESET_INSLIST(db_handle);
+			}
+			CON_SET_CURR_PS(db_handle, ps);
 			if (acc_dbf.insert(db_handle, db_keys, db_vals, n) < 0) {
 				LM_ERR("failed to insert into %.*s table\n", acc_env.text.len, acc_env.text.s);
 				return -1;
@@ -623,8 +622,10 @@ int acc_db_request( struct sip_msg *rq, struct sip_msg *rpl,
 				for (extra=db_leg_tags, i=m; extra; extra=extra->next, i++) {
 					VAL_STR(db_vals+i)=LEG_VALUE( j, extra, ctx);
 				}
-				if (con_set_inslist(&acc_dbf,db_handle,ins_list,db_keys,n) < 0 )
+				if (con_set_inslist(&acc_dbf, db_handle, ins_list, db_keys, n) < 0) {
 					CON_RESET_INSLIST(db_handle);
+				}
+				CON_SET_CURR_PS(db_handle, ps);
 				if (acc_dbf.insert(db_handle, db_keys, db_vals, n) < 0) {
 					LM_ERR("failed to insert into %.*s table\n", acc_env.text.len, acc_env.text.s);
 					accX_unlock(&ctx->lock);
@@ -634,8 +635,10 @@ int acc_db_request( struct sip_msg *rq, struct sip_msg *rpl,
 			accX_unlock(&ctx->lock);
 		}
 	} else {
-		if (con_set_inslist(&acc_dbf,db_handle,ins_list,db_keys,m) < 0 )
-				CON_RESET_INSLIST(db_handle);
+		if (con_set_inslist(&acc_dbf, db_handle, ins_list, db_keys, m) < 0) {
+			CON_RESET_INSLIST(db_handle);
+		}
+		CON_SET_CURR_PS(db_handle, ps);
 		if (acc_dbf.insert(db_handle, db_keys, db_vals, m) < 0) {
 			LM_ERR("failed to insert into %.*s table\n", acc_env.text.len, acc_env.text.s);
 			return -1;
@@ -691,8 +694,6 @@ int acc_db_cdrs(struct dlg_cell *dlg, struct sip_msg *msg, acc_ctx_t* ctx)
 
 	total = ret + 5;
 	acc_dbf.use_table(db_handle, &table);
-	CON_SET_CURR_PS(db_handle, &my_ps);
-
 
 	/* prevent acces for setting variable */
 	accX_lock(&ctx->lock);
@@ -701,8 +702,10 @@ int acc_db_cdrs(struct dlg_cell *dlg, struct sip_msg *msg, acc_ctx_t* ctx)
 		VAL_STR(db_vals+i) = ctx->extra_values[extra->tag_idx].value;
 
 	if (!ctx->leg_values) {
-		if (con_set_inslist(&acc_dbf,db_handle,&ins_list,db_keys,total) < 0 )
+		if (con_set_inslist(&acc_dbf, db_handle, &ins_list, db_keys, total) < 0) {
 			CON_RESET_INSLIST(db_handle);
+		}
+		CON_SET_CURR_PS(db_handle, &my_ps);
 		if (acc_dbf.insert(db_handle, db_keys, db_vals, total) < 0) {
 			LM_ERR("failed to insert into database\n");
 			accX_unlock(&ctx->lock);
@@ -717,8 +720,10 @@ int acc_db_cdrs(struct dlg_cell *dlg, struct sip_msg *msg, acc_ctx_t* ctx)
 				VAL_STR(db_vals+ret+j+1) = LEG_VALUE( i, extra, ctx);
 			}
 
-			if (con_set_inslist(&acc_dbf,db_handle,&ins_list,db_keys,total) < 0 )
+			if (con_set_inslist(&acc_dbf, db_handle, &ins_list, db_keys, total) < 0) {
 				CON_RESET_INSLIST(db_handle);
+			}
+			CON_SET_CURR_PS(db_handle, &my_ps);
 			if (acc_dbf.insert(db_handle,db_keys,db_vals,total) < 0) {
 				LM_ERR("failed inserting into database\n");
 				accX_unlock(&ctx->lock);

--- a/modules/alias_db/alookup.c
+++ b/modules/alias_db/alookup.c
@@ -103,9 +103,9 @@ static int alias_db_query(struct sip_msg* _msg, str* table_s,
 	}
 
 	adbf.use_table(db_handle, table_s);
+
 	if (!ald_append_branches)
 		CON_SET_CURR_PS(db_handle, my_ps[ps_idx]);
-
 	if(adbf.query( db_handle, db_keys, NULL, db_vals, db_cols,
 		(flags&ALIAS_NO_DOMAIN_FLAG)?1:2 /*no keys*/, 2 /*no cols*/,
 		NULL, &db_res)!=0)

--- a/modules/auth_db/checks.c
+++ b/modules/auth_db/checks.c
@@ -117,8 +117,8 @@ static inline int check_username(struct sip_msg* _m, str* _table,
 	VAL_STR(vals + 2) = _uri->user;
 
 	auth_dbf.use_table(auth_db_handle, _table);
-	CON_SET_CURR_PS(auth_db_handle, &my_ps);
 
+	CON_SET_CURR_PS(auth_db_handle, &my_ps);
 	if (auth_dbf.query(auth_db_handle, keys, 0, vals, cols, 3, 1, 0, &res) < 0)
 	{
 		LM_ERR("Error while querying database\n");
@@ -213,7 +213,6 @@ int does_uri_exist(struct sip_msg* _msg, str* uri, str* _table)
 	VAL_STR(vals + 1) = p_uri.host;
 
 	CON_SET_CURR_PS(auth_db_handle, &my_ps);
-
 	if (auth_dbf.query(auth_db_handle, keys, 0, vals, cols, (use_domain ? 2 : 1),
 				1, 0, &res) < 0) {
 		LM_ERR("Error while querying database\n");
@@ -315,10 +314,9 @@ int get_auth_id(struct sip_msg* _msg, str *_table, str* uri,
 	VAL_NULL(vals + 1) = 0;
 	VAL_STR(vals + 1) = sip_uri.host;
 
-	CON_SET_CURR_PS(auth_db_handle, &my_ps);
-
 	/* if use_domain is set also the domain column of the database table will
 	   be honoured in the following query (see sixth parameter) */
+	CON_SET_CURR_PS(auth_db_handle, &my_ps);
 	if (auth_dbf.query(auth_db_handle, keys, 0, vals, cols, (use_domain ? 2 : 1),
 	2, 0, &dbres) < 0) {
 		LM_ERR("Error while querying database\n");

--- a/modules/call_center/cc_db.c
+++ b/modules/call_center/cc_db.c
@@ -915,7 +915,6 @@ int cc_write_cdr( str *un, str *fid, str *aid, int type, int rt, int wt, int tt,
 	vals[10].val.int_val = cid;
 
 	CON_SET_CURR_PS(cc_acc_db_handle, &my_ps);
-
 	if (cc_acc_dbf.insert( cc_acc_db_handle, columns, vals, 11) < 0) {
 		LM_ERR("CDR insert failed\n");
 		return -1;

--- a/modules/db_mysql/dbase.c
+++ b/modules/db_mysql/dbase.c
@@ -976,15 +976,14 @@ int db_mysql_query(const db_con_t* _h, const db_key_t* _k, const db_op_t* _op,
 		}
 
 		ret = db_mysql_do_prepared_query(_h, &query_holder, _v, _n, NULL, 0);
+		CON_RESET_CURR_PS(_h);
 		if (ret != 0) {
-			CON_RESET_CURR_PS(_h);
 			if (_r)
 				*_r = NULL;
 			return ret;
 		}
 
 		ret = db_mysql_store_result(_h, _r);
-		CON_RESET_CURR_PS(_h);
 		return ret;
 	}
 	return db_do_query(_h, _k, _op, _v, _c, _n, _nc, _o, _r,
@@ -1333,7 +1332,10 @@ int db_mysql_delete(const db_con_t* _h, const db_key_t* _k, const db_op_t* _o,
 		if (CON_HAS_UNINIT_PS(_h)||!has_stmt_ctx(_h,&(CON_MYSQL_PS(_h)->ctx))){
 			ret = db_do_delete(_h, _k, _o, _v, _n, db_mysql_val2str,
 				db_mysql_submit_dummy_query);
-			if (ret!=0) {CON_RESET_CURR_PS(_h);return ret;}
+			if (ret != 0) {
+				CON_RESET_CURR_PS(_h);
+				return ret;
+			}
 		}
 		ret = db_mysql_do_prepared_query(_h, &query_holder, _v, _n, NULL, 0);
 		CON_RESET_CURR_PS(_h);
@@ -1366,7 +1368,10 @@ int db_mysql_update(const db_con_t* _h, const db_key_t* _k, const db_op_t* _o,
 		if (CON_HAS_UNINIT_PS(_h)||!has_stmt_ctx(_h,&(CON_MYSQL_PS(_h)->ctx))){
 			ret = db_do_update(_h, _k, _o, _v, _uk, _uv, _n, _un,
 				db_mysql_val2str, db_mysql_submit_dummy_query);
-			if (ret!=0) {CON_RESET_CURR_PS(_h);return ret;}
+			if (ret != 0) {
+				CON_RESET_CURR_PS(_h);
+				return ret;
+			}
 		}
 		ret = db_mysql_do_prepared_query(_h, &query_holder, _uv, _un, _v, _n);
 		CON_RESET_CURR_PS(_h);
@@ -1393,7 +1398,10 @@ int db_mysql_replace(const db_con_t* _h, const db_key_t* _k, const db_val_t* _v,
 		if (CON_HAS_UNINIT_PS(_h)||!has_stmt_ctx(_h,&(CON_MYSQL_PS(_h)->ctx))){
 			ret = db_do_replace(_h, _k, _v, _n, db_mysql_val2str,
 				db_mysql_submit_dummy_query);
-			if (ret!=0) {CON_RESET_CURR_PS(_h);return ret;}
+			if (ret != 0) {
+				CON_RESET_CURR_PS(_h);
+				return ret;
+			}
 		}
 		ret = db_mysql_do_prepared_query(_h, &query_holder, _v, _n, NULL, 0);
 		CON_RESET_CURR_PS(_h);

--- a/modules/dialog/dlg_db_handler.c
+++ b/modules/dialog/dlg_db_handler.c
@@ -519,7 +519,6 @@ int remove_ended_dlgs_from_db(void)
 	VAL_INT(values) = DLG_STATE_DELETED ;
 
 	CON_SET_CURR_PS(dialog_db_handle, &my_ps);
-
 	if(dialog_dbf.delete(dialog_db_handle, match_keys, 0, values, 1) < 0) {
 		LM_ERR("failed to delete database information\n");
 		return -1;
@@ -884,8 +883,8 @@ int dlg_timer_remove_from_db(struct dlg_cell *cell)
 	if (dlg_del_curr_no == dlg_bulk_del_no) {
 		LM_DBG("triggering delete for %d dialogs\n",dlg_del_curr_no);
 
-		CON_SET_CURR_PS(dialog_db_handle, &my_ps);
 		CON_USE_OR_OP(dialog_db_handle);
+		CON_SET_CURR_PS(dialog_db_handle, &my_ps);
 		if(dialog_dbf.delete(dialog_db_handle, dlg_del_keys,
 					0, dlg_del_values, dlg_bulk_del_no) < 0)
 			LM_ERR("failed to delete bulk database information !!!\n");
@@ -950,7 +949,6 @@ int remove_dialog_from_db(struct dlg_cell * cell)
 	VAL_BIGINT(values) = dlg_get_db_id(cell);
 
 	CON_SET_CURR_PS(dialog_db_handle, &my_ps);
-
 	if(dialog_dbf.delete(dialog_db_handle, match_keys, 0, values, 1) < 0) {
 		LM_ERR("failed to delete database information\n");
 		return -1;
@@ -992,7 +990,6 @@ int update_dialog_timeout_info(struct dlg_cell * cell)
 			 cell->tl.timeout - get_ticks()) );
 
 	CON_SET_CURR_PS(dialog_db_handle, &my_ps_update);
-
 	if((dialog_dbf.update(dialog_db_handle, (insert_keys), 0,
 					(values), (insert_keys+1), (values+1), 1, 1)) !=0){
 		LM_ERR("could not update database timeout info\n");
@@ -1104,7 +1101,6 @@ int update_dialog_dbinfo(struct dlg_cell * cell)
 		SET_ROUTE_VALUE(values+28, cell->rt_on_hangup);
 
 		CON_SET_CURR_PS(dialog_db_handle, &my_ps_insert);
-
 		if((dialog_dbf.insert(dialog_db_handle, insert_keys, values,
 								DIALOG_TABLE_TOTAL_COL_NO)) !=0){
 			LM_ERR("could not add another dialog to db - state=%d callid=%.*s\n",
@@ -1148,7 +1144,6 @@ int update_dialog_dbinfo(struct dlg_cell * cell)
 		SET_STR_VALUE(values+23, cell->legs[callee_leg].contact);
 
 		CON_SET_CURR_PS(dialog_db_handle, &my_ps_update);
-
 		if((dialog_dbf.update(dialog_db_handle, (insert_keys), 0,
 						(values), (insert_keys+11), (values+11), 1, 13)) !=0){
 			LM_ERR("could not update database info\n");
@@ -1175,7 +1170,6 @@ int update_dialog_dbinfo(struct dlg_cell * cell)
 		set_final_update_cols(values+18, cell, 0);
 
 		CON_SET_CURR_PS(dialog_db_handle, &my_ps_update_vp);
-
 		if((dialog_dbf.update(dialog_db_handle, (insert_keys), 0,
 						(values), (insert_keys+18), (values+18), 1, 4)) !=0){
 			LM_ERR("could not update database info\n");
@@ -1643,11 +1637,11 @@ void dialog_update_db(unsigned int ticks, void *do_lock)
 				SET_ROUTE_VALUE(values+27, cell->rt_on_timeout);
 				SET_ROUTE_VALUE(values+28, cell->rt_on_hangup);
 
-				CON_SET_CURR_PS(dialog_db_handle, &my_ps_insert);
-				if (con_set_inslist(&dialog_dbf,dialog_db_handle,
-				&ins_list,insert_keys,DIALOG_TABLE_TOTAL_COL_NO) < 0 )
+				if (con_set_inslist(&dialog_dbf, dialog_db_handle,
+						&ins_list, insert_keys, DIALOG_TABLE_TOTAL_COL_NO) < 0) {
 					CON_RESET_INSLIST(dialog_db_handle);
-
+				}
+				CON_SET_CURR_PS(dialog_db_handle, &my_ps_insert);
 				if((dialog_dbf.insert(dialog_db_handle, insert_keys,
 				values, DIALOG_TABLE_TOTAL_COL_NO)) !=0){
 					LM_ERR("could not add another dialog to db - state=%d callid=%.*s\n",
@@ -2334,11 +2328,11 @@ static int restore_dlg_db(void)
 			SET_ROUTE_VALUE(values+27, cell->rt_on_timeout);
 			SET_ROUTE_VALUE(values+28, cell->rt_on_hangup);
 
-			CON_SET_CURR_PS(dialog_db_handle, &my_ps_insert);
-			if (con_set_inslist(&dialog_dbf,dialog_db_handle,
-			&ins_list,insert_keys,DIALOG_TABLE_TOTAL_COL_NO) < 0 )
+			if (con_set_inslist(&dialog_dbf, dialog_db_handle,
+					&ins_list, insert_keys, DIALOG_TABLE_TOTAL_COL_NO) < 0) {
 				CON_RESET_INSLIST(dialog_db_handle);
-
+			}
+			CON_SET_CURR_PS(dialog_db_handle, &my_ps_insert);
 			if((dialog_dbf.insert(dialog_db_handle, insert_keys,
 			values, DIALOG_TABLE_TOTAL_COL_NO)) !=0){
 				LM_ERR("could not add another dialog to db - state=%d callid=%.*s\n",

--- a/modules/emergency/report_emergency.c
+++ b/modules/emergency/report_emergency.c
@@ -173,13 +173,13 @@ int report(struct emergency_report *report, str db_url, str table_report) {
 
 	LM_DBG("storing info...\n");
 
-	if (con_set_inslist(&db_funcs, db_con, &ins_list, db_keys, NR_KEYS) < 0)
+	if (con_set_inslist(&db_funcs, db_con, &ins_list, db_keys, NR_KEYS) < 0) {
 		CON_RESET_INSLIST(db_con);
+	}
 	CON_SET_CURR_PS(db_con, &emergency_ps);
-
 	if (db_funcs.insert(db_con, db_keys, db_vals, NR_KEYS) < 0) {
 		LM_ERR("failed to insert into database\n");
-		return -1;;
+		return -1;
 	}
 
 	return 1;

--- a/modules/group/group.c
+++ b/modules/group/group.c
@@ -146,8 +146,8 @@ int db_is_user_in(struct sip_msg* _msg, str* hf_s, str* grp_s)
 	VAL_STR(vals + 1) = *grp_s;
 
 	group_dbf.use_table(group_dbh, &table);
-	CON_SET_CURR_PS(group_dbh, &my_ps);
 
+	CON_SET_CURR_PS(group_dbh, &my_ps);
 	if (group_dbf.query(group_dbh, keys, 0, vals, col, (use_domain) ? (3): (2),
 				1, 0, &res) < 0) {
 		LM_ERR("failed to query database\n");

--- a/modules/presence/notify.c
+++ b/modules/presence/notify.c
@@ -564,7 +564,6 @@ int add_waiting_watchers(watcher_t* watchers, str pres_uri, str event)
 	}
 
 //	CON_SET_CURR_PS(pa_db, &my_ps);
-
 	if (pa_dbf.query (pa_db, query_cols, 0, query_vals,
 		 result_cols, n_query_cols, n_result_cols, 0, &result) < 0)
 	{
@@ -1731,9 +1730,9 @@ int presentity_has_subscribers(str* pres_uri, pres_ev_t* event)
 		LM_ERR("in use_table\n");
 		goto error;
 	}
-	CON_SET_CURR_PS(pa_db, ps);
 
-	if ( pa_dbf.query(pa_db, keys, 0, vals, cols, 3, 1, 0, &res) < 0) {
+	CON_SET_CURR_PS(pa_db, ps);
+	if (pa_dbf.query(pa_db, keys, 0, vals, cols, 3, 1, 0, &res) < 0) {
 		LM_ERR("DB query failed\n");
 		goto error;
 	}

--- a/modules/presence/presence.c
+++ b/modules/presence/presence.c
@@ -1069,7 +1069,6 @@ int pres_db_delete_status(subs_t* s)
 	n_query_cols++;
 
 	CON_SET_CURR_PS(pa_db, &my_ps);
-
 	if(pa_dbf.delete(pa_db, query_cols, 0, query_vals, n_query_cols)< 0)
 	{
 		LM_ERR("sql delete failed\n");

--- a/modules/presence/subscribe.c
+++ b/modules/presence/subscribe.c
@@ -145,8 +145,8 @@ int delete_db_subs(str pres_uri, str ev_stored_name, str to_tag)
 		return -1;
 	}
 
-	CON_SET_CURR_PS(pa_db, &my_ps);
 	LM_DBG("delete subs \n");
+	CON_SET_CURR_PS(pa_db, &my_ps);
 	if(pa_dbf.delete(pa_db, query_cols, 0, query_vals,
 				n_query_cols)< 0 )
 	{
@@ -1201,7 +1201,6 @@ int get_database_info(struct sip_msg* msg, subs_t* subs, int* reply_code, str* r
 	}
 
 	CON_SET_CURR_PS(pa_db, &my_ps);
-
 	if (pa_dbf.query (pa_db, query_cols, 0, query_vals,
 		 result_cols, n_query_cols, n_result_cols, 0,  &result) < 0)
 	{
@@ -1668,10 +1667,8 @@ void update_db_subs(db_con_t *db,db_func_t *dbf, shtable_t hash_table,
 	update_vals[0].val.int_val = (int)time(NULL);
 	update_ops[0] = OP_LT;
 
-	CON_SET_CURR_PS(db, &my_ps_delete);
 	if (dbf->use_table(db, &active_watchers_table) < 0) {
 		LM_ERR("deleting expired information from database\n");
-		CON_RESET_CURR_PS(db);
 		return;
 	}
 
@@ -1680,6 +1677,7 @@ void update_db_subs(db_con_t *db,db_func_t *dbf, shtable_t hash_table,
 		/* no clustering, simply delete all expired subs */
 		LM_DBG("delete all expired subscriptions\n");
 
+		CON_SET_CURR_PS(db, &my_ps_delete);
 		if (dbf->delete(db, update_cols, update_ops, update_vals, 1) < 0)
 			LM_ERR("deleting expired information from database\n");
 
@@ -1697,13 +1695,11 @@ void update_db_subs(db_con_t *db,db_func_t *dbf, shtable_t hash_table,
 				sh_tags[i]->len, sh_tags[i]->s);
 
 			update_vals[1].val.str_val = *sh_tags[i];
+			CON_SET_CURR_PS(db, &my_ps_delete);
 			if (dbf->delete(db, update_cols, update_ops, update_vals, 2) < 0)
 				LM_ERR("deleting expired information from database\n");
 			i++;
 		}
-
-		if (i == 0)
-			CON_RESET_CURR_PS(db);
 	}
 
 	return;

--- a/modules/sipcapture/sipcapture.c
+++ b/modules/sipcapture/sipcapture.c
@@ -2752,8 +2752,9 @@ static int sip_capture_store(struct _sipcapture_object *sco,
 	ret=1;
 
 	/* each query has it's own parameters for the prepared statements */
-	if (con_set_inslist(&db_funcs,db_con,&sc_ins_list,db_keys+1,NR_KEYS-1) < 0)
-	               CON_RESET_INSLIST(db_con);
+	if (con_set_inslist(&db_funcs, db_con, &sc_ins_list, db_keys + 1, NR_KEYS - 1) < 0) {
+		CON_RESET_INSLIST(db_con);
+	}
 	CON_SET_CURR_PS(db_con, &sc_ps);
 
 	if (!actx && db_sync_store(db_vals+1, db_keys+1, NR_KEYS-1) != 1) {
@@ -4704,8 +4705,9 @@ static int report_capture(struct sip_msg* msg, str* table, str* cor_id,
 	}
 
 	/* each query has it's own parameters for the prepared statements */
-	if (con_set_inslist(&db_funcs,db_con,&rc_ins_list,db_keys,NR_KEYS) < 0 )
-	               CON_RESET_INSLIST(db_con);
+	if (con_set_inslist(&db_funcs, db_con, &rc_ins_list, db_keys, NR_KEYS) < 0) {
+		CON_RESET_INSLIST(db_con);
+	}
 	CON_SET_CURR_PS(db_con, &rc_ps);
 
 	if (!actx && db_sync_store(db_vals, rtcp_db_keys, rtp_keys_no) != 1) {

--- a/modules/speeddial/sdlookup.c
+++ b/modules/speeddial/sdlookup.c
@@ -136,8 +136,8 @@ int sd_lookup(struct sip_msg* _msg, str* table_s, str* uri_s)
 	}
 
 	db_funcs.use_table(db_handle, table_s);
-	CON_SET_CURR_PS(db_handle, &my_ps);
 
+	CON_SET_CURR_PS(db_handle, &my_ps);
 	if(db_funcs.query(db_handle, db_keys, NULL, db_vals, db_cols,
 		nr_keys /*no keys*/, 1 /*no cols*/, NULL, &db_res)!=0)
 	{

--- a/modules/tracer/tracer.c
+++ b/modules/tracer/tracer.c
@@ -1142,10 +1142,11 @@ static inline int insert_siptrace(st_db_struct_t *st_db,
 		db_vals[13].val.str_val.len = 0;
 	}
 
-	CON_SET_CURR_PS(st_db->con, &siptrace_ps);
-	if (con_set_inslist(&st_db->funcs,st_db->con,
-						&st_db->ins_list,keys,NR_KEYS) < 0 )
+	if (con_set_inslist(&st_db->funcs, st_db->con,
+			&st_db->ins_list, keys, NR_KEYS) < 0) {
 		CON_RESET_INSLIST(st_db->con);
+	}
+	CON_SET_CURR_PS(st_db->con, &siptrace_ps);
 	if(st_db->funcs.insert(st_db->con, keys, vals, NR_KEYS) < 0) {
 		LM_ERR("error storing trace\n");
 		return -1;

--- a/modules/usrloc/ucontact.c
+++ b/modules/usrloc/ucontact.c
@@ -677,13 +677,13 @@ int db_insert_ucontact(ucontact_t* _c,query_list_t **ins_list, int update)
 
 	if ( !update ) {
 		/* do simple insert */
-		CON_SET_CURR_PS(ul_dbh, &myI_ps);
 		if (ins_list) {
 			if (con_set_inslist(&ul_dbf,ul_dbh,ins_list,keys + start,
 						nr_vals) < 0 )
 				CON_RESET_INSLIST(ul_dbh);
 		}
 
+		CON_SET_CURR_PS(ul_dbh, &myI_ps);
 		if (ul_dbf.insert(ul_dbh, keys + start, vals + start, nr_vals) < 0) {
 			LM_ERR("inserting contact in db failed\n");
 			goto out_err;
@@ -824,7 +824,6 @@ int db_update_ucontact(ucontact_t* _c)
 	}
 
 	CON_SET_CURR_PS(ul_dbh, &my_ps);
-
 	if (ul_dbf.update(ul_dbh, keys1, 0, vals1, keys2, vals2, 1, 15)<0) {
 		LM_ERR("updating database failed\n");
 		goto out_err;
@@ -864,7 +863,6 @@ int db_delete_ucontact(ucontact_t* _c)
 	}
 
 	CON_SET_CURR_PS(ul_dbh, &my_ps);
-
 	if (ul_dbf.delete(ul_dbh, keys, 0, vals, 1) < 0) {
 		LM_ERR("deleting from database failed\n");
 		return -1;

--- a/modules/usrloc/udomain.c
+++ b/modules/usrloc/udomain.c
@@ -794,7 +794,6 @@ urecord_t* db_load_urecord(db_con_t* _c, udomain_t* _d, str *_aor)
 	}
 
 	/* CON_SET_CURR_PS(_c, &my_ps); - this is still dangerous with STMT */
-
 	if (ul_dbf.query(_c, keys, 0, vals, columns, use_domain ? 2:1, UL_COLS - 2,
 	                 order, &res) < 0) {
 		LM_ERR("db_query failed\n");

--- a/modules/usrloc/ul_mi.c
+++ b/modules/usrloc/ul_mi.c
@@ -650,7 +650,6 @@ static mi_response_t *mi_sync_domain(udomain_t *dom)
 	}
 
 	CON_SET_CURR_PS(ul_dbh, &my_ps);
-
 	if (ul_dbf.delete(ul_dbh, 0, 0, 0, 0) < 0) {
 		LM_ERR("failed to delete from database\n");
 		return 0;

--- a/modules/usrloc/urecord.c
+++ b/modules/usrloc/urecord.c
@@ -485,7 +485,6 @@ int db_delete_urecord(urecord_t* _r)
 	}
 
 	CON_SET_CURR_PS(ul_dbh, &my_ps);
-
 	if (ul_dbf.delete(ul_dbh, keys, 0, vals, (use_domain) ? (2) : (1)) < 0) {
 		LM_ERR("failed to delete from database\n");
 		return -1;


### PR DESCRIPTION
_This is a continuation of #2468._

_(It has that commit, and adds the following commit on top of that.)_

----

Because CON_SET_CURR_PS is always followed by an immediate call to CON_RESET_CURR_PS inside the DB function, it makes sense to call CON_SET_CURR_PS just before the DB call.

Otherwise you could get this:
```c
   CON_SET_CURR_PS(...);

   for (i = 0; i < n; ++i) {
       // first insert uses prepared statement
       db.insert(...);
       // but second time in the loop, we use "plain" text queries
   }
```
The updated pattern would look like this:
```c
   for (i = 0; i < n; ++i) {
       // the ps handle is always reset, so we reinit it every time
       CON_SET_CURR_PS(...);
       db.insert(...);
   }
```
Note that we don't need any explicit CON_RESET_CURR_PS() at odd points anymore (like was added in 57caa6c). A SET is immediately followed by an implicit RESET.