### PR TITLE
fix t_wait_no_more_branches behaviour

### DIFF
--- a/modules/tm/t_fwd.c
+++ b/modules/tm/t_fwd.c
@@ -1029,7 +1029,7 @@ int t_wait_no_more_branches( struct cell *t)
 	 * number of branches) */
 	for ( b=t->nr_of_outgoings-1; b>=t->first_branch ; b-- ) {
 		if (t->uac[b].flags & T_UAC_IS_PHONY) {
-			t->uac[b].br_flags=t->nr_of_outgoings+1;
+			t->uac[b].br_flags=t->nr_of_outgoings;
 			return 0;
 		}
 	}
@@ -1091,11 +1091,11 @@ int t_inject_branch( struct cell *t, struct sip_msg *msg, int flags)
 		which_cancel( t, &cancel_bm );
 	}
 
-	if (flags&TM_INJECT_FLAG_LAST)
-		t_wait_no_more_branches(t);
-
 	/* generated the new branches, without branch counter reset */
 	rc = t_forward_nonack( t, &faked_req , NULL, 0, 1/*locked*/ );
+
+	if ((rc==1) && (flags&TM_INJECT_FLAG_LAST))
+		t_wait_no_more_branches(t);
 
 	/* do we have to cancel the existing branches before injecting new ones? */
 	if (flags&TM_INJECT_FLAG_CANCEL) {


### PR DESCRIPTION

1. Issue: https://github.com/OpenSIPS/opensips/issues/2891
2. Logic:
a) t_wait_no_more_branches(): max number of allowed branches is set to the current number of branches
b) but really it add +1 to the max number of allowed branches. This leads to that OS consider that we are waiting for one more branch. Such logic comes from t_inject_branch() internal logic. First, OS calles t_wait_no_more_branches() inside t_inject_branch() and add +1 to max allowed branches before branch will be injected.
It works right for t_inject_branch() logic. But when we call "naked" t_wait_no_more_branches() in route script - OS adds +1 branch to max allowed, so we can never reach one branch yet. 
c) in my fix t_wait_no_more_branches(): max number of allowed branches is set to the current number of branches (but not add +1 to max allowed branches
d) reffering to "c", we need to change logic in t_inject_branches()
e) in my fix, first we create branch inside t_inject_branches() and only if branch was created clear - call t_wait_no_more_branches(). So OS set number of allowed branches to the current number of branches properly

**Details**
Issue: https://github.com/OpenSIPS/opensips/issues/2891
1. Problem. In Push Notification scenario (and any other), when we call t_wait_for_new_branches() in route script, we are able to stop wait for branches by calling t_wait_no_more_branches in ONREPLY_ROUTE, FAILURE_ROUTE etc as mentioned in docs.
It means that when t_wait_no_more_branches() was calling and all branches got 4XX status, call will be terminated.
But in real it does'nt happen due to the wrong logic in t_wait_no_more_branches() internal code. So call is active until FR_INV_TIMEOT expires.
2. Fix. Now t_wait_no_more_branches() stops waiting for new branches correctly. And call will be terminated if all branches will reach 4XX status.

**Solution**
1. PR fix properly max allowed branches when calling t_wait_no_more_branches()
2. PR corrects t_inject_branches() according to above item.

**Closing issues**
Issue: https://github.com/OpenSIPS/opensips/issues/2891

**Summary**
PR will fix behaviour of t_wait_no_more_branches() calling inside route script.
OS will set number of allowed branches to the current number of branches properly.
When all branches will reach 4XX status, call will be terminated. (In current implementation OS is still waiting for one more branch)