### PR TITLE
uac_auth: fix qop-value for MD5 hashing

### DIFF
--- a/modules/uac_auth/auth.c
+++ b/modules/uac_auth/auth.c
@@ -240,6 +240,7 @@ int do_uac_auth(str *msg_body, str *method, str *uri, struct uac_credential *crd
 	const struct digest_auth_calc *digest_calc;
 	str_const cnonce;
 	str_const nc;
+	str_const qop;
 
 	digest_calc = get_digest_calc(auth->algorithm);
 	if (digest_calc == NULL) {
@@ -285,8 +286,13 @@ int do_uac_auth(str *msg_body, str *method, str *uri, struct uac_credential *crd
 		    !(auth->flags&QOP_AUTH), &ha2) != 0)
 			return (-1);
 
+		if (auth->flags & QOP_AUTH) {
+			qop = str_const_init(QOP_AUTH_STR);
+		} else {
+			qop = str_const_init(QOP_AUTHINT_STR);
+		}
 		if (digest_calc->response(&ha1, &ha2, str2const(&auth->nonce),
-		    str2const(&auth->qop), &nc, &cnonce, response) != 0)
+		    &qop, &nc, &cnonce, response) != 0)
 			return (-1);
 		auth_nc_cnonce->nc = nc;
 		auth_nc_cnonce->cnonce = cnonce;


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!
In order to consider and evaluate your PR, it is mandatory to provide detailed information about (1) what is the issue the PR addresses, (2) how the PR is solving the issue (logic and coding), (3) what are (if any) limitations of the proposed PR and (4) if there are any known side-effects/ backward compatibility issues/SIP interoperability issues.
Note that if the PR is missing information, it might take longer to be merged, as extra resources have to be allocated by the maintainers to reverse engineer the changes, understand them, understand the motivation, etc. That is why it is important to provide as much information as possible.
-->

**Summary**
<!-- Summary of the PR - what the PR is aiming to solve -->
The digest authentication response incorrect when the qop value is set to `auth,auth-int` and the MD5 hashing algorithm is being used. This PR fixes that.

**Details**
<!--
Details about the content of the PR - is it a bug fix, a new feature or perhaps a hack? Explain the **motivation** for making this change.
What existing problem does the pull request solve? Is this a particular problem (i.e. only some particular scenarios are affected, only some UACs, etc) or a generic one?
Do not assume others understand what you're trying to do and provide as much information as you may have.
-->
According to the documentation, the `uac_auth` module supports both qop values of `auth` and `auth-int`, but when both values are presented, `auth` is preferred. (Source: https://opensips.org/html/docs/modules/3.2.x/uac_auth.html)

The qop value is being filled with `auth,auth-int` for hashing instead of `auth` as described in RFC2617. The parsing set the qop flag correctly, but keeps the original qop value and using that later for hashing which causing the issue.

**Solution**
<!-- Explain how your PR fixes the problem. Are there any remaining concerns that might need to be addressed? -->
Based on the parsing result, use the appropriate qop value (`auth` or `auth-int`) for MD5 hashing.

**Compatibility**
<!-- Does your change break other scenarios, or do they need to be migrated in order to work similarly? -->
The issue has been present since e53751e (v3.2.0), and requires a backport to v3.2.x and v3.3.x

**Closing issues**
<!-- Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). -->
N/A.