### PR TITLE
Fix bug that leg_is_answered may return false positive if branch index is greater than allocated leg array

### DIFF
--- a/modules/dialog/dlg_handlers.c
+++ b/modules/dialog/dlg_handlers.c
@@ -435,7 +435,7 @@ static inline void push_reply_in_dialog(struct sip_msg *rpl, struct cell* t,
 
 	/* has the downstream element forked an extra branch starting from ours?
 	 * Treat these extra branches exactly the same (a callee leg) */
-	if (leg_is_answered(&dlg->legs[leg])) {
+	if (leg < dlg->legs_no[DLG_LEGS_ALLOCED] && leg_is_answered(&dlg->legs[leg])) {
 		leg = dlg_clone_callee_leg(dlg, leg);
 		if (leg < 0) {
 			LM_ERR("failed to add callee leg!\n");


### PR DESCRIPTION
**Summary**
The branch index in `push_reply_in_dialog` may be greater than the allocated dialog->leg array, so `leg_is_answered` can access to non-init memory and return false positive.

**Details**
This fix the stacktrace:
```
#0  0x00007f973cd400cc in memcpy (__len=<optimized out>, __src=<optimized out>, __dest=<optimized out>)
    at /usr/include/x86_64-linux-gnu/bits/string_fortified.h:34
#1  shm_str_dup (src=0x7f973d7371f8, dst=0x7f973d736d08) at ../../ut.h:771
#2  dlg_clone_callee_leg (dlg=dlg@entry=0x7f973d725528, cloned_leg_idx=cloned_leg_idx@entry=4) at dlg_hash.c:358
#3  0x00007f973cd56233 in push_reply_in_dialog (mangled_to=0x7ffc39162570, mangled_from=0x7ffc39162560, dlg=<optimized out>, t=<optimized out>, 
    rpl=0x7f977d4c44e8) at dlg_handlers.c:439
#4  dlg_onreply (t=<optimized out>, type=<optimized out>, param=<optimized out>) at dlg_handlers.c:544
#5  0x00007f973a6a5f4c in run_trans_callbacks (type=type@entry=8, trans=trans@entry=0x7f973d8d5250, req=<optimized out>, rpl=rpl@entry=0x7f977d4c44e8, 
    code=code@entry=180) at t_hooks.c:209
#6  0x00007f973a658e3d in relay_reply (t=0x7f973d8d5250, p_msg=<optimized out>, branch=<optimized out>, msg_status=<optimized out>, 
    cancel_bitmap=<optimized out>) at t_reply.c:1288
#7  0x00007f973a65b874 in reply_received (p_msg=0x7f977d4c44e8) at t_reply.c:1660
#8  0x000055d23213d69d in forward_reply ()
#9  0x000055d232122ad1 in receive_msg ()
#10 0x000055d23229595d in ?? ()
#11 0x000055d232278b0a in ?? ()
#12 0x000055d23227a352 in tcp_worker_proc_loop ()
#13 0x000055d232286346 in tcp_start_processes ()
#14 0x000055d2320f1149 in main ()
```

**Solution**
Check if branch index is in allocated dlg->legs before checking `leg_is_answered`

**Compatibility**
No compatibility problem
