### PR TITLE
EVI: Event subscribers expiry enhancements

### DIFF
--- a/evi/event_interface.c
+++ b/evi/event_interface.c
@@ -595,9 +595,6 @@ static int evi_print_subscriber(mi_item_t *subs_obj, evi_subs_p subs)
 	} else {
 		if (add_mi_string(subs_obj, MI_SSTR("expire"), MI_SSTR("never")) < 0)
 			return -1;
-		/* If an event is never expired then its timeout should be never as well*/
-		if (add_mi_string(subs_obj, MI_SSTR("ttl"), MI_SSTR("never")) < 0)
-			return -1;
 	}
 	/* XXX - does subscription time make sense? */
 

--- a/evi/event_interface.c
+++ b/evi/event_interface.c
@@ -511,6 +511,8 @@ static int evi_print_subscriber(mi_item_t *subs_obj, evi_subs_p subs)
 {
 	evi_reply_sock *sock;
 	str socket;
+	long now;
+	int expiry_countdown;
 
 	if (!subs || !subs->trans_mod || !subs->trans_mod->print) {
 		LM_ERR("subscriber does not have a print method exported\n");
@@ -533,9 +535,11 @@ static int evi_print_subscriber(mi_item_t *subs_obj, evi_subs_p subs)
 			subs->trans_mod->proto.len, subs->trans_mod->proto.s,
 			socket.len, socket.s) < 0)
 		return -1;
-
+	
 	if (sock->flags & EVI_EXPIRE) {
-		if (add_mi_number(subs_obj, MI_SSTR("expire"), sock->expire) < 0)
+		now = time(0);
+		expiry_countdown = sock->expire - (now - subs->reply_sock->subscription_time);
+		if (add_mi_number(subs_obj, MI_SSTR("expire"), expiry_countdown) < 0)
 			return -1;
 	} else {
 		if (add_mi_string(subs_obj, MI_SSTR("expire"), MI_SSTR("never")) < 0)

--- a/evi/event_interface.c
+++ b/evi/event_interface.c
@@ -123,8 +123,49 @@ int evi_raise_event(event_id_t id, evi_params_t* params)
 	set_avp_list(bak_avps);
 
 	return status;
-}
+}/* this function checks the subscribers of an event and remove them if 
+they are past their expiry - dont want to print expired events as well */
+void evi_remove_expired_subs(event_id_t id) {
+	evi_subs_p subs, prev;
+	long now;
 
+	lock_get(events[id].lock);
+	now = time(0);
+	subs = events[id].subscribers;
+	prev = NULL;
+	while (subs) {
+		if (!subs->reply_sock) {
+			LM_ERR("unknown destination\n");
+			continue;
+		}
+		/* check expire */
+		if (!(subs->reply_sock->flags & EVI_PENDING) &&
+			subs->reply_sock->flags & EVI_EXPIRE &&
+			subs->reply_sock->subscription_time +
+			subs->reply_sock->expire < now) {
+			LM_DBG("removing expired subscriber %.*s:%.*s:%d for event %.*s\n",
+				subs->trans_mod->proto.len,subs->trans_mod->proto.s,
+				subs->reply_sock->address.len, subs->reply_sock->address.s,
+				subs->reply_sock->port,events[id].name.len,events[id].name.s);
+			if (subs->trans_mod && subs->trans_mod->free)
+				subs->trans_mod->free(subs->reply_sock);
+			else
+				shm_free(subs->reply_sock);
+			if (!prev) {
+				events[id].subscribers = subs->next;
+				shm_free(subs);
+				subs = events[id].subscribers;
+			} else {
+				prev->next = subs->next;
+				shm_free(subs);
+				subs = prev->next;
+			}
+			continue;
+		}
+		subs = subs->next;
+	}
+	lock_release(events[id].lock);
+}
 /* XXX: this function should release its parameters before exiting */
 int evi_raise_event_msg(struct sip_msg *msg, event_id_t id, evi_params_t* params)
 {
@@ -538,8 +579,14 @@ static int evi_print_subscriber(mi_item_t *subs_obj, evi_subs_p subs)
 	
 	if (sock->flags & EVI_EXPIRE) {
 		now = time(0);
+		/* calculate the remaining time for the subscriber to be expired */
 		expiry_countdown = sock->expire - (now - subs->reply_sock->subscription_time);
-		if (add_mi_number(subs_obj, MI_SSTR("expire"), expiry_countdown) < 0)
+		if (expiry_countdown > 0) {
+			if (add_mi_number(subs_obj, MI_SSTR("expire"), expiry_countdown) < 0)
+				return -1;
+		}
+		/* Mark event as expired if time-to-expire is reached*/
+		if (add_mi_string(subs_obj, MI_SSTR("expire"), MI_SSTR("expired")) < 0)
 			return -1;
 	} else {
 		if (add_mi_string(subs_obj, MI_SSTR("expire"), MI_SSTR("never")) < 0)
@@ -681,6 +728,8 @@ mi_response_t *w_mi_subscribers_list(const mi_params_t *params,
 		goto error;
 
 	for (i = 0; i < events_no; i++) {
+		/* before printing the subs list check for any expired subscribers and remove them*/
+		evi_remove_expired_subs(events[i].id);
 		if (!events[i].subscribers)
 			continue;
 
@@ -707,13 +756,16 @@ mi_response_t *w_mi_subscribers_list_1(const mi_params_t *params,
 {
 	str event_s;
 	evi_event_p event;
-
+	int evid;
 	if (get_mi_string_param(params, "event", &event_s.s, &event_s.len) < 0)
 		return init_mi_param_error();
 
 	event = evi_get_event(&event_s);
 	if (!event)
 		return init_mi_error(404, MI_SSTR("Event not published"));
+	/* get the event id & before printing the subs list check for any expired subscribers and remove them*/
+	evid = evi_get_id(&event_s);
+	evi_remove_expired_subs(evid);
 
 	return mi_subscribers_list(event, NULL);
 }
@@ -725,13 +777,16 @@ mi_response_t *w_mi_subscribers_list_2(const mi_params_t *params,
 	str subs_s;
 	evi_event_p event;
 	evi_subs_p subs;
-
+	int evid;
 	if (get_mi_string_param(params, "event", &event_s.s, &event_s.len) < 0)
 		return init_mi_param_error();
 
 	event = evi_get_event(&event_s);
 	if (!event)
 		return init_mi_error(404, MI_SSTR("Event not published"));
+	/* get the event id & before printing the subs list check for any expired subscribers and remove them*/
+	evid = evi_get_id(&event_s);
+	evi_remove_expired_subs(evid);
 
 	if (get_mi_string_param(params, "socket", &subs_s.s, &subs_s.len) < 0)
 		return init_mi_param_error();

--- a/evi/event_interface.c
+++ b/evi/event_interface.c
@@ -123,7 +123,8 @@ int evi_raise_event(event_id_t id, evi_params_t* params)
 	set_avp_list(bak_avps);
 
 	return status;
-}/* this function checks the subscribers of an event and remove them if 
+}
+/* this function checks the subscribers of an event and remove them if 
 they are past their expiry - dont want to print expired events as well */
 void evi_remove_expired_subs(event_id_t id) {
 	evi_subs_p subs, prev;
@@ -576,7 +577,6 @@ static int evi_print_subscriber(mi_item_t *subs_obj, evi_subs_p subs)
 			subs->trans_mod->proto.len, subs->trans_mod->proto.s,
 			socket.len, socket.s) < 0)
 		return -1;
-	
 	if (sock->flags & EVI_EXPIRE) {
 		now = time(0);
 		/* calculate the remaining time for the subscriber to be expired */


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!
In order to consider and evaluate your PR, it is mandatory to provide detailed information about (1) what is the issue the PR addresses, (2) how the PR is solving the issue (logic and coding), (3) what are (if any) limitations of the proposed PR and (4) if there are any known side-effects/ backward compatibility issues/SIP interoperability issues.
Note that if the PR is missing information, it might take longer to be merged, as extra resources have to be allocated by the maintainers to reverse engineer the changes, understand them, understand the motivation, etc. That is why it is important to provide as much information as possible.
-->

**Summary**
<!-- Summary of the PR - what the PR is aiming to solve -->
Following issues or rather minor inconvenience were faced when printing "subscribers_list" from MI modules.

1 - The subscribers of any event could only print their static time of subscription i.e 3600 and from output of MI command users can't tell when the subscription will actually expire. or how long this subscription is valid for.
2 - The "expired" subscription to an event continue to print their subscription data with original values when "subscriber_list" MI command is executed.
3 - The expired subscription to an event was ONLY removed when that event is raised. Until the event is raised the MI command keep printing the possibly expired subscription which is incorrect information to the users.

**Details**
<!--
Details about the content of the PR - is it a bug fix, a new feature or perhaps a hack? Explain the **motivation** for making this change.
What existing problem does the pull request solve? Is this a particular problem (i.e. only some particular scenarios are affected, only some UACs, etc) or a generic one?
Do not assume others understand what you're trying to do and provide as much information as you may have.
-->
Writing an external monitor of opensips Events Interface which can create new subscriptions to events when they are expired or not found, The outputs of the MI command "opensips-cli -x mi subscribers_list" continued to give wrong information which made if impossible to judge when an event subscription will expire. Hence I present this PR with following results:

1 - EVI: prints the subscriber expiry as a countdown value relevant to the subscriber's original expiry time.
2 - EVI: marks the subscriber as "expired" if it goes beyond its expiry time
3 - EVI: remove the expired subscribers from the list if MI command "subscribers_list" is executed.

**Solution**
<!-- Explain how your PR fixes the problem. Are there any remaining concerns that might need to be addressed? -->
1 - Create a function `evi_remove_expired_subs` that takes the event-id and parses all its subscribes; for each subscriber its subscription_time is added with expiry time and compared with current time. 
2 - if the time difference goes negative then the subscriber is removed from the list and subs list is assigned back to the event.
3 - Before printing the subscribers of an event, the event-id is passed to this new function to refresh its subscribers list.

**Compatibility**
<!-- Does your change break other scenarios, or do they need to be migrated in order to work similarly? -->
Tested with opensips 3.3.1
```
version: opensips 3.3.1 (x86_64/linux)
flags: STATS: On, EXTRA_DEBUG, DISABLE_NAGLE, USE_MCAST, SHM_MMAP, PKG_MALLOC, Q_MALLOC, F_MALLOC, HP_MALLOC, DBG_MALLOC, CC_O0, FAST_LOCK-ADAPTIVE_WAIT
ADAPTIVE_WAIT_LOOPS=1024, MAX_RECV_BUFFER_SIZE 262144, MAX_LISTEN 16, MAX_URI_SIZE 1024, BUF_SIZE 65535
poll method support: poll, epoll, sigio_rt, select.
git revision: d187a0bd5
main.c compiled on 18:01:16 Sep 20 2022 with gcc 8
```
**Closing issues**
<!-- Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). -->
