### PR TITLE
tls_wolfssl: show supported cipher suites on module init

### DIFF
--- a/modules/tls_wolfssl/wolfssl.c
+++ b/modules/tls_wolfssl/wolfssl.c
@@ -119,6 +119,15 @@ static void _wolfssl_init_ssl_methods(void)
 	ssl_versions[TLS_USE_TLSv1_3-1] = TLS1_3_VERSION;
 }
 
+static void _wolfssl_show_ciphers(void)
+{
+	char ciphers[4096];
+	int ret = wolfSSL_get_ciphers(ciphers, (int)sizeof(ciphers));
+	if(ret == SSL_SUCCESS){
+		LM_INFO("Ciphers: %s\n", ciphers);
+	}
+}
+
 static void *oss_malloc(size_t size)
 {
 	return shm_malloc(size);
@@ -173,6 +182,8 @@ static int mod_init(void)
 	wolfSSL_Init();
 
 	_wolfssl_init_ssl_methods();
+
+	_wolfssl_show_ciphers();
 
 	return 0;
 }


### PR DESCRIPTION
**Summary**
Logs all supported cipher suites on tls_wolfssl module initialization.

**Details**
It's useful to know what TLS cipher suites supported by current OpenSIPS build.

