### PR TITLE
sql_cacher: Allow for individual entry reload in full caching mode.

### DIFF
--- a/modules/sql_cacher/README
+++ b/modules/sql_cacher/README
@@ -243,7 +243,7 @@ modparam("sql_cacher", "reload_interval", 5)
 
 1.5.1. sql_cacher_reload
 
-   Reloads the entire SQL table in cache in full caching mode.
+   Reloads the entire SQL table in cache or the single key (if key provided) in full caching mode.
 
    Reloads the given key or invalidates all the keys in cache in
    on demand mode.

--- a/modules/sql_cacher/sql_cacher.c
+++ b/modules/sql_cacher/sql_cacher.c
@@ -1072,7 +1072,7 @@ static mi_item_t *mi_reload(const mi_params_t *params, str *key)
 		return init_mi_error(500, MI_SSTR("ERROR Cache entry not found"));
 	}
 
-	if (db_hdls->c_entry->on_demand) {
+	if (db_hdls->c_entry->on_demand || key) {
 		if (key) {
 			src_key.len = db_hdls->c_entry->id.len + key->len;
 			src_key.s = pkg_malloc(src_key.len);


### PR DESCRIPTION
**Summary**
Allow for individual entry reload in full caching mode.

**Details**
I would like to load the entire table using full caching mode.
On demand when a change to an individual record is made, I would like to reload
the individual key I know has just changed using mi command without
reloading all other unchaged million records.

This commit, depending on whether a key param is provided, the entire table will be reloaded or just that record.

- `mi sql_cacher_reload id=my-table`  - Reloads the entire table
- `mi sql_cacher_reload id=my-table key=record-id` - reloads only a single record
