### PR TITLE
Add options to set_dlg_profile and unset_dlg_profile to remove all values on a profile

### DIFF
--- a/modules/dialog/dialog.c
+++ b/modules/dialog/dialog.c
@@ -123,7 +123,7 @@ static int w_match_dialog(struct sip_msg *msg, void *seq_match_mode_val);
 static int api_match_dialog(struct sip_msg *msg, int _seq_match_mode);
 static int w_validate_dialog(struct sip_msg*);
 static int w_fix_route_dialog(struct sip_msg*);
-static int w_set_dlg_profile(struct sip_msg *msg, str *prof_name, str *value, str *remove_value);
+static int w_set_dlg_profile(struct sip_msg *msg, str *prof_name, str *value, int *clear_values);
 static int w_unset_dlg_profile(struct sip_msg *msg, str *prof_name, str *value);
 static int w_is_in_profile(struct sip_msg *msg, str *prof_name, str *value);
 static int w_get_profile_size(struct sip_msg *msg, str *prof_name,
@@ -189,7 +189,7 @@ static const cmd_export_t cmds[]={
 	{"set_dlg_profile", (cmd_function)w_set_dlg_profile, {
 		{CMD_PARAM_STR,0,0},
 		{CMD_PARAM_STR|CMD_PARAM_OPT,0,0},
-		{CMD_PARAM_STR|CMD_PARAM_OPT,0,0}, {0,0,0}},
+		{CMD_PARAM_INT|CMD_PARAM_OPT,0,0}, {0,0,0}},
 		REQUEST_ROUTE| FAILURE_ROUTE | ONREPLY_ROUTE | BRANCH_ROUTE},
 	{"unset_dlg_profile", (cmd_function)w_unset_dlg_profile, {
 		{CMD_PARAM_STR,0,0},
@@ -1127,7 +1127,7 @@ static int w_fix_route_dialog(struct sip_msg *req)
 }
 
 
-static int w_set_dlg_profile(struct sip_msg *msg, str *prof_name, str *value, str *remove_value)
+static int w_set_dlg_profile(struct sip_msg *msg, str *prof_name, str *value, int *clear_values)
 {
 	struct dlg_cell *dlg;
 	struct dlg_profile_table *profile;
@@ -1149,15 +1149,10 @@ static int w_set_dlg_profile(struct sip_msg *msg, str *prof_name, str *value, st
 			return -1;	
 		}
 
-		if (remove_value) {
-			if (remove_value->len == 0) {
-				if (unset_dlg_profile_all_values(dlg, profile) < 0) {
-					LM_DBG("dialog not found in profile %.*s\n",
-							prof_name->len, prof_name->s);
-				}
-			} else if (unset_dlg_profile( dlg, remove_value, profile) < 0) {
-				LM_WARN("dialog not found in profile %.*s with value %.*s\n",
-						prof_name->len, prof_name->s, remove_value->len, remove_value->s);
+		if (clear_values && *clear_values) {
+			if (unset_dlg_profile_all_values(dlg, profile) < 0) {
+				LM_DBG("dialog not found in profile %.*s\n",
+				       prof_name->len, prof_name->s);
 			}
 		}
 
@@ -1193,11 +1188,6 @@ static int w_unset_dlg_profile(struct sip_msg *msg, str *prof_name, str *value)
 
 	if (profile->has_value) {
 		if (!value) {
-			LM_WARN("missing value\n");
-			return -1;
-		}
-
-		if (value->len == 0) {
 			if (unset_dlg_profile_all_values(dlg, profile) < 0) {
 				LM_DBG("dialog not found in profile %.*s\n",
 						prof_name->len, prof_name->s);

--- a/modules/dialog/dialog.c
+++ b/modules/dialog/dialog.c
@@ -123,7 +123,7 @@ static int w_match_dialog(struct sip_msg *msg, void *seq_match_mode_val);
 static int api_match_dialog(struct sip_msg *msg, int _seq_match_mode);
 static int w_validate_dialog(struct sip_msg*);
 static int w_fix_route_dialog(struct sip_msg*);
-static int w_set_dlg_profile(struct sip_msg *msg, str *prof_name, str *value);
+static int w_set_dlg_profile(struct sip_msg *msg, str *prof_name, str *value, str *remove_value);
 static int w_unset_dlg_profile(struct sip_msg *msg, str *prof_name, str *value);
 static int w_is_in_profile(struct sip_msg *msg, str *prof_name, str *value);
 static int w_get_profile_size(struct sip_msg *msg, str *prof_name,
@@ -188,6 +188,7 @@ static const cmd_export_t cmds[]={
 		REQUEST_ROUTE},
 	{"set_dlg_profile", (cmd_function)w_set_dlg_profile, {
 		{CMD_PARAM_STR,0,0},
+		{CMD_PARAM_STR|CMD_PARAM_OPT,0,0},
 		{CMD_PARAM_STR|CMD_PARAM_OPT,0,0}, {0,0,0}},
 		REQUEST_ROUTE| FAILURE_ROUTE | ONREPLY_ROUTE | BRANCH_ROUTE},
 	{"unset_dlg_profile", (cmd_function)w_unset_dlg_profile, {
@@ -1126,7 +1127,7 @@ static int w_fix_route_dialog(struct sip_msg *req)
 }
 
 
-static int w_set_dlg_profile(struct sip_msg *msg, str *prof_name, str *value)
+static int w_set_dlg_profile(struct sip_msg *msg, str *prof_name, str *value, str *remove_value)
 {
 	struct dlg_cell *dlg;
 	struct dlg_profile_table *profile;
@@ -1147,6 +1148,19 @@ static int w_set_dlg_profile(struct sip_msg *msg, str *prof_name, str *value)
 			LM_WARN("missing value\n");
 			return -1;	
 		}
+
+		if (remove_value) {
+			if (remove_value->len == 0) {
+				if (unset_dlg_profile_all_values(dlg, profile) < 0) {
+					LM_DBG("dialog not found in profile %.*s\n",
+							prof_name->len, prof_name->s);
+				}
+			} else if (unset_dlg_profile( dlg, remove_value, profile) < 0) {
+				LM_WARN("dialog not found in profile %.*s with value %.*s\n",
+						prof_name->len, prof_name->s, remove_value->len, remove_value->s);
+			}
+		}
+
 		if ( set_dlg_profile( dlg, value, profile, 0) < 0 ) {
 			LM_ERR("failed to set profile\n");
 			return -1;
@@ -1182,7 +1196,14 @@ static int w_unset_dlg_profile(struct sip_msg *msg, str *prof_name, str *value)
 			LM_WARN("missing value\n");
 			return -1;
 		}
-		if ( unset_dlg_profile( dlg, value, profile) < 0 ) {
+
+		if (value->len == 0) {
+			if (unset_dlg_profile_all_values(dlg, profile) < 0) {
+				LM_DBG("dialog not found in profile %.*s\n",
+						prof_name->len, prof_name->s);
+				return -1;
+			}
+		} else if (unset_dlg_profile( dlg, value, profile) < 0) {
 			LM_WARN("dialog not found in profile %.*s with value %.*s\n",
 					prof_name->len, prof_name->s, value->len, value->s);
 			return -1;

--- a/modules/dialog/dlg_profile.h
+++ b/modules/dialog/dlg_profile.h
@@ -118,6 +118,8 @@ int set_dlg_profile(struct dlg_cell *dlg, str *value,
 int unset_dlg_profile(struct dlg_cell *dlg, str *value,
 		struct dlg_profile_table *profile);
 
+int unset_dlg_profile_all_values(struct dlg_cell *dlg, struct dlg_profile_table *profile);
+
 int is_dlg_in_profile(struct dlg_cell *dlg, struct dlg_profile_table *profile,
 		str *value);
 

--- a/modules/dialog/doc/dialog_admin.xml
+++ b/modules/dialog/doc/dialog_admin.xml
@@ -1951,7 +1951,7 @@ if (load_dialog_ctx("$var(callid)")) {
 
 	<section id="func_set_dlg_profile" xreflabel="set_dlg_profile()">
 		<title>
-		<function moreinfo="none">set_dlg_profile(profile,[value],[remove_value])</function>
+		<function moreinfo="none">set_dlg_profile(profile, [value], [clear_values])</function>
 		</title>
 		<para>
 		Inserts the current dialog into a profile. Note that if the profile does
@@ -1976,9 +1976,9 @@ if (load_dialog_ctx("$var(callid)")) {
 			</para>
 		</listitem>
 		<listitem>
-			<para><emphasis>remove_value (string, optional)</emphasis> - optional profile value
-				to remove before setting the new value. If it is an empty string ("") all values for the profile
-				will be removed before setting the new value.
+			<para><emphasis>clear_values (boolean, optional)</emphasis> - if set to
+				<emphasis>true</emphasis> (1), all values of the profile will be cleared
+				before setting the given value.  Default: <emphasis>false</emphasis>.
 			</para>
 		</listitem>
 		</itemizedlist>
@@ -1991,13 +1991,12 @@ if (load_dialog_ctx("$var(callid)")) {
 		<programlisting format="linespecific">
 ...
 set_dlg_profile("inboundCall");
-set_dlg_profile("caller",$fu);
-...
-#Set a new value while removing an old value
-set_dlg_profile("caller",$fu,$var(old_fu));
-...
-#Set a new value while removing all old values
-set_dlg_profile("caller",$fu,"");
+
+# Set a new value (all other values are kept intact)
+set_dlg_profile("caller", $fu);
+
+# Set a new value while removing all previous values
+set_dlg_profile("caller", $fu, true);
 ...
 </programlisting>
 		</example>
@@ -2006,7 +2005,7 @@ set_dlg_profile("caller",$fu,"");
 
 	<section id="func_unset_dlg_profile" xreflabel="unset_dlg_profile()">
 		<title>
-		<function moreinfo="none">unset_dlg_profile(profile,[value],[remove_all])</function>
+		<function moreinfo="none">unset_dlg_profile(profile, [value])</function>
 		</title>
 		<para>
 		Removes the current dialog from a profile.
@@ -2025,8 +2024,10 @@ set_dlg_profile("caller",$fu,"");
 		<listitem>
 			<para><emphasis>value (string, optional)</emphasis> - string value to
 			define the belonging of the dialog to the profile - note that the
-			profile must support values. If set to an empty string ("") all values for
-			the profile will be removed.
+			profile must support values.
+			</para>
+			<para>NEW in 3.4: for profiles with value, by omitting this parameter
+				you can now clear all values of the given profile.
 			</para>
 		</listitem>
 		</itemizedlist>
@@ -2039,10 +2040,10 @@ set_dlg_profile("caller",$fu,"");
 		<programlisting format="linespecific">
 ...
 unset_dlg_profile("inboundCall");
-unset_dlg_profile("caller",$fu);
+unset_dlg_profile("caller", $fu);
 ...
-#Remove all values in a profile
-unset_dlg_profile("caller","");
+# Remove all values in a profile
+unset_dlg_profile("caller");
 ...
 </programlisting>
 		</example>

--- a/modules/dialog/doc/dialog_admin.xml
+++ b/modules/dialog/doc/dialog_admin.xml
@@ -1951,7 +1951,7 @@ if (load_dialog_ctx("$var(callid)")) {
 
 	<section id="func_set_dlg_profile" xreflabel="set_dlg_profile()">
 		<title>
-		<function moreinfo="none">set_dlg_profile(profile,[value])</function>
+		<function moreinfo="none">set_dlg_profile(profile,[value],[remove_value])</function>
 		</title>
 		<para>
 		Inserts the current dialog into a profile. Note that if the profile does
@@ -1975,6 +1975,12 @@ if (load_dialog_ctx("$var(callid)")) {
 			profile must support values.
 			</para>
 		</listitem>
+		<listitem>
+			<para><emphasis>remove_value (string, optional)</emphasis> - optional profile value
+				to remove before setting the new value. If it is an empty string ("") all values for the profile
+				will be removed before setting the new value.
+			</para>
+		</listitem>
 		</itemizedlist>
 		<para>
 		This function can be used from REQUEST_ROUTE, BRANCH_ROUTE,
@@ -1987,6 +1993,12 @@ if (load_dialog_ctx("$var(callid)")) {
 set_dlg_profile("inboundCall");
 set_dlg_profile("caller",$fu);
 ...
+#Set a new value while removing an old value
+set_dlg_profile("caller",$fu,$var(old_fu));
+...
+#Set a new value while removing all old values
+set_dlg_profile("caller",$fu,"");
+...
 </programlisting>
 		</example>
 	</section>
@@ -1994,7 +2006,7 @@ set_dlg_profile("caller",$fu);
 
 	<section id="func_unset_dlg_profile" xreflabel="unset_dlg_profile()">
 		<title>
-		<function moreinfo="none">unset_dlg_profile(profile,[value])</function>
+		<function moreinfo="none">unset_dlg_profile(profile,[value],[remove_all])</function>
 		</title>
 		<para>
 		Removes the current dialog from a profile.
@@ -2013,7 +2025,8 @@ set_dlg_profile("caller",$fu);
 		<listitem>
 			<para><emphasis>value (string, optional)</emphasis> - string value to
 			define the belonging of the dialog to the profile - note that the
-			profile must support values.
+			profile must support values. If set to an empty string ("") all values for
+			the profile will be removed.
 			</para>
 		</listitem>
 		</itemizedlist>
@@ -2027,6 +2040,9 @@ set_dlg_profile("caller",$fu);
 ...
 unset_dlg_profile("inboundCall");
 unset_dlg_profile("caller",$fu);
+...
+#Remove all values in a profile
+unset_dlg_profile("caller","");
 ...
 </programlisting>
 		</example>


### PR DESCRIPTION
**Summary**
This adds the ability for set_dlg_profile() and unset_dlg_profile() to optionally remove all other values associated with a given dialog profile when called. In the case of set_dlg_profile() the removal happens before setting the new value.

**Details**
This makes working with profile values that you tend to overwrite much easier. You don't need to explicitly call unset_dlg_profile() for every previous value when setting new ones.

**Solution**
This:
unset_dlg_profile("caller",$var(oldfu));
set_dlg_profile("caller",$fu);

Becomes just:
set_dlg_profile("caller",$fu, 1);

You can also clear all values on a profile with:
unset_dlg_profile("caller",,1);

**Compatibility**
The new parameter is optional, and does not break prior usage.

We have been running this patch in production on 3.2 without issue.