### PR TITLE
Fix flag usage in compression module

### DIFF
--- a/modules/compression/compression.c
+++ b/modules/compression/compression.c
@@ -653,7 +653,7 @@ static int mc_compact(struct sip_msg* msg, mc_whitelist_p wh_list, void* flags_p
 		goto error;
 	}
 
-	if (tm_api.t_gett && msg->flags&FL_TM_CB_REGISTERED)
+	if (tm_api.t_gett && msg->msg_flags&FL_TM_CB_REGISTERED)
 		goto error;
 
 	/*register tm callback if tm api */
@@ -661,7 +661,7 @@ static int mc_compact(struct sip_msg* msg, mc_whitelist_p wh_list, void* flags_p
 			tm_api.register_tmcb( msg, 0, TMCB_PRE_SEND_BUFFER,
 				wrap_tm_compact, NULL, 0) != 1) {
 		LM_ERR("failed to add tm TMCB_PRE_SEND_BUFFER callback\n");
-		msg->flags |= FL_TM_CB_REGISTERED;
+		msg->msg_flags |= FL_TM_CB_REGISTERED;
 		goto error;
 	}
 
@@ -1102,7 +1102,7 @@ static int mc_compress(struct sip_msg* msg, int *algo_p, int *flags_p,
 		goto end;
 	}
 
-	if (tm_api.t_gett && msg->flags&FL_TM_CB_REGISTERED) {
+	if (tm_api.t_gett && msg->msg_flags&FL_TM_CB_REGISTERED) {
 		ret = 1;
 		goto end;
 	}
@@ -1112,7 +1112,7 @@ static int mc_compress(struct sip_msg* msg, int *algo_p, int *flags_p,
 			tm_api.register_tmcb( msg, 0, TMCB_PRE_SEND_BUFFER,
 				wrap_tm_compress, NULL, 0) != 1) {
 		LM_ERR("failed to add tm TMCB_PRE_SEND_BUFFER callback\n");
-		msg->flags |= FL_TM_CB_REGISTERED;
+		msg->msg_flags |= FL_TM_CB_REGISTERED;
 		goto end;
 	}
 


### PR DESCRIPTION
The compression module seems to erroneously use the 'flags' field instead of the 'msg_flags' field for tracking if callbacks have already been set on the message.

The 'flags' field is for script level flags (setflag(), isflagset(), etc, script level functions).
This can lead to collisions with script level flags and unexpected behavior. As an example, calls to mc_compact began failing after I had introduced a new flag into my script which caused a collision with the flag used by the compression module.