### PR TITLE
fix: rtpengine_play_media: From-tag given, but no such tag exists

### DIFF
--- a/modules/rtpengine/rtpengine.c
+++ b/modules/rtpengine/rtpengine.c
@@ -2128,8 +2128,8 @@ static bencode_item_t *rtpe_function_call(bencode_buffer_t *bencbuf, struct sip_
 			LM_ERR("No to-tag present\n");
 			goto error;
 		}
-		bencode_dictionary_add_str(ng_flags.dict, "from-tag", &ng_flags.to_tag);
-		bencode_dictionary_add_str(ng_flags.dict, "to-tag", &ng_flags.from_tag);
+		bencode_dictionary_add_str(ng_flags.dict, "from-tag", &ng_flags.from_tag);
+		bencode_dictionary_add_str(ng_flags.dict, "to-tag", &ng_flags.to_tag);
 	}
 
 	bencode_dictionary_add_string(ng_flags.dict, "command", command_strings[op]);


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!
In order to consider and evaluate your PR, it is mandatory to provide detailed information about (1) what is the issue the PR addresses, (2) how the PR is solving the issue (logic and coding), (3) what are (if any) limitations of the proposed PR and (4) if there are any known side-effects/ backward compatibility issues/SIP interoperability issues.
Note that if the PR is missing information, it might take longer to be merged, as extra resources have to be allocated by the maintainers to reverse engineer the changes, understand them, understand the motivation, etc. That is why it is important to provide as much information as possible.
-->

**Summary**
<!-- Summary of the PR - what the PR is aiming to solve -->

rtpengine send command is `from-tag15:27001SIPpTag0166:to-tag13:mBKQX9KBvtv6p`, but the real from-tag is `mBKQX9KBvtv6p` and to-tag is `27001SIPpTag016`


```log
[1650441552.378531] WARNING: [9b76ba05-3b22-123b-94be-00505689b376]: [control] Protocol error in packet from 192.168.33.2:48941: From-tag g
iven, but no such tag exists [d4:file27:/usr/local/etc/ringback.mp37:call-id36:9b76ba05-3b22-123b-94be-00505689b37613:received-froml3:IP414
:172.16.200.172e8:from-tag15:27001SIPpTag0166:to-tag13:mBKQX9KBvtv6p7:command10:play media]
[1650441560.402120] INFO: [9b76ba05-3b22-123b-94be-00505689b376]: [control] Received command 'delete' from 192.168.33.2:48941
[1650441560.402244] INFO: [9b76ba05-3b22-123b-94be-00505689b376]: [core] Scheduling deletion of call branch 'mBKQX9KBvtv6p' (via-branch '')
 in 30 seconds
[1650441560.402257] INFO: [9b76ba05-3b22-123b-94be-00505689b376]: [control] Replying to 'delete' from 192.168.33.2:48941 (elapsed time 0.00
0112 sec)
[1650441590.000149] INFO: [9b76ba05-3b22-123b-94be-00505689b376]: [core] Call branch 'mBKQX9KBvtv6p' (via-branch '') deleted, no more branc
hes remaining
[1650441590.000190] INFO: [9b76ba05-3b22-123b-94be-00505689b376]: [core] Final packet stats:
[1650441590.000195] INFO: [9b76ba05-3b22-123b-94be-00505689b376]: [core] --- Tag 'mBKQX9KBvtv6p', created 0:38 ago for branch ''
[1650441590.000197] INFO: [9b76ba05-3b22-123b-94be-00505689b376]: [core] ---     subscribed to ''
[1650441590.000199] INFO: [9b76ba05-3b22-123b-94be-00505689b376]: [core] ---     subscription for ''
[1650441590.000204] INFO: [9b76ba05-3b22-123b-94be-00505689b376]: [core] ------ Media #1 (audio over RTP/AVP) using unknown codec
[1650441590.000211] INFO: [9b76ba05-3b22-123b-94be-00505689b376]: [core] --------- Port    192.168.33.2:20012 <>  192.168.40.216:36994, SSR
C 0, 0 p, 0 b, 0 e, 38 ts
[1650441590.000215] INFO: [9b76ba05-3b22-123b-94be-00505689b376]: [core] --------- Port    192.168.33.2:20013 <>  192.168.40.216:36995 (RTC
P), SSRC 0, 0 p, 0 b, 0 e, 38 ts
[1650441590.000218] INFO: [9b76ba05-3b22-123b-94be-00505689b376]: [core] --- Tag '', created 0:38 ago for branch ''
[1650441590.000221] INFO: [9b76ba05-3b22-123b-94be-00505689b376]: [core] ---     subscribed to 'mBKQX9KBvtv6p'
[1650441590.000222] INFO: [9b76ba05-3b22-123b-94be-00505689b376]: [core] ---     subscription for 'mBKQX9KBvtv6p'
[1650441590.000225] INFO: [9b76ba05-3b22-123b-94be-00505689b376]: [core] ------ Media #1 (audio over RTP/AVP) using unknown codec
[1650441590.000229] INFO: [9b76ba05-3b22-123b-94be-00505689b376]: [core] --------- Port    192.168.33.2:20000 <>                :0    , SSR
C 0, 0 p, 0 b, 0 e, 38 ts
[1650441590.000232] INFO: [9b76ba05-3b22-123b-94be-00505689b376]: [core] --------- Port    192.168.33.2:20001 <>                :0     (RTC
```

**Details**
<!--
Details about the content of the PR - is it a bug fix, a new feature or perhaps a hack? Explain the **motivation** for making this change.
What existing problem does the pull request solve? Is this a particular problem (i.e. only some particular scenarios are affected, only some UACs, etc) or a generic one?
Do not assume others understand what you're trying to do and provide as much information as you may have.
-->

i use rtpengine_play_media in onreply router.  

```
onreply_route[tm_onreply]{
    route(check_source);

    fix_nated_contact();

    route(change_sdp, "answer");
    route(r_ring_back);
}

route[r_ring_back]{
    xlog("LOG_PREFIX enter ringback route");

    if (isflagset("IS_FROM_EDGE")) {
        return(-1);
    }

    $var(rs) = $(rs{s.int});

    xlog("LOG_PREFIX r_ring_back $var(rs) from_tag=$ft to_tag=$tt");

    if ($var(rs) >= 180 && $var(rs) <= 183) {
        xlog("LOG_PREFIX play ringback");
        rtpengine_play_media("from-tag=$ft file=CF_RINGBACK_FILE");
        return(1);
    }

    if ($var(rs) >= 200 ) {
        xlog("LOG_PREFIX stop ringback");
        rtpengine_stop_media("from-tag=$ft file=CF_RINGBACK_FILE");
        return(1);
    }
}
```

**Solution**
<!-- Explain how your PR fixes the problem. Are there any remaining concerns that might need to be addressed? -->

so I change the rtpengine.c, and test it in my compute, then the audio can play correctly. 

**Compatibility**
<!-- Does your change break other scenarios, or do they need to be migrated in order to work similarly? -->

**Closing issues**
<!-- Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). -->
