### PR TITLE
Fix crashes in dialog module and in acc module when current context is not initialized or destroyed. Refactor and enhance call_center module for horizontal scale and reduce complexity of popular operations

### DIFF
--- a/modules/acc/acc_logic.c
+++ b/modules/acc/acc_logic.c
@@ -220,7 +220,7 @@ acc_ctx_t* try_fetch_ctx(void)
 	struct cell* t;
 	struct dlg_cell* dlg;
 
-	if ((ret = ACC_GET_CTX()) == NULL) {
+	if (current_processing_ctx && (ret = ACC_GET_CTX()) == NULL) {
 		if (!tmb.t_gett || (t = tmb.t_gett()) == T_UNDEFINED)
 			t = NULL;
 

--- a/modules/b2b_logic/logic.c
+++ b/modules/b2b_logic/logic.c
@@ -1560,15 +1560,24 @@ int _b2b_handle_reply(struct sip_msg *msg, b2bl_tuple_t *tuple,
 				}
 				else
 				{
-					ret = run_init_negreply_cb(msg, tuple, entity);
-					if (ret == -1) {
-						goto error;
-					} else if (ret == 0) {
-						SEND_REPLY_TO_PEER_OR_GOTO_DONE;
-						LM_DBG("Negative reply [%d] - delete[%p]\n",
-							statuscode, tuple);
-						b2b_mark_todel(tuple);
-					}
+                    /* this may be a 487 reply because an entity has sent CANCEL */
+                    if (tuple->state == B2B_CANCEL_STATE && statuscode == 487) {
+                        SEND_REPLY_TO_PEER_OR_GOTO_DONE;
+                        LM_DBG("Terminated (due to CANCEL request) reply [%d] - delete[%p]\n",
+                            statuscode, tuple);
+                        b2b_mark_todel(tuple);
+                    }
+                    else {
+                        ret = run_init_negreply_cb(msg, tuple, entity);
+                        if (ret == -1) {
+                            goto error;
+                        } else if (ret == 0) {
+                            SEND_REPLY_TO_PEER_OR_GOTO_DONE;
+                            LM_DBG("Negative reply [%d] - delete[%p]\n",
+                                statuscode, tuple);
+                            b2b_mark_todel(tuple);
+                        }
+                    }
 				}
 				b2bl_print_tuple(tuple, L_DBG);
 			}

--- a/modules/b2b_logic/records.c
+++ b/modules/b2b_logic/records.c
@@ -80,10 +80,10 @@ void b2bl_print_tuple(b2bl_tuple_t* tuple, int level)
 
 	if(tuple)
 	{
-		LM_GEN1(level, "[%p]->[%.*s] to_del=[%d] lifetime=[%d]"
+		LM_GEN1(level, "[%p]->[%.*s] to_del=[%d] lifetime=[%d] state=[%d]"
 			" bridge_entities[%p][%p][%p]\n",
 			tuple, tuple->key->len, tuple->key->s,
-			tuple->to_del, tuple->lifetime,
+			tuple->to_del, tuple->lifetime, tuple->state,
 			tuple->bridge_entities[0], tuple->bridge_entities[1],
 			tuple->bridge_entities[2]);
 		for (index = 0; index < MAX_B2BL_ENT; index++)

--- a/modules/call_center/call_center.c
+++ b/modules/call_center/call_center.c
@@ -898,8 +898,13 @@ int b2bl_callback_customer(b2bl_cb_params_t *params, unsigned int event)
 		lock_set_release( data->call_locks, call->lock_idx );
 		return 1;
 	}
+    
+    if (event == B2B_RE_INVITE_CB) {
+        lock_set_release( data->call_locks, call->lock_idx );
+		return 1;
+    }
 
-	/* we are not interested in B2B_RE_INVITE_CB and B2B_CONFIRMED_CB
+	/* we are not interested in B2B_CONFIRMED_CB
 	 * events, just in the BYEs from media/agent side */
 	if (event!=B2B_BYE_CB) {
 		lock_set_release( data->call_locks, call->lock_idx );

--- a/modules/call_center/call_center.c
+++ b/modules/call_center/call_center.c
@@ -1378,9 +1378,14 @@ static void cc_timer_agents(unsigned int ticks, void* param)
 				dest = flow->recordings[AUDIO_FLOW_ID];
 
 			// make a copy for destination to agent
-			out.len = OUT_BUF_LEN(dest.len);
+			out.len = OUT_BUF_LEN(dest.len + (flow ? (strlen(RURI_PARAM_FID) + flow->id.len) : 0));
 			out.s = out_buf;
-			memcpy( out.s, dest.s, out.len);
+			memcpy( out.s, dest.s, dest.len < out.len ? dest.len : out.len);
+            // append flow id to RURI
+            if (flow && dest.len + strlen(RURI_PARAM_FID) + flow->id.len <= out.len) {
+                memcpy(out.s + dest.len, RURI_PARAM_FID, strlen(RURI_PARAM_FID));
+                memcpy(out.s + dest.len + strlen(RURI_PARAM_FID), flow->id.s, flow->id.len);
+            }
 			
 			call->prev_state = call->state;
 			if(!flow || !flow->recordings[AUDIO_FLOW_ID].len) {

--- a/modules/call_center/cc_data.h
+++ b/modules/call_center/cc_data.h
@@ -216,6 +216,8 @@ struct cc_call {
 	struct cc_call *prev_list;
 };
 
+#define RURI_PARAM_FID ";cc_fid="
+
 #define is_call_in_queue(_data, _call)  ((_call)->lower_in_queue || (_call)->higher_in_queue || \
 		(_data->queue.first==_call && _data->queue.last==_call))
 

--- a/modules/call_center/cc_data.h
+++ b/modules/call_center/cc_data.h
@@ -264,6 +264,12 @@ void agent_raise_event(struct cc_agent *agent, struct cc_call *call);
 
 void clean_cc_old_data(struct cc_data *data);
 
+void clean_cc_old_data_by_flow(struct cc_data *data, str *flow_name);
+
+void clean_cc_data_by_agent(struct cc_data *data, str *agent_id);
+
+void clean_cc_all_data(struct cc_data *data);
+
 void clean_cc_unref_data(struct cc_data *data);
 
 int cc_queue_push_call(struct cc_data *data, struct cc_call *call, int top);

--- a/modules/call_center/cc_data.h
+++ b/modules/call_center/cc_data.h
@@ -62,6 +62,7 @@ struct cc_flow {
 	unsigned long processed_calls;
 	unsigned int logged_agents;
 	unsigned int ongoing_calls;
+    struct cc_agent *last_selected_agent; //round-robin cursor to pick an agent for a call
 	/* statistics */
 	stat_var *st_incalls;
 	stat_var *st_dist_incalls;
@@ -254,7 +255,7 @@ struct cc_call* new_cc_call(struct cc_data *data, struct cc_flow *flow,
 void free_cc_call(struct cc_data *data, struct cc_call *call);
 
 struct cc_agent* get_free_agent_by_skill(struct cc_data *data,
-		unsigned int skill);
+		struct cc_flow *flow);
 
 void log_agent_to_flows(struct cc_data *data, struct cc_agent *agent,
 		int login);
@@ -297,6 +298,14 @@ static inline void remove_cc_agent(struct cc_data* data,
 				data->last_online_agent = prev_agent;
 		}
 	}
+    
+    if (agent->loged_in) { // update if agent was the cursor of any flow
+        struct cc_flow *flow;
+        for(flow=data->flows; flow; flow=flow->next) {
+            if (agent == flow->last_selected_agent)
+                flow->last_selected_agent = prev_agent;
+        }
+    }
 }
 
 

--- a/modules/call_center/cc_db.h
+++ b/modules/call_center/cc_db.h
@@ -60,7 +60,8 @@ int cc_connect_rt_db(const str *rt_db_url);
 void cc_close_db(void);
 void cc_close_rt_db(void);
 
-int cc_load_db_data( struct cc_data *data);
+int cc_load_db_data( struct cc_data *data, str *flow_name);
+int cc_load_db_agent_data( struct cc_data *data, str *agent_id);
 
 int cc_write_cdr( str *un, str *fid, str *aid, int type,
 		int rt, int wt, int tt , int pt, int rej, int fst, int cid);
@@ -72,6 +73,7 @@ int cc_db_update_call(struct cc_call *call);
 int cc_db_delete_call(struct cc_call *call);
 int cc_db_restore_calls( struct cc_data *data);
 void cc_db_update_agent_wrapup_end(struct cc_agent* agent);
+void cc_db_update_agent_logstate(str* agent_id, int loged_in);
 int b2bl_callback_customer(b2bl_cb_params_t *params, unsigned int event);
 
 #endif

--- a/modules/call_center/cc_db.h
+++ b/modules/call_center/cc_db.h
@@ -49,6 +49,10 @@ extern str ccf_m_queue_column;
 extern str ccf_m_dissuading_column;
 extern str ccf_m_flow_id_column;
 
+extern str cc_skill_table_name;
+extern str ccs_agentid_column;
+extern str ccs_skill_column;
+
 int init_cc_db(const str *db_url);
 int init_cc_acc_db(const str *acc_db_url);
 int init_cc_rt_db(const str *rt_db_url);

--- a/modules/call_center/cc_queue.c
+++ b/modules/call_center/cc_queue.c
@@ -141,7 +141,7 @@ int cc_call_state_machine(struct cc_data *data, struct cc_call *call,
 			s = int2str((unsigned long)pos, &len);
 		else
 			s = NULL;
-		leg->s = (char*)pkg_malloc(out->len+(s?(queue_pos_param.len+len+2):0));
+		leg->s = (char*)pkg_malloc(out->len+(s?(queue_pos_param.len+len+2):0) + strlen(RURI_PARAM_FID) + call->flow.len);
 		if (leg->s) {
 			leg->len = out->len;
 			memcpy(leg->s,out->s,out->len);
@@ -153,6 +153,12 @@ int cc_call_state_machine(struct cc_data *data, struct cc_call *call,
 				memcpy(leg->s+leg->len, s, len);
 				leg->len += len;
 			}
+            // append flow id to RURI
+            memcpy(leg->s+leg->len, RURI_PARAM_FID, strlen(RURI_PARAM_FID));
+            leg->len += strlen(RURI_PARAM_FID);
+            memcpy(leg->s+leg->len, call->flow.s, call->flow.len);
+            leg->len += call->flow.len;
+            
 			call->prev_state = call->state;
 			call->state = state;
 			return 0;

--- a/modules/call_center/cc_queue.c
+++ b/modules/call_center/cc_queue.c
@@ -79,7 +79,7 @@ int cc_call_state_machine(struct cc_data *data, struct cc_call *call,
 			/* search for an available agent */
 			/* if we have a flow_id recording, we push the call in the queue */
 			if (!call->flow->recordings[AUDIO_FLOW_ID].len)
-				agent = get_free_agent_by_skill( data, call->flow->skill);
+				agent = get_free_agent_by_skill( data, call->flow);
 			else
 				agent = NULL;
 			if (agent) {

--- a/modules/dialog/dlg_handlers.c
+++ b/modules/dialog/dlg_handlers.c
@@ -598,13 +598,22 @@ static void dlg_onreply(struct cell* t, int type, struct tmcb_params *param)
 		event = DLG_EVENT_TDEL;
 	} else if (param->code<200) {
 		event = DLG_EVENT_RPL1xx;
-		ctx_lastdstleg_set(DLG_CALLER_LEG);
+        
+        if (current_processing_ctx) {
+            ctx_lastdstleg_set(DLG_CALLER_LEG);
+        }
 	} else if (param->code<300) {
 		event = DLG_EVENT_RPL2xx;
-		ctx_lastdstleg_set(DLG_CALLER_LEG);
+        
+        if (current_processing_ctx) {
+            ctx_lastdstleg_set(DLG_CALLER_LEG);
+        }
 	} else {
 		event = DLG_EVENT_RPL3xx;
-		ctx_lastdstleg_set(DLG_CALLER_LEG);
+        
+        if (current_processing_ctx) {
+            ctx_lastdstleg_set(DLG_CALLER_LEG);
+        }
 	}
 
 	next_state_dlg(dlg, event, DLG_DIR_UPSTREAM, &old_state, &new_state,

--- a/scripts/mysql/call_center-create.sql
+++ b/scripts/mysql/call_center-create.sql
@@ -23,10 +23,17 @@ CREATE TABLE cc_agents (
     agentid CHAR(128) NOT NULL,
     location CHAR(128) NOT NULL,
     logstate INT(10) UNSIGNED DEFAULT 0 NOT NULL,
-    skills CHAR(255) NOT NULL,
     wrapup_end_time INT(11) DEFAULT 0 NOT NULL,
     wrapup_time INT(11) DEFAULT 0 NOT NULL,
     CONSTRAINT unique_agentid UNIQUE (agentid)
+) ENGINE=InnoDB;
+
+INSERT INTO version (table_name, table_version) values ('cc_skills','1');
+CREATE TABLE cc_skills (
+    id INT(10) UNSIGNED AUTO_INCREMENT PRIMARY KEY NOT NULL,
+    agentid CHAR(128) NOT NULL,
+    skill CHAR(64) NOT NULL,
+    CONSTRAINT unique_agentid_skill UNIQUE (agentid, skill)
 ) ENGINE=InnoDB;
 
 INSERT INTO version (table_name, table_version) values ('cc_cdrs','1');
@@ -65,4 +72,5 @@ CREATE TABLE cc_calls (
 ) ENGINE=InnoDB;
 
 CREATE INDEX b2buaid_idx ON cc_calls (b2buaid);
+CREATE INDEX skill_idx ON cc_skills (skill);
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!
In order to consider and evaluate your PR, it is mandatory to provide detailed information about (1) what is the issue the PR addresses, (2) how the PR is solving the issue (logic and coding), (3) what are (if any) limitations of the proposed PR and (4) if there are any known side-effects/ backward compatibility issues/SIP interoperability issues.
Note that if the PR is missing information, it might take longer to be merged, as extra resources have to be allocated by the maintainers to reverse engineer the changes, understand them, understand the motivation, etc. That is why it is important to provide as much information as possible.
-->

**Summary**
* This pull request fixed this issue and related crashed https://github.com/OpenSIPS/opensips/issues/2976.
* And add ability to destroy B2B if a 487 reply received due to CANCEL request.
* This pull request also refactor the flow and agent management of call_center module. This use AVL tree to manage flows and agents which reduce complexity of lookup from O(n) to O(logn). Switch the previous implementation which relays on reference counter (may causes cross reference in further development or hard to implement cluster sync data) to use simple O(logn) lookup. So lookup a flow or agent in thousand of flows/agents now is very cheap.
* The last commit also add ability to do partial db load which aims to support horizontal scale of call_center module.
* This pull request also add another table cc_skills to better support partial load of data but still keep old columns for backward compatibility purpose. The redundant columns will be removed in newer minor version.
* call_center modules now do not load skill data to memory but treats it as abstract data to describe the relationship among flows and agents. Skill data will be processed on load and store only relationships of flow and agent in memory.
* The relationships between flow and agent now use AVL tree & linked list to manage and it's 2 way, so get flows or agent or agents of flows now easier. To be more precise, check a agent in flow has O(logn) complexity, check a flow of a gent has O(number of flow of that agent).
* Support HOLD feature and Session Timers.

**Details**
* In b2b_clean process, the current processing context is NULL and it causes OpenSIPS crash because these module need to write to current context without checking it availability.
* User now can set `dynamic_load` to 1 to enable dynamic load mode, in which all data does not load into memory at startup but only when needed (handle_call is called).

**Closing issues**
`closes #2976 `, `closes #2977`
