### PR TITLE
Fix cookie collision when using rtpengine/rtpproxy modules

### DIFF
--- a/modules/rtpengine/rtpengine.c
+++ b/modules/rtpengine/rtpengine.c
@@ -320,7 +320,7 @@ static int rtpengine_stats_used = 0;
 static int rtpengine_disable_tout = 60;
 static int rtpengine_retr = 5;
 static int rtpengine_tout = 1;
-static pid_t mypid;
+static int myprefix = 0;
 static unsigned int myseqn = 0;
 static str extra_id_pv_param = {NULL, 0};
 static char *setid_avp_param = NULL;
@@ -1500,7 +1500,7 @@ static int connect_rtpengines(void)
 static int
 child_init(int rank)
 {
-	mypid = getpid();
+	myprefix+=getpid()+rand()%10000;
 
 	if(*rtpe_set_list==NULL )
 		return 0;
@@ -1580,7 +1580,7 @@ static char * gencookie(void)
 {
 	static char cook[34];
 
-	sprintf(cook, "%d_%u ", (int)mypid, myseqn);
+	sprintf(cook, "%d_%u ", myprefix, myseqn);
 	myseqn++;
 	return cook;
 }

--- a/modules/rtpengine/rtpengine.c
+++ b/modules/rtpengine/rtpengine.c
@@ -320,7 +320,8 @@ static int rtpengine_stats_used = 0;
 static int rtpengine_disable_tout = 60;
 static int rtpengine_retr = 5;
 static int rtpengine_tout = 1;
-static int myprefix = 0;
+static pid_t mypid;
+static int myrand = 0;
 static unsigned int myseqn = 0;
 static str extra_id_pv_param = {NULL, 0};
 static char *setid_avp_param = NULL;
@@ -1500,7 +1501,8 @@ static int connect_rtpengines(void)
 static int
 child_init(int rank)
 {
-	myprefix+=getpid()+rand()%10000;
+	mypid = getpid();
+	myrand = rand()%10000;
 
 	if(*rtpe_set_list==NULL )
 		return 0;
@@ -1580,7 +1582,7 @@ static char * gencookie(void)
 {
 	static char cook[34];
 
-	sprintf(cook, "%d_%u ", myprefix, myseqn);
+	sprintf(cook, "%d_%d_%u ", (int)mypid, myrand, myseqn);
 	myseqn++;
 	return cook;
 }

--- a/modules/rtpproxy/rtpproxy.c
+++ b/modules/rtpproxy/rtpproxy.c
@@ -350,7 +350,7 @@ static int rtpproxy_retr = 5;
 static int rtpproxy_tout = -1;
 static char *rtpproxy_timeout = 0;
 static int rtpproxy_autobridge = 0;
-static pid_t mypid;
+static int myprefix = 0;
 static unsigned int myseqn = 0;
 static str nortpproxy_str = str_init("a=nortpproxy:yes");
 str rtpp_notify_socket = {0, 0};
@@ -1381,7 +1381,7 @@ child_init(int rank)
 	if(*rtpp_set_list==NULL )
 		return 0;
 
-	mypid = getpid();
+	myprefix+=getpid()+rand()%10000;
 
 	return connect_rtpproxies();
 }
@@ -1905,7 +1905,7 @@ static char * gencookie(void)
 {
 	static char cook[34];
 
-	sprintf(cook, "%d_%u ", (int)mypid, myseqn);
+	sprintf(cook, "%d_%u ", myprefix, myseqn);
 	myseqn++;
 	return cook;
 }

--- a/modules/rtpproxy/rtpproxy.c
+++ b/modules/rtpproxy/rtpproxy.c
@@ -350,7 +350,8 @@ static int rtpproxy_retr = 5;
 static int rtpproxy_tout = -1;
 static char *rtpproxy_timeout = 0;
 static int rtpproxy_autobridge = 0;
-static int myprefix = 0;
+static pid_t mypid;
+static int myrand = 0;
 static unsigned int myseqn = 0;
 static str nortpproxy_str = str_init("a=nortpproxy:yes");
 str rtpp_notify_socket = {0, 0};
@@ -1381,7 +1382,8 @@ child_init(int rank)
 	if(*rtpp_set_list==NULL )
 		return 0;
 
-	myprefix+=getpid()+rand()%10000;
+	mypid = getpid();
+	myrand = rand()%10000;
 
 	return connect_rtpproxies();
 }
@@ -1905,7 +1907,7 @@ static char * gencookie(void)
 {
 	static char cook[34];
 
-	sprintf(cook, "%d_%u ", myprefix, myseqn);
+	sprintf(cook, "%d_%d_%u ", (int)mypid, myrand, myseqn);
 	myseqn++;
 	return cook;
 }


### PR DESCRIPTION
When using Docker, PIDs often are the same between OpenSIPS instances and cannot be used as a good source for cookie prefix. Use prefix with random influence instead.

Fixes #2459