### PR TITLE
Fix crash when vendor hasn't price for prefix

### DIFF
--- a/modules/rate_cacher/rate_cacher.c
+++ b/modules/rate_cacher/rate_cacher.c
@@ -1869,6 +1869,7 @@ static int script_get_vendor_price(struct sip_msg *msg, str *vendorid,
 		unlock_bucket_read( entry->lock );
 		LM_ERR("No prefix match for %.*s on vendor %.*s \n",
 		dnis->len,dnis->s,vendorid->len,vendorid->s);
+		return -1;
 	}
 
 	pv_val.flags = PV_VAL_STR;


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!
In order to consider and evaluate your PR, it is mandatory to provide detailed information about (1) what is the issue the PR addresses, (2) how the PR is solving the issue (logic and coding), (3) what are (if any) limitations of the proposed PR and (4) if there are any known side-effects/ backward compatibility issues/SIP interoperability issues.
Note that if the PR is missing information, it might take longer to be merged, as extra resources have to be allocated by the maintainers to reverse engineer the changes, understand them, understand the motivation, etc. That is why it is important to provide as much information as possible.
-->

**Summary**
<!-- Summary of the PR - what the PR is aiming to solve -->
This PR add fix to rate_cacher module for case when getting price for vendor fails.

**Details**
<!--
Details about the content of the PR - is it a bug fix, a new feature or perhaps a hack? Explain the **motivation** for making this change.
What existing problem does the pull request solve? Is this a particular problem (i.e. only some particular scenarios are affected, only some UACs, etc) or a generic one?
Do not assume others understand what you're trying to do and provide as much information as you may have.
-->
If I call function get_vendor_price of rate_caher in route script when I doesn't have price for prefix - OpenSIPS crashes and then restarts

Example of route script:
```
if (!get_vendor_price($var(carrier_name),$rU,$avp(vprefix),$avp(vdst),$avp(vprice),$avp(vmin),$avp(vinc))) {
	xlog("L_NOTICE", "Rating failed");
	send_reply(503, "Service Unavailable");
	exit;
}
```

Log with script trace:
```
Jul 13 09:43:52 ostest /usr/local/sbin/opensips[18962]: [Script Trace][/etc/opensips/opensips.cfg:410][me][core if] -> (INVITE from 10.15.0.16, ruri=sip:74951112233@172.16.1.1:5060)
Jul 13 09:43:52 ostest /usr/local/sbin/opensips[18962]: [Script Trace][/etc/opensips/opensips.cfg:405][me][module get_vendor_price] -> (INVITE from 10.15.0.16, ruri=sip:74951112233@172.16.1.1:5060)
Jul 13 09:43:52 ostest /usr/local/sbin/opensips[18962]: ERROR:rate_cacher:script_get_vendor_price: No prefix match for 74951112233 on vendor testvendor
Jul 13 09:43:52 ostest /usr/local/sbin/opensips[18962]: CRITICAL:core:sig_usr: segfault in process pid: 18962, id: 13
Jul 13 09:43:52 ostest /usr/local/sbin/opensips[18949]: INFO:core:handle_sigs: child process 18962 exited by a signal 11
Jul 13 09:43:52 ostest /usr/local/sbin/opensips[18949]: INFO:core:handle_sigs: core was not generated
Jul 13 09:43:52 ostest /usr/local/sbin/opensips[18949]: INFO:core:handle_sigs: terminating due to SIGCHLD
Jul 13 09:43:52 ostest /usr/local/sbin/opensips[18950]: INFO:core:sig_usr: signal 15 received
Jul 13 09:43:52 ostest /usr/local/sbin/opensips[18951]: INFO:core:sig_usr: signal 15 received
Jul 13 09:43:52 ostest /usr/local/sbin/opensips[18953]: INFO:core:sig_usr: signal 15 received
Jul 13 09:43:52 ostest /usr/local/sbin/opensips[18951]: DIGEST-MD5 common mech free
Jul 13 09:43:52 ostest /usr/local/sbin/opensips[18950]: DIGEST-MD5 common mech free
Jul 13 09:43:52 ostest /usr/local/sbin/opensips[18956]: DIGEST-MD5 common mech free
```

**Solution**
<!-- Explain how your PR fixes the problem. Are there any remaining concerns that might need to be addressed? -->
If get_rate_price_prefix fails - do "return -1" and stop next steps of processing, because without normal return of this sub-function it is impossible.

**Compatibility**
<!-- Does your change break other scenarios, or do they need to be migrated in order to work similarly? -->

**Closing issues**
<!-- Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). -->
