### PR TITLE
Rename an ldap_connect() to opensips_ldap_connect()

### DIFF
--- a/modules/ldap/ldap_api_fn.c
+++ b/modules/ldap/ldap_api_fn.c
@@ -118,7 +118,7 @@ struct ld_conn* get_ldap_connection(struct ld_session* lds)
 		return NULL;
 	}
 
-	if (ldap_connect(lds->name, NULL) < 0) {
+	if (opensips_ldap_connect(lds->name, NULL) < 0) {
 			LM_ERR("failed to create new ldap connection!\n");
 			return NULL;
 	}

--- a/modules/ldap/ldap_connect.c
+++ b/modules/ldap/ldap_connect.c
@@ -113,7 +113,7 @@ error:
 }
 
 
-int ldap_connect(char* _ld_name, struct ld_conn* conn)
+int opensips_ldap_connect(char* _ld_name, struct ld_conn* conn)
 {
 	int rc;
 	int ldap_proto_version;
@@ -411,7 +411,7 @@ int ldap_reconnect(char* _ld_name, struct ld_conn* conn)
 		return -1;
 	}
 
-	if ((rc = ldap_connect(_ld_name, conn)) != 0)
+	if ((rc = opensips_ldap_connect(_ld_name, conn)) != 0)
 	{
 		LM_ERR("[%s]: reconnect failed\n",
 				_ld_name);

--- a/modules/ldap/ldap_connect.h
+++ b/modules/ldap/ldap_connect.h
@@ -43,7 +43,7 @@
 /* forward declaration for this structure */
 struct ld_conn;
 
-extern int ldap_connect(char* _ld_name, struct ld_conn* conn);
+extern int opensips_ldap_connect(char* _ld_name, struct ld_conn* conn);
 extern int ldap_disconnect(char* _ld_name, struct ld_conn* conn);
 extern int ldap_reconnect(char* _ld_name, struct ld_conn* conn);
 extern int ldap_get_vendor_version(char** _version);

--- a/modules/ldap/ldap_mod.c
+++ b/modules/ldap/ldap_mod.c
@@ -186,7 +186,7 @@ static int child_init(int rank)
 		}
 
 		/* won't check for null in get_ld_session since it's barely been initialized */
-		if (ldap_connect(ld_name, &get_ld_session(ld_name)->conn_s) != 0)
+		if (opensips_ldap_connect(ld_name, &get_ld_session(ld_name)->conn_s) != 0)
 		{
 			LM_ERR("[%s]: failed to connect to LDAP host(s)\n", ld_name);
 			ldap_disconnect(ld_name, NULL);


### PR DESCRIPTION
The name clashes with openldap-2.6.1's ldap_connect() and a compiler errors
on the mismatching protype:

~~~~
gcc -fPIC -DPIC -O2 -flto=auto -ffat-lto-objects -fexceptions -g -grecord-gcc-switches -pipe -Wall -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2 -Wp,-D_GLIBCXX_ASSERTIONS -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -fstack-protector-strong -specs=/usr/lib/rpm/redhat/redhat-annobin-cc1 -mbranch-protection=standard -fasynchronous-unwind-tables -fstack-clash-protection -fgnu89-inline -DMOD_NAME='ldap' -DPKG_MALLOC  -DSHM_MMAP  -DUSE_MCAST  -DDISABLE_NAGLE  -DSTATISTICS  -DHAVE_RESOLV_RES  -DF_MALLOC  -DQ_MALLOC  -DHP_MALLOC  -DDBG_MALLOC   -DNAME='"opensips"' -DVERSION='"3.1.7"' -DARCH='"aarch64"' -DOS='"linux"' -DCOMPILER='"gcc 12"' -D__CPU_aarch64 -D__OS_linux -D__SMP_yes -DCFG_DIR='"/etc/opensips/"'  -DHAVE_GETHOSTBYNAME2 -DHAVE_UNION_SEMUN -DHAVE_SCHED_YIELD -DHAVE_MSG_NOSIGNAL -DHAVE_MSGHDR_MSG_CONTROL -DHAVE_ALLOCA_H -DHAVE_TIMEGM -DUSE_POSIX_SEM   -DHAVE_EPOLL -DHAVE_SIGIO_RT -DHAVE_SELECT -c ld_session.c -o ld_session.o
[...]
In file included from ld_session.c:33:
ldap_connect.h:46:12: error: conflicting types for 'ldap_connect'; have 'int(char *, struct ld_conn *)'
   46 | extern int ldap_connect(char* _ld_name, struct ld_conn* conn);
      |            ^~~~~~~~~~~~
In file included from ld_session.h:34,
                 from ld_session.c:32:
/usr/include/ldap.h:1555:1: note: previous declaration of 'ldap_connect' with type 'int(LDAP *)' {aka 'int(struct ldap *)'}
 1555 | ldap_connect( LDAP *ld );
      | ^~~~~~~~~~~~
make[1]: *** [../../Makefile.rules:26: ld_session.o] Error 1
~~~~

Because it's an a function internal to the ldap module, this patch fixes it
with renaming the function.

Signed-off-by: Petr Písař <ppisar@redhat.com>