### PR TITLE
Fix: regex segfault if max_groups is exceeded

### DIFF
--- a/modules/regex/regex_mod.c
+++ b/modules/regex/regex_mod.c
@@ -326,7 +326,7 @@ static int load_pcres(int action)
 			i++;
 			/* Check if there are more patterns than the max value */
 			if (i >= max_groups) {
-        i--;
+				i--;
 				LM_ERR("max_groups: %d exceeded, continuing without processing subsequent groups\n", max_groups);
 				break;
 			}

--- a/modules/regex/regex_mod.c
+++ b/modules/regex/regex_mod.c
@@ -327,7 +327,7 @@ static int load_pcres(int action)
 			/* Check if there are more patterns than the max value */
 			if (i >= max_groups) {
         i--;
-				LM_ERR("max_groups: %d exceeded, continuing without proessing subsequent groups\n", max_groups);
+				LM_ERR("max_groups: %d exceeded, continuing without processing subsequent groups\n", max_groups);
 				break;
 			}
 			/* Start the regular expression with '(' */

--- a/modules/regex/regex_mod.c
+++ b/modules/regex/regex_mod.c
@@ -326,9 +326,9 @@ static int load_pcres(int action)
 			i++;
 			/* Check if there are more patterns than the max value */
 			if (i >= max_groups) {
-				LM_ERR("max patterns exceeded\n");
-				fclose(f);
-				goto err;
+        i--;
+				LM_ERR("max_groups: %d exceeded, continuing without proessing subsequent groups\n", max_groups);
+				break;
 			}
 			/* Start the regular expression with '(' */
 			patterns[i][0] = '(';


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!
In order to consider and evaluate your PR, it is mandatory to provide detailed information about (1) what is the issue the PR addresses, (2) how the PR is solving the issue (logic and coding), (3) what are (if any) limitations of the proposed PR and (4) if there are any known side-effects/ backward compatibility issues/SIP interoperability issues.
Note that if the PR is missing information, it might take longer to be merged, as extra resources have to be allocated by the maintainers to reverse engineer the changes, understand them, understand the motivation, etc. That is why it is important to provide as much information as possible.
-->

**Summary**
<!-- Summary of the PR - what the PR is aiming to solve -->
Fix: regex segfault if max_groups is exceeded

**Details**
<!--
Details about the content of the PR - is it a bug fix, a new feature or perhaps a hack? Explain the **motivation** for making this change.
What existing problem does the pull request solve? Is this a particular problem (i.e. only some particular scenarios are affected, only some UACs, etc) or a generic one?
Do not assume others understand what you're trying to do and provide as much information as you may have.
-->
The example provided in the doc has a regex_group file that contains 3 regex groups.
If the max_groups parameter is set to 2 a segfault happens as shown here:

Apr 29 14:01:38 [1] INFO:regex:mod_init: initializing module...
Apr 29 14:01:38 [1] NOTICE:regex:mod_init: loading pcres...
Apr 29 14:01:38 [1] ERROR:regex:load_pcres: max patterns exceeded
Apr 29 14:01:38 [1] CRITICAL:regex:mod_init: failed to load pcres
Apr 29 14:01:38 [1] CRITICAL:core:qm_free_dbg: freeing already freed pointer, first free: regex_mod.c: free_shared_memory(526) - aborting

**Solution**
<!-- Explain how your PR fixes the problem. Are there any remaining concerns that might need to be addressed? -->
The variable "i" is used to count the number of processed groups and it is compared against the max_groups variable.
The problem is that at the end of the loop that processes each group the "num_pcres_tmp" variable is set to "i + 1".
The "num_pcres_tmp" variable now has a value which is too large.

The fix is to decrement the variable "i" if the max_groups check fails.

If the max_groups check failed, all processing of the regex module would stop because of the "goto err" statement.  This has been changed so that any already processed regex groups are used and the module is allowed to continue.

Logging in this case has been enhanced to more clearly indicate that max_groups has been exceeded and that subsequent groups will not be processed.

**Compatibility**
<!-- Does your change break other scenarios, or do they need to be migrated in order to work similarly? -->

**Closing issues**
<!-- Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). -->
