### PR TITLE
Fix crash in tracer module when negative hop-by-hop ACK received during b2b tracing

### DIFF
--- a/modules/b2b_entities/dlg.c
+++ b/modules/b2b_entities/dlg.c
@@ -1091,9 +1091,15 @@ logic_notify:
 
 		tm_tran = tmb.t_gett();
 
-		/* start tracing for this transaction */
-		b2b_run_tracer( dlg, msg, tm_tran);
-	
+		/* if a valid transaction was created, trace it
+		   NOTE that the end2end ACK forms a separate transaction
+		   (even if TM will return a NULL transaction) and
+		   we will trace it as standalone request, while a negative hop-by-hop ACK
+		   (part of INVITE transaction) we will get T_UNDEFINED, so not to be traced
+		*/
+		if (tm_tran != T_UNDEFINED)
+			b2b_run_tracer(dlg, msg, tm_tran);
+
 		if(method_value != METHOD_ACK)
 		{
 			if(method_value == METHOD_UPDATE)

--- a/modules/tracer/doc/tracer_admin.xml
+++ b/modules/tracer/doc/tracer_admin.xml
@@ -398,6 +398,7 @@ modparam("tracer", "file_mode", 0644)
 				</listitem>
 			</itemizedlist>
 			<para>If both <emphasis>C</emphasis> and <emphasis>c</emphasis> flags are missing, tracing of both sides/legs is assumed.</para>
+			<para>NOTE these flags are supported only by transactional and dialog tracing</para>
 		</listitem>
 
 		<listitem>

--- a/modules/tracer/tracer.c
+++ b/modules/tracer/tracer.c
@@ -1392,6 +1392,12 @@ static int trace_b2b_transaction(struct sip_msg* msg, void *trans, void* param)
 	/* context for the request message */
 	SET_TRACER_CONTEXT( info );
 
+	if (t==T_UNDEFINED) {
+		/* Negative hop-by-hop ACK shouldn't be here */
+		LM_BUG("undefined transaction received here\n");
+		return 0;
+	}
+
 	if (t==NULL) {
 		/* the only situation when we do not have a transaction, is for
 		 * UAS/inbound ACK request, so trace it as a standalone msg */


### PR DESCRIPTION
This PR fixed tracer module crash during b2b tracing.

end2end ACK forms a separate transaction
(even if TM will return a NULL transaction) and
we will trace it as standalone request, while a negative hop-by-hop ACK
(part of INVITE transaction) we will get T_UNDEFINED, so not to be traced

try to trace T_UNDEFINED ACK causes crash