### PR TITLE
Fix bug in weight-based sort

### DIFF
--- a/modules/drouting/drouting.c
+++ b/modules/drouting/drouting.c
@@ -2913,11 +2913,11 @@ static int weight_based_sort(pgw_list_t *pgwl, int size, unsigned short *idx)
 		}
 		if (weight_sum) {
 			/* randomly select number */
-			rand_no = (unsigned int)(weight_sum*((double)rand()/((double)RAND_MAX+1)));
+			rand_no = (unsigned int)(weight_sum*((double)rand()/((double)RAND_MAX)));
 			LM_DBG("random number is %d\n",rand_no);
 			/* select the element */
 			for( i=first ; i<size ; i++ )
-				if (running_sum[i]>rand_no) break;
+				if (running_sum[i]>=rand_no) break;
 			if (i==size) {
 				LM_CRIT("bug in weight sort, first=%u, size=%u, rand_no=%u, total weight=%u\n",
 					first, size, rand_no, weight_sum);
@@ -2930,7 +2930,7 @@ static int weight_based_sort(pgw_list_t *pgwl, int size, unsigned short *idx)
 			}
 		} else {
 			/* randomly select index */
-			//	i = (unsigned int)((size-first)*((double)rand()/((double)RAND_MAX+1)));
+			//	i = (unsigned int)((size-first)*((double)rand()/((double)RAND_MAX)));
 			i = first;
 		}
 		LM_DBG("selecting element %d with weight %d\n",

--- a/modules/drouting/drouting.c
+++ b/modules/drouting/drouting.c
@@ -2913,7 +2913,7 @@ static int weight_based_sort(pgw_list_t *pgwl, int size, unsigned short *idx)
 		}
 		if (weight_sum) {
 			/* randomly select number */
-			rand_no = (unsigned int)(weight_sum*((float)rand()/(float)RAND_MAX));
+			rand_no = (unsigned int)(weight_sum*((double)rand()/((double)RAND_MAX+1)));
 			LM_DBG("random number is %d\n",rand_no);
 			/* select the element */
 			for( i=first ; i<size ; i++ )
@@ -2930,7 +2930,7 @@ static int weight_based_sort(pgw_list_t *pgwl, int size, unsigned short *idx)
 			}
 		} else {
 			/* randomly select index */
-			//	i = (unsigned int)((size-first)*((float)rand()/RAND_MAX));
+			//	i = (unsigned int)((size-first)*((double)rand()/((double)RAND_MAX+1)));
 			i = first;
 		}
 		LM_DBG("selecting element %d with weight %d\n",


### PR DESCRIPTION
**Summary**
Quotient used in random number generation in weight_based_sort() function should always be less than 1 to avoid unexpected behaviour

**Type**
Bug fix

**Solution**
- Changed RAND_MAX to RAND_MAX + 1 so that the quotient will always be less than 1
- Changed casting from float to double to avoid rounding errors, particularly when the value of rand() nears RAND_MAX and thus the quotient could round to 1 unintentionally

**Compatibility**
The proposed solution is a strict improvement with no risk of side-effects