### PR TITLE
Fix To: header and sockets for b2b transfer

### DIFF
--- a/modules/b2b_logic/records.h
+++ b/modules/b2b_logic/records.h
@@ -55,6 +55,7 @@ typedef struct b2bl_entity_id
 	struct b2bl_entity_id* peer;
 	struct b2bl_entity_id* prev;
 	struct b2bl_entity_id* next;
+	struct socket_info* force_send_socket;
 }b2bl_entity_id_t;
 
 struct b2bl_new_entity {


### PR DESCRIPTION
This patch fixes the case for transfers. When new leg for transfer created, it generates To: header using RURI of previous header. In case if RURI has some parameters, new To: also has these parameters. It breaks Microsoft Teams transfers. We need make To: header and skip RURI parameters to avoid of this. Also this patch helps to set sockets properly for transfer legs.