### PR TITLE
3.2 fix tracer crash

### DIFF
--- a/modules/tracer/tracer.c
+++ b/modules/tracer/tracer.c
@@ -1472,7 +1472,7 @@ static struct b2b_tracer* b2b_set_tracer_cb(void)
 	/* as parameter, set the tracing info from the current contect */
 	tracer.param = (void*)info;
 
-	if (tracer.param==NULL) {
+	if (tracer.param==NULL || !info->has_trace_b2b) {
 		tracer.f = NULL;
 		tracer.f_freep = NULL;
 	} else {
@@ -1492,6 +1492,8 @@ static int trace_b2b(struct sip_msg *msg, trace_info_p info)
 	 * install the tracing callback into the B2B logic
 	 */
 	msg->msg_flags |= FL_USE_SIPTRACE;
+    
+    info->has_trace_b2b = 1;
 
 	return 0;
 }

--- a/modules/tracer/tracer.c
+++ b/modules/tracer/tracer.c
@@ -1422,6 +1422,11 @@ static int trace_b2b_transaction(struct sip_msg* msg, void *trans, void* param)
     if (current_processing_ctx) { // There may be no context if b2bl is called in timer job
         SET_TRACER_CONTEXT( info );
     }
+    
+    if (info==NULL || info->instances==NULL) {
+        LM_BUG("No trace instances to process\n");
+		return 0;
+    }
 
 	if (t==T_UNDEFINED) {
 		/* Negative hop-by-hop ACK shouldn't be here */

--- a/modules/tracer/tracer.c
+++ b/modules/tracer/tracer.c
@@ -1417,9 +1417,11 @@ static int trace_b2b_transaction(struct sip_msg* msg, void *trans, void* param)
 {
 	trace_info_p info = (trace_info_p)param;
 	struct cell *t = (struct cell*)trans;
-
-	/* context for the request message */
-	SET_TRACER_CONTEXT( info );
+    
+    /* context for the request message */
+    if (current_processing_ctx) { // There may be no context if b2bl is called in timer job
+        SET_TRACER_CONTEXT( info );
+    }
 
 	if (t==T_UNDEFINED) {
 		/* Negative hop-by-hop ACK shouldn't be here */

--- a/modules/tracer/tracer.c
+++ b/modules/tracer/tracer.c
@@ -2017,7 +2017,7 @@ static int trace_w(struct sip_msg *msg, tlist_elem_p list,
 			msg->REQ_METHOD == METHOD_INVITE && !trace_has_totag(msg)) {
 		LM_DBG("tracing dialog!\n");
 	} else if (trace_flags == TRACE_DIALOG) {
-		LM_DBG("can't trace dialog! Will try to trace transaction\n");
+		LM_WARN("can't trace dialog! Will try to trace transaction\n");
 		trace_flags = TRACE_TRANSACTION;
 	}
 
@@ -2025,7 +2025,7 @@ static int trace_w(struct sip_msg *msg, tlist_elem_p list,
 	msg->first_line.type == SIP_REQUEST) {
 		LM_DBG("tracing transaction!\n");
 	} else if (trace_flags == TRACE_TRANSACTION) {
-		LM_DBG("can't trace transaction! Will trace only this message!\n");
+		LM_WARN("can't trace transaction! Will trace only this message!\n");
 		trace_flags = TRACE_MESSAGE;
 	}
 

--- a/modules/tracer/tracer.c
+++ b/modules/tracer/tracer.c
@@ -1127,6 +1127,34 @@ static void destroy(void)
 	destroy_dyn_tracing();
 }
 
+static void trace_info_ref(trace_info_p _ti, unsigned int _cnt)
+{
+	if (_ti->ref_lock ) {
+		lock_get(_ti->ref_lock);
+		_ti->ref += _cnt;
+		lock_release(_ti->ref_lock);
+	}
+}
+
+static void trace_info_unref(trace_info_p _ti, unsigned int _cnt)
+{
+	int should_free = 0;
+
+	if (_ti->ref_lock ) {
+		lock_get(_ti->ref_lock);
+		_ti->ref -= _cnt;
+		if (_ti->ref == 0)
+			should_free = 1;
+		lock_release(_ti->ref_lock);
+	}
+
+	if (should_free) {
+		lock_dealloc(_ti->ref_lock);
+		shm_free(_ti);
+	}	
+}
+
+
 
 
 static inline int insert_siptrace(st_db_struct_t *st_db,
@@ -1316,8 +1344,6 @@ static void trace_transaction_dlgcb(struct dlg_cell* dlg, int type,
 	trace_info_p info = (trace_info_p)*params->param;
 	int reverte_dir = 0;
 
-	TRACE_FLAG_UNSET(info, TRACE_INFO_TRAN);
-
 	if (dlgb.get_direction()==DLG_DIR_UPSTREAM)
 		reverte_dir = 1;
 
@@ -1364,25 +1390,25 @@ static void free_trace_info_shm(void *param, int type)
 			info->instances = it->next;
 		shm_free(it);
 	}
-	if ((info->flags & ~TRACE_INFO_STAT) == 0)
-		shm_free(param);
+
+	/* TODO - this not 100% handle multiple tracing instances,
+	 * but prevents accessing invalid memory due to refcounting
+	 * simultaneous transactions within the same dialog */
+	trace_info_unref(info,1);
 }
 
 static void free_trace_info_tm(void *param)
 {
-	TRACE_FLAG_UNSET((trace_info_p)param, TRACE_INFO_TRAN);
 	free_trace_info_shm(param, TRACE_TRANSACTION);
 }
 
 static void free_trace_info_b2b(void *param)
 {
-	TRACE_FLAG_UNSET((trace_info_p)param, TRACE_INFO_B2B);
 	free_trace_info_shm(param, TRACE_B2B);
 }
 
 static void free_trace_info_dlg(void *param)
 {
-	TRACE_FLAG_UNSET((trace_info_p)param, TRACE_INFO_DIALOG);
 	free_trace_info_shm(param, TRACE_DIALOG);
 }
 
@@ -1442,7 +1468,7 @@ static struct b2b_tracer* b2b_set_tracer_cb(void)
 		tracer.f = NULL;
 		tracer.f_freep = NULL;
 	} else {
-		TRACE_FLAG_SET(info, TRACE_INFO_B2B);
+		trace_info_ref(info,1);
 		tracer.f = trace_b2b_transaction;
 		tracer.f_freep = free_trace_info_b2b;
 	}
@@ -1468,21 +1494,8 @@ static int trace_transaction(struct sip_msg* msg, trace_info_p info, int reverse
 	if (msg==NULL)
 		return 0;
 
-	if (TRACE_FLAG_ISSET(info, TRACE_INFO_TRAN)) {
-		LM_DBG("transacton callbacks already registered!\n");
-		return 0;
-	}
-
 	/* context for the request message */
 	SET_TRACER_CONTEXT(info);
-
-	/* CANCEL forms a separate transaction, so it ok to install the
-	 * callback again. */
-	if (msg->REQ_METHOD!=METHOD_CANCEL &&
-	TRACE_FLAG_ISSET(info, TRACE_INFO_TRAN)) {
-		LM_DBG("transaction callbacks already registered!\n");
-		return 0;
-	}
 
 	/* allows catching statelessly forwarded ACK in stateful transactions
 	 * and stateless replies */
@@ -1500,19 +1513,13 @@ static int trace_transaction(struct sip_msg* msg, trace_info_p info, int reverse
 		return -1;
 	}
 
-	TRACE_FLAG_SET(info, TRACE_INFO_TRAN);
+	trace_info_ref(info,1);
 	return 0;
 }
 
 static int trace_dialog(struct sip_msg *msg, trace_info_p info)
 {
 	struct dlg_cell* dlg;
-
-	/* only register if callbacks were not previously registered */
-	if (TRACE_FLAG_ISSET(info, TRACE_INFO_DIALOG)) {
-		LM_DBG("dialog callbacks already registered!\n");
-		return 0;
-	}
 
 	if (!dlgb.create_dlg || ! dlgb.get_dlg) {
 		LM_ERR("Can't trace dialog! Api not loaded!\n");
@@ -1540,11 +1547,11 @@ static int trace_dialog(struct sip_msg *msg, trace_info_p info)
 	/* here also free trace info param because we are sure that
 	 * this callback is ran only once - when dialog gets for
 	 * the first time in DELETED state */
-	TRACE_FLAG_SET(info, TRACE_INFO_DIALOG);
+	trace_info_ref(info,1);
 	if(dlgb.register_dlgcb(dlg,DLGCB_TERMINATED,
 				trace_transaction_dlgcb,info,free_trace_info_dlg)!=0) {
 		LM_ERR("failed to register dialog callback\n");
-		TRACE_FLAG_UNSET(info, TRACE_INFO_DIALOG);
+		trace_info_unref(info,1);
 		return -1;
 	}
 
@@ -1887,6 +1894,7 @@ static int sip_trace_handle(struct sip_msg *msg, tlist_elem_p el,
 					pkg_free(instance);
 					return -1;
 				}
+				memset(info, 0, sizeof(trace_info_t));
 			} else {
 				info = shm_malloc(sizeof(trace_info_t));
 				if (!info) {
@@ -1894,8 +1902,22 @@ static int sip_trace_handle(struct sip_msg *msg, tlist_elem_p el,
 					shm_free(instance);
 					return -1;
 				}
+				memset(info, 0, sizeof(trace_info_t));
+				info->ref_lock = lock_alloc(); 
+				if (!info->ref_lock) {
+					LM_ERR("could not allocate lock!\n");
+					shm_free(instance);
+					shm_free(info);
+					return -1;
+				}
+				if (!lock_init(info->ref_lock)) {
+					lock_dealloc(info->ref_lock);
+					LM_ERR("could not init lock!\n");
+					shm_free(instance);
+					shm_free(info);
+					return -1;
+				}
 			}
-			memset(info, 0, sizeof(trace_info_t));
 			SET_TRACER_CONTEXT(info);
 			info->instances = instance;
 		}
@@ -3659,7 +3681,6 @@ int register_traced_type(char* name)
 
 	return id;
 }
-
 
 static int is_id_traced(int id, trace_instance_p info)
 {

--- a/modules/tracer/tracer.c
+++ b/modules/tracer/tracer.c
@@ -1541,15 +1541,19 @@ static int trace_dialog(struct sip_msg *msg, trace_info_p info)
 		LM_ERR("Can't trace dialog! Api not loaded!\n");
 		return -1;
 	}
+    
+    // get current dialog first before create a new one
+    dlg=dlgb.get_dlg();
+    if (!dlg) {
+        if (dlgb.create_dlg(msg, 0)<1) {
+            LM_ERR("failed to create dialog!\n");
+            return -1;
+        }
+        dlg=dlgb.get_dlg();
+    }
 
-	if (dlgb.create_dlg(msg, 0)<1) {
-		LM_ERR("failed to create dialog!\n");
-		return -1;
-	}
-
-	dlg=dlgb.get_dlg();
 	if (dlg==NULL) {
-		LM_CRIT("BUG: no dialog found after create dialog\n");
+		LM_CRIT("BUG: no dialog found\n");
 		return -1;
 	}
 

--- a/modules/tracer/tracer.c
+++ b/modules/tracer/tracer.c
@@ -144,8 +144,7 @@ static int sip_trace_instance(struct sip_msg*, trace_instance_p, int, int);
 static struct b2b_tracer* b2b_set_tracer_cb(void);
 static int trace_b2b(struct sip_msg*, trace_info_p);
 static int trace_dialog(struct sip_msg*, trace_info_p);
-static int trace_transaction(struct sip_msg* msg, trace_info_p info,
-		char dlg_tran, int reverte_dir);
+static int trace_transaction(struct sip_msg* msg, trace_info_p info, int reverte_dir);
 
 
 static void trace_onreq_out(struct cell* t, int type, struct tmcb_params *ps,
@@ -200,8 +199,8 @@ static int pipport2su (str *sproto, str *ip, unsigned short port,
 static int parse_trace_id(unsigned int type, void *val);
 static int parse_trace_syslog_level(unsigned int type, void *val);
 
-void free_trace_info_pkg(void *param);
-void free_trace_info_shm(void *param);
+static void free_trace_info_pkg(void *param);
+static void free_trace_info_shm(void *param, int type);
 static void free_trace_filters(struct trace_filter *list);
 
 
@@ -1322,7 +1321,7 @@ static void trace_transaction_dlgcb(struct dlg_cell* dlg, int type,
 	if (dlgb.get_direction()==DLG_DIR_UPSTREAM)
 		reverte_dir = 1;
 
-	if (trace_transaction(params->msg, info, 1, reverte_dir)<0) {
+	if (trace_transaction(params->msg, info, reverte_dir)<0) {
 		LM_ERR("trace transaction failed!\n");
 		return;
 	}
@@ -1331,7 +1330,7 @@ static void trace_transaction_dlgcb(struct dlg_cell* dlg, int type,
 	sip_trace(params->msg, info, reverte_dir?TRACE_C_CALLEE:TRACE_C_CALLER);
 }
 
-void free_trace_info_pkg(void *param)
+static void free_trace_info_pkg(void *param)
 {
 	trace_info_p info = (trace_info_p)param;
 	trace_instance_p it, next;
@@ -1345,18 +1344,43 @@ void free_trace_info_pkg(void *param)
 	pkg_free(param);
 }
 
-void free_trace_info_shm(void *param)
+static void free_trace_info_shm(void *param, int type)
 {
 	trace_info_p info = (trace_info_p)param;
-	trace_instance_p it, next;
+	trace_instance_p it, next, prev;
 
-	for (it = info->instances; it; it = next) {
+	for (prev = NULL, it = info->instances; it; it = next) {
+		/* we should only release instances that only used tm */
 		next = it->next;
+		if (it->trace_flags != type) {
+			prev = it;
+			continue;
+		}
 		if (it->trace_list->dynamic)
 			trace_id_unref(it->trace_list);
+		if (prev)
+			prev->next = it->next;
+		else
+			info->instances = it->next;
 		shm_free(it);
 	}
-	shm_free(param);
+	if (!prev)
+		shm_free(param);
+}
+
+static void free_trace_info_tm(void *param)
+{
+	free_trace_info_shm(param, TRACE_TRANSACTION);
+}
+
+static void free_trace_info_b2b(void *param)
+{
+	free_trace_info_shm(param, TRACE_B2B);
+}
+
+static void free_trace_info_dlg(void *param)
+{
+	free_trace_info_shm(param, TRACE_DIALOG);
 }
 
 
@@ -1415,7 +1439,7 @@ static struct b2b_tracer* b2b_set_tracer_cb(void)
 		tracer.f_freep = NULL;
 	} else {
 		tracer.f = trace_b2b_transaction;
-		tracer.f_freep = free_trace_info_shm;
+		tracer.f_freep = free_trace_info_b2b;
 	}
 
 	return &tracer;
@@ -1434,11 +1458,15 @@ static int trace_b2b(struct sip_msg *msg, trace_info_p info)
 }
 
 
-static int trace_transaction(struct sip_msg* msg, trace_info_p info,
-								char dlg_tran, int reverse_dir)
+static int trace_transaction(struct sip_msg* msg, trace_info_p info, int reverse_dir)
 {
 	if (msg==NULL)
 		return 0;
+
+	if (TRACE_FLAG_ISSET(info, TRACE_INFO_TRAN)) {
+		LM_DBG("transacton callbacks already registered!\n");
+		return 0;
+	}
 
 	/* context for the request message */
 	SET_TRACER_CONTEXT(info);
@@ -1462,8 +1490,7 @@ static int trace_transaction(struct sip_msg* msg, trace_info_p info,
 	}
 
 	if(tmb.register_tmcb( msg, 0, TMCB_MSG_SENT_OUT,
-	reverse_dir?trace_tm_out_rev:trace_tm_out, info,
-	dlg_tran?0:free_trace_info_shm) <=0) {
+	reverse_dir?trace_tm_out_rev:trace_tm_out, info, free_trace_info_tm) <=0) {
 		LM_ERR("can't register TM SEND OUT callback\n");
 		return -1;
 	}
@@ -1509,13 +1536,13 @@ static int trace_dialog(struct sip_msg *msg, trace_info_p info)
 	 * this callback is ran only once - when dialog gets for
 	 * the first time in DELETED state */
 	if(dlgb.register_dlgcb(dlg,DLGCB_TERMINATED,
-				trace_transaction_dlgcb,info,free_trace_info_shm)!=0) {
+				trace_transaction_dlgcb,info,free_trace_info_dlg)!=0) {
 		LM_ERR("failed to register dialog callback\n");
 		return -1;
 	}
 
 	/* also trace this transaction */
-	if (trace_transaction(msg, info, 1, 0/*initial request*/) < 0) {
+	if (trace_transaction(msg, info, 0/*initial request*/) < 0) {
 		LM_ERR("failed to trace initial INVITE transaction!\n");
 		return -1;
 	}
@@ -1541,7 +1568,7 @@ static void siptrace_dlg_cancel(struct cell* t, int type, struct tmcb_params *pa
 
 	LM_DBG("Tracing incoming cancel due to trace_dialog() \n");
 
-	if (trace_transaction(req, *param->param, 1, 0 /*initial request*/) < 0) {
+	if (trace_transaction(req, *param->param, 0 /*initial request*/) < 0) {
 		LM_ERR("trace transaction failed!\n");
 		return;
 	}
@@ -1839,6 +1866,7 @@ static int sip_trace_handle(struct sip_msg *msg, tlist_elem_p el,
 	instance->control_flags = control_flags;
 	instance->trace_list=el;
 	instance->trace_types = trace_types;
+	instance->trace_flags = trace_flags;
 
 	if (trace_flags != TRACE_MESSAGE) {
 		info = GET_TRACER_CONTEXT;
@@ -1885,7 +1913,7 @@ static int sip_trace_handle(struct sip_msg *msg, tlist_elem_p el,
 			return -1;
 		}
 	} else if (trace_flags==TRACE_TRANSACTION) {
-		if (trace_transaction(msg, info, 0, 0 /*initial request*/) < 0) {
+		if (trace_transaction(msg, info, 0 /*initial request*/) < 0) {
 			LM_ERR("trace transaction failed!\n");
 			return -1;
 		}

--- a/modules/tracer/tracer.h
+++ b/modules/tracer/tracer.h
@@ -144,6 +144,12 @@ typedef struct trace_info {
 	/* connection id correlationg sip message with transport messages */
 	unsigned long long conn_id;
 
+	/* ref cnt of number of uses */ 
+	unsigned int ref;
+
+	/* lock for ref cnt ops */
+	gen_lock_t* ref_lock;
+
 	trace_instance_p instances;
 } trace_info_t, *trace_info_p;
 

--- a/modules/tracer/tracer.h
+++ b/modules/tracer/tracer.h
@@ -149,6 +149,8 @@ typedef struct trace_info {
 
 	/* lock for ref cnt ops */
 	gen_lock_t* ref_lock;
+    
+    char has_trace_b2b;
 
 	trace_instance_p instances;
 } trace_info_t, *trace_info_p;

--- a/modules/tracer/tracer.h
+++ b/modules/tracer/tracer.h
@@ -123,6 +123,7 @@ typedef struct trace_instance {
 	str forced_correlation_id;
 	int control_flags;
 	int trace_types;
+	int trace_flags;
 	tlist_elem_p trace_list;
 
 	struct trace_instance *next;


### PR DESCRIPTION
**Summary**
This pull request try to backport some fixes of tracer module from 3.3 to 3.2 and also fix some new bugs

**Details**
* This fix wrong tracing b2b while script writer want transaction
* Add some code to prevent further wrong memory access like above causes crashing
* Fix crash when B2B is called from timer job
* Enhance the trace dialog to get current dialog instead of always create a new one

**Solution**
Just some small hotfixes

**Compatibility**
No compatibility issue

**Closing issues**
Fix #2992 without creating a new message flag
