### PR TITLE
Fix qop validation if the qop is not provided

### DIFF
--- a/modules/auth/api.c
+++ b/modules/auth/api.c
@@ -229,6 +229,13 @@ auth_result_t pre_auth(struct sip_msg* _m, str* _realm, hdr_types_t _hftype,
 		goto stalenonce;
 	}
 	qop_type_t qop = dcp->qop.qop_parsed;
+	if (qop == QOP_UNSPEC_D) {
+		/*
+		 * RFC8760: If the "qop" parameter is not specified, then
+		 * the default value is "auth".
+		 */
+		qop = QOP_AUTH_D;
+	}
 	if (np.qop != qop) {
 		switch (np.qop) {
 		case QOP_AUTH_AUTHINT_D:


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!
In order to consider and evaluate your PR, it is mandatory to provide detailed information about (1) what is the issue the PR addresses, (2) how the PR is solving the issue (logic and coding), (3) what are (if any) limitations of the proposed PR and (4) if there are any known side-effects/ backward compatibility issues/SIP interoperability issues.
Note that if the PR is missing information, it might take longer to be merged, as extra resources have to be allocated by the maintainers to reverse engineer the changes, understand them, understand the motivation, etc. That is why it is important to provide as much information as possible.
-->

**Summary**

Relax qop validation: according to the RFC8760 if the qop is not provided, the qop=auth should be assumed.

**Details**

RFC-2069 has been superseeded by RFC-2617 (Digest Authentication), in a backwards-compatible way.
The qop parameter becomes mandatory for an implementation supporting RFC-8760 ([source](https://www.rfc-editor.org/rfc/rfc8760.html#name-updates-to-the-sip-digest-a)).
Still, to maintain backwards-compatibility with previous, RFC-2617 digest auth implementations, RFC-8760 mentions in § 2.6-4.8.1 that "... the "qop" parameter is optional for clients and servers based on [[RFC3261](https://www.rfc-editor.org/rfc/rfc8760.html#RFC3261)] to receive. If the "qop" parameter is not specified, then the default value is "auth"." ([source](https://www.rfc-editor.org/rfc/rfc8760.html#section-2.6-4.8.1)).
The bug is that part (3) is not well-implemented, so the current RFC 8760 implementation is too strict, not allowing an unspecified "qop" anymore, thus breaking backwards-compatibility with RFC-2617.

**Solution**

Assume qop is "auth" if qop is not specified.

**Compatibility**

Should not be any,

**Closing issues**

Closes	#2995
