### PR TITLE
[db_oracle] Log notice level error information when attempting to reconnect

### DIFF
--- a/modules/db_oracle/dbase.c
+++ b/modules/db_oracle/dbase.c
@@ -320,7 +320,9 @@ bind_err:
 	}
 
 ora_err:
-	LM_ERR("driver: %s\n", db_oracle_error(con, status));
+	/* Print notice level error information when attempting to reconnect. */
+	LM_GEN(((pass == -1 && !con->connected) ? L_NOTICE : L_ERR),
+		"driver: %s\n", db_oracle_error(con, status));
 stop_exec:
 	if (stmthp)
 		OCIHandleFree(stmthp, OCI_HTYPE_STMT);

--- a/modules/db_oracle/dbase.c
+++ b/modules/db_oracle/dbase.c
@@ -64,7 +64,7 @@ static const char* db_oracle_errorinfo(ora_con_t* con)
 			(OraText*)errbuf, sizeof(errbuf),
 			OCI_HTYPE_ERROR) != OCI_SUCCESS) errbuf[0] = '\0';
 	else if (db_oracle_connection_lost(errcd)) {
-		LM_ERR("connection dropped\n");
+		LM_DBG("connection dropped\n");
 		db_oracle_disconnect(con);
 	}
 


### PR DESCRIPTION
Currently, when a connection is lost, an error-level log will be printed and then a reconnect operation will be performed.
The logs can contains many misleading error-level logs. The error message after a failed reconnection should be printed at the ERROR level, but the error message during the reconnection should not be considered as an error.

The PR log notice-level error information when attempting to reconnect, and reconnection errors will continue to be logged at the error-level.

Misleading logs:

```
Feb 01 04:02:12 xxxxxx opensips[1772700]: WARNING:core:handle_timer_job: timer job <clstr-heartbeats-timer> has a 50000 us delay in execution
Feb 01 09:06:38 xxxxxx opensips[1772710]: ERROR:db_oracle:db_oracle_errorinfo: connection dropped
Feb 01 09:06:38 xxxxxx opensips[1772710]: ERROR:db_oracle:db_oracle_submit_query: driver: ORA-03135: connection lost contact
                                          Process ID: 1961
                                          Session ID: 150 Serial number: 25127
Feb 01 09:06:38 xxxxxx opensips[1772710]: NOTICE:db_oracle:db_oracle_submit_query: attempt repeat after reconnect
Feb 01 09:06:38 xxxxxx opensips[1772710]: NOTICE:tls_openssl:verify_callback: depth = 1, verify success
Feb 01 09:06:38 xxxxxx opensips[1772710]: NOTICE:tls_openssl:verify_callback: depth = 0, verify success
Feb 01 09:06:44 xxxxxx opensips[1772705]: NOTICE:tls_openssl:verify_callback: depth = 1, verify success
Feb 01 09:06:44 xxxxxx opensips[1772705]: NOTICE:tls_openssl:verify_callback: depth = 0, verify success
Feb 01 09:06:44 xxxxxx opensips[1772705]: ERROR:db_oracle:db_oracle_errorinfo: connection dropped
Feb 01 09:06:44 xxxxxx opensips[1772705]: ERROR:db_oracle:db_oracle_submit_query: driver: ORA-03135: connection lost contact
                                          Process ID: 1957
                                          Session ID: 1438 Serial number: 38115
Feb 01 09:06:44 xxxxxx opensips[1772705]: NOTICE:db_oracle:db_oracle_submit_query: attempt repeat after reconnect
Feb 01 09:06:44 xxxxxx opensips[1772705]: NOTICE:tls_openssl:verify_callback: depth = 0, verify success
Feb 01 09:07:07 xxxxxx opensips[1772699]: ERROR:db_oracle:db_oracle_errorinfo: connection dropped
Feb 01 09:07:07 xxxxxx opensips[1772699]: ERROR:db_oracle:db_oracle_submit_query: driver: ORA-03135: connection lost contact
                                          Process ID: 1947
                                          Session ID: 469 Serial number: 57051
Feb 01 09:07:07 xxxxxx opensips[1772699]: NOTICE:db_oracle:db_oracle_submit_query: attempt repeat after reconnect
Feb 01 09:08:07 xxxxxx opensips[1772711]: ERROR:db_oracle:db_oracle_errorinfo: connection dropped
Feb 01 09:08:07 xxxxxx opensips[1772711]: ERROR:db_oracle:db_oracle_submit_query: driver: ORA-03135: connection lost contact
                                          Process ID: 1973
                                          Session ID: 595 Serial number: 8857
Feb 01 09:08:07 xxxxxx opensips[1772711]: NOTICE:db_oracle:db_oracle_submit_query: attempt repeat after reconnect
Feb 01 09:19:23 xxxxxx opensips[1772705]: NOTICE:tls_openssl:verify_callback: depth = 1, verify success
Feb 01 09:19:23 xxxxxx opensips[1772705]: NOTICE:tls_openssl:verify_callback: depth = 0, verify success
Feb 01 09:39:02 xxxxxx opensips[1772705]: NOTICE:tls_openssl:verify_callback: depth = 1, verify success
Feb 01 09:39:02 xxxxxx opensips[1772705]: NOTICE:tls_openssl:verify_callback: depth = 0, verify success
Feb 01 09:39:07 xxxxxx opensips[1772698]: ERROR:db_oracle:db_oracle_errorinfo: connection dropped
Feb 01 09:39:07 xxxxxx opensips[1772698]: ERROR:db_oracle:db_oracle_submit_query: driver: ORA-03135: connection lost contact
                                          Process ID: 1945
                                          Session ID: 403 Serial number: 49968
Feb 01 09:39:07 xxxxxx opensips[1772698]: NOTICE:db_oracle:db_oracle_submit_query: attempt repeat after reconnect
Feb 01 09:40:07 xxxxxx opensips[1772702]: ERROR:db_oracle:db_oracle_errorinfo: connection dropped
Feb 01 09:40:07 xxxxxx opensips[1772702]: ERROR:db_oracle:db_oracle_submit_query: driver: ORA-03135: connection lost contact
                                          Process ID: 1951
                                          Session ID: 521 Serial number: 2305
Feb 01 09:40:07 xxxxxx opensips[1772702]: NOTICE:db_oracle:db_oracle_submit_query: attempt repeat after reconnect
Feb 01 09:45:46 xxxxxx opensips[1772705]: NOTICE:tls_openssl:verify_callback: depth = 1, verify success
Feb 01 09:45:46 xxxxxx opensips[1772705]: NOTICE:tls_openssl:verify_callback: depth = 0, verify success
```

References about ORA-03135:

* [ORA-03135: connection lost contact](http://nimishgarg.blogspot.com/2015/04/ora-03135-connection-lost-contact.html)
* [SQLNET.EXPIRE_TIME Parameter](https://docs.oracle.com/cd/E11882_01/network.112/e10835/sqlnet.htm#NETRF209)

