### PR TITLE
Explicitly add fPIC and DPIC for gcc

### DIFF
--- a/Makefile.defs
+++ b/Makefile.defs
@@ -1340,7 +1340,7 @@ ifeq		($(LDTYPE), solaris)
 else
 		#gcc and maybe others, => gnu ld
 		LDFLAGS+=-Wl,-O2 -Wl,-E $(PROFILE)
-		MOD_LDFLAGS=-shared $(LDFLAGS)
+		MOD_LDFLAGS=-shared -fPIC -DPIC $(LDFLAGS)
 endif
 endif
 ifeq    ($(CC_NAME), clang)
@@ -1372,7 +1372,7 @@ ifeq		($(LDTYPE), solaris)
 else
 			#gnu or other ld type
 			LDFLAGS+=-Wl,-E $(PROFILE)
-			MOD_LDFLAGS=-shared $(LDFLAGS)
+			MOD_LDFLAGS=-shared -fPIC -DPIC $(LDFLAGS)
 endif
 endif
 ifeq	($(CC_NAME), icc)


### PR DESCRIPTION
This addresses linking on Fedora 34 and later with gcc 11:

```
gcc -shared -Wl,-z,relro -Wl,--as-needed  -Wl,-z,now -specs=/usr/lib/rpm/redhat/redhat-hardened-ld  -Wl,-O2 -Wl,-E   alarm_checks.o hashTable.o interprocess_buffer.o openserMIBNotifications.o openserObjects.o openserSIPCommonObjects.o openserSIPContactTable.o openserSIPMethodSupportedTable.o openserSIPPortTable.o openserSIPRegUserLookupTable.o openserSIPRegUserTable.o openserSIPServerObjects.o openserSIPStatusCodesTable.o snmpstats.o sub_agent.o utilities.o  -L/usr/lib64 -lnetsnmpmibs -lnetsnmpagent -lnetsnmp -Wl,-z,relro -Wl,--as-needed -Wl,-z,now -specs=/usr/lib/rpm/redhat/redhat-hardened-ld -lm -lsensors -ldl -lm -lrpm -lrpmio -Wl,--enable-new-dtags -Wl,-z,relro -Wl,--as-needed -Wl,-z,now -specs=/usr/lib/rpm/redhat/redhat-hardened-ld -lm -lssl -lssl -lcrypto  -o snmpstats.so
/usr/bin/ld: /tmp/cccfDV1K.ltrans0.ltrans.o: warning: relocation against `event_shm_threshold' in read-only section `.text'
/usr/bin/ld: /tmp/cccfDV1K.ltrans0.ltrans.o: relocation R_X86_64_PC32 against undefined symbol `ctime_buf' can not be used when making a shared object; recompile with -fPIC
/usr/bin/ld: final link failed: bad value
collect2: error: ld returned 1 exit status
make[1]: Leaving directory '/builddir/build/BUILD/opensips-3.1.7/modules/snmpstats'
make[1]: *** [../../Makefile.rules:39: snmpstats.so] Error 1
make: *** [Makefile:197: modules] Error 2
```

Closes #2734.

Signed-off-by: Peter Lemenkov <lemenkov@gmail.com>

<!--
Thanks for submitting a pull request!
In order to consider and evaluate your PR, it is mandatory to provide detailed information about (1) what is the issue the PR addresses, (2) how the PR is solving the issue (logic and coding), (3) what are (if any) limitations of the proposed PR and (4) if there are any known side-effects/ backward compatibility issues/SIP interoperability issues.
Note that if the PR is missing information, it might take longer to be merged, as extra resources have to be allocated by the maintainers to reverse engineer the changes, understand them, understand the motivation, etc. That is why it is important to provide as much information as possible.
-->

**Summary**
<!-- Summary of the PR - what the PR is aiming to solve -->

**Details**
<!--
Details about the content of the PR - is it a bug fix, a new feature or perhaps a hack? Explain the **motivation** for making this change.
What existing problem does the pull request solve? Is this a particular problem (i.e. only some particular scenarios are affected, only some UACs, etc) or a generic one?
Do not assume others understand what you're trying to do and provide as much information as you may have.
-->

**Solution**
<!-- Explain how your PR fixes the problem. Are there any remaining concerns that might need to be addressed? -->

**Compatibility**
<!-- Does your change break other scenarios, or do they need to be migrated in order to work similarly? -->

**Closing issues**
<!-- Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). -->
