### PR TITLE
Corrected 'getting contacts' log

### DIFF
--- a/lib/reg/lookup.c
+++ b/lib/reg/lookup.c
@@ -178,7 +178,7 @@ fetch_urecord:
 
 		aor_uri = &branch_uris[idx];
 		LM_DBG("getting contacts from aor [%.*s] "
-		       "in branch %d\n", aor.len, aor.s, idx);
+		       "in branch %d\n", aor_uri->len, aor_uri->s, idx);
 
 		if (extract_aor(aor_uri, &aor, NULL, &call_id, reg_use_domain) < 0) {
 			LM_ERR("failed to extract address of record for branch uri\n");


### PR DESCRIPTION
**Summary**
Hi this is a small correction in a log line in lib/reg/lookup.c

The line intends to print the current AOR being processed but it is actually using the old AOR that was already processed.

**Details**
I detected this issue originally in opensips 3.2 commit b243666098be44226ade6a7df2b62851efcb5de8 as it was causing confusion to understand debug logs.
