### PR TITLE
Adding tm function t_reply_by_callid

### DIFF
--- a/modules/tm/README
+++ b/modules/tm/README
@@ -72,6 +72,7 @@ tm Module
 
               1.4.21. t_flush_flags()
               1.4.22. t_anycast_replicate()
+              1.4.23  t_reply_by_callid()
 
         1.5. Exported Pseudo-Variables
 
@@ -173,6 +174,7 @@ tm Module
    1.42. t_write_req/unix usage
    1.43. t_flush_flags usage
    1.44. t_anycast_replicate usage
+   1.45. t_reply_by_callid usage
 
 Chapter 1. Admin Guide
 
@@ -1370,6 +1372,58 @@ if (is_method("ACK|CANCEL") && !t_check_trans()) {
         t_anycast_replicate();
         exit;
 }
+...
+
+1.4.23. t_reply_by_callid(code, reason_phrase, [callid], [cseq])
+
+   This function is used to send a reply to
+   an existing INVITE transaction.
+   The usual use case is when opensips is used as an UAS
+   and when an INVITE is receveid, it is "parked" locally on
+   opensips by replying to it with
+   t_reply(180, "Ringing" or t_reply(183, "Session Progress")
+   and later we need to handle CANCEL or BYE for it and send
+   '487 Request Terminated' to the original INVITE transaction.
+
+   The callid and cseq used to identify the transaction
+   will be obtained from the current messsage being processed.
+   But they can be passed explicitly so that for example we can
+   handle a BYE where the cseq must be the cseq
+   of the INVITE minus one.
+
+   This function can be used from REQUEST_ROUTE.
+
+   Example 1.45. t_reply_by_callid usage
+...
+
+route{
+	if($rU == "LOCAL_PARK") {
+		if(is_method("INVITE")) {
+			$T_fr_timeout = 10;
+			$T_fr_inv_timeout = 10;
+			append_to_reply("Contact: sip:LOCAL_PARK@$socket_in(ip):$socket_in(port)\r\n");
+			t_reply(180, "Ringing");
+			t_wait_for_new_branches();
+		} else if(is_method("CANCEL")) {
+			if(!t_reply_by_callid(487, "Request Terminated")) {
+				sl_send_reply(481, "Call Leg/Transaction Does Not Exist");
+			} else {
+				sl_send_reply(200, "OK");
+			}
+		} else if(is_method("BYE")) {
+			$var(prev_cseq) = ($(cs{s.int}) - 1);
+			if(!t_reply_by_callid(487, "Request Terminated", , $var(prev_cseq))) {
+				sl_send_reply(481, "Call Leg/Transaction Does Not Exist");
+			} else {
+				sl_send_reply(200, "OK");
+			}
+		} else if(is_method("ACK")) {
+			t_relay();
+		}
+		exit;
+	}
+}
+
 ...
 
 1.5. Exported Pseudo-Variables


### PR DESCRIPTION
**Summary**
This is to permit to use opensips as a UAS and "park" incoming calls on it by replying to INVITEs using t_reply(180, "Ringing") or t_reply(183, "Session Progress"). Then later when we get CANCEL or BYE for the INVITE transaction, to be able to send a reply to that transaction (that would be usually a "487 Request Terminated'").

This is based on this discussion:
  https://opensips.org/pipermail/users/2022-October/046310.html
(I'm not the OP, I just have a similar use case).

**Details**
This PR implements new function t_reply_by_callid on module tm.
Basically, I want to act on an INVITE and reply to it with '180 Ringing'
Then, later when the INVITE is cancelled by CANCEL or BYE, I want to be able to reply with '487 Request Terminated' to the original transaction.
The current way to permit this (as discussed in the mailing list thread is):
  - create a transaction for the INVITE and store the trans_id in a database with the callid as retrieval key.
  - when we receive CANCEL/BYE mark the transaction as cancelled in the database
  - periodically check the database and send either '408 Request Timeout' or '487 Request Terminated'

So the motivation is:
  - to avoid having to poll a database for pending transactions
  - to avoid having to use mi interface (requiring an external app/script)

**Solution**
With t_reply_by_callid, everything can be done by opensips.cfg without need of database or external app/script.

Sample usage: https://pastebin.com/dhKm6TDi

I tested 3 scenarios using sipp:
  - INVITE and CANCEL (https://pastebin.com/6b5AHyYh)
  - INVITE, no answer and BYE (https://pastebin.com/HXD0WuBC)
  - INVITE and transaction timeout (https://pastebin.com/0WbfGRxr)

Functional tests were performed respectively as:
```
sipp -s LOCAL_PARK -i 127.0.0.1 -p 5002 -sf invite_cancel_uac.xml -r 200 -l 600 127.0.0.1 -m 1

sipp -s LOCAL_PARK -i 127.0.0.1 -p 5004 -sf invite_no_answer_bye_uac.xml -r 200 -l 600 127.0.0.1 -m 1

sipp -s LOCAL_PARK -i 127.0.0.1 -p 5006 -sf invite_timeout_uac.xml -r 200 -l 600 127.0.0.1 -m 1
```
Then I removed the "-m 1" option which limits sipp to generate a single call and the load tests (ongoing) reached millions of calls without issues so far.

**Compatibility**
There should be no compatibility issues as we don't modify any existing underlying function. 
We just create and expose a new function using the code that already exist. 

