### PR TITLE
Fix /var/run to /run

### DIFF
--- a/etc/opensips.cfg
+++ b/etc/opensips.cfg
@@ -69,7 +69,7 @@ loadmodule "sipmsgops.so"
 
 #### FIFO Management Interface
 loadmodule "mi_fifo.so"
-modparam("mi_fifo", "fifo_name", "/var/run/opensips/opensips_fifo")
+modparam("mi_fifo", "fifo_name", "/run/opensips/opensips_fifo")
 modparam("mi_fifo", "fifo_mode", 0666)
 
 #### USeR LOCation module

--- a/modules/acc/etc/radiusclient.conf
+++ b/modules/acc/etc/radiusclient.conf
@@ -61,7 +61,7 @@ login_radius	/usr/local/sbin/login.radius
 #
 # if opensips don't run as root, this directory should be used
 # the debian init script for example use this location
-seqfile		/var/run/opensips/opensips_radius.seq
+seqfile		/run/opensips/opensips_radius.seq
 
 # file which specifies mapping between ttyname and NAS-Port attribute
 mapfile		/usr/local/etc/radiusclient/port-id-map

--- a/modules/call_control/call_control.c
+++ b/modules/call_control/call_control.c
@@ -126,7 +126,7 @@ int parse_stop(unsigned int type, void *val);
 
 // Local global variables
 static CallControlSocket callcontrol_socket = {
-    "/var/run/callcontrol/socket", // name
+    "/run/callcontrol/socket", // name
     -1,                            // sock
     500,                           // timeout in 500 milliseconds if there is no answer
     0,                             // time of the last failure

--- a/modules/call_control/doc/call_control_admin.xml
+++ b/modules/call_control/doc/call_control_admin.xml
@@ -223,7 +223,7 @@ modparam("call_control", "disable", 1)
       <para>
         <emphasis>
           Default value is 
-            <quote>/var/run/callcontrol/socket</quote>.
+            <quote>/run/callcontrol/socket</quote>.
         </emphasis>
       </para>
 
@@ -231,7 +231,7 @@ modparam("call_control", "disable", 1)
       <title>Setting the <varname>socket_name</varname> parameter</title>
         <programlisting format="linespecific">
 ...
-modparam("call_control", "socket_name", "/var/run/callcontrol/socket")
+modparam("call_control", "socket_name", "/run/callcontrol/socket")
 ...
         </programlisting>
       </example>

--- a/modules/mediaproxy/doc/mediaproxy_admin.xml
+++ b/modules/mediaproxy/doc/mediaproxy_admin.xml
@@ -173,7 +173,7 @@ modparam("mediaproxy", "disable", 1)
       <para>
         <emphasis>
           Default value is 
-            <quote>/var/run/mediaproxy/dispatcher.sock</quote>.
+            <quote>/run/mediaproxy/dispatcher.sock</quote>.
         </emphasis>
       </para>
 
@@ -181,7 +181,7 @@ modparam("mediaproxy", "disable", 1)
       <title>Setting the <varname>mediaproxy_socket</varname> parameter</title>
         <programlisting format="linespecific">
 ...
-modparam("mediaproxy", "mediaproxy_socket", "/var/run/mediaproxy/dispatcher.sock")
+modparam("mediaproxy", "mediaproxy_socket", "/run/mediaproxy/dispatcher.sock")
 ...
         </programlisting>
       </example>

--- a/modules/mediaproxy/mediaproxy.c
+++ b/modules/mediaproxy/mediaproxy.c
@@ -177,7 +177,7 @@ static int mediaproxy_disabled = False;
 static str ice_candidate = str_init("none");
 
 static MediaproxySocket mediaproxy_socket = {
-    "/var/run/mediaproxy/dispatcher.sock", // name
+    "/run/mediaproxy/dispatcher.sock", // name
     -1,                                    // sock
     500,                                   // timeout in 500 milliseconds if there is no answer
     0,                                     // time of the last failure

--- a/modules/mi_fifo/doc/mi_fifo_admin.xml
+++ b/modules/mi_fifo/doc/mi_fifo_admin.xml
@@ -105,7 +105,7 @@
 			you are getting this error while trying to use
 			<emphasis>opensips-cli</emphasis>, you can fix it by either store
 			the fifo file in a non-sticky bit directory (such as
-			<emphasis>/var/run/opensips</emphasis>), or disable the fifo
+			<emphasis>/run/opensips</emphasis>), or disable the fifo
 			protection using <emphasis>sysctl fs.protected_fifos = 0</emphasis>
 			(NOT RECOMMENDED).
 		</para>

--- a/modules/nat_traversal/doc/nat_traversal_admin.xml
+++ b/modules/nat_traversal/doc/nat_traversal_admin.xml
@@ -487,7 +487,7 @@ modparam("nat_traversal", "keepalive_extra_headers", "User-Agent: OpenSIPS\r\nX-
       <title>Setting the <varname>keepalive_state_file</varname> parameter</title>
         <programlisting format="linespecific">
 ...
-modparam("nat_traversal", "keepalive_state_file", "/var/run/opensips/keepalive_state")
+modparam("nat_traversal", "keepalive_state_file", "/run/opensips/keepalive_state")
 ...
         </programlisting>
       </example>

--- a/packaging/arch/opensips.tmpfiles.conf
+++ b/packaging/arch/opensips.tmpfiles.conf
@@ -1,1 +1,1 @@
-d /var/run/opensips 0755 opensips opensips
+d /run/opensips 0755 opensips opensips

--- a/packaging/debian/opensips.init
+++ b/packaging/debian/opensips.init
@@ -25,7 +25,7 @@ DESC=opensips
 CFGFILE=/etc/opensips/opensips.cfg
 M4CFGFILE=/etc/opensips/opensips.m4
 M4ARCHIVEDIR=/etc/opensips/archive
-HOMEDIR=/var/run/opensips
+HOMEDIR=/run/opensips
 PIDFILE=$HOMEDIR/$NAME.pid
 DEFAULTS=/etc/default/opensips
 RUN_OPENSIPS=no
@@ -69,9 +69,9 @@ create_radius_seqfile ()
     # write to the file. If the file exists before opensips starts, it
     # won't change it's ownership and will be writable for both root
     # and opensips, no matter what options are chosen at install time
-    RADIUS_SEQ_FILE=/var/run/opensips/opensips_radius.seq
-    if [ -d /var/run/opensips ]; then
-	chown ${USER}:${GROUP} /var/run/opensips
+    RADIUS_SEQ_FILE=/run/opensips/opensips_radius.seq
+    if [ -d /run/opensips ]; then
+	chown ${USER}:${GROUP} /run/opensips
 
 	if [ ! -f $RADIUS_SEQ_FILE ]; then
 	    touch $RADIUS_SEQ_FILE
@@ -108,7 +108,7 @@ case "$1" in
 	check_opensips_config
 	create_radius_seqfile
 
-	# dirs under /var/run will go away on reboot.
+	# dirs under /run will go away on reboot.
 	mkdir -p "$HOMEDIR"
 	chmod 775 "$HOMEDIR"
 	chown "$USER:$GROUP" "$HOMEDIR" >/dev/null 2>&1 || true

--- a/packaging/debian/opensips.postinst
+++ b/packaging/debian/opensips.postinst
@@ -4,7 +4,7 @@
 
 PKG=opensips
 DEFAULTS=/etc/default/opensips
-HOMEDIR=/var/run/opensips
+HOMEDIR=/run/opensips
 
 set -e
 

--- a/packaging/redhat_fedora/opensips.init
+++ b/packaging/redhat_fedora/opensips.init
@@ -6,7 +6,7 @@
 # description: OpenSIPS is a fast SIP Server.
 #
 # processname: opensips
-# pidfile: /var/run/opensips.pid
+# pidfile: /run/opensips.pid
 # config: /etc/opensips/opensips.cfg
 #
 ### BEGIN INIT INFO
@@ -23,7 +23,7 @@
 prog=opensips
 opensips=/usr/sbin/$prog
 cfgdir="/etc/$prog"
-pidfile="/var/run/$prog.pid"
+pidfile="/run/$prog.pid"
 lockfile="/var/lock/subsys/$prog"
 configfile="$cfgdir/$prog.cfg"
 m4configfile="$cfgdir/$prog.m4"

--- a/packaging/redhat_fedora/opensips.tmpfiles.conf
+++ b/packaging/redhat_fedora/opensips.tmpfiles.conf
@@ -1,1 +1,1 @@
-d /var/run/opensips 0755 opensips opensips
+d /run/opensips 0755 opensips opensips


### PR DESCRIPTION
**Summary**
Filesystem Hierarchy Standard 3.0 released in 2015.
It's time to fix /var/run to /run
