### PR TITLE
Significantly reduce file descriptors consumption

### DIFF
--- a/ipc.h
+++ b/ipc.h
@@ -28,12 +28,12 @@ extern int ipc_shared_fd_read;
 #define IPC_TYPE_NONE (-1)
 #define ipc_bad_handler_type(htype) ((htype) < 0)
 
-#define IPC_FD_READ(_proc_no)   pt[_proc_no].ipc_pipe[0]
-#define IPC_FD_WRITE(_proc_no)  pt[_proc_no].ipc_pipe[1]
+#define IPC_FD_READ(_proc_no)   pt[_proc_no].ipc_pipe
+#define IPC_FD_WRITE(_proc_no)  pt[_proc_no].ipc_pipe
 #define IPC_FD_READ_SELF        IPC_FD_READ(process_no)
 #define IPC_FD_READ_SHARED      ipc_shared_fd_read
-#define IPC_FD_SYNC_READ(_proc_no)   pt[_proc_no].ipc_sync_pipe[0]
-#define IPC_FD_SYNC_WRITE(_proc_no)  pt[_proc_no].ipc_sync_pipe[1]
+#define IPC_FD_SYNC_READ(_proc_no)   pt[_proc_no].ipc_sync_pipe
+#define IPC_FD_SYNC_WRITE(_proc_no)  pt[_proc_no].ipc_sync_pipe
 #define IPC_FD_SYNC_READ_SELF        IPC_FD_SYNC_READ(process_no)
 
 /* prototype of IPC handler - function called by the IPC engine

--- a/pt.h
+++ b/pt.h
@@ -49,10 +49,8 @@ struct process_table {
 	/* various flags describing properties of this process */
 	unsigned int flags;
 
-	/* pipe used by the process to receive designated jobs (used by IPC)
-	 * [1] for writting into by other process,
-	 * [0] to listen on by this process */
-	int ipc_pipe[2];
+	/* pipe used by the process to receive designated jobs (used by IPC) */
+	int ipc_pipe;
 	/* same as above, but the holder used when the corresponding process
 	 * does not exist */
 	int ipc_pipe_holder[2];
@@ -61,7 +59,7 @@ struct process_table {
 	 * this pipe should only be used by a process to synchronously receive a
 	 * message after he knows that some other process will send it for sure,
 	 * and there's no other job that can overlap in the meantime */
-	int ipc_sync_pipe[2];
+	int ipc_sync_pipe;
 	/* same as above, but holder for non-existing processes */
 	int ipc_sync_pipe_holder[2];
 


### PR DESCRIPTION
**Summary**

Significantly reduce file descriptors consumption (by 30-50%). From 8,000 to 5,800 using the example below.

**Details**

Reduce number of sockets created by closing off one half of the socketpair in child after forking. This results in 30% decrease of the total number of sockets allocated, from 8k to some 5.8k on my test config with 10 workers and 10 sockets.

The issue works fine with my tests here, the issue reported in #3081 is believed to be false positive due to submitter not doing proper recompilation of the modules.

**Solution**

Usual scenario involving shared pipe / socketpair in parent / child is that two descriptors returned by the system call are then split with first descriptor used by parent and then the second is closed off by parent and the second used by a child and the first is closed by the child (or vice versa). OpenSIPS breaks this rule by keeping both descriptors open in both parent and child, effectively wasting up descriptor space. This could lead to hitting a system-wide limit or some excessive system load due to enormous size of the descriptor table.

**OpenSIPS Configs Tested**

***opensips1.cfg***

```
mpath="modules/"

loadmodule "proto_udp.so"
loadmodule "proto_tcp.so"
loadmodule "dialog/dialog.so"

loadmodule "sipmsgops/sipmsgops.so"
loadmodule "uac/uac.so"
loadmodule "uac_auth/uac_auth.so"
loadmodule "signaling/signaling.so"
loadmodule "auth/auth.so"

loadmodule "sl/sl.so"
loadmodule "tm/tm.so"
loadmodule "rr/rr.so"
loadmodule "maxfwd/maxfwd.so"
loadmodule "rtpproxy/rtpproxy.so"
loadmodule "textops/textops.so"

modparam("uac_auth", "credential", "mightyuser:VoIPTests.NET:s3cr3tpAssw0Rd")
modparam("auth", "username_spec", "$var(username)")
modparam("auth", "password_spec", "$var(password)")
modparam("auth", "calculate_ha1", 1)

modparam("rtpproxy", "rtpproxy_sock", "cunix:/tmp/p.sock")
modparam("rtpproxy", "rtpproxy_disable_tout", 1)

listen=udp:192.168.23.1:5060
listen=udp:[::1]:5060
listen=tcp:127.0.0.1:12340
listen=tcp:127.0.0.1:12341
listen=tcp:127.0.0.1:12342
listen=tcp:127.0.0.1:12343
listen=tcp:127.0.0.1:12344
listen=tcp:127.0.0.1:12345
listen=tcp:127.0.0.1:12346
listen=tcp:127.0.0.1:12347
listen=tcp:127.0.0.1:12348
listen=tcp:127.0.0.1:12349
udp_workers=10

route {
    xlog("OpenSIPS received a request $rm ($ci) from $si\n");
    ## initial sanity checks -- messages with
    ## max_forwards==0, or excessively long requests
    if (!mf_process_maxfwd_header(10)) {
        sl_send_reply(483, "Too Many Hops");
        exit;
    };

    ## shield us against retransmits
    if (!t_newtran()) {
        sl_reply_error();
        exit;
    };

    if (is_method("INVITE")) {
        if (!has_totag()) {
            $var(username)="mightyuser";
            $var(password)="s3cr3tpAssw0Rd";
            if (!pv_www_authorize("VoIPTests.NET")) {
                $var(challenge_using) = "md5,md5-sess,sha-256,sha-256-sess,sha-512-256,sha-512-256-sess";
                www_challenge("VoIPTests.NET", "auth-int,auth", $var(challenge_using));
                exit;
            }
            consume_credentials();
        }
        t_reply(100, "Trying");
        if (rtpproxy_offer("r")) {
            t_on_reply("1");
            if (!has_totag()) {

                t_on_failure("invite");
                create_dialog();
            } else {
                t_on_failure("re_invite");
            }
        };
    };

    if (is_method("BYE")) {
        xlog("    calling rtpproxy_unforce()\n");
        rtpproxy_unforce();
    };

    record_route();

    if (loose_route()) {
        t_relay();
        exit;
    };

    if ($sp == 5061) {
        $rp = 5062;
    } else {
        $rp = 5061;
    };
    t_relay();
    ##rtpproxy_stream2uac("ringback", "10");
    exit;
}

onreply_route[1]
{
    xlog("OpenSIPS received a reply $rs/$rm ($ci) from $si\n");
    if ($rs =~ "(183)|2[0-9][0-9]") {
        xlog("  calling search()\n");
        if(!search("^Content-Length:[ ]*0")) {
            xlog("    calling rtpproxy_answer()\n");
            rtpproxy_answer("r");
            ##rtpproxy_stream2uas("ringback", "10");
        };
    };
}

failure_route[invite]
{
    xlog("OpenSIPS handling $rm ($ci) failure in from $si in failure_route[invite]\n");
    if (t_check_status("40[17]")) {
        $var(accept_algs) = "md5-sess,sha-256-sess";
        if (uac_auth($var(accept_algs))) {
            xlog("    uac_auth() SUCCESS\n");
            t_on_failure("uac_auth_fail");
            t_relay();
            exit;
        } else {
            xlog("    uac_auth() FAILURE\n");
        }
    }
    xlog("    calling rtpproxy_unforce()\n");
    rtpproxy_unforce();
}

failure_route[re_invite]
{
    xlog("OpenSIPS handling $rm ($ci) failure in from $si in failure_route[re_invite]\n");
    if (t_was_cancelled()) {
        exit;
    }

    if (t_check_status("40[17]")) {
        $var(accept_algs) = "md5-sess,sha-256-sess";
        if (uac_auth($var(accept_algs))) {
            xlog("    uac_auth() SUCCESS\n");
            t_on_failure("uac_auth_fail");
            t_relay();
            exit;
        } else {
            xlog("    uac_auth() FAILURE\n");
        }
    }
}

failure_route[uac_auth_fail]
{
    xlog("OpenSIPS handling $rm ($ci) failure in from $si in failure_route[uac_auth_fail]\n");
    xlog("    calling rtpproxy_unforce()\n");
    rtpproxy_unforce();
}
```

***opensips2.cfg***

```
debug_mode=yes
log_level=3
xlog_level=3
log_stderror=yes
log_facility=LOG_LOCAL0
udp_workers=4

#dns_try_ipv6=yes
socket=udp:0.0.0.0:5060   # CUSTOMIZE ME
socket=tcp:0.0.0.0:5060
#socket=bin:0.0.0.0:5160

mpath="modules/"

loadmodule "proto_tcp.so"
loadmodule "proto_udp.so"
loadmodule "signaling.so"
loadmodule "sl/sl.so"

loadmodule "db_mysql/db_mysql.so"

loadmodule "tm/tm.so"

modparam("tm", "fr_timeout", 5)
modparam("tm", "fr_inv_timeout", 30)
modparam("tm", "restart_fr_on_each_reply", 0)
modparam("tm", "onreply_avp_mode", 1)

loadmodule "sipmsgops/sipmsgops.so"
loadmodule "httpd/httpd.so"
modparam("httpd", "ip", "192.168.23.158")
modparam("httpd", "port", 8899)
loadmodule "mi_http/mi_http.so"
loadmodule "mi_html/mi_html.so"

loadmodule "drouting/drouting.so"
modparam("drouting", "db_url", "mysql://root:whocares?@127.0.0.1/opensips")



route{
        xlog("new request");
}
```