### PR TITLE
Fix profile sizes count on restart

### DIFF
--- a/modules/dialog/dlg_db_handler.c
+++ b/modules/dialog/dlg_db_handler.c
@@ -487,9 +487,9 @@ void read_dialog_profiles(char *b, int l, struct dlg_cell *dlg,int double_check,
 				continue;
 			}
 		}
-		if (set_dlg_profile( dlg, profile->has_value ? &val : NULL, profile,
-		    is_replicated) < 0 )
-			LM_ERR("failed to add to profile, skipping....\n");
+		if (load_dlg_profile( dlg, profile->has_value ? &val : NULL, profile,
+				      is_replicated, 1) < 0 )
+		  	LM_ERR("failed to add to profile, skipping....\n");
 		next:
 			;
 	} while(p!=end);

--- a/modules/dialog/dlg_profile.h
+++ b/modules/dialog/dlg_profile.h
@@ -84,6 +84,9 @@ struct dialog_list{
 typedef int (*set_dlg_profile_f)(struct dlg_cell *dlg, str *value,
                         struct dlg_profile_table *profile, char is_replicated);
 
+typedef int (*load_dlg_profile_f)(struct dlg_cell *dlg, str *value,
+                        struct dlg_profile_table *profile, char is_replicated, int no_increment_cached);
+
 typedef int (*unset_dlg_profile_f)(struct dlg_cell *dlg, str *value,
                          struct dlg_profile_table *profile);
 
@@ -111,6 +114,9 @@ struct dlg_profile_table *get_dlg_profile(str *name);
 void destroy_linkers(struct dlg_cell *dlg);
 void destroy_linkers_unsafe(struct dlg_cell *dlg);
 void remove_dlg_prof_table(struct dlg_cell *dlg, char cachedb_dec);
+
+int load_dlg_profile(struct dlg_cell *dlg, str *value,
+		struct dlg_profile_table *profile, char is_replicated, int no_increment_cached);
 
 int set_dlg_profile(struct dlg_cell *dlg, str *value,
 		struct dlg_profile_table *profile, char is_replicated);


### PR DESCRIPTION
In case of OpenSIPS crash or reload, profile sizes were incremented on
reload when the dialog module was reloading the ongoing dialogs from the
database.

In case a cache module is used to store profile values, we might expect
it to be correct when OpenSIPS crashes. If we increment the profile size
when OpenSIPS restarts, then the counters are incremented twice for the
same dialog.
