### PR TITLE
b2b_logic: saftey check on old_entity->peer

### DIFF
--- a/modules/b2b_logic/bridging.c
+++ b/modules/b2b_logic/bridging.c
@@ -2151,16 +2151,19 @@ int b2bl_bridge_msg(struct sip_msg* msg, str* key, int entity_no, str *adv_ct)
 		}
 		old_entity->disconnected = 1;
 	}
-	if (old_entity->peer->peer == old_entity)
-		old_entity->peer->peer = NULL;
-	else
+	if (old_entity->peer)
 	{
-		LM_ERR("Unexpected chain: old_entity=[%p] and "
-			"old_entity->peer->peer=[%p]\n",
-			old_entity, old_entity->peer->peer);
-		goto error;
+		if (old_entity->peer->peer == old_entity)
+			old_entity->peer->peer = NULL;
+		else
+		{
+			LM_ERR("Unexpected chain: old_entity=[%p] and "
+				"old_entity->peer->peer=[%p]\n",
+				old_entity, old_entity->peer->peer);
+			goto error;
+		}
+		old_entity->peer = NULL;
 	}
-	old_entity->peer = NULL;
 
 	/* remove the disconected entity from the tuple */
 	if(0 == b2bl_drop_entity(old_entity, tuple))


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!
In order to consider and evaluate your PR, it is mandatory to provide detailed information about (1) what is the issue the PR addresses, (2) how the PR is solving the issue (logic and coding), (3) what are (if any) limitations of the proposed PR and (4) if there are any known side-effects/ backward compatibility issues/SIP interoperability issues.
Note that if the PR is missing information, it might take longer to be merged, as extra resources have to be allocated by the maintainers to reverse engineer the changes, understand them, understand the motivation, etc. That is why it is important to provide as much information as possible.
-->

**Summary**
<!-- Summary of the PR - what the PR is aiming to solve -->
This PR is aiming to avoid a crash when using the b2b_logic module in an edge case.

**Details**
<!--
Details about the content of the PR - is it a bug fix, a new feature or perhaps a hack? Explain the **motivation** for making this change.
What existing problem does the pull request solve? Is this a particular problem (i.e. only some particular scenarios are affected, only some UACs, etc) or a generic one?
Do not assume others understand what you're trying to do and provide as much information as you may have.
-->

It was noticed that in a `b2b_bridge_request` call that the function calls `b2bl_bridge_msg` which is using `old_entity->peer` without checking whether it is NULL or not, like `old_entity->peer->peer == old_entity`.

The following snippets are from a coredump but sensitive information was removed.

```
(gdb) p tuple->bridge_entities
$9 = {0x7f51f5657480, 0x7f51f28577f8, 0x0}
(gdb) p tuple->bridge_entities[1]
$12 = (b2bl_entity_id_t *) 0x7f51f28577f8
(gdb) p *tuple->bridge_entities[1]
$13 = {scenario_id = {s = 0x7f51f28578ea "callee", len = 6}, key = {
    s = 0x7f51f28578d0 "B2B.234.4994781.1674134122", len = 26}, to_uri = {
    s = 0x7f51f28578f0 "sip:example@example.com", len = 50}, proxy = {s = 0x0, len = 0}, from_uri = {
    s = 0x7f51f2857922 "sip:example@example.com", len = 22}, from_dname = {s = 0x0, len = 0}, hdrs = {s = 0x0, len = 0}, adv_contact = {s = 0x0, len = 0}, dlginfo = 0x0, rejected = 0,
  disconnected = 1, state = 0, no = 1, sdp_type = 0, type = B2B_CLIENT, stats = {key = {s = 0x0, len = 0}, start_time = 13926551, setup_time = 0, call_time = 0}, peer = 0x0, prev = 0x0, next = 0x0}
(gdb) p *tuple->bridge_entities[0]
$14 = {scenario_id = {s = 0x7f51f565756d "caller", len = 6}, key = {
    s = 0x7f51f5657558 "B2B.323.40.1674134122", len = 21}, to_uri = {
    s = 0x7f51f5657573 "sip:example@example.com", len = 50}, proxy = {s = 0x0, len = 0}, from_uri = {
    s = 0x7f51f56575a5 "sip:example@example.com", len = 22}, from_dname = {s = 0x0, len = 0}, hdrs = {s = 0x0, len = 0}, adv_contact = {s = 0x0, len = 0}, dlginfo = 0x7f51f2df6428, rejected = 0,
  disconnected = 0, state = 0, no = 0, sdp_type = 0, type = B2B_SERVER, stats = {key = {s = 0x0, len = 0}, start_time = 13926551, setup_time = 0, call_time = 0}, peer = 0x7f51f4fdfd48, prev = 0x0, next = 0x0}
```

It seems that this was actually happening on tuple that was marked for deletion.

```
(gdb) p *tuple
$18 = {
  id = 0,
  hash_index = 234,
  key = 0x7f51f63036c8,
  scenario_id = 0x7f51f5062cf0,
  init_sdp = {
    s = 0x0,
    len = 0
  },
  state = -2,
  req_routeid = 2,
  reply_routeid = -1,
  servers = {0x7f51f5657480, 0x7f51f4fdfd48, 0x0},
  clients = {0x0, 0x0, 0x0},
  bridge_entities = {0x7f51f5657480, 0x7f51f28577f8, 0x0},
  bridge_initiator = 0x0,
  bridge_flags = 0,
  to_del = 1,
  extra_headers = 0x7f51f23354b0,
  next = 0x0,
  prev = 0x0,
  lifetime = 13926587,
  local_contact = {
    s = 0x7f51f1b56140 "sip:127.0.0.1:5080",
    len = 22
  },
  sdp = {
    s = 0x0,
    len = 0
  },
  b1_sdp = {
    s = 0x0,
    len = 0
  },
  db_flag = 2,
  repl_flag = 0,
  vals = 0x0,
  tracer = {
    f = 0x0,
    param = 0x0,
    f_freep = 0x0
  },
  cbf = 0x0,
  cb_mask = 0,
  cb_param = 0x0
}
```

**Solution**
<!-- Explain how your PR fixes the problem. Are there any remaining concerns that might need to be addressed? -->
This is just avoid the crash by not deref the `old_entity->peer` but this is after that anyways set to NULL.

**Compatibility**
<!-- Does your change break other scenarios, or do they need to be migrated in order to work similarly? -->
It shouldn't break anything but maybe it is already undefined behaviour when it got to this point.

**Closing issues**
<!-- Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). -->
