### PR TITLE
b2b: fix BYE request pending

### DIFF
--- a/modules/b2b_entities/dlg.c
+++ b/modules/b2b_entities/dlg.c
@@ -1135,7 +1135,7 @@ logic_notify:
 
 				if(dlg->uas_tran && dlg->uas_tran!=T_UNDEFINED)
 				{
-					if(dlg->uas_tran->uas.request)
+					if(method_value != METHOD_BYE && dlg->uas_tran->uas.request)
 					/* there is another transaction for which no reply
 					 * was sent out */
 					{


### PR DESCRIPTION
I offer to not generate 491 request pending when BYE come even if there is race condition. BYE must finish dialog. In another case we get hung calls.