### PR TITLE
Fix -Werror=format-security

### DIFF
--- a/menuconfig/curses.c
+++ b/menuconfig/curses.c
@@ -89,7 +89,7 @@ again:
 
 	/* print title in colour */
 	attron(COLOR_PAIR(1));
-	mvprintw(HIGH_NOTICE_Y,max_x/2-20,menu->parent?menu->parent->name:"OpenSIPS Main Configuration Menu");
+	mvprintw(HIGH_NOTICE_Y,max_x/2-20,"%s",menu->parent?menu->parent->name:"OpenSIPS Main Configuration Menu");
 	/* print footer */
 	print_notice(NOTICE_Y,NOTICE_X,0,"Press h for navigation help.");
 	attroff(COLOR_PAIR(1));
@@ -205,7 +205,7 @@ again:
 
 	/* print title in colour */
 	attron(COLOR_PAIR(1));
-	mvprintw(HIGH_NOTICE_Y,max_x/2-20,menu->name);
+	mvprintw(HIGH_NOTICE_Y,max_x/2-20,"%s",menu->name);
 	attroff(COLOR_PAIR(1));
 
 	if (should_scroll) {
@@ -248,7 +248,7 @@ again:
 	/* print current item description */
 	if (current->description) {
 		attron(COLOR_PAIR(1));
-		print_notice(NOTICE_Y,NOTICE_X,0,current->description);
+		print_notice(NOTICE_Y,NOTICE_X,0,"%s",current->description);
 		attroff(COLOR_PAIR(1));
 	}
 


### PR DESCRIPTION
```
make[1]: Entering directory '/builddir/build/BUILD/opensips-3.1.9/menuconfig'
gcc -O2 -flto=auto -ffat-lto-objects -fexceptions -g -grecord-gcc-switches -pipe -Wall -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2 -Wp,-D_GLIBCXX_ASSERTIONS -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -fstack-protector-strong -specs=/usr/lib/rpm/redhat/redhat-annobin-cc1 -m64 -mtune=generic -fasynchronous-unwind-tables -fstack-clash-protection -fcf-protection -g -Wall -DMENUCONFIG_CFG_PATH=\"/usr/share/opensips//menuconfig_templates/\" -DMENUCONFIG_GEN_PATH=\"/usr/etc/opensips/\" -DMENUCONFIG_HAVE_SOURCES=0    -c -o cfg.o cfg.c
gcc -O2 -flto=auto -ffat-lto-objects -fexceptions -g -grecord-gcc-switches -pipe -Wall -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2 -Wp,-D_GLIBCXX_ASSERTIONS -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -fstack-protector-strong -specs=/usr/lib/rpm/redhat/redhat-annobin-cc1 -m64 -mtune=generic -fasynchronous-unwind-tables -fstack-clash-protection -fcf-protection -g -Wall -DMENUCONFIG_CFG_PATH=\"/usr/share/opensips//menuconfig_templates/\" -DMENUCONFIG_GEN_PATH=\"/usr/etc/opensips/\" -DMENUCONFIG_HAVE_SOURCES=0    -c -o curses.o curses.c
curses.c: In function 'draw_sibling_menu':
curses.c:92:75: error: format not a string literal and no format arguments [-Werror=format-security]
   92 |         mvprintw(HIGH_NOTICE_Y,max_x/2-20,menu->parent?menu->parent->name:"OpenSIPS Main Configuration Menu");
      |                                                                           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
curses.c: In function 'draw_item_list':
curses.c:208:9: error: format not a string literal and no format arguments [-Werror=format-security]
  208 |         mvprintw(HIGH_NOTICE_Y,max_x/2-20,menu->name);
      |         ^~~~~~~~
curses.c:251:17: error: format not a string literal and no format arguments [-Werror=format-security]
  251 |                 print_notice(NOTICE_Y,NOTICE_X,0,current->description);
      |                 ^~~~~~~~~~~~
cc1: some warnings being treated as errors
make[1]: *** [<builtin>: curses.o] Error 1
make[1]: Leaving directory '/builddir/build/BUILD/opensips-3.1.9/menuconfig'
make: *** [Makefile:482: opensipsmc] Error 2
```

Signed-off-by: Peter Lemenkov <lemenkov@gmail.com>