### PR TITLE
Kworm83 stir shaken patch

### DIFF
--- a/modules/stir_shaken/stir_shaken.c
+++ b/modules/stir_shaken/stir_shaken.c
@@ -784,7 +784,7 @@ static int add_identity_hf(struct sip_msg *msg, EVP_PKEY *pkey,
 
 	hdr_buf.len = IDENTITY_HDR_LEN + unsigned_buf.len + 1/*'.'*/ +
 		calc_base64_encode_len(RAW_SIG_LEN) + 1/*';'*/ + HDR_INFO_PARAM_LEN +
-		2/*'<','>'*/ + cr_url->len + 1/*';'*/ + HDR_PPT_PARAM_LEN + CRLF_LEN;
+		2/*'<','>'*/ + cr_url->len + 1/*';'*/ + HDR_ALG_PARAM_LEN + 1/*';'*/ + HDR_PPT_PARAM_LEN + CRLF_LEN;
 	hdr_buf.s = pkg_malloc(hdr_buf.len);
 	if (!hdr_buf.s) {
 		LM_ERR("oom!\n");
@@ -814,6 +814,9 @@ static int add_identity_hf(struct sip_msg *msg, EVP_PKEY *pkey,
 	hdr_buf.len += cr_url->len;
 	hdr_buf.s[hdr_buf.len++] = '>';
 	hdr_buf.s[hdr_buf.len++] = ';';
+	memcpy(hdr_buf.s + hdr_buf.len, HDR_ALG_PARAM_S, HDR_ALG_PARAM_LEN);
++       hdr_buf.len += HDR_ALG_PARAM_LEN;
++       hdr_buf.s[hdr_buf.len++] = ';';
 	memcpy(hdr_buf.s + hdr_buf.len, HDR_PPT_PARAM_S, HDR_PPT_PARAM_LEN);
 	hdr_buf.len += HDR_PPT_PARAM_LEN;
 	memcpy(hdr_buf.s + hdr_buf.len, CRLF, CRLF_LEN);

--- a/modules/stir_shaken/stir_shaken.c
+++ b/modules/stir_shaken/stir_shaken.c
@@ -815,8 +815,8 @@ static int add_identity_hf(struct sip_msg *msg, EVP_PKEY *pkey,
 	hdr_buf.s[hdr_buf.len++] = '>';
 	hdr_buf.s[hdr_buf.len++] = ';';
 	memcpy(hdr_buf.s + hdr_buf.len, HDR_ALG_PARAM_S, HDR_ALG_PARAM_LEN);
-+       hdr_buf.len += HDR_ALG_PARAM_LEN;
-+       hdr_buf.s[hdr_buf.len++] = ';';
+        hdr_buf.len += HDR_ALG_PARAM_LEN;
+        hdr_buf.s[hdr_buf.len++] = ';';
 	memcpy(hdr_buf.s + hdr_buf.len, HDR_PPT_PARAM_S, HDR_PPT_PARAM_LEN);
 	hdr_buf.len += HDR_PPT_PARAM_LEN;
 	memcpy(hdr_buf.s + hdr_buf.len, CRLF, CRLF_LEN);

--- a/modules/stir_shaken/stir_shaken.h
+++ b/modules/stir_shaken/stir_shaken.h
@@ -69,7 +69,9 @@
 #define IDENTITY_HDR_LEN (sizeof(IDENTITY_HDR_S)-1)
 #define HDR_INFO_PARAM_S "info="
 #define HDR_INFO_PARAM_LEN (sizeof(HDR_INFO_PARAM_S)-1)
-#define HDR_PPT_PARAM_S "ppt=\"shaken\""
+#define HDR_ALG_PARAM_S "alg=ES256"
+#define HDR_ALG_PARAM_LEN (sizeof(HDR_ALG_PARAM_S)-1)
+#define HDR_PPT_PARAM_S "ppt=shaken"
 #define HDR_PPT_PARAM_LEN (sizeof(HDR_PPT_PARAM_S)-1)
 
 #define USE_IDENTITY_CODE 428


### PR DESCRIPTION
**Summary**
Patch to bring Identity header more inline with current stir/shaken real world implementations
<!-- Summary of the PR - what the PR is aiming to solve -->

**Details**
In looking at standards/example documentation along with actual Identity headers received from North American carriers I have noticed that they include the "alg=ES256" parameter in the Identity header as well as not having double quotes around shaken in the ppt parameter.   I'm not sure that poses a problem with actual signing but this patch makes the Identity header for OpenSIPS match what is used by large carriers such as Bandwidth, Verizon, ANPI/Intelliquent/etc.  I ran across this while testing our own signing and hearing from other carriers that our Identity header was different in the above regards.

**Solution**
My PR adds the alg=ES256 parameter and remove the double quotes to make the ppt=shaken parameter

**Compatibility**
I do not believe this change will break any Identity headers as the largest carriers in NA are using them.  I do not have a way to test against any European/Latin America/etc carriers but assuming they are using the same standards it will be correct for them as well.

**Closing issues**
none