### PR TITLE
dialog: try to get a options/reinvite last direction

### DIFF
--- a/modules/dialog/dlg_timer.c
+++ b/modules/dialog/dlg_timer.c
@@ -840,7 +840,17 @@ void dlg_options_routine(unsigned int ticks , void * attr)
 		shm_free(it);
 		it = curr;
 
-		init_dlg_term_reason(dlg,"Ping Timeout",sizeof("Ping Timeout")-1);
+		if (dlg->legs[DLG_CALLER_LEG].reply_received == DLG_PING_FAIL)
+			init_dlg_term_reason(dlg,"Downstream Ping Timeout",sizeof("Downstream Ping Timeout")-1);
+		else if (dlg->legs[callee_idx(dlg)].reply_received == DLG_PING_FAIL)
+			init_dlg_term_reason(dlg,"Upstream Ping Timeout",sizeof("Upstream Ping Timeout")-1);
+		else{
+			LM_WARN("Ping Timeout: flags[%u] caller rr[%u] callee rr[%u]\n",
+					dlg->flags,
+					dlg->legs[DLG_CALLER_LEG].reply_received,
+					dlg->legs[callee_idx(dlg)].reply_received);
+			init_dlg_term_reason(dlg,"Ping Timeout",sizeof("Ping Timeout")-1);
+		}
 		/* FIXME - maybe better not to send BYE both ways as we know for
 		 * sure one end in down . */
 		dlg_end_dlg(dlg,0,1);
@@ -937,7 +947,17 @@ void dlg_reinvite_routine(unsigned int ticks , void * attr)
 		shm_free(it);
 		it = curr;
 
-		init_dlg_term_reason(dlg,"ReINVITE Ping Timeout",sizeof("ReINVITE Ping Timeout")-1);
+		if (dlg->legs[DLG_CALLER_LEG].reinvite_confirmed == DLG_PING_FAIL)
+			init_dlg_term_reason(dlg,"Downstream ReINVITE Ping Timeout",sizeof("Downstream ReINVITE Ping Timeout")-1);
+		else if (dlg->legs[callee_idx(dlg)].reinvite_confirmed == DLG_PING_FAIL)
+			init_dlg_term_reason(dlg,"Upstream ReINVITE Ping Timeout",sizeof("Upstream ReINVITE Ping Timeout")-1);
+		else{
+			LM_WARN("Ping Timeout: flags[%u] caller rc[%u] callee rc[%u]\n",
+					dlg->flags,
+					dlg->legs[DLG_CALLER_LEG].reinvite_confirmed,
+					dlg->legs[callee_idx(dlg)].reinvite_confirmed);
+			init_dlg_term_reason(dlg,"ReINVITE Ping Timeout",sizeof("ReINVITE Ping Timeout")-1);
+		}
 		/* FIXME - maybe better not to send BYE both ways as we know for
 		 * sure one end in down . */
 		dlg_end_dlg(dlg,0,1);


### PR DESCRIPTION
**Summary**
This patch adds extra details in case of SIP ping failures within dialog.

**Details**
This patch improves visibility of call disconnection reason/direction in case of SIP ping failures within dialog. Before we lack information about the party which caused timeout ad now we know it. I've added one extra if(..) clause for some unknown case.

Tested in a real environment.