### PR TITLE
rtpengine: allow weight, setid params when calling `rtpengine_enable`

### DIFF
--- a/modules/rtpengine/doc/rtpengine_admin.xml
+++ b/modules/rtpengine/doc/rtpengine_admin.xml
@@ -1360,17 +1360,26 @@ rtpengine_play_dtmf("0"); # send the 0 code upstream
 				<listitem><para>
 					<emphasis>enable</emphasis> - 1 - enable, 0 - disable the &rtp; proxy.
 				</para></listitem>
+        <listitem><para>
+					<emphasis>weight</emphasis> (optional)  the weight to be used when load balancing.
+				</para></listitem>
+        <listitem><para>
+					<emphasis>setid</emphasis> (optional) the set ID of the nodes to be updated. If provided, only nodes in the provided set will be updated.
+				</para></listitem>
 			</itemizedlist>
 			<para>
 			NOTE: if a &rtp; proxy is defined multiple times (in the same or
-			different set), all of its instances will be enables/disabled.
+			different set), all of its instances will be enabled/disbled IF no set ID is provided.
 			</para>
 			<example>
 			<title>
 			<function moreinfo="none">rtpengine_enable</function> usage</title>
 			<programlisting format="linespecific">
 ...
+## disable all rtpengines by URL
 $ opensips-cli -x mi rtpengine_enable udp:192.168.2.133:8081 0
+## enable rtpengine by URL and set ID (3), while also updating weight (25)
+$ opensips-cli -x mi rtpengine_enable url=udp:192.168.2.133:8081 enable=1 setid=3 weight=25
 ...
 			</programlisting>
 			</example>


### PR DESCRIPTION
**Summary**
This PR adds the ability to (optionally) provide `weight` and `setid` params when calling the MI `rtpengine_enable` method.  Similar to the rtpproxy module, the `setid` param acts as a filter when enabling/disabling nodes.  The `weight` param updates the node(s) load-balancing weight.  Since the new params are optional, the MI signature is backwards compatible.

**Justification**
I was looking for a way to dynamically set the load-balancing weights of a single set of rtpengine nodes at startup without having to maintain multiple tables/views via a SQL backend. The current balancing algo is quite simple, so I didn't want to mess with it. However, the combo of `rtpengine_show` and `rtpengine_enable` (after this PR) gives the ability to modify via script!