### PR TITLE
Fix crash when restore b2b with tracer enabled due to NULL msg

### DIFF
--- a/modules/b2b_logic/records.c
+++ b/modules/b2b_logic/records.c
@@ -328,7 +328,7 @@ b2bl_tuple_t* b2bl_insert_new(struct sip_msg* msg, unsigned int hash_index,
 	tuple->req_routeid = init_params->req_routeid;
 	tuple->reply_routeid = init_params->reply_routeid;
 
-	if (set_tracer_func && msg->msg_flags&tracer_msg_flag_filter)
+	if (set_tracer_func && msg && msg->msg_flags&tracer_msg_flag_filter)
 		tuple->tracer = *set_tracer_func();
 
 	LM_DBG("new tuple [%p]->[%.*s]\n", tuple, b2bl_key->len, b2bl_key->s);


### PR DESCRIPTION
**Summary**
Fix bug when b2b restore entities from database with tracer enabled

**Details**
Fix the backtrace:
```
#0  0x00007f225341a909 in b2bl_insert_new (msg=<optimized out>, hash_index=<optimized out>, init_params=<optimized out>, body=<optimized out>, 
    custom_hdrs=<optimized out>, local_index=<optimized out>, b2bl_key_s=<optimized out>, db_flag=<optimized out>, repl_flag=<optimized out>) at records.c:331
#1  0x00007f225341e2c5 in b2bl_add_tuple (tuple=0x7ffd0553af80) at b2bl_db.c:269
#2  b2b_logic_restore () at b2bl_db.c:487
#3  0x00007f2253406bea in mod_init () at b2b_logic.c:418
```

**Solution**
Make sure `msg` is not NULL

**Compatibility**
No compatibility problem, just a hotfix
