### PR TITLE
presence: Add old-etag to event

### DIFF
--- a/modules/presence/doc/presence_admin.xml
+++ b/modules/presence/doc/presence_admin.xml
@@ -991,6 +991,9 @@ opensips-cli -x mi pres_expose presence ^sip:10\.0\.5\.[0-9]*
 				<emphasis>etag</emphasis> - the entity tag
 			</para></listitem>
 			<listitem><para>
+				<emphasis>old_etag</emphasis> - the entity tag to be refreshed
+			</para></listitem>
+			<listitem><para>
 				<emphasis>body</emphasis> - the body of the
 					PUBLISH request
 			</para></listitem>

--- a/modules/presence/presentity.c
+++ b/modules/presence/presentity.c
@@ -560,7 +560,7 @@ int update_presentity(struct sip_msg* msg, presentity_t* presentity,
 			LM_DBG("pres <%.*s> my turn is %d, current turn is %d\n",pres_uri.len,
 				pres_uri.s, turn, p->current_turn);
 
-			/* wait to get our turn as order of handling pubishs
+			/* wait to get our turn as order of handling publish
 			   (need to wait the ongoing published to terminate
 			   before starting */
 			while (p && turn!=p->current_turn) {
@@ -892,7 +892,7 @@ error:
 }
 
 
-/*  This is just a wrappter over "update_presentity" to be able to export the
+/*  This is just a wrapper over "update_presentity" to be able to export the
  *  function via the internal API - basically provides the "publishing" support
  *  without actually having the PUBLISH SIP request, but directly a presentity
  */
@@ -936,7 +936,7 @@ int pres_htable_restore(void)
 		goto error;
 	}
 
-	/* select the whole tabel and all the columns */
+	/* select the whole table and all the columns */
 	if (DB_CAPABILITY(pa_dbf, DB_CAP_FETCH))
 	{
 		if(pa_dbf.query(pa_db,0,0,0,result_cols, 0,


### PR DESCRIPTION
**Summary**
The events emitted from the presence module are missing the old_etag value of the presentity. 

**Details**
In order to track presentities fully the events should contain the old_etag. This allows the consumer to keep track of the old/new tag and properly update its state. Without the old_etag un-publishing a presentity can not be tracked.

**Solution**
Emit publish event after update is successful, and include the `old_etag` field in it.

Also fixed a few typos in the presence module comments.

**Compatibility**
I would think adding an extra field to the events does not break compatibility.

**Closing issues**
