### PR TITLE
rtpengine: enhancement of set/node management

### DIFF
--- a/modules/rtpengine/doc/rtpengine_admin.xml
+++ b/modules/rtpengine/doc/rtpengine_admin.xml
@@ -1447,6 +1447,15 @@ $ opensips-cli -x mi rtpengine_show
 			Reloads all rtpengine sets from the database. Used only when the
 			<quote><xref linkend="param_db_url"/></quote> parameter is set.
 			</para>
+			<para>Parameters:</para>
+			<itemizedlist>
+				<listitem><para>
+					<emphasis>type</emphasis> (optional) soft - when reloading nodes
+					from the database, reuse any existing sockets and keep existing
+					node disabled state. If not provided, then all nodes and sockets
+					will first be torndown and then nodes will be loaded from the database.
+				</para></listitem>
+			</itemizedlist>
 			<para>
 			No parameter.
 			</para>
@@ -1456,6 +1465,7 @@ $ opensips-cli -x mi rtpengine_show
 			<programlisting format="linespecific">
 ...
 $ opensips-cli -x mi rtpengine_reload
+$ opensips-cli -x mi rtpengine_reload type=soft
 ...
 			</programlisting>
 			</example>

--- a/modules/rtpengine/rtpengine.c
+++ b/modules/rtpengine/rtpengine.c
@@ -361,7 +361,6 @@ static pv_spec_t err_pv;
 
 static char ** rtpe_strings=0;
 static int rtpe_sets=0; /*used in rtpengine_set_store()*/
-static int rtpe_set_count = 0;
 static int rtpe_ctx_idx = -1;
 struct rtpe_set_head **rtpe_set_list =0;
 struct rtpe_set **default_rtpe_set=0;
@@ -1025,7 +1024,6 @@ static int rtpengine_add_rtpengine_set( char * rtp_proxies, int set_id)
 		}
 
 		(*rtpe_set_list)->rset_last = rtpe_list;
-		rtpe_set_count++;
 	}
 
 	return 0;

--- a/modules/rtpengine/rtpengine.c
+++ b/modules/rtpengine/rtpengine.c
@@ -1570,6 +1570,7 @@ static inline int rtpengine_connect_node(struct rtpe_node *pnode)
 
 static int connect_rtpengines(int force_test)
 {
+	int i;
 	struct rtpe_set  *rtpe_list;
 	struct rtpe_node *pnode;
 
@@ -1585,6 +1586,8 @@ static int connect_rtpengines(int force_test)
 			LM_ERR("no more pkg memory\n");
 			return -1;
 		}
+		for (i=rtpe_number; i<*rtpe_no; i++)
+			rtpe_socks[i] = -1; /* init new elems */
 	}
 	rtpe_number = *rtpe_no;
 

--- a/modules/rtpengine/rtpengine.c
+++ b/modules/rtpengine/rtpengine.c
@@ -2381,7 +2381,7 @@ static struct rtpe_node *get_rtpe_node(str *node, struct rtpe_set *set)
 	struct rtpe_node *rnode;
 
 	/* check last list version */
-	if (my_version != *list_version && update_rtpengines() < 0) {
+	if (my_version != *list_version && update_rtpengines(0) < 0) {
 		LM_ERR("cannot update rtpengines list\n");
 		return NULL;
 	}

--- a/modules/rtpengine/rtpengine.c
+++ b/modules/rtpengine/rtpengine.c
@@ -319,6 +319,7 @@ static struct rtpe_node *select_rtpe_node(str, struct rtpe_set *);
 static struct rtpe_node *lookup_rtpe_node(struct rtpe_set * rtpe_list, str *rtpe_url);
 static void free_rtpe_set(int);
 static void free_rtpe_node(struct rtpe_set *, str *);
+static void disconnect_rtpe_socket(int);
 static char *send_rtpe_command(struct rtpe_node *, bencode_item_t *, int *);
 static int get_extra_id(struct sip_msg* msg, str *id_str);
 
@@ -1621,9 +1622,7 @@ static int update_rtpengines(void)
 	LM_DBG("updating list from %d to %d [%d]\n", my_version, *list_version, rtpe_number);
 	my_version = *list_version;
 	for (i = 0; i < rtpe_number; i++) {
-		shutdown(rtpe_socks[i], SHUT_RDWR);
-		close(rtpe_socks[i]);
-		rtpe_socks[i] = -1;
+		disconnect_rtpe_socket(i);
 	}
 
 	return connect_rtpengines();
@@ -1747,6 +1746,15 @@ static void free_rtpe_sets(void)
 	}
 	(*rtpe_set_list)->rset_first = NULL;
 	(*rtpe_set_list)->rset_last = NULL;
+}
+
+static void disconnect_rtpe_socket(int idx)
+{
+	LM_DBG("disconnect socket idx=%d\n", idx);
+
+	shutdown(rtpe_socks[idx], SHUT_RDWR);
+	close(rtpe_socks[idx]);
+	rtpe_socks[idx] = -1;
 }
 
 static void mod_destroy(void)

--- a/modules/rtpengine/rtpengine.h
+++ b/modules/rtpengine/rtpengine.h
@@ -29,6 +29,11 @@
 #include "bencode.h"
 #include "../../str.h"
 
+/* flags for set, node, and socket management */
+#define RTPE_TEARDOWN_NODE    (1<<0)
+#define RTPE_TEARDOWN_SET     (1<<1)
+#define RTPE_TEARDOWN_SOCKETS (1<<2)
+
 struct rtpe_node {
 	unsigned int		idx;			/* overall index */
 	str					rn_url;			/* unparsed, deletable */
@@ -37,6 +42,7 @@ struct rtpe_node {
 	int					rn_disabled;	/* found unaccessible? */
 	unsigned			rn_weight;		/* for load balancing */
 	unsigned int		rn_recheck_ticks;
+	int					rn_flags;
 	struct rtpe_node	*rn_next;
 };
 
@@ -47,6 +53,7 @@ struct rtpe_set{
 	unsigned int		rtpe_node_count;
 	int 				set_disabled;
 	unsigned int		set_recheck_ticks;
+	int 				set_flags;
 	struct rtpe_node	*rn_first;
 	struct rtpe_node	*rn_last;
 	struct rtpe_set     *rset_next;
@@ -56,6 +63,20 @@ struct rtpe_set{
 struct rtpe_set_head{
 	struct rtpe_set		*rset_first;
 	struct rtpe_set		*rset_last;
+};
+
+
+struct rtpe_version{
+	unsigned int version;
+	int version_flags;
+	struct rtpe_version *version_next;
+};
+
+
+struct rtpe_version_head{
+	unsigned int version_count;
+	struct rtpe_version *version_first;
+	struct rtpe_version *version_last;
 };
 
 #define RTPENGINE_TABLE_VERSION 1


### PR DESCRIPTION
**Summary**
This PR seeks to improve the mechanism by which nodes (and their respective sockets) are managed:
1. When loading set data from the database or module param, only allow one node per set per URL to be stored in memory. This cuts out redundancy in probing the same endpoint and shortens delays within the SIP procs when the redundant node is unreachable. If a user is putting multiple nodes in their set(s) to achieve load-balancing, the better approach is to use the existing weighting mechanism.
2. Extend the work done in 9ccd25fc282db8b2452254790c5492fc5829e382 to now completely remove node probing from the SIP context. With this PR, probing will be done at startup by each process (via `child_init`), by the timer procs, and by the HTTPD proc after a `rtpengine_reload` command. One con to this approach is that nodes are currently set to enabled, added to the set, and then probed.  If an unreachable node is added to the set via `rtpengine_reload`, then there is a chance that a SIP proc could select the node while the HTTPD proc is probing it. With the existing logic, the SIP proc would have been forced to first probe the node, then go onto the next node.  To address this, we could add a module param, say`default_node_state`, that could be used to dictate what behavior is more desirable (ie add node to set disabled, and wait for probing to enable before the node is selectable by SIP procs).
3. Free write lock from HTTPD proc before probing nodes. The justification is similar to (2) in that probing is pulled out of SIP context, so no need to lock the set from SIP readers.
4. Introduce "soft" reload option to MI `rtpengine_reload` command. The general idea with this type of reload is to reuse sockets and leave nodes enablement as is (ie if disabled, stay disabled) to minimize disruption to SIP procs. If the node exists in memory, then the existing node is reused (including all sockets and disabled state). If the node does not exist in memory, then it is added to the set and sockets are built per process. Remaining nodes are removed from the set and sockets are destroyed, as they have no associated database record.
5. Introduce version history for set list. Essentially, when a proc determines that it's time to reload socket data it traverses the version history to determine what type of reload to perform (ie soft or hard). I implemented this to allow for proper handling of hard and soft reloads, as race conditions pop up since set data is in shared memory while sockets are maintained per process (and multiple `rtpengine_reloads` could occur before proc hits reload logic).

I have this as a Draft, as it depends upon a commit 6123943afe21031dec8f4207f6f2bbc0dbb06b5d in #2603.  I also wanted to get some feedback from the OpenSIPS team to see your thoughts, feedback, and suggestions!

**Compatibility**
There should be no compatibility issues. The default reload behavior is to perform a hard reload of nodes/sockets, which is the existing behavior.
