### PR TITLE
Fix pua_dialoginfo not sending PUBLISH in some cases

### DIFF
--- a/modules/pua/pua.c
+++ b/modules/pua/pua.c
@@ -731,6 +731,11 @@ static void hashT_clean(unsigned int ticks,void *param)
 					p= p->next;
 					continue;
 				}
+				/* the presentity is not expired yet */
+				else if (p->expires + 5 >= now) {
+					p= p->next;
+					continue;
+				}
 
 				LM_DBG("Found expired: uri= %.*s\n", p->pres_uri->len,
 						p->pres_uri->s);


### PR DESCRIPTION
This fixes a problem where pua_dialoginfo does not send a PUBLISH in
some cases when a dialog is terminated before having been confirmed.

It occurs when a presentity can not be found in the hash when the
PUBLISH is supposed to happen.

The reason is that the send_publish_int function explicitely prevents
sending a PUBLISH with expires 0 and an empty body when the hash does
not contain the corresponding presentity.

The reason why it happens is the result of a race condition between the
PUBLISH and hashT_clean. When a dialog PUBLISH is emitted to indicate
the early state because of a 18x Ringing, the expires is set to
fr_inv_timer, which is in general rather short if you implement call
forwarding on no answer for example.

If that timer is set to 30 seconds, which is the default value at which
the hashT_clean occurs by default, hashT_clean will not refresh the
PUBLISH because it expires between the current hashT_clean execution and
the next one. Worse, it will even delete it even though it is not
expired yet. In other words, if hashT_clean is fired before the call is
rejected due to fr_inv_timer, and the presentity is supposed to expire
before the next hashT_clean execution, it is deleted from the hash. The
consequence is that the PUBLISH indicated the terminated state can not
be sent.

To fix that problem, we make sure presentities are deleted only if there
are really expired.
