### PR TITLE
setting pack_last->next to NULL when iteration finishes

### DIFF
--- a/modules/drouting/drouting.c
+++ b/modules/drouting/drouting.c
@@ -941,6 +941,8 @@ static void dr_prob_handler(unsigned int ticks, void* param)
 			}
 		}
 
+		pack_last->next = NULL;
+
 		lock_stop_read( it->ref_lock );
 
 

--- a/modules/drouting/drouting.c
+++ b/modules/drouting/drouting.c
@@ -941,7 +941,9 @@ static void dr_prob_handler(unsigned int ticks, void* param)
 			}
 		}
 
-		pack_last->next = NULL;
+		if(pack_last) {
+			pack_last->next = NULL;
+		}
 
 		lock_stop_read( it->ref_lock );
 


### PR DESCRIPTION

**Summary**
This solves #3053.
**Details**

**Solution**
In the dr_prob_handler, the pack_last->next was not being set to NULL after iteration of destinations finishes.
So eventually, an invalid memory access would happen.

**Compatibility**
There should be no compatibility issues.

**Closing issues**
closes #3053
