### PR TITLE
[db_oracle] Using DB_STRING as character type

### DIFF
--- a/modules/db_oracle/dbase.c
+++ b/modules/db_oracle/dbase.c
@@ -385,6 +385,8 @@ badparam:
 		return -1;
 	}
 
+	CON_ORA(_h)->pqdata = &cb;
+	CON_ORA(_h)->bindpos = 0;
 	CON_RESET_CURR_PS(_h); /* no prepared statements support */
 	memset(&cb, 0, sizeof(cb));
 

--- a/modules/db_oracle/res.c
+++ b/modules/db_oracle/res.c
@@ -213,8 +213,8 @@ set_flt:
 		case SQLT_AFC:		/* Ansi fixed char */
 		case SQLT_AVC:		/* Ansi Var char */
 //		case SQLT_RID:		/* rowid */
-			LM_DBG("use DB_STR result type\n");
-			RES_TYPES(_r)[i] = DB_STR;
+			LM_DBG("use DB_STRING result type\n");
+			RES_TYPES(_r)[i] = DB_STRING;
 dyn_str:
 			dtype = SQLT_CHR;
 			len = 0; /* DATA_SIZE is ub2 */


### PR DESCRIPTION
**Changes**

1) Using DB_STRING as character type in db_oracle module (Fix https://github.com/OpenSIPS/opensips/issues/2706)

Modules (e.g. load_balancer) using DB_STRING as character type to checking column type,
but the db_oracle module using DB_STR, this cause checking fail during the start-up phase and opensips going to exit.


2) Fix crash on db_oracle_raw_query()

The Function db_oracle_submit_query() required that CON_ORA(_h)->pqdata is not null, but db_oracle_raw_query() do not set.

