### PR TITLE
Enhance module version check to also check the SCM ID

### DIFF
--- a/Makefile.defs
+++ b/Makefile.defs
@@ -470,9 +470,9 @@ INSTALL_MAN ?= $(INSTALL) -m 644
 
 
 ifeq ($(VERSIONTYPE),)
-VERSIONTYPE = $(shell if [ -d ".svn" ]; then \
+VERSIONTYPE = $(shell if [ -d "${TOP_SRCDIR}/.svn" ]; then \
 			  		echo "svn"; \
-				elif [ -d ".git" ]; then \
+				elif [ -d "${TOP_SRCDIR}/.git" ]; then \
 					echo "git"; \
 				fi )
 endif
@@ -496,7 +496,7 @@ ifneq ($(VERSIONTYPE),)
   endif
 
   ifeq ($(THISREVISION),)
-  THISREVISION = $(shell if [ -f main.c -a -f Makefile.defs ] ; then \
+  THISREVISION = $(shell if [ -f ${TOP_SRCDIR}/main.c -a -f ${TOP_SRCDIR}/Makefile.defs ] ; then \
 				if [ -x "$(GETVERSION)" ] ; then \
 					$(GETVERSION) $(GETVERSIONOPTS) ;\
 				fi ;\
@@ -504,9 +504,9 @@ ifneq ($(VERSIONTYPE),)
   endif
 else
   # git is the default versioning method
-  VERSIONTYPE = $(shell [ -f ".gitrevision" ] && echo "git")
+  VERSIONTYPE = $(shell [ -f "${TOP_SRCDIR}/.gitrevision" ] && echo "git")
   ifneq ($(VERSIONTYPE),)
-    THISREVISION = $(shell cat .gitrevision)
+    THISREVISION = $(shell cat ${TOP_SRCDIR}/.gitrevision)
   endif
   OLDREVISION = "$(THISREVISION)"
 endif

--- a/main.c
+++ b/main.c
@@ -172,6 +172,11 @@ static char* flags=OPENSIPS_COMPILE_FLAGS;
 static int user_id = 0;
 static int group_id = 0;
 
+const struct scm_version core_scm_ver = {
+	.type = VERSIONTYPE,
+	.rev = THISREVISION
+};
+
 /**
  * Print compile-time constants
  */
@@ -186,7 +191,7 @@ static void print_ct_constants(void)
 		BUF_SIZE );
 	printf("poll method support: %s.\n", poll_support);
 #ifdef VERSIONTYPE
-	printf("%s revision: %s\n", VERSIONTYPE, THISREVISION);
+	printf("%s revision: %s\n", core_scm_ver.type, core_scm_ver.rev);
 #endif
 }
 

--- a/sr_module.h
+++ b/sr_module.h
@@ -97,10 +97,12 @@ typedef int (*mod_proc_wrapper)();
 
 #define OPENSIPS_DLFLAGS	RTLD_NOW
 
-#define MODULE_VERSION \
-	OPENSIPS_FULL_VERSION, \
-	OPENSIPS_COMPILE_FLAGS
-
+#define MODULE_VERSION { \
+	.version = OPENSIPS_FULL_VERSION, \
+	.compile_flags = OPENSIPS_COMPILE_FLAGS, \
+	.scm.type = VERSIONTYPE, \
+	.scm.rev = THISREVISION \
+}
 
 #define PROC_FLAG_INITCHILD    (1<<0)
 #define PROC_FLAG_HAS_IPC      (1<<1)
@@ -151,8 +153,11 @@ struct sr_module{
 struct module_exports{
 	const char* name;               /*!< null terminated module name */
 	enum module_type type;
-	const char *version;            /*!< module version */
-	const char *compile_flags;      /*!< compile flags used on the module */
+	const struct {
+		const char *version;    /*!< module version */
+		const char *compile_flags;/*!< compile flags used on the module */
+		struct scm_version scm; /*< SCM version info */
+	} ver_info;
 	unsigned int dlflags;           /*!< flags for dlopen */
 
 	load_function load_f;           /*!< function called immediately after a

--- a/test/fuzz/fuzz_standalone.h
+++ b/test/fuzz/fuzz_standalone.h
@@ -25,8 +25,7 @@
  *
  */
 
-#if !defined(_FUZZ_STANDALONE_H)
-#define _FUZZ_STANDALONE_H
+#pragma once
 
 #include <assert.h>
 #if defined(FUZZ_STANDALONE)
@@ -38,6 +37,9 @@
 #include "../../context.h"
 #include "../../core_stats.h"
 #include "../../dset.h"
+
+/* Dummy */
+const struct scm_version core_scm_ver;
 
 #if defined(__linux__)
 static int optreset; /* Not present in linux */
@@ -117,4 +119,3 @@ main(int argc, char *argv[])
     return (0);
 }
 #endif /* FUZZ_STANDALONE */
-#endif /* _FUZZ_STANDALONE_H */

--- a/version.h
+++ b/version.h
@@ -186,5 +186,11 @@
 	USE_PTHREAD_MUTEX_STR USE_UMUTEX_STR USE_POSIX_SEM_STR \
 	USE_SYSV_SEM_STR DBG_LOCK_STR
 
+struct scm_version {
+	const char *type;	/*!< VERSIONTYPE we've compiled with */
+	const char *rev;	/*!< THISREVISION we've compiled with */
+};
+
+extern const struct scm_version core_scm_ver;
 
 #endif


### PR DESCRIPTION
**Summary**

This change enhances module version check to also check the SCM ID (i.e. git hash) and refuse to load module if they differ.

**Details**

Often when the OpenSIPS internal APIs or structures change this also requires all modules to be recompiled. Otherwise the OpenSIPS would crash or misbehave in an unpredictable and very hard to debug way. It is believed to be the cause of failure reported here #3081 and possibly many other issues that cannot be reproduced.

**Solution**

We embed SCM type (i.e. "git") and SCM revision (i.e. "abcdef123") into the module_exports struct and compare them with respective values compiled into code once module is loaded. Error is reported and OpenSIPS exits with an error if an mismatch is found:

***Trying to load module compiled before this change***
```
$ ./opensips -FE -f o1.cfg
May  8 18:51:56 [2810577] DBG:core:add_module_dependency: adding type 1 dependency proto_tcp - (module proto_hep)
May  8 18:51:56 [2810577] DBG:core:load_module: loading module modules/signaling/signaling.so
May  8 18:51:56 [2810577] DBG:core:register_module: register_pv: signaling
May  8 18:51:56 [2810577] DBG:core:pv_add_extra: extra items list is not initialized
May  8 18:51:56 [2810577] DBG:core:add_module_dependency: adding type 1 dependency signaling - (module tm)
May  8 18:51:56 [2810577] DBG:core:add_module_dependency: adding type 1 dependency signaling - (module sl)
May  8 18:51:56 [2810577] DBG:core:load_module: loading module modules/sl/sl.so
May  8 18:51:56 [2810577] DBG:core:load_module: loading module modules/db_mysql/db_mysql.so
May  8 18:51:56 [2810577] CRITICAL:core:version_control: BUG - SCM type not defined in module <modules/db_mysql/db_mysql.so> (try `make clean all modules' and reinstall everything)
```

***Trying to load mis-matched revision***
```
$ ./opensips -FE -f o1.cfg
May  8 20:19:22 [2830822] DBG:core:add_module_dependency: adding type 1 dependency proto_tcp - (module proto_hep)
May  8 20:19:22 [2830822] DBG:core:load_module: loading module modules/signaling/signaling.so
May  8 20:19:22 [2830822] DBG:core:register_module: register_pv: signaling
May  8 20:19:22 [2830822] DBG:core:pv_add_extra: extra items list is not initialized
May  8 20:19:22 [2830822] DBG:core:add_module_dependency: adding type 1 dependency signaling - (module tm)
May  8 20:19:22 [2830822] DBG:core:add_module_dependency: adding type 1 dependency signaling - (module sl)
May  8 20:19:22 [2830822] DBG:core:load_module: loading module modules/sl/sl.so
May  8 20:19:22 [2830822] DBG:core:load_module: loading module modules/db_mysql/db_mysql.so
May  8 20:19:22 [2830822] ERROR:core:version_control: module SCM revision mismatch for db_mysql
core: fcad64a53
module: 54572a71f (try `make clean all modules' and reinstall everything)
```