### PR TITLE
[db_oracle] Do not change asynch mode when connection lost.

### DIFF
--- a/modules/db_oracle/asynch.c
+++ b/modules/db_oracle/asynch.c
@@ -189,9 +189,9 @@ sword begin_timelimit(ora_con_t* con, int connect)
 }
 
 
-static sword remap_status(ora_con_t* con, sword status)
+static sword remap_status(ora_con_t* con, sword status, sword *errcode)
 {
-	sword code;
+	sword code = 0;
 
 	if (   status == OCI_ERROR
 	    && OCIErrorGet(con->errhp, 1, NULL, &code,
@@ -200,6 +200,7 @@ static sword remap_status(ora_con_t* con, sword status)
 	{
 		status = OCI_STILL_EXECUTING;
 	}
+	if (errcode) *errcode = code;
 	return status;
 }
 
@@ -214,7 +215,7 @@ int wait_timelimit(ora_con_t* con, sword status)
 	if (!cur_asynch_mode)
 		return 0;
 
-	if (remap_status(con, status) != OCI_STILL_EXECUTING)
+	if (remap_status(con, status, NULL) != OCI_STILL_EXECUTING)
 		return 0;
 
 	gettimeofday(&cur, NULL);
@@ -230,12 +231,12 @@ int wait_timelimit(ora_con_t* con, sword status)
 int done_timelimit(ora_con_t* con, sword status)
 {
 	int ret = 0;
+	sword code;
 
 	if (!cur_asynch_mode)
 		return 0;
 
-	if (remap_status(con, status) == OCI_STILL_EXECUTING) {
-		sword code;
+	if (remap_status(con, status, &code) == OCI_STILL_EXECUTING) {
 
 		status = OCIBreak(con->svchp, con->errhp);
 		if (status != OCI_SUCCESS)
@@ -256,8 +257,8 @@ int done_timelimit(ora_con_t* con, sword status)
 		db_oracle_disconnect(con);
 		++ret;
 	} else {
-		status = change_mode(con);
-		if (status != OCI_SUCCESS) {
+		if (!db_oracle_connection_lost(code) &&
+				(status = change_mode(con)) != OCI_SUCCESS) {
 			LM_ERR("driver: %s\n", db_oracle_error(con, status));
 			++ret;
 		} else {

--- a/modules/db_oracle/dbase.c
+++ b/modules/db_oracle/dbase.c
@@ -63,7 +63,17 @@ static const char* db_oracle_errorinfo(ora_con_t* con)
 	if (OCIErrorGet(con->errhp, 1, NULL, &errcd,
 			(OraText*)errbuf, sizeof(errbuf),
 			OCI_HTYPE_ERROR) != OCI_SUCCESS) errbuf[0] = '\0';
-	else switch (errcd) {
+	else if (db_oracle_connection_lost(errcd)) {
+		LM_ERR("conneciom dropped\n");
+		db_oracle_disconnect(con);
+	}
+
+	return errbuf;
+}
+
+int db_oracle_connection_lost(sword errcode)
+{
+	switch (errcode) {
 	case 28:	/* your session has been killed */
 	case 30:	/* session ID does not exists */
 	case 31:	/* session marked for kill */
@@ -113,13 +123,10 @@ static const char* db_oracle_errorinfo(ora_con_t* con)
 	case 12561:	/* tns unknown error */
 	case 12608:	/* tns send timeount */
 	case 12609:	/* tns receive timeount */
-	    LM_ERR("conneciom dropped\n");
-	    db_oracle_disconnect(con);
-	default:
-		break;
+		return 1;
 	}
 
-	return errbuf;
+	return 0;
 }
 
 const char* db_oracle_error(ora_con_t* con, sword status)

--- a/modules/db_oracle/ora_con.h
+++ b/modules/db_oracle/ora_con.h
@@ -98,4 +98,9 @@ sword db_oracle_reconnect(ora_con_t* con);
  */
 const char* db_oracle_error(ora_con_t* con, sword status);
 
+/*
+ * Does the error code indicate that the connection has been lost
+ */
+int db_oracle_connection_lost(sword errcode);
+
 #endif /* ORA_CON_H */


### PR DESCRIPTION
**Summary**

The PR try closes https://github.com/OpenSIPS/opensips/issues/2846.

**Details**

According to the contents of the paragraph "Setting Blocking Modes" at [OCI Programming Basics](http://www.cis.famu.edu/support/10g/Oracle_Database_10g/doc/appdev.102/b14250/oci02bas.htm),
We must set OCI_ATTR_NONBLOCKING_MODE attribute only after OCISessionBegin() or OCILogon2() has been called. Otherwise, an error will be returned.

In my test, when the connection lost due to a network error,
change OCI_ATTR_NONBLOCKING_MODE attribute also cause an error,
the error is ORA-03126 in my test.

In the case, the function done_timelimit will always fail with ORA-03126 error, 
and the con->errhp will overwritten with the new error code, 
the error code is not considered as a connection loss,
and subsequent operations will always throw this error,
and the lost connection never reconnect.

**Solution**

In the done_timelimit function, don't call change_mode function when the db connection lost, so the function do not override the error, and return success, the caller can continue to check the error, and detect that whether need to reconnect the database.
