### PR TITLE
b2b_logic: Fix missing lock release

### DIFF
--- a/modules/b2b_logic/logic.c
+++ b/modules/b2b_logic/logic.c
@@ -3382,7 +3382,7 @@ str* b2b_process_scenario_init(struct sip_msg* msg, b2bl_cback_f cbf,
 
 	if (new_entities_no != MAX_BRIDGE_ENT-1) {
 		LM_ERR("Two bridge entities required!\n");
-		return NULL;
+		goto error;
 	}
 
 	if (new_entities[0]->type == B2B_SERVER)


### PR DESCRIPTION



**Summary**
<!-- Summary of the PR - what the PR is aiming to solve -->
Fix deadlock when `new_entities_no` is not 2.
