### PR TITLE
B2B: fix hardcoded 60 seconds tuple timeout, allow 0 as tuple timeout…

### DIFF
--- a/modules/b2b_logic/doc/b2b_logic_admin.xml
+++ b/modules/b2b_logic/doc/b2b_logic_admin.xml
@@ -472,7 +472,7 @@ modparam("b2b_logic", "b2bl_th_init_timeout", 60)
 				<emphasis>flags (string, optional)</emphasis> - meanings of the flags is as follows:
 				<itemizedlist>
 					<listitem><para>
-					<emphasis>t[nn]</emphasis> - Call setup timeout for topology hiding scenario.
+					<emphasis>t[nn]</emphasis> - Call setup timeout. 0 sets timeout to max_duration value.
 					Example: t300.
 					</para></listitem>
 					<listitem><para>

--- a/modules/b2b_logic/logic.c
+++ b/modules/b2b_logic/logic.c
@@ -2946,7 +2946,10 @@ str* create_top_hiding_entities(struct sip_msg* msg, b2bl_cback_f cbf,
 	ctx->data = tuple;
 
 	/* if it will not be confirmed -> delete */
-	tuple->lifetime = params->init_timeout + get_ticks();
+	if (params->init_timeout == 0)
+		tuple->lifetime = max_duration + get_ticks();
+	else
+		tuple->lifetime = params->init_timeout + get_ticks();
 
 	/* create new server */
 	server_id = b2b_api.server_new(msg, &tuple->local_contact,
@@ -3251,7 +3254,10 @@ str* b2b_process_scenario_init(struct sip_msg* msg, b2bl_cback_f cbf,
 		LM_ERR("Failed to insert new scenario instance record\n");
 		goto error;
 	}
-	tuple->lifetime = 60 + get_ticks();
+	if (init_params->init_timeout == 0)
+		tuple->lifetime = max_duration + get_ticks();
+	else
+		tuple->lifetime = init_params->init_timeout + get_ticks();
 
 	/* save tuple in global variable for accesss from local routes */
 	local_ctx_tuple = tuple;


### PR DESCRIPTION
… which means maximum duration