### PR TITLE
Add REUSE_PORT socket option

### DIFF
--- a/cfg.lex
+++ b/cfg.lex
@@ -328,8 +328,9 @@ DOT			\.
 CR			\n
 
 ANY		"any"
-ANYCAST "anycast"
-FRAG "frag"
+ANYCAST	("anycast"|"ANYCAST")
+FRAG	("frag"|"FRAG")
+REUSE_PORT	("reuse_port"|"REUSE_PORT")
 
 
 COM_LINE	#
@@ -588,6 +589,7 @@ SPACE		[ ]
 <INITIAL>{CR}		{ count();/* return CR;*/ }
 <INITIAL>{ANY}		{ count(); return ANY; }
 <INITIAL>{ANYCAST}	{ count(); return ANYCAST; }
+<INITIAL>{REUSE_PORT}	{ count(); return REUSE_PORT; }
 <INITIAL>{FRAG}		{ count(); return FRAG; }
 <INITIAL>{SLASH}	{ count(); return SLASH; }
 <INITIAL>{SCALE_UP_TO}		{ count(); return SCALE_UP_TO; }

--- a/cfg.y
+++ b/cfg.y
@@ -433,6 +433,7 @@ extern int cfg_parse_only_routes;
 %token ANY
 %token ANYCAST
 %token FRAG
+%token REUSE_PORT
 %token SCRIPTVARERR
 %token SCALE_UP_TO
 %token SCALE_DOWN_TO
@@ -642,6 +643,9 @@ socket_def_param: ANYCAST { IFOR();
 					}
 				| FRAG { IFOR();
 					p_tmp.flags |= SI_FRAG;
+					}
+				| REUSE_PORT { IFOR();
+					p_tmp.flags |= SI_REUSEPORT;
 					}
 				| USE_WORKERS NUMBER { IFOR();
 					p_tmp.workers=$2;

--- a/ip_addr.h
+++ b/ip_addr.h
@@ -89,7 +89,7 @@ union sockaddr_union{
 
 
 enum si_flags { SI_NONE=0, SI_IS_IP=1, SI_IS_LO=2, SI_IS_MCAST=4,
-	SI_IS_ANYCAST=8, SI_FRAG=16 };
+	SI_IS_ANYCAST=8, SI_FRAG=16, SI_REUSEPORT=32 };
 
 struct receive_info {
 	struct ip_addr src_ip;

--- a/modules/cgrates/cgrates_engine.c
+++ b/modules/cgrates/cgrates_engine.c
@@ -270,7 +270,7 @@ static int cgrc_conn(struct cgr_conn *c)
 
 	tcp_con_get_profile(&c->engine->su, src_su, PROTO_TCP, &prof);
 
-	s = tcp_sync_connect_fd(src_su, &c->engine->su, PROTO_TCP, &prof);
+	s = tcp_sync_connect_fd(src_su, &c->engine->su, PROTO_TCP, &prof, 0);
 	if (s < 0) {
 		LM_ERR("cannot connect to %.*s:%d\n", c->engine->host.len,
 				c->engine->host.s, c->engine->port);

--- a/modules/proto_ws/ws_common.h
+++ b/modules/proto_ws/ws_common.h
@@ -649,7 +649,7 @@ static struct tcp_connection* ws_sync_connect(struct socket_info* send_sock,
 		goto error;
 	}
 
-	if (tcp_init_sock_opt(s, prof)<0){
+	if (tcp_init_sock_opt(s, prof, send_sock->flags)<0){
 		LM_ERR("tcp_init_sock_opt failed\n");
 		goto error;
 	}

--- a/net/net_tcp.h
+++ b/net/net_tcp.h
@@ -79,7 +79,7 @@ mi_response_t *mi_tcp_list_conns(const mi_params_t *params,
 int tcp_init_listener(struct socket_info *si);
 
 /* helper function to set all TCP related options to a socket */
-int tcp_init_sock_opt(int s, struct tcp_conn_profile *prof);
+int tcp_init_sock_opt(int s, struct tcp_conn_profile *prof, enum si_flags socketflags);
 
 /********************** TCP conn management functions ************************/
 

--- a/net/tcp_common.h
+++ b/net/tcp_common.h
@@ -31,7 +31,7 @@ int tcp_connect_blocking_timeout(int fd, const struct sockaddr *servaddr,
 
 
 int tcp_sync_connect_fd(union sockaddr_union* src, union sockaddr_union* dst,
-                 enum sip_protos proto, struct tcp_conn_profile *prof);
+                 enum sip_protos proto, struct tcp_conn_profile *prof, enum si_flags flags);
 
 struct tcp_connection* tcp_sync_connect(struct socket_info* send_sock,
                union sockaddr_union* server, struct tcp_conn_profile *prof,


### PR DESCRIPTION


<!--
Thanks for submitting a pull request!
In order to consider and evaluate your PR, it is mandatory to provide detailed information about (1) what is the issue the PR addresses, (2) how the PR is solving the issue (logic and coding), (3) what are (if any) limitations of the proposed PR and (4) if there are any known side-effects/ backward compatibility issues/SIP interoperability issues.
Note that if the PR is missing information, it might take longer to be merged, as extra resources have to be allocated by the maintainers to reverse engineer the changes, understand them, understand the motivation, etc. That is why it is important to provide as much information as possible.
-->

**Summary**
Add a REUSE_PORT option for TCP sockets.


**Details**
<!--
Details about the content of the PR - is it a bug fix, a new feature or perhaps a hack? Explain the **motivation** for making this change.
What existing problem does the pull request solve? Is this a particular problem (i.e. only some particular scenarios are affected, only some UACs, etc) or a generic one?
Do not assume others understand what you're trying to do and provide as much information as you may have.
-->
This allows outgoing TCP connections to reuse a listening port as a source port. This is useful for example when using "forced_socket" with the "uac_registrant" module, or when using "force_send_socket()". Without this change, "forced_socket" and "force_send_socket()" have no obvious effect for TCP sockets.

The behaviour of sockets that do not use the REUSE_PORT option is unchanged.

I also noticed some of the other socket options (ANYCAST, FRAG) are documented in uppercase but only implemented in lowercase, so I made these accept either uppercase or lowercase as well.

We found Kamailio's similar option ( https://www.kamailio.org/wiki/cookbooks/5.4.x/core#tcp_reuse_port ) useful in the past.

**Solution**
<!-- Explain how your PR fixes the problem. Are there any remaining concerns that might need to be addressed? -->
Adds another `enum si_flags` value called `SI_REUSEPORT`. When this flag is enabled, TCP sockets have the `SO_REUSEADDR` and `SO_REUSEPORT` sockopt's enabled, and no longer override the port number to 0 before calling `bind()`. When the SI_REUSEPORT flag is not enabled, the behaviour is the same as before.

Remaining concerns: maybe you don't like changing the API for `tcp_init_sock_opt` and `tcp_sync_connect_fd` (which both gained a parameter to take an `enum si_flags` argument). Another way to do it would be to make every place that *calls* `tcp_init_sock_opt` or `tcp_sync_connect_fd` check the flags and enable SO_REUSEADDR/SO_REUSEPORT if necessary. I think the way I have done it is neater, but I don't know how important API stability is for the modules.

**Compatibility**
<!-- Does your change break other scenarios, or do they need to be migrated in order to work similarly? -->
I can't imagine any scenarios that this change breaks.

**Closing issues**
<!-- Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). -->
