### PR TITLE
feat: add ds_inherit_dst_state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ out
 log
 *.log
 *.html
+.vscode

--- a/modules/dispatcher/dispatch.c
+++ b/modules/dispatcher/dispatch.c
@@ -1164,7 +1164,10 @@ int ds_reload_db(ds_partition_t *partition)
 	if (old_data) {
 		/* copy the state of the destinations from the old set
 		 * (for the matching ids) */
-		ds_inherit_state( old_data, new_data);
+		if (ds_inherit_dst_state) {
+			ds_inherit_state( old_data, new_data);
+		}
+		
 		ds_destroy_data_set( old_data );
 	}
 

--- a/modules/dispatcher/dispatch.h
+++ b/modules/dispatcher/dispatch.h
@@ -59,6 +59,7 @@
 
 
 extern int ds_persistent_state;
+extern int ds_inherit_dst_state;
 
 typedef struct _ds_dest
 {

--- a/modules/dispatcher/dispatcher.c
+++ b/modules/dispatcher/dispatcher.c
@@ -74,6 +74,7 @@ static int ds_ping_interval = 0;
 int ds_ping_maxfwd = -1;
 int ds_probing_mode = 0;
 int ds_persistent_state = 1;
+int ds_inherit_dst_state = 1;
 int_list_t *ds_probing_list = NULL;
 
 /* db partiton info */
@@ -301,6 +302,7 @@ static param_export_t params[]={
 	{"ds_probing_list",       STR_PARAM|USE_FUNC_PARAM, (void*)set_probing_list},
 	{"ds_define_blacklist",   STR_PARAM|USE_FUNC_PARAM, (void*)set_ds_bl},
 	{"persistent_state",      INT_PARAM, &ds_persistent_state},
+	{"ds_inherit_dst_state",      INT_PARAM, &ds_inherit_dst_state},
 	{"fetch_freeswitch_stats", INT_PARAM, &fetch_freeswitch_stats},
 	{"max_freeswitch_weight", INT_PARAM, &max_freeswitch_weight},
 	{"cluster_id",            INT_PARAM, &ds_cluster_id },

--- a/modules/dispatcher/doc/dispatcher_admin.xml
+++ b/modules/dispatcher/doc/dispatcher_admin.xml
@@ -659,6 +659,27 @@ modparam("dispatcher", "persistent_state", 0)
 		</example>
 	</section>
 
+	<section id="param_ds_inherit_dst_state" xreflabel="ds_inherit_dst_state">
+		<title><varname>ds_inherit_dst_state</varname> (int)</title>
+		<para>
+		Specifies whether the <emphasis>state</emphasis> 
+		should be inherit from old state when ds_reload or not.
+		</para>
+		<para>
+		<emphasis>Default value is <quote>1</quote> (enabled).
+		</emphasis>
+		</para>
+		<example>
+		<title>Set the <varname>ds_inherit_dst_state</varname> parameter</title>
+		<programlisting format="linespecific">
+...
+# disable all DB operations with the state of a destination
+modparam("dispatcher", "ds_inherit_dst_state", 0)
+...
+</programlisting>
+		</example>
+	</section>
+
 	<section id="param_cluster_id" xreflabel="cluster_id">
 		<title><varname>cluster_id</varname> (integer)</title>
 		<para>
@@ -1699,4 +1720,3 @@ opensips-cli -x mi ds_reload
 	</section>
 	</section>
 </chapter>
-


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!
In order to consider and evaluate your PR, it is mandatory to provide detailed information about (1) what is the issue the PR addresses, (2) how the PR is solving the issue (logic and coding), (3) what are (if any) limitations of the proposed PR and (4) if there are any known side-effects/ backward compatibility issues/SIP interoperability issues.
Note that if the PR is missing information, it might take longer to be merged, as extra resources have to be allocated by the maintainers to reverse engineer the changes, understand them, understand the motivation, etc. That is why it is important to provide as much information as possible.
-->

**Summary**
<!-- Summary of the PR - what the PR is aiming to solve -->

the command ds_reload can't reset the state of one dest, because it will inherit old state and ignore the new state in db.

for example
step1: dispatcher table 

| id  | setid | destination | state |
| --- | --- | --- | --- |
| 1 | 1 | sip:1.2.3.4:5060 | 0

step2: run opensips
step3: opensips mi show the sip:1.2.3.4:5060 is active
step4: change the dist state to 1, from db table

| id  | setid | destination | state |
| --- | --- | --- | --- |
| 1 | 1 | sip:1.2.3.4:5060 | 1

step5: run opensips mi ds_reload
step6: opensips mi show dest sip:1.2.3.4:5060 is active, not disabled



**Details**
<!--
Details about the content of the PR - is it a bug fix, a new feature or perhaps a hack? Explain the **motivation** for making this change.
What existing problem does the pull request solve? Is this a particular problem (i.e. only some particular scenarios are affected, only some UACs, etc) or a generic one?
Do not assume others understand what you're trying to do and provide as much information as you may have.
-->

**Solution**
<!-- Explain how your PR fixes the problem. Are there any remaining concerns that might need to be addressed? -->

i add the param ds_inherit_dst_state(default is 1) to 0,  to make opensips not inherit the old data。

**Compatibility**
<!-- Does your change break other scenarios, or do they need to be migrated in order to work similarly? -->

because ds_inherit_dst_state default is 1, so it not change old behave

**Closing issues**
<!-- Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). -->
