### PR TITLE
ip_addr: simplify check for RFC 1918

### DIFF
--- a/ip_addr.c
+++ b/ip_addr.c
@@ -188,7 +188,7 @@ int ip_addr_is_1918(str *s_ip)
 
 	/* is it an IPv4 address? */
 	if ( (ip=str2ip(s_ip))==NULL )
-		return -1;
+		return 0;
 
 	netaddr = ntohl(ip->u.addr32[0]);
 
@@ -197,7 +197,7 @@ int ip_addr_is_1918(str *s_ip)
 			return 1;
 	}
 
-	return -1;
+	return 0;
 }
 
 

--- a/modules/nat_traversal/nat_traversal.c
+++ b/modules/nat_traversal/nat_traversal.c
@@ -747,9 +747,6 @@ get_contact_uri(struct sip_msg* msg, struct sip_uri *uri, contact_t **_c)
     return True;
 }
 
-
-#define is_private_address(x) (ip_addr_is_1918(x)==1 ? 1 : 0)
-
 // Test if address of signaling is different from address in 1st Via field
 static Bool
 test_source_address(struct sip_msg *msg)
@@ -775,7 +772,7 @@ test_private_contact(struct sip_msg *msg)
     if (!get_contact_uri(msg, &uri, &contact))
         return False;
 
-    return is_private_address(&(uri.host));
+    return ip_addr_is_1918(&(uri.host));
 }
 
 
@@ -783,7 +780,7 @@ test_private_contact(struct sip_msg *msg)
 static Bool
 test_private_via(struct sip_msg *msg)
 {
-    return is_private_address(&(msg->via1->host));
+    return ip_addr_is_1918(&(msg->via1->host));
 }
 
 

--- a/modules/nathelper/nathelper.c
+++ b/modules/nathelper/nathelper.c
@@ -794,7 +794,7 @@ sdp_1918(struct sip_msg* msg)
 		if (pf != AF_INET || isnulladdr(&ip, pf))
 			return 0;
 
-		ret |= (ip_addr_is_1918(&ip) == 1) ? 1 : 0;
+		ret |= ip_addr_is_1918(&ip);
 	}
 
 	return ret;
@@ -807,7 +807,7 @@ static int
 via_1918(struct sip_msg* msg)
 {
 
-	return (ip_addr_is_1918(&(msg->via1->host)) == 1) ? 1 : 0;
+	return ip_addr_is_1918(&(msg->via1->host));
 }
 
 /*

--- a/transformations.c
+++ b/transformations.c
@@ -2001,7 +2001,7 @@ int tr_eval_ip(struct sip_msg *msg, tr_param_t *tp,int subtype,
 			if(!(val->flags&PV_VAL_STR))
 				val->rs.s = int2str(val->ri, &val->rs.len);
 
-			val->ri = (ip_addr_is_1918(&(val->rs))==1) ? 1 : 0;
+			val->ri = ip_addr_is_1918(&(val->rs));
 
 			val->flags = PV_TYPE_INT|PV_VAL_INT|PV_VAL_STR;
 			val->rs.s = int2str(val->ri, &val->rs.len);


### PR DESCRIPTION
This function is used everywhere as follows:

```c
flag = (ip_addr_is_1918(x)==1) ? 1 : 0;
```

Let's just make it return the expected 0 or 1.

Signed-off-by: Peter Lemenkov <lemenkov@gmail.com>