### PR TITLE
Don't increase tcp_workers_no above tcp_workers_max_no (fixes segfault in debug mode)

### DIFF
--- a/main.c
+++ b/main.c
@@ -764,7 +764,7 @@ try_again:
 			}
 		}
 		if (tcp_count_processes(NULL)!=0) {
-			if (tcp_workers_no!=2) {
+			if (tcp_workers_no>2) {
 				LM_NOTICE("setting TCP children to 2 (found %d)\n",
 					tcp_workers_no);
 				tcp_workers_no = 2;

--- a/main.c
+++ b/main.c
@@ -342,6 +342,7 @@ int main(int argc, char** argv)
 	int ret;
 	unsigned int seed;
 	int rfd;
+	int want_tcp_workers_no;
 
 	/*init*/
 	ret=-1;
@@ -764,10 +765,12 @@ try_again:
 			}
 		}
 		if (tcp_count_processes(NULL)!=0) {
-			if (tcp_workers_no>2) {
-				LM_NOTICE("setting TCP children to 2 (found %d)\n",
+			want_tcp_workers_no = (tcp_workers_max_no>=2) ? 2 : tcp_workers_max_no;
+			if (tcp_workers_no != want_tcp_workers_no) {
+				LM_NOTICE("setting TCP children to %d (found %d)\n",
+					want_tcp_workers_no,
 					tcp_workers_no);
-				tcp_workers_no = 2;
+				tcp_workers_no = want_tcp_workers_no;
 			}
 		}
 

--- a/modules/uac_registrant/registrant.c
+++ b/modules/uac_registrant/registrant.c
@@ -292,7 +292,7 @@ static int mod_init(void)
 		register_timer("uac_reg_check", timer_check, (void*)(long)param, _timer,
 			TIMER_FLAG_DELAY_ON_DELAY);
 	} else {
-		LM_ERR("timer_interval=[%d] MUST be bigger then reg_hsize=[%d]\n",
+		LM_ERR("timer_interval=[%d] MUST be at least as big as reg_hsize=[%d]\n",
 			timer_interval, reg_hsize);
 		return -1;
 	}

--- a/net/net_tcp.c
+++ b/net/net_tcp.c
@@ -2014,11 +2014,6 @@ int tcp_start_processes(int *chd_rank, int *startup_done)
 	if (tcp_disabled)
 		return 0;
 
-	if (tcp_workers_no > tcp_workers_max_no)
-		LM_BUG("can't run more TCP workers than the amount we allocated memory for: "
-			"tcp_workers_no=%d > tcp_workers_max_no=%d",
-			tcp_workers_no, tcp_workers_max_no);
-
 	/* estimate max fd. no:
 	 * 1 tcp send unix socket/all_proc,
 	 *  + 1 udp sock/udp proc + 1 tcp_worker sock/tcp worker*

--- a/net/net_tcp.c
+++ b/net/net_tcp.c
@@ -1985,7 +1985,7 @@ static void tcp_process_graceful_terminate(int sender, void *param)
 }
 
 
-/* counts the number of TPC processes to start with; this number may 
+/* counts the number of TCP processes to start with; this number may
  * change during runtime due auto-scaling */
 int tcp_count_processes(unsigned int *extra)
 {
@@ -1996,7 +1996,7 @@ int tcp_count_processes(unsigned int *extra)
 
 
 	if (s_profile && extra) {
-		/* how many can be forked over th number of procs to start with ?*/
+		/* how many can be forked over the number of procs to start with ?*/
 		if (s_profile->max_procs > tcp_workers_no)
 			*extra = s_profile->max_procs - tcp_workers_no;
 	}

--- a/net/net_tcp.c
+++ b/net/net_tcp.c
@@ -2014,6 +2014,11 @@ int tcp_start_processes(int *chd_rank, int *startup_done)
 	if (tcp_disabled)
 		return 0;
 
+	if (tcp_workers_no > tcp_workers_max_no)
+		LM_BUG("can't run more TCP workers than the amount we allocated memory for: "
+			"tcp_workers_no=%d > tcp_workers_max_no=%d",
+			tcp_workers_no, tcp_workers_max_no);
+
 	/* estimate max fd. no:
 	 * 1 tcp send unix socket/all_proc,
 	 *  + 1 udp sock/udp proc + 1 tcp_worker sock/tcp worker*


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!
In order to consider and evaluate your PR, it is mandatory to provide detailed information about (1) what is the issue the PR addresses, (2) how the PR is solving the issue (logic and coding), (3) what are (if any) limitations of the proposed PR and (4) if there are any known side-effects/ backward compatibility issues/SIP interoperability issues.
Note that if the PR is missing information, it might take longer to be merged, as extra resources have to be allocated by the maintainers to reverse engineer the changes, understand them, understand the motivation, etc. That is why it is important to provide as much information as possible.
-->

**Summary**

This pull request fixes segfaults in debug mode caused by trying to start more TCP workers than the amount that memory was allocated for, when the config file contains `tcp_workers=1`.

(I also included fixes for 2 typos in comments & 1 slightly erroneous error message).

**Details**
<!--
Details about the content of the PR - is it a bug fix, a new feature or perhaps a hack? Explain the **motivation** for making this change.
What existing problem does the pull request solve? Is this a particular problem (i.e. only some particular scenarios are affected, only some UACs, etc) or a generic one?
Do not assume others understand what you're trying to do and provide as much information as you may have.
-->

When running in debug mode, `main()` checks if there are to be any TCP processes, and if so, it sets `tcp_workers_no` to 2, even if `tcp_workers_no` was previously only 1. This happens after `tcp_init()` has run, which has already allocated memory based on `tcp_workers_max_no`. Increasing `tcp_workers_no` above `tcp_workers_max_no` causes buffer overruns leading to segfaults.

**Solution**
<!-- Explain how your PR fixes the problem. Are there any remaining concerns that might need to be addressed? -->

I have changed the code in `main()` so that it can only decrease, and never increase, `tcp_workers_no`, so that it is no longer at risk of exceeding `tcp_workers_max_no`. I have also added a safety check in the start of `tcp_start_processes()`, comparable to the one in `fork_dynamic_tcp_processes()`, that calls `LM_BUG()` if it tries to start more processes than the `tcp_workers_max_no`.

(It is possible that there is a comparable bug related to `main()` in debug mode increasing `udp_workers_no` in the same manner, although there is no corresponding `udp_workers_max_no` and I didn't look any harder than that.)

**Compatibility**
<!-- Does your change break other scenarios, or do they need to be migrated in order to work similarly? -->

I don't expect this change breaks any scenarios.

**Closing issues**
<!-- Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). -->
