### PR TITLE
FRAUD Module - limitation of call attempts per second

### DIFF
--- a/modules/fraud_detection/frd_load.c
+++ b/modules/fraud_detection/frd_load.c
@@ -40,6 +40,8 @@
 #define FRD_START_H_COL               "start_hour"
 #define FRD_END_H_COL                 "end_hour"
 #define FRD_DAYS_COL                  "daysoftheweek"
+#define FRD_CPS_THRESH_WARN_COL       "cps_warning"
+#define FRD_CPS_THRESH_CRIT_COL       "cps_critical"
 #define FRD_CPM_THRESH_WARN_COL       "cpm_warning"
 #define FRD_CPM_THRESH_CRIT_COL       "cpm_critical"
 #define FRD_CALLDUR_THRESH_WARN_COL   "call_duration_warning"
@@ -61,6 +63,8 @@ str prefix_col = str_init(FRD_PREFIX_COL);
 str start_h_col = str_init(FRD_START_H_COL);
 str end_h_col = str_init(FRD_END_H_COL);
 str days_col = str_init(FRD_DAYS_COL);
+str cps_thresh_warn_col = str_init(FRD_CPS_THRESH_WARN_COL);
+str cps_thresh_crit_col = str_init(FRD_CPS_THRESH_CRIT_COL);
 str cpm_thresh_warn_col = str_init(FRD_CPM_THRESH_WARN_COL);
 str cpm_thresh_crit_col = str_init(FRD_CPM_THRESH_CRIT_COL);
 str calldur_thresh_warn_col = str_init(FRD_CALLDUR_THRESH_WARN_COL);
@@ -290,11 +294,14 @@ static int frd_load_data(dr_head_p drp, free_list_t **fl)
 	db_val_t *values;
 
 	db_key_t query_cols[] = {
-		&rid_col, &pid_col, &prefix_col, &start_h_col, &end_h_col, &days_col,
-		&cpm_thresh_warn_col, &cpm_thresh_crit_col, &calldur_thresh_warn_col,
-		&calldur_thresh_crit_col, &totalc_thresh_warn_col, &totalc_thresh_crit_col,
-		&concalls_thresh_warn_col, &concalls_thresh_crit_col, &seqcalls_thresh_warn_col,
-		&seqcalls_thresh_crit_col
+		&rid_col, &pid_col, &prefix_col,
+		&start_h_col, &end_h_col, &days_col,
+		&cps_thresh_warn_col, &cps_thresh_crit_col,
+		&cpm_thresh_warn_col, &cpm_thresh_crit_col,
+		&calldur_thresh_warn_col, &calldur_thresh_crit_col,
+		&totalc_thresh_warn_col, &totalc_thresh_crit_col,
+		&concalls_thresh_warn_col, &concalls_thresh_crit_col,
+		&seqcalls_thresh_warn_col, &seqcalls_thresh_crit_col
 	};
 
 	if (db_handle == NULL) {

--- a/modules/fraud_detection/frd_stats.h
+++ b/modules/fraud_detection/frd_stats.h
@@ -33,9 +33,13 @@
 
 #define FRD_USER_HASH_SIZE 1024
 #define FRD_PREFIX_HASH_SIZE 8
+/* MINUTE WINDOW*/
 #define FRD_SECS_PER_WINDOW 60
+/* SECOND WINDOW*/
+#define FRD_SECS_PER_WINDOW_1 1
 
 typedef struct {
+	unsigned int cps;
 	unsigned int cpm;
 	unsigned int total_calls;
 	unsigned int concurrent_calls;
@@ -46,6 +50,7 @@ typedef struct {
 	unsigned int last_matched_rule;
 	time_t last_matched_time;
 	unsigned short calls_window[FRD_SECS_PER_WINDOW];
+	unsigned short calls_window_1[FRD_SECS_PER_WINDOW_1];
 } frd_stats_t;
 
 typedef struct _frd_hash_item {
@@ -66,7 +71,8 @@ typedef struct {
 } frd_threshold_t;
 
 typedef struct {
-	frd_threshold_t cpm_thr, call_duration_thr, total_calls_thr,
+	frd_threshold_t cps_thr, cpm_thr,
+					call_duration_thr, total_calls_thr,
 					concurrent_calls_thr, seq_calls_thr;
 } frd_thresholds_t;
 


### PR DESCRIPTION
**Summary**
- Modify the fraud_detection module to obtain the limitation of call attempts per second.
- Call per minute not affected with separate window.
- Functionality for carrier-level scaling with a per-second statistics window.
- Interoperability with opensips-cli

```
opensips-cli -x -- mi show_fraud_stats prefix=AA user=BB
{
    "cps": a,
    "cpm": b,
    "total_calls": c,
    "concurrent_calls": d,
    "seq_calls": e
}
```
- Need to upgrade the table
```
+---------------------------+------------------+------+-----+---------+----------------+
| Field                     | Type             | Null | Key | Default | Extra          |
+---------------------------+------------------+------+-----+---------+----------------+
| ruleid                    | int(10) unsigned | NO   | PRI | NULL    | auto_increment |
| profileid                 | int(10) unsigned | NO   |     | NULL    |                |
| prefix                    | char(64)         | NO   |     | NULL    |                |
| start_hour                | char(5)          | NO   |     | 00:00   |                |
| end_hour                  | char(5)          | NO   |     | 23:59   |                |
| daysoftheweek             | char(64)         | NO   |     | Mon-Sun |                |
| cps_warning               | int(5) unsigned  | NO   |     | 0       |                | *
| cps_critical              | int(5) unsigned  | NO   |     | 0       |                | *
| cpm_warning               | int(5) unsigned  | NO   |     | 0       |                |
| cpm_critical              | int(5) unsigned  | NO   |     | 0       |                |
| call_duration_warning     | int(5) unsigned  | NO   |     | 0       |                |
| call_duration_critical    | int(5) unsigned  | NO   |     | 0       |                |
| total_calls_warning       | int(5) unsigned  | NO   |     | 0       |                |
| total_calls_critical      | int(5) unsigned  | NO   |     | 0       |                |
| concurrent_calls_warning  | int(5) unsigned  | NO   |     | 0       |                |
| concurrent_calls_critical | int(5) unsigned  | NO   |     | 0       |                |
| sequential_calls_warning  | int(5) unsigned  | NO   |     | 0       |                |
| sequential_calls_critical | int(5) unsigned  | NO   |     | 0       |                |
| comment                   | char(255)        | YES  |     |         |                |
+---------------------------+------------------+------+-----+---------+----------------+
```

**Details**
- Tried with 200 INVITEs per second with SIPP injector and set to critical KPI of 50 INVITEs per second.
- UAC remains at 200 INVITEs per second.
- Opensips sends the 503s due to CPS limitations.
- The UAS receives 49 INVITES per second.

**Solution**
```
make clean
make
cp fraud_detection.so /usr/local/lib64/opensips/modules/fraud_detection.so
systemctl restart opensips.service
```

**Compatibility**
```
version: opensips 3.2.11 (x86_64/linux)
flags: STATS: On, DISABLE_NAGLE, USE_MCAST, SHM_MMAP, PKG_MALLOC, Q_MALLOC, F_MALLOC, HP_MALLOC, DBG_MALLOC, FAST_LOCK-ADAPTIVE_WAIT
ADAPTIVE_WAIT_LOOPS=1024, MAX_RECV_BUFFER_SIZE 262144, MAX_LISTEN 16, MAX_URI_SIZE 1024, BUF_SIZE 65535
poll method support: poll, epoll, sigio_rt, select.
git revision: 0726e126c
main.c compiled on 18:20:28 Feb 26 2023 with gcc 10
```

**Code block**
```
# Check Fraud
xlog("L_DBG","SCRIPT:DBG: [FRAUD] | Try to match a fraud rule within the given fraud profile 1 | [fU]=$fU | [rU]=$rU\n");
$var(fraudcode) = check_fraud("$fU","$rU",1);
switch ($var(fraudcode)) {
	case 2:
		xlog("L_DBG","SCRIPT:DBG: [FRAUD] | No matching rule found, call ok");
		break;
	case 1:
		xlog("L_DBG","SCRIPT:DBG: [FRAUD] | Matching rule found, but call still ok");
		break;
	case -1:
		xlog("L_DBG","SCRIPT:DBG: [FRAUD] | Possible fraud detected in warning level, please check events, but call will complete");
		break;
	case -2:
		xlog("L_DBG","SCRIPT:DBG: [FRAUD] | Possible fraud detected in critical level, please check events, call will be dropped for security reasons");
		send_reply(503,"Exceeded outbound level agreement");
		exit;
		break;
	case -3:
		xlog("L_DBG","SCRIPT:DBG: [FRAUD] | Malfuntion in fraud detection module, something went wrong (internal mechanism failed");
		break;
	default:
		xlog("L_DBG","SCRIPT:DBG: [FRAUD] | Undefined return code");
		break;
}
```

**Closing issues**

