### PR TITLE
fix sqlite memory leak for row values

### DIFF
--- a/modules/db_sqlite/dbase.c
+++ b/modules/db_sqlite/dbase.c
@@ -55,6 +55,7 @@ static int db_sqlite_store_result(const db_con_t* _h, db_res_t** _r, const db_va
 static int db_sqlite_bind_values(sqlite3_stmt* stmt, const db_val_t* _v, const int _n);
 #endif
 static int db_sqlite_free_result_internal(const db_con_t* _h, db_res_t* _r);
+static void db_sqlite_free_result_rows(db_res_t* _r);
 
 static int db_sqlite_submit_dummy_query(const db_con_t* _h, const str* _s)
 {
@@ -265,10 +266,7 @@ int db_sqlite_fetch_result(const db_con_t* _h, db_res_t** _r, const int nrows)
 		}
 	} else {
 		/* free old rows */
-		if(RES_ROWS(*_r)!=0)
-			db_free_rows(*_r);
-		RES_ROWS(*_r) = 0;
-		RES_ROW_N(*_r) = 0;
+		db_sqlite_free_result_rows(*_r);
 	}
 
 	/* determine the number of rows remaining to be processed */
@@ -822,6 +820,36 @@ int db_sqlite_free_result(db_con_t* _h, db_res_t* _r)
 	_r = NULL;
 
 	return 0;
+}
+
+/**
+ * Release a result set from memory.
+ * \param _r result set whose rows and values should be freed
+ * \return void
+ */
+static void db_sqlite_free_result_rows(db_res_t* _r)
+{
+	db_val_t* values;
+
+	if (!_r) {
+		LM_DBG("nothing to free!\n");
+		return;
+	}
+
+	if(RES_ROWS(_r)!=0)
+	{
+		values = _r->rows[0].values;
+		/* db_sqlite_allocate_rows allocates memory for rows and values separately.
+		 * Hence freeing rows using generic function and then values separately*/
+		db_free_rows(_r);
+		if(values)
+		{
+			pkg_free(values);
+			values = NULL;
+		}
+	}
+	RES_ROWS(_r) = 0;
+	RES_ROW_N(_r) = 0;
 }
 
 /**


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!
In order to consider and evaluate your PR, it is mandatory to provide detailed information about (1) what is the issue the PR addresses, (2) how the PR is solving the issue (logic and coding), (3) what are (if any) limitations of the proposed PR and (4) if there are any known side-effects/ backward compatibility issues/SIP interoperability issues.
Note that if the PR is missing information, it might take longer to be merged, as extra resources have to be allocated by the maintainers to reverse engineer the changes, understand them, understand the motivation, etc. That is why it is important to provide as much information as possible.
-->

**Summary**
Details in ticket : https://github.com/OpenSIPS/opensips/issues/2608
OpenSIPS process leaks memory after running lb_reload [ load balancer ] when reading load balancer data from sqlite db.

**Details**
Fix is to avoid memory leak when freeing sqlite query's result values

**Solution**
After applying the fix , memory leak does not occur.

