### PR TITLE
Fix problem where incorrect NOTIFYs are sent

### DIFF
--- a/modules/presence/presentity.c
+++ b/modules/presence/presentity.c
@@ -630,7 +630,12 @@ int update_presentity(struct sip_msg* msg, presentity_t* presentity,
 			}
 			*sent_reply= 1;
 
-			if(publ_notify(presentity, pres_uri, body.s ? &body : 0,
+			/* If we do not have a body to NOTIFY, rely solely on
+			 * the NOTIFY from the DB right below
+			 * Otherwise, expired dialog presentities that gets
+			 * deleted will trigger a NOTIFY with an old state.
+			 */
+			if(body.s && publ_notify(presentity, pres_uri, &body,
 			&presentity->old_etag, rules_doc, NULL, 1, NULL) < 0)
 			{
 				LM_ERR("while sending notify\n");


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!
In order to consider and evaluate your PR, it is mandatory to provide detailed information about (1) what is the issue the PR addresses, (2) how the PR is solving the issue (logic and coding), (3) what are (if any) limitations of the proposed PR and (4) if there are any known side-effects/ backward compatibility issues/SIP interoperability issues.
Note that if the PR is missing information, it might take longer to be merged, as extra resources have to be allocated by the maintainers to reverse engineer the changes, understand them, understand the motivation, etc. That is why it is important to provide as much information as possible.
-->

**Summary**
When a presentity expires, opensips will clean it correctly. In case of
dialog event presentities, it is necessary to notify that the dialog
event has expired.

**Details**
To do so, opensips 3 will generate a NOTIFY from the DB as the original
NOTIFY request does not have a body resulting from a PUBLISH. In that
case, we had two NOTIFY requests following up eachother, one with an
incorrect old state/body caused by the old presentity that was expiring.
