### PR TITLE
Fix NULL to_uri due to b2b_msg_get_to is called after accessing to_uri

### DIFF
--- a/modules/b2b_logic/logic.c
+++ b/modules/b2b_logic/logic.c
@@ -4901,6 +4901,13 @@ int b2bl_bridge_msg(struct sip_msg* msg, str* key, int entity_no, str *adv_ct)
 	b2bl_print_tuple(tuple, L_DBG);
 
 	b2b_api.apply_lumps(msg);
+    
+    if (b2b_msg_get_from(msg, &from_uri, &from_dname)< 0 ||
+	b2b_msg_get_to(msg, &to_uri, b2bl_htable[hash_index].flags)< 0)
+	{
+		LM_ERR("Failed to get to or from from the message\n");
+		goto error;
+	}
 
 	if (!adv_ct) {
 		memset(&ct_uri, 0, sizeof(struct sip_uri));
@@ -4917,12 +4924,6 @@ int b2bl_bridge_msg(struct sip_msg* msg, str* key, int entity_no, str *adv_ct)
 	}
 
 	/* create server entity from Invite */
-	if (b2b_msg_get_from(msg, &from_uri, &from_dname)< 0 ||
-	b2b_msg_get_to(msg, &to_uri, b2bl_htable[hash_index].flags)< 0)
-	{
-		LM_ERR("Failed to get to or from from the message\n");
-		goto error;
-	}
 	server_id = b2b_api.server_new(msg, adv_ct ? adv_ct : &local_contact,
 			b2b_server_notify, &b2bl_mod_name, tuple->key, get_tracer(tuple));
 	if(server_id == NULL)


### PR DESCRIPTION
Fix the bug that a call to b2b_bridge_request will be failed with error message `Not a valid sip uri` if the script writer does not provide advertised_contact parameter to the server or client entity when created it.

This small fix just move the init of `to_uri` to before when it is accessed if `adv_ct` is not provided.