### PR TITLE
Fix buffer overflow in b2b_logic

### DIFF
--- a/modules/b2b_logic/logic.c
+++ b/modules/b2b_logic/logic.c
@@ -2684,7 +2684,7 @@ str *b2b_scenario_hdrs(struct b2bl_new_entity *entity)
 				continue;
 			}
 			b2b_hdrs_buf.s = tmp_buf;
-			b2b_hdrs_buf_len += len;
+			b2b_hdrs_buf_len = b2b_hdrs_buf.len + len;
 		}
 		memcpy(b2b_hdrs_buf.s + b2b_hdrs_buf.len, name_value.s.s, name_value.s.len);
 		b2b_hdrs_buf.len += name_value.s.len;


### PR DESCRIPTION
**Summary**
This is a bug fix. It fixes a buffer overflow in b2b_logic.

**Details**
We were getting crashes that looked like this:
CRITICAL:core:qm_debug_frag: qm_*: fragm. 0x7f20f2acdd60 (address 0x7f20f2acdd90) end overwritten(73552d697275522d, 3034342b203a7265)!

The size of the b2b_hdrs_buf.s buffer is tracked in the b2b_hdrs_buf_len static variable.
It's possible for this to get out of sync with the actual size of the buffer (allocated by pkg_realloc).

**Solution**
This commit keeps b2b_hdrs_buf_len in sync with the actual size of the buffer.

**Compatibility**
Should be fine.

**Triggering the Crash**
We pass headers into b2b_client_new() using extra_hdrs/extra_hdr_bodies. After starting OpenSIPs we send gradually increasing header value lengths until the crash happens.

**Question**
Should I cherry-pick this to other maintained branches?