### PR TITLE
Fix in-dialog ACK being relayed with a wrong CSEQ

### DIFF
--- a/modules/dialog/dlg_handlers.c
+++ b/modules/dialog/dlg_handlers.c
@@ -2129,12 +2129,8 @@ after_unlock5:
 
 			dlg_lock (d_table, d_entry);
 
-			if (dlg->legs[dst_leg].last_gen_cseq ||
-			dlg->legs[dst_leg].last_inv_gen_cseq ) {
-				if (dlg->legs[dst_leg].last_inv_gen_cseq)
-					update_val = dlg->legs[dst_leg].last_inv_gen_cseq;
-				else
-					update_val = dlg->legs[dst_leg].last_gen_cseq;
+			if (dlg->legs[dst_leg].last_gen_cseq) {
+				update_val = dlg->legs[dst_leg].last_gen_cseq;
 				dlg_unlock( d_table, d_entry );
 
 				if (update_msg_cseq(req,0,update_val) != 0) {


### PR DESCRIPTION
**Summary**
Fixes wrong CSEQ on ACK requests

**Details**
There are cases where opensips can handle a reINVITE before the ACK that
acknowledges the previous INVITE/200 OK exchange.

In that case, the ACK would be relayed with the reINVITE CSEQ, leading
to interoperability issues.

**Solution**
We now never use the generated invite cseq for ACK requests. This change
also works with reINVITE pings.

It seems the problem was introduced in
27b0b21b2f2aa7b29fdaf0b7bc35274979fc55b0

**Closing issues**
Closes #1071

<!--
Thanks for submitting a pull request!
In order to consider and evaluate your PR, it is mandatory to provide detailed information about (1) what is the issue the PR addresses, (2) how the PR is solving the issue (logic and coding), (3) what are (if any) limitations of the proposed PR and (4) if there are any known side-effects/ backward compatibility issues/SIP interoperability issues.
Note that if the PR is missing information, it might take longer to be merged, as extra resources have to be allocated by the maintainers to reverse engineer the changes, understand them, understand the motivation, etc. That is why it is important to provide as much information as possible.
-->


<!-- Summary of the PR - what the PR is aiming to solve -->


<!--
Details about the content of the PR - is it a bug fix, a new feature or perhaps a hack? Explain the **motivation** for making this change.
What existing problem does the pull request solve? Is this a particular problem (i.e. only some particular scenarios are affected, only some UACs, etc) or a generic one?
Do not assume others understand what you're trying to do and provide as much information as you may have.
-->


<!-- Explain how your PR fixes the problem. Are there any remaining concerns that might need to be addressed? -->

**Compatibility**
<!-- Does your change break other scenarios, or do they need to be migrated in order to work similarly? -->


<!-- Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). -->
