### PR TITLE
add_local_rport script function corrupts VIA header params

### DIFF
--- a/msg_translator.c
+++ b/msg_translator.c
@@ -2179,6 +2179,7 @@ char * build_req_buf_from_sip_req( struct sip_msg* msg,
 		if (via_params && !extra_params.len) {
 			/* if no other parameters were added yet, consider via_params */
 			extra_params.len = via_params->len;
+			id_len = via_params->len;
 			/* otherwise, the via_params were already copied in the id block */
 		}
 		extra_params.len += RPORT_LEN-1; /* last char in RPORT define is '='

--- a/msg_translator.c
+++ b/msg_translator.c
@@ -2179,7 +2179,6 @@ char * build_req_buf_from_sip_req( struct sip_msg* msg,
 		if (via_params && !extra_params.len) {
 			/* if no other parameters were added yet, consider via_params */
 			extra_params.len = via_params->len;
-			id_len = via_params->len;
 			/* otherwise, the via_params were already copied in the id block */
 		}
 		extra_params.len += RPORT_LEN-1; /* last char in RPORT define is '='
@@ -2195,8 +2194,10 @@ char * build_req_buf_from_sip_req( struct sip_msg* msg,
 		if(id_buf!=0) {
 			memcpy(extra_params.s, id_buf, id_len);
 			pkg_free(id_buf);
-		} else if (via_params)
+		} else if (via_params) {
 			memcpy(extra_params.s, via_params->s, via_params->len);
+			id_len = via_params->len;
+		}
 		memcpy(extra_params.s+id_len, RPORT, RPORT_LEN-1);
 		extra_params.s[extra_params.len]='\0';
 		LM_DBG("extra param added: <%.*s>\n",extra_params.len, extra_params.s);


### PR DESCRIPTION
**Summary**
When using `add_local_rport` script function in addition to another VIA param this causes the VIA header to be corrupted when the transport is UDP.

This behaviour was observed when using the `clusterer` module in addition to the replication capabilities of the `tm` module which inserts the param into the header `cid=1`

When the rport is added, this caused a memory buffer corruption where the new memory buffer was the size of the existing via params in addition to the size of rport; + null terminator, in this use case it would be 12 bytes in size. When the rport; is added the header would be appended with null characters that matched the length of the other parameters.

Example VIA header `SIP/2.0/UDP 192.123.123.123:5060;branch=z9hG4bK07ee.57275dd7.0;rport\0\0\0\0\0\0`

This header was observed when viewing the pcap in Wireshark but the first indication there was issues was when SIPp got tripped up by the request. Note that the cid parameter has been overwritten

The desired behaviour is `SIP/2.0/UDP 192.123.123.123:5060;branch=z9hG4bK07ee.57275dd7.0;cid=1;rport`

**Details**
This PR is a bug fix which fixes a latent issue that has only been exposed by the usage of the replication in the tm module in addition to adding the rport param, though this is a general issue where any VIA params would be corrupted with this mechanism.

**Solution**
Because the scenario here uses UDP as the transport protocol this statement is skipped https://github.com/OpenSIPS/opensips/blob/master/msg_translator.c#L2150 which means the `extra_param` structure is null, both the string is null and length is null.

Because the flag is set we enter this if statement here https://github.com/OpenSIPS/opensips/blob/master/msg_translator.c#L2176 on line 2178 the id_len is set to 0 and the id_buf is also set to 0(null pointer) 

id_buf is a null pointer so we enter this case in the if statement https://github.com/OpenSIPS/opensips/blob/master/msg_translator.c#L2197 which copies the existing via params into the buffer which was allocated on line 2187 which is equal to the lengh of the existing params + the length of the string `rport;` and null terminator. In this case `cid=1` is copied into the buffer which now is set to something like `cid=1;\0\0\0\0\0\0\0`

We exit the if statement and begin to append `rport;` into the buffer https://github.com/OpenSIPS/opensips/blob/master/msg_translator.c#L2199 but this fails because the pointer arithmetic is invalid because `id_len` is equal to 0 so we start at the beginning of the buffer appending `rport` thus overriding the existing params giving us a buffer like this `rport;\0\0\0\0\0\0\0`

The solution is to set `id_len` also to the length of `extra_params.len` before it's mutated here https://github.com/OpenSIPS/opensips/blob/master/msg_translator.c#L2184 this gives us the length of the original VIA params allowing us to safely perform the pointer arithmetic.

**Compatibility**
This change will not break existing behaviour.
