### PR TITLE
B2B: Fix static buffer size because 1024 bytes is not enough often fo…

### DIFF
--- a/modules/b2b_entities/dlg.c
+++ b/modules/b2b_entities/dlg.c
@@ -46,7 +46,7 @@
 #include "b2be_db.h"
 #include "b2be_clustering.h"
 
-#define BUF_LEN              1024
+#define BUF_LEN              65535
 
 str ack = str_init(ACK);
 str bye = str_init(BYE);


### PR DESCRIPTION
…r messages with large number of headers