### PR TITLE
domain: add support for `DB_BLOB` attrs type

### DIFF
--- a/db/db_val.h
+++ b/db/db_val.h
@@ -227,6 +227,17 @@ static inline void db_print_val(db_val_t *v)
 			} else { \
 				_str = VAL_STR(_val); \
 			} \
+		} else if ((_val)->type==DB_BLOB) { \
+			if ( VAL_BLOB(_val).s==NULL || VAL_BLOB(_val).len==0 ) { \
+				if (_not_empty) { \
+					LM_ERR("value in column %s cannot be empty\n", _col_name); \
+					goto _error_label;\
+				} else { \
+					_str = VAL_BLOB(_val) ;\
+				} \
+			} else { \
+				_str = VAL_BLOB(_val); \
+			} \
 		} else {\
 			LM_ERR("column %s does not have a string type (found %d)\n",\
 				_col_name,(_val)->type); \

--- a/modules/domain/domain.c
+++ b/modules/domain/domain.c
@@ -271,6 +271,8 @@ int reload_domain_table ( void )
 			attrs.len = strlen(attrs.s);
 		} else if (VAL_TYPE(val + 1) == DB_STR) {
 			attrs = VAL_STR(val + 1);
+		} else if (VAL_TYPE(val + 1) == DB_BLOB) {
+			attrs = VAL_BLOB(val + 1);
 		} else {
 			LM_ERR("Database problem on attrs column\n");
 			domain_dbf.free_result(db_handle, res);


### PR DESCRIPTION
**Summary**
The PR allows the domain module to accept BLOB type from database for attrs column.  If using the standard opensips [schema](https://github.com/OpenSIPS/opensips/blob/master/scripts/mysql/domain-create.sql) for the domain module, the column is always of CHAR type.  However, if using custom schema it's often times desirable to setup a VIEW to some other table/DB that provides configuration data in a different schema.  The problem is that simple SELECT statements in the VIEW definition can lead to BLOB fields instead of CHAR in the response, even when explicit CASTing is done.

For example, doing a simple GROUP results in BLOB if `group_concat_max_len` <= 512 (https://mariadb.com/kb/en/group_concat/):

>If group_concat_max_len <= 512, the return type is VARBINARY or VARCHAR; otherwise, the return type is BLOB or TEXT. The choice between binary or non-binary types depends from the input.

**Solution**
Also parse the DB_BLOB type.

**Compatibility**
There should be no compatibility issues.
