### PR TITLE
b2b: inherit sending socket when create new dialog after negative ACK

### DIFF
--- a/modules/b2b_entities/dlg.c
+++ b/modules/b2b_entities/dlg.c
@@ -3196,6 +3196,7 @@ dummy_reply:
 			new_dlg->prev = dlg->prev;
 			new_dlg->add_dlginfo = dlg->add_dlginfo;
 			new_dlg->last_method = dlg->last_method;
+			new_dlg->send_sock = dlg->send_sock;
 			new_dlg->tracer = dlg->tracer;
 
 //			dlg = b2b_search_htable(htable, hash_index, local_index);


### PR DESCRIPTION
This small fix allows to inherit sending socket when create new dialog using previous dialog data.