### PR TITLE
route: fix crash when get an integer parameter by $param(i)

### DIFF
--- a/route.c
+++ b/route.c
@@ -862,7 +862,7 @@ static int eval_elem(struct expr* e, struct sip_msg* msg, pv_value_t *val)
 					{
 						if(val!=NULL)
 							memcpy(val, &lval, sizeof(pv_value_t));
-						if(lval.flags&PV_VAL_STR)
+						if(pvv_is_str(&lval))
 						{
 							if(!((lval.flags&PV_VAL_PKG)
 									|| (lval.flags&PV_VAL_SHM)))


### PR DESCRIPTION
When using $var(x)=$param(1) to obtain integer parameter values for route(xx, 3, ..), maybe duplicate a string from a fly pointer due to a type mismatch.

opensips.cfg

```
route {
    ...
    route(lb, 3);
}

route[lb] {
    $var(load_balancer_group) = $param(1);
    ...
}
```

Associated commit: https://github.com/OpenSIPS/opensips/commit/6b9e140f6576ba66be6f74e686a5fd33c0a16603

