### PR TITLE
Allow to drop non-provisional message to improve the flexibility and some how compatibility of OpenSIPS to SIP clients

### DIFF
--- a/modules/tm/t_reply.c
+++ b/modules/tm/t_reply.c
@@ -1599,7 +1599,7 @@ int reply_received( struct sip_msg  *p_msg )
 		/* run block - first per branch and then global one */
 		if ( t->uac[branch].on_reply &&
 		(run_top_route(sroutes->onreply[t->uac[branch].on_reply],p_msg)
-		&ACT_FL_DROP) && (msg_status<200) ) {
+		&ACT_FL_DROP) ) {
 			set_route_type(old_route_type);
 			if (onreply_avp_mode) {
 				UNLOCK_REPLIES( t );
@@ -1609,7 +1609,7 @@ int reply_received( struct sip_msg  *p_msg )
 			goto done;
 		}
 		if(t->on_reply && (run_top_route(sroutes->onreply[t->on_reply],p_msg)
-		&ACT_FL_DROP) && (msg_status<200) ) {
+		&ACT_FL_DROP) ) {
 			set_route_type(old_route_type);
 			if (onreply_avp_mode) {
 				UNLOCK_REPLIES( t );

--- a/modules/tm/t_reply.c
+++ b/modules/tm/t_reply.c
@@ -1605,7 +1605,7 @@ int reply_received( struct sip_msg  *p_msg )
 				UNLOCK_REPLIES( t );
 				set_avp_list( backup_list );
 			}
-			LM_DBG("dropping provisional reply %d\n", msg_status);
+			LM_DBG("dropping reply %d\n", msg_status);
 			goto done;
 		}
 		if(t->on_reply && (run_top_route(sroutes->onreply[t->on_reply],p_msg)
@@ -1615,7 +1615,7 @@ int reply_received( struct sip_msg  *p_msg )
 				UNLOCK_REPLIES( t );
 				set_avp_list( backup_list );
 			}
-			LM_DBG("dropping provisional reply %d\n", msg_status);
+			LM_DBG("dropping reply %d\n", msg_status);
 			goto done;
 		}
 		set_route_type(old_route_type);


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!
In order to consider and evaluate your PR, it is mandatory to provide detailed information about (1) what is the issue the PR addresses, (2) how the PR is solving the issue (logic and coding), (3) what are (if any) limitations of the proposed PR and (4) if there are any known side-effects/ backward compatibility issues/SIP interoperability issues.
Note that if the PR is missing information, it might take longer to be merged, as extra resources have to be allocated by the maintainers to reverse engineer the changes, understand them, understand the motivation, etc. That is why it is important to provide as much information as possible.
-->

**Summary**
I personally have no idea while we don't allow script writer to drop non-provisional reply if they intend to. In my company we are facing more than few clients facing the problem while processing 487 reply for their self canceled invite. These clients try to clean up their resources asap when people hangup (I tried pjsua 2.11 and there is that problem too, seem like pjsua 2.12 fixed it), so the next 487 reply make them think that it's a new request from server and does not work properly anymore.

Regarding OpenSIPS, I think flexibility is the difference that people think about so why we restrict people from doing what they intent to if it does not cause any bad expectation.

**Solution**
Remove restriction to allow dropping of any reply no matter what the status code is

**Compatibility**
No backward compatibility problem unless people try to drop non-provisional reply (it does not work before and now work).

**Closing issues**
#2987

**Notes**
If this pull request is approved, I will update the document later
