### PR TITLE
Add `avp_shuffle` function

### DIFF
--- a/modules/avpops/avpops_impl.c
+++ b/modules/avpops/avpops_impl.c
@@ -1036,6 +1036,49 @@ error:
 	return -1;
 }
 
+int ops_shuffle_avp( struct sip_msg* msg, struct fis_param* src)
+{
+	struct usr_avp *src_avp, *rnd_avp;
+	struct usr_avp *temp_avp = NULL;
+	int_str src_val, rnd_val;
+	unsigned short avp_type;
+	int avp_name;
+	int n, rnd_idx;
+
+	/* get avp src name */
+	if(avpops_get_aname(msg, src, &avp_name, &avp_type)!=0)
+	{
+		LM_ERR("failed to get src AVP name\n");
+		goto error;
+	}
+
+	/* count AVPs */
+	n = 0;
+	while ((temp_avp=search_first_avp(avp_type, avp_name, NULL, temp_avp)) != 0)
+		n++;
+
+	/* randomize AVPs */
+	for ( ; n>1; n-- ) {
+		rnd_idx = random() % n;
+		if (rnd_idx == (n-1))
+			continue;
+
+		LM_DBG("swapping [%d] <--> [%d]\n", (n-1), rnd_idx);
+
+		src_avp = search_index_avp(avp_type, avp_name, &src_val, (n-1));
+		rnd_avp = search_index_avp(avp_type, avp_name, &rnd_val, rnd_idx);
+
+		if ( replace_avp(avp_type|(rnd_avp->flags&AVP_VAL_STR), avp_name, rnd_val, (n-1))==-1 ||
+					replace_avp(avp_type|(src_avp->flags&AVP_VAL_STR), avp_name, src_val, rnd_idx)==-1 ) {
+			LM_ERR("failed to swap avp\n");
+			goto error;
+		}
+	}
+
+	return 1;
+error:
+	return -1;
+}
 
 #define STR_BUF_SIZE  1024
 static char str_buf[STR_BUF_SIZE];

--- a/modules/avpops/avpops_impl.h
+++ b/modules/avpops/avpops_impl.h
@@ -150,6 +150,9 @@ int ops_delete_avp(struct sip_msg* msg,
 int ops_copy_avp(struct sip_msg* msg, struct fis_param* name1,
 								struct fis_param* name2);
 
+int ops_shuffle_avp(struct sip_msg* msg,
+								struct fis_param *param);
+
 int ops_pushto_avp(struct sip_msg* msg, struct fis_param* dst,
 								struct fis_param* ap);
 

--- a/modules/avpops/doc/avpops_admin.xml
+++ b/modules/avpops/doc/avpops_admin.xml
@@ -980,6 +980,45 @@ if(is_avp_set("$avp(foo)"))
 				</programlisting>
 			</example>
 		</section>
+		<section id="func_avp_shuffle" xreflabel="avp_shuffle()">
+			<title>
+				<function moreinfo="none">avp_shuffle(name)
+				</function>
+			</title>
+			<para>
+			Randomly shuffles AVPs with <emphasis>name</emphasis>.
+			</para>
+			<para>Meaning of the parameters is as follows:</para>
+			<itemizedlist>
+			<listitem>
+				<para><emphasis>name (string, no expand)</emphasis> - name of AVP to shuffle.
+				Parameter syntax is:
+				<itemizedlist>
+					<listitem><para><emphasis>
+					name = avp_name
+					</emphasis></para></listitem>
+				</itemizedlist>
+				</para>
+			</listitem>
+			</itemizedlist>
+			<para>
+			This function can be used from REQUEST_ROUTE, FAILURE_ROUTE,
+			BRANCH_ROUTE, LOCAL_ROUTE and ONREPLY_ROUTE.
+			</para>
+			<example>
+				<title><function>avp_shuffle</function> usage</title>
+				<programlisting format="linespecific">
+...
+$avp(foo) := "str1";
+$avp(foo)  = "str2";
+$avp(foo)  = "str3";
+xlog("Initial AVP list is: $(avp(foo)[*])\n");       # str3 str2 str1
+if(avp_shuffle("$avp(foo)"))
+    xlog("Shuffled AVP list is: $(avp(foo)[*])\n");  # str1, str3, str2 (for example)
+...
+				</programlisting>
+			</example>
+		</section>
 		<section id="func_avp_print" xreflabel="avp_print()">
 			<title>
 				<function moreinfo="none">avp_print()

--- a/usr_avp.c
+++ b/usr_avp.c
@@ -187,7 +187,7 @@ struct usr_avp *search_index_avp(unsigned short flags,
 {
 	struct usr_avp *avp = NULL;
 
-	while ( (avp=search_first_avp( flags, name, 0, avp))!=0 ) {
+	while ( (avp=search_first_avp( flags, name, val, avp))!=0 ) {
 		if( index == 0 ){
 			return avp;
 		}


### PR DESCRIPTION
**Summary**
Adds utility function to shuffle AVPs.  I think you can do similar logic with the `set_select_weight` but this wrapper is handy to randomize in place.

**Example Usage**
```
$avp(foo) := "str1";
$avp(foo) = "str2";
$avp(foo) = "str3";
xlog("Initial AVP list is: $(avp(foo)[*])\n");       # str3 str2 str1
if(avp_shuffle("$avp(foo)"))
    xlog("Shuffled AVP list is: $(avp(foo)[*])\n");  # str1, str3, str2 (for example)
```
