### PR TITLE
Improve passthru_prack behaviour so it actually passes through PRACKs

### DIFF
--- a/modules/b2b_entities/dlg.h
+++ b/modules/b2b_entities/dlg.h
@@ -107,6 +107,7 @@ typedef struct b2b_dlg
 	struct cell*         uac_tran;
 	struct cell*         uas_tran;
 	struct cell*         update_tran;
+	struct cell*         prack_tran;
 	struct cell*         cancel_tm_tran;
 	dlg_leg_t*           legs;
 	struct socket_info*  send_sock;
@@ -118,6 +119,7 @@ typedef struct b2b_dlg
 	struct b2b_tracer   *tracer;
 	void                *param;
 	b2b_param_free_cb    free_param;
+	str                  prack_headers;
 }b2b_dlg_t;
 
 typedef struct b2b_entry


### PR DESCRIPTION
**Summary**

The b2b_entities module has a passthru_prack toggle, which in theory should cause PRACKs to behave in an end-to-end manner when set to 1.

Unfortunately the existing behaviour only does half of what's expected. It stops our b2b module from responding with PRACKs itself (upon seeing Requires: 100rel), but it has no logic to actually deal with PRACK replies when they eventually come back.

**Details**
This patch implements the missing behaviour so the PRACKs are truly end-to-end.

**Solution**

When a message requesting 100rel is identified, dlg is updated with the RAck header that the subsequent PRACK will have to use.

PRACKs are now correctly proxied with the appropriate RAck set to match the message which requested the 100rel.

b2b_dlg_t struct now has an additional prack_tran, which is used to keep track of the PRACK transaction, so we know how to deal with the 200 OK which comes for the PRACK.


**Compatibility**
Yes, it changes how passthru_prack behaves, but I don't think the existing behaviour is correct. Or at least it's very confusing, because it contradicts the docs.


**Closing issues**
<!-- Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). -->
