### PR TITLE
Wait for more data if WS header doesn't have extended length yet

### DIFF
--- a/modules/proto_ws/ws_common.h
+++ b/modules/proto_ws/ws_common.h
@@ -329,7 +329,8 @@ static enum ws_close_code inline ws_parse(struct ws_req *req)
 			/* extended case */
 			if (req->tcp.pos - req->tcp.buf < WS_MIN_HDR_LEN + WS_ELENC_SIZE +
 					WS_IF_MASK_SIZE(req))
-				return 0;
+				/* wait for more data to come */
+				goto update_parsed;
 
 			clen = WS_ELENC(req);
 			if ((clen+WS_MIN_HDR_LEN+WS_ELENC_SIZE+WS_IF_MASK_SIZE(req))>
@@ -345,7 +346,8 @@ static enum ws_close_code inline ws_parse(struct ws_req *req)
 			/* extended case */
 			if (req->tcp.pos - req->tcp.buf < WS_MIN_HDR_LEN + WS_ELEN_SIZE +
 					WS_IF_MASK_SIZE(req))
-				return 0;
+				/* wait for more data to come */
+				goto update_parsed;
 
 			req->tcp.content_len = WS_ELEN(req);
 			if ((req->tcp.content_len+WS_MIN_HDR_LEN+WS_ELEN_SIZE+WS_IF_MASK_SIZE(req))>


### PR DESCRIPTION
`ws_read_raw` is only ran to receive data from the TCP connection if `req->tcp.parsed >= req->tcp.pos`. We fail to update `req->tcp.parsed` if we have enough data to read a minimum WS header but we don't have enough data to read the extended length part of the header.

I've changed the `return 0;` in the corresponding conditions to `goto update_parsed;` which is the code that is run if we don't have enough data to read a minimum WS header.