### PR TITLE
dialog: Dont walk through empty dialog table

### DIFF
--- a/modules/dialog/dlg_hash.c
+++ b/modules/dialog/dlg_hash.c
@@ -1000,6 +1000,9 @@ void _ref_dlg(struct dlg_cell *dlg, unsigned int cnt)
 
 void _unref_dlg(struct dlg_cell *dlg, unsigned int cnt)
 {
+	if (d_table==0)
+		return;
+
 	struct dlg_entry *d_entry;
 
 	d_entry = &(d_table->entries[dlg->h_entry]);


### PR DESCRIPTION
We've got a following stacktrace:

(gdb) bt
.0  0x00007fba1e0edceb in _unref_dlg (dlg=0x7fba24689470, cnt=1) at dlg_hash.c:1007
.1  0x00007fba216c4a3e in empty_tmcb_list (head=head@entry=0x7fba26ab5da0) at t_hooks.c:53
.2  0x00007fba2169f978 in free_cell (dead_cell=0x7fba26ab5d30) at h_table.c:127
.3  0x00007fba216a24c3 in free_hash_table () at h_table.c:357
.4  0x00007fba216957d5 in tm_shutdown () at t_funcs.c:91
.5  0x0000555a8c6e4aec in destroy_modules () at sr_module.c:544
.6  0x0000555a8c6deb47 in cleanup (show_status=1) at main.c:366
.7  0x0000555a8c6df4cc in shutdown_opensips (status=<optimized out>) at main.c:530
.8  0x0000555a8c6dfe4a in handle_sigs () at main.c:568
.9  0x0000555a8c64d754 in main_loop () at main.c:868
.10 main (argc=<optimized out>, argv=<optimized out>) at main.c:1491
(gdb) p *d_table
Cannot access memory at address 0x0
(gdb)

Looks like dialog module was unloaded already. This means that OpenSIPS
already called `mod_destroy` in dialog.c and `destroy_dlg_table`. This
means `d_table` was assigned to `NULL`.

Signed-off-by: Peter Lemenkov <lemenkov@gmail.com>