### PR TITLE
dispatcher: add optional partition param to MI `ds_list`

### DIFF
--- a/modules/dispatcher/doc/dispatcher_admin.xml
+++ b/modules/dispatcher/doc/dispatcher_admin.xml
@@ -1652,6 +1652,10 @@ opensips-cli -x mi ds_set_state a 2 sip:10.0.0.202
 				<emphasis>full</emphasis> (optional) - adds the weight,
 				priority and description fields to the listing
 			</para></listitem>
+			<listitem><para>
+				<emphasis>partition</emphasis> (optional) - return only
+				destinations and sets in the provided partition.
+			</para></listitem>
 		</itemizedlist>
 		<para>
 		MI FIFO Command Format:


### PR DESCRIPTION
**Summary**
This PR adds an optional ***partition*** param to the `ds_list` MI command.

**Details**
When working with large dispatcher data, the response JSON can be quite large when calling `ds_list` as it currently returns all partition data. If partitions are used, it would be nice to include a way to filter the response at the server level to cut down on the response size.

**Compatibility**
Backwards compatible, as this is an optional param; default is still to return all data.
