### PR TITLE
Rebuilding a replicated packet from a UDP source adds an extra null t…

### DIFF
--- a/modules/tm/cluster.c
+++ b/modules/tm/cluster.c
@@ -323,8 +323,15 @@ static bin_packet_t *tm_replicate_packet(struct sip_msg *msg, int type)
 	tmp.len = sizeof(struct ip_addr);
 	TM_BIN_PUSH(str, &tmp, "src host");
 	TM_BIN_PUSH(int, msg->rcv.src_port, "src port");
-	tmp.s = msg->buf;
-	tmp.len = msg->len + 1; /* XXX: add '\0' terminator - receive_msg expects it */
+
+	/* XXX: Check if the buffer has a null terminator, if not add '\0' terminator - receive_msg expects it */
+	if (msg->buf[msg->len] == '\0') {
+		tmp.s = msg->buf;
+		tmp.len = msg->len;
+	} else {
+		tmp.s = msg->buf;
+		tmp.len = msg->len + 1;
+	}
 	TM_BIN_PUSH(str, &tmp, "message");
 
 	return &packet;


### PR DESCRIPTION
…erminator

**Summary**
When using the clustering capabilities of the `tm` module to facilitate binary replication of SIP replies the function for building a replicated packet appends a null terminator to the buffer implicitly, this is so on the recieving end the `receive_msg` function can properly handle the message. 

The function in question `tm_replicate_packet` blindly adds a null terminator at the end of the buffer and increments the buffer length by one, this is regardless of if it already has a null terminator or not, in the case of the replicated reply it will already have a null terminator and it will look as so `0D 0A 00` when it should only end with `0D 0A` this doesn't cause any issues if the replies stick to using UDP as it drops the null terminator but it causes issues when at any stage the reply is transported through TCP which then causes the SIP UA to interpret the 180 and 200 as segments of the same SIP message due to the additional `00` character at the end.

**Details**
Bug fix to check for the null terminator before replicating the message to prevent issue when the message is sent down TCP.

**Solution**
Simply checks if there is a null terminator before appending one

**Compatibility**
Will not have compatibiliy issues
