### PR TITLE
Reduce db_is_neq_type complexity

### DIFF
--- a/db/db_ut.c
+++ b/db/db_ut.c
@@ -418,48 +418,34 @@ int db_print_set(const db_con_t* _c, char* _b, const int _l, const db_key_t* _k,
 int db_is_neq_type(db_type_t _t0, db_type_t _t1)
 {
 	// LM_DBG("t0=%d t1=%d!\n", _t0, _t1);
-	if(_t0 == _t1)
-		return 0;
-
-	switch(_t1) {
-	case DB_INT:
-		if(_t0==DB_BIGINT || _t0==DB_DATETIME || _t0==DB_BITMAP)
-			return 0;
-		break;
-
-	case DB_STRING:
-		if(_t0==DB_STR || _t0 == DB_BLOB)
-			return 0;
-		break;
-
-	case DB_STR:
-		if(_t0==DB_STRING || _t0==DB_BLOB)
-			return 0;
-		break;
-
+	switch(_t0) {
 	case DB_BIGINT:
-		if(_t0==DB_INT || _t0==DB_DATETIME || _t0==DB_BITMAP)
-			return 0;
-		break;
-
-	case DB_BLOB:
-		if(_t0==DB_STR || _t0==DB_STRING)
-			return 0;
-		break;
-
-	case DB_DATETIME:
-		if(_t0==DB_INT || _t0==DB_BIGINT || _t0==DB_BITMAP)
-			return 0;
-		break;
-
 	case DB_BITMAP:
-		if(_t0==DB_INT || _t0==DB_BIGINT || _t0==DB_DATETIME)
+	case DB_DATETIME:
+	case DB_INT:
+		switch(_t1) {
+		case DB_BIGINT:
+		case DB_BITMAP:
+		case DB_DATETIME:
+		case DB_INT:
 			return 0;
-		break;
-
+		default:
+			return 1;
+		}
+	case DB_BLOB:
+	case DB_STR:
+	case DB_STRING:
+		switch(_t1) {
+		case DB_BLOB:
+		case DB_STR:
+		case DB_STRING:
+			return 0;
+		default:
+			return 1;
+		}
 	default:
 		break;
 	}
 
-	return 1;
+	return _t0 != _t1;
 }


### PR DESCRIPTION
The code was correct, but overly verbose. Boil it down to the intention and rely on the compiler to work its magic.

(Outsmarting the compiler _may_ sometimes work, but one can wonder whether the reduced readability and room for future error is worth it.)