### PR TITLE
Don't forget to release the insertq lock when downscaling workers

### DIFF
--- a/db/db_insertq.c
+++ b/db/db_insertq.c
@@ -643,6 +643,8 @@ void ql_force_process_disconnect(int p_id)
 				it->dbf.close(it->conn[p_id]);
 				it->conn[p_id]=NULL;
 			}
+
+			lock_release(it->lock);
 		}
 	}
 }

--- a/pt.c
+++ b/pt.c
@@ -408,10 +408,10 @@ void dynamic_process_final_exit(void)
 	/* if a TCP proc by chance, reset the tcp-related data */
 	tcp_reset_worker_slot();
 
-	/* mark myself as DYNAMIC (just in case) to have an err-less terminatio */
+	/* mark myself as DYNAMIC (just in case) to have an err-less termination */
 	pt[process_no].flags |= OSS_PROC_SELFEXIT;
 	LM_INFO("doing self termination\n");
 
-	/* the process slot in the proc table will be purge on SIGCHLG by main */
+	/* the process slot in the proc table will be purge on SIGCHLD by main */
 	exit(0);
 }


### PR DESCRIPTION
Not sure if this is a problem or of the locks gets freed correctly after exit(). But it looks nicer this way.

----

I'm trying to find a root cause for the problem that causes #2467 and I bumped into this. It may very well not be a problem. But cleaning up after yourself is never a bad idea.

(Somewhere in the diff between 2.4 and 3.1, there is something that changes mysql reconnect stability, it seems. We now see lots of `error while submitting query` on lightly loaded (acceptance) hosts, which in turn likely causes the crash with the uninitialized op_t.)