### PR TITLE
rtpengine: allow setid param when calling `rtpengine_enable`

### DIFF
--- a/modules/rtpengine/doc/rtpengine_admin.xml
+++ b/modules/rtpengine/doc/rtpengine_admin.xml
@@ -1380,17 +1380,23 @@ rtpengine_play_dtmf("0"); # send the 0 code upstream
 				<listitem><para>
 					<emphasis>enable</emphasis> - 1 - enable, 0 - disable the &rtp; proxy.
 				</para></listitem>
+        <listitem><para>
+					<emphasis>setid</emphasis> (optional) the set ID of the nodes to be updated. If provided, only nodes in the provided set will be updated.
+				</para></listitem>
 			</itemizedlist>
 			<para>
 			NOTE: if a &rtp; proxy is defined multiple times (in the same or
-			different set), all of its instances will be enables/disabled.
+			different set), all of its instances will be enabled/disbled IF no set ID is provided.
 			</para>
 			<example>
 			<title>
 			<function moreinfo="none">rtpengine_enable</function> usage</title>
 			<programlisting format="linespecific">
 ...
+## disable all rtpengines by URL
 $ opensips-cli -x mi rtpengine_enable udp:192.168.2.133:8081 0
+## enable rtpengine by URL and set ID (3)
+$ opensips-cli -x mi rtpengine_enable url=udp:192.168.2.133:8081 enable=1 setid=3
 ...
 			</programlisting>
 			</example>

--- a/modules/rtpengine/rtpengine.c
+++ b/modules/rtpengine/rtpengine.c
@@ -652,6 +652,7 @@ static param_export_t params[] = {
 static mi_export_t mi_cmds[] = {
 	{ MI_ENABLE_RTP_ENGINE, 0, 0, 0, {
 		{mi_enable_rtp_proxy, {"url", "enable", 0}},
+		{mi_enable_rtp_proxy, {"url", "enable", "setid", 0}},
 		{EMPTY_MI_RECIPE}}
 	},
 	{ MI_SHOW_RTP_ENGINES, 0, 0, 0, {
@@ -1032,7 +1033,7 @@ static mi_response_t *mi_enable_rtp_proxy(const mi_params_t *params,
 								struct mi_handler *async_hdl)
 {
 	str rtpe_url;
-	int enable;
+	int enable, set;
 	struct rtpe_set * rtpe_list;
 	struct rtpe_node * crt_rtpe;
 	int found;
@@ -1049,10 +1050,15 @@ static mi_response_t *mi_enable_rtp_proxy(const mi_params_t *params,
 
 	if (get_mi_int_param(params, "enable", &enable) < 0)
 		return init_mi_param_error();
+	if (try_get_mi_int_param(params, "setid", &set) < 0)
+		set = -1;
 
 	RTPE_START_READ();
 	for(rtpe_list = (*rtpe_set_list)->rset_first; rtpe_list != NULL;
 					rtpe_list = rtpe_list->rset_next){
+
+    if (set !=-1 && set != rtpe_list->id_set)
+      continue;
 
 		for(crt_rtpe = rtpe_list->rn_first; crt_rtpe != NULL;
 						crt_rtpe = crt_rtpe->rn_next){


### PR DESCRIPTION
**Summary**
This PR adds the ability to (optionally) provide setid param when calling the MI rtpengine_enable method. Similar to the rtpproxy module, the setid param acts as a filter when enabling/disabling nodes.

**Details**
Rework of PR #2600 