### PR TITLE
Improve xyz_challenge() API to allow generating challenges like qop="auth,auth-int" as well as qop="auth-int,auth"; Make qop mandatory for the MD5-sess as well.

### DIFF
--- a/lib/digest_auth/dauth_nonce.c
+++ b/lib/digest_auth/dauth_nonce.c
@@ -59,7 +59,7 @@ _Static_assert(offsetof(struct nonce_context_priv, pub) == 0,
 
 struct nonce_payload {
 	int index;
-	uint64_t qop:2;
+	uint64_t qop:3;
 	uint64_t alg:3;
 	uint64_t expires_sec:34;
 	uint64_t expires_usec:20;

--- a/modules/auth/api.c
+++ b/modules/auth/api.c
@@ -231,8 +231,8 @@ auth_result_t pre_auth(struct sip_msg* _m, str* _realm, hdr_types_t _hftype,
 	qop_type_t qop = dcp->qop.qop_parsed;
 	if (np.qop != qop) {
 		switch (np.qop) {
-		case QOP_TYPE_AUTH_AUTH_INT:
-		case QOP_TYPE_AUTH_INT_AUTH:
+		case QOP_AUTH_AUTHINT_D:
+		case QOP_AUTHINT_AUTH_D:
 			if (qop == QOP_AUTH_D || qop == QOP_AUTHINT_D)
 				break;
 			/* Fall through */

--- a/modules/auth/api.c
+++ b/modules/auth/api.c
@@ -229,10 +229,17 @@ auth_result_t pre_auth(struct sip_msg* _m, str* _realm, hdr_types_t _hftype,
 		goto stalenonce;
 	}
 	qop_type_t qop = dcp->qop.qop_parsed;
-	if ((np.qop != qop) &&
-	    (np.qop != QOP_TYPE_BOTH || (qop != QOP_AUTH_D && qop != QOP_AUTHINT_D))) {
-		LM_DBG("nonce does not match qop\n");
-		goto stalenonce;
+	if (np.qop != qop) {
+		switch (np.qop) {
+		case QOP_TYPE_AUTH_AUTH_INT:
+		case QOP_TYPE_AUTH_INT_AUTH:
+			if (qop == QOP_AUTH_D || qop == QOP_AUTHINT_D)
+				break;
+			/* Fall through */
+		default:
+			LM_DBG("nonce (%d) does not match qop (%d)\n", np.qop, qop);
+			goto stalenonce;
+		}
 	}
 	if (is_nonce_stale(&np, nonce_expire)) {
 		LM_DBG("stale nonce value received\n");

--- a/modules/auth/challenge.h
+++ b/modules/auth/challenge.h
@@ -28,7 +28,8 @@
 
 #define QOP_TYPE_AUTH      QOP_AUTH_D
 #define QOP_TYPE_AUTH_INT  QOP_AUTHINT_D
-#define QOP_TYPE_BOTH      (QOP_AUTH_D + QOP_AUTHINT_D)
+#define QOP_TYPE_AUTH_INT_AUTH  QOP_AUTHINT_AUTH_D
+#define QOP_TYPE_AUTH_AUTH_INT  QOP_AUTH_AUTHINT_D
 
 int fixup_qop(void** param);
 

--- a/modules/auth/challenge.h
+++ b/modules/auth/challenge.h
@@ -26,11 +26,6 @@
 
 #include "../../parser/msg_parser.h"
 
-#define QOP_TYPE_AUTH      QOP_AUTH_D
-#define QOP_TYPE_AUTH_INT  QOP_AUTHINT_D
-#define QOP_TYPE_AUTH_INT_AUTH  QOP_AUTHINT_AUTH_D
-#define QOP_TYPE_AUTH_AUTH_INT  QOP_AUTH_AUTHINT_D
-
 int fixup_qop(void** param);
 
 /*

--- a/parser/digest/digest.c
+++ b/parser/digest/digest.c
@@ -125,7 +125,7 @@ dig_err_t check_dig_cred(dig_cred_t* _c)
 	     /* If QOP parameter is present, some additional
 	      * requirements must be met
 	      */
-	if ((_c->qop.qop_parsed == QOP_AUTH_D) || (_c->qop.qop_parsed == QOP_AUTHINT_D)) {
+	if (_c->qop.qop_parsed != QOP_UNSPEC_D) {
 		     /* CNONCE must be specified */
 		if (_c->cnonce.s == 0) res |= E_DIG_CNONCE;
 		     /* and also nonce count must be specified */
@@ -175,6 +175,8 @@ void print_cred(dig_cred_t* _c)
 		CASE_PRINTENUM(QOP_UNSPEC_D);
 		CASE_PRINTENUM(QOP_AUTH_D);
 		CASE_PRINTENUM(QOP_AUTHINT_D);
+		CASE_PRINTENUM(QOP_AUTHINT_AUTH_D);
+		CASE_PRINTENUM(QOP_AUTH_AUTHINT_D);
 		CASE_PRINTENUM(QOP_OTHER_D);
 		}
 		printf("NC        = \'%.*s\'\n", _c->nc.len, _c->nc.s);

--- a/parser/digest/digest_parser.h
+++ b/parser/digest/digest_parser.h
@@ -69,7 +69,9 @@ typedef enum qop_type {
 	QOP_UNSPEC_D = 0,   /* QOP parameter not present in response */
 	QOP_AUTH_D = 1,     /* Authentication only */
 	QOP_AUTHINT_D = 2,  /* Authentication with integrity checks */
-	QOP_OTHER_D = 4     /* Unknown */
+	QOP_AUTHINT_AUTH_D = 3,  /* Authentication with integrity checks+Authentication only */
+	QOP_AUTH_AUTHINT_D = 4,  /* Authentication only+Authentication with integrity checks */
+	QOP_OTHER_D = 5     /* Unknown */
 } qop_type_t;
 
 /* Canonical QOP names */


### PR DESCRIPTION
**Summary**
Improve  {www/proxy}_challenge() API to allow generating challenges like qop="auth,auth-int" as well as qop="auth-int,auth"; Make qop mandatory for the MD5-sess as well.

**Details**
This is useful for testing purposes as well as to indicate a preference in which UAC is supposed to perform authentication. Also clean code a bit to remove redundant declarations.

**Solution**
www_authenticate(..., "auth,auth-int", ...) would generate qop="auth,auth-int", www_authenticate(..., "auth-int,auth", ...): qop="auth-int,auth".

**Compatibility**
Tested with few UACs at OpenSIPIt'02.
