### PR TITLE
Exported t_lookup_callid

### DIFF
--- a/modules/tm/t_lookup.h
+++ b/modules/tm/t_lookup.h
@@ -104,6 +104,7 @@ typedef int (*tislocal_f)(struct sip_msg*);
 typedef int (*tnewtran_f)(struct sip_msg*);
 typedef int (*tget_ti_f)(struct sip_msg*, unsigned int*, unsigned int*);
 typedef int (*tlookup_ident_f)(struct cell**, unsigned int, unsigned int);
+typedef int (*tlookup_callid_f)(struct cell** trans, str callid, str cseq);
 
 int t_is_local(struct sip_msg*);
 int t_get_trans_ident(struct sip_msg* p_msg,

--- a/modules/tm/tm.c
+++ b/modules/tm/tm.c
@@ -654,6 +654,7 @@ int load_tm( struct tm_binds *tmb)
 	tmb->t_check_trans = (cmd_function)t_check_trans;
 	tmb->t_get_trans_ident = t_get_trans_ident;
 	tmb->t_lookup_ident = t_lookup_ident;
+	tmb->t_lookup_callid = t_lookup_callid;
 	tmb->t_gett = get_t;
 	tmb->t_get_e2eackt = get_e2eack_t;
 	tmb->t_get_picked = t_get_picked_branch;

--- a/modules/tm/tm_load.h
+++ b/modules/tm/tm_load.h
@@ -65,6 +65,7 @@ struct tm_binds {
 	tislocal_f       t_is_local;
 	tget_ti_f        t_get_trans_ident;
 	tlookup_ident_f  t_lookup_ident;
+	tlookup_callid_f t_lookup_callid;
 	taddblind_f      t_addblind;
 	treply_f         t_reply_unsafe;
 


### PR DESCRIPTION
**Summary**
Function t_lookup_callid is currently not available via load_tm()

**Details**
This PR just exposes the function in the struct tm_binds.
I built it and tested with a custom module and it works.
