### PR TITLE
sipmsgops: fix allowed routes for exported functions

### DIFF
--- a/modules/sipmsgops/doc/sipmsgops_admin.xml
+++ b/modules/sipmsgops/doc/sipmsgops_admin.xml
@@ -68,7 +68,7 @@
 		</itemizedlist>
 		<para>
 		This function can be used from REQUEST_ROUTE, FAILURE_ROUTE,
-		BRANCH_ROUTE, ERROR_ROUTE.
+		BRANCH_ROUTE and ERROR_ROUTE.
 		</para>
 		<example>
 		<title><function>append_to_reply</function> usage</title>
@@ -110,7 +110,7 @@ append_to_reply("Foo: $rm at $Ts\r\n");
 		</para>
 		<para>
 		This function can be used from REQUEST_ROUTE, ONREPLY_ROUTE,
-		FAILURE_ROUTE, BRANCH_ROUTE.
+		FAILURE_ROUTE, BRANCH_ROUTE and LOCAL_ROUTE.
 		</para>
 		<example>
 		<title><function>append_hf</function> usage</title>
@@ -140,7 +140,7 @@ append_hf("From-username: $fU\r\n", "Call-ID");
 		</itemizedlist>
 		<para>
 		This function can be used from REQUEST_ROUTE, ONREPLY_ROUTE,
-		FAILURE_ROUTE, BRANCH_ROUTE.
+		FAILURE_ROUTE, BRANCH_ROUTE and LOCAL_ROUTE.
 		</para>
 		<example>
 		<title><function>insert_hf</function> usage</title>
@@ -175,7 +175,7 @@ insert_hf("To-username: $tU\r\n");
 		</itemizedlist>
 		<para>
 		This function can be used from REQUEST_ROUTE, ONREPLY_ROUTE,
-		FAILURE_ROUTE, BRANCH_ROUTE.
+		FAILURE_ROUTE, BRANCH_ROUTE and LOCAL_ROUTE.
 		</para>
 		<example>
 		<title><function>insert_hf</function> usage</title>
@@ -210,8 +210,8 @@ insert_hf("To-username: $tU\r\n", "Call-ID");
 		</listitem>
 		</itemizedlist>
 		<para>
-		This function can be used from REQUEST_ROUTE, FAILURE_ROUTE,
-		BRANCH_ROUTE.
+		This function can be used from REQUEST_ROUTE, FAILURE_ROUTE
+		and BRANCH_ROUTE.
 		</para>
 		<example>
 		<title><function>append_urihf</function> usage</title>
@@ -246,7 +246,7 @@ append_urihf("CC-Diversion: ", "\r\n");
 		</itemizedlist>
 		<para>
 		This function can be used from REQUEST_ROUTE, ONREPLY_ROUTE,
-		FAILURE_ROUTE, BRANCH_ROUTE.
+		FAILURE_ROUTE, BRANCH_ROUTE and LOCAL_ROUTE.
 		</para>
 		<example>
 		<title><function>is_present_hf</function> usage</title>
@@ -303,7 +303,7 @@ if (is_present_hf("From")) log(1, "From HF Present");
 		</para>
 		<para>
 		This function can be used from REQUEST_ROUTE, FAILURE_ROUTE,
-		BRANCH_ROUTE.
+		BRANCH_ROUTE and LOCAL_ROUTE.
 		</para>
 		<example>
 		<title><function>append_time</function> usage</title>
@@ -349,7 +349,7 @@ append_time();
 		</itemizedlist>
 		<para>
 		This function can be used from REQUEST_ROUTE, ONREPLY_ROUTE,
-		FAILURE_ROUTE, and BRANCH_ROUTE.
+		FAILURE_ROUTE, BRANCH_ROUTE and LOCAL_ROUTE.
 		</para>
 		<example>
 		<title><function>is_method</function> usage</title>
@@ -387,7 +387,7 @@ if(is_method("OPTION|UPDATE"))
 		</itemizedlist>
 		<para>
 		This function can be used from REQUEST_ROUTE, ONREPLY_ROUTE,
-		FAILURE_ROUTE and BRANCH_ROUTE.
+		FAILURE_ROUTE, BRANCH_ROUTE and LOCAL_ROUTE.
 		</para>
 		<example>
 		<title><function>remove_hf</function> usage</title>
@@ -423,7 +423,7 @@ if(remove_hf("User-Agent"))
 		</itemizedlist>
 		<para>
 		This function can be used from REQUEST_ROUTE, ONREPLY_ROUTE,
-		FAILURE_ROUTE and BRANCH_ROUTE.
+		FAILURE_ROUTE, BRANCH_ROUTE and LOCAL_ROUTE.
 		</para>
 		<example>
 		<title><function>remove_hf_re</function> usage</title>
@@ -456,7 +456,7 @@ remove_hf_re("^X-g.+[0-9]");
 		</itemizedlist>
 		<para>
 		This function can be used from REQUEST_ROUTE, ONREPLY_ROUTE,
-		FAILURE_ROUTE and BRANCH_ROUTE.
+		FAILURE_ROUTE, BRANCH_ROUTE and LOCAL_ROUTE.
 		</para>
 		<example>
 		<title><function>remove_hf_glob</function> usage</title>
@@ -627,7 +627,8 @@ ruri_tel2sip();
 		</listitem>
 		</itemizedlist>
 		<para>
-		This function can be used from REQUEST_ROUTE and FAILURE_ROUTE.
+		This function can be used from REQUEST_ROUTE, FAILURE_ROUTE
+		and LOCAL_ROUTE.
 		</para>
 		<example>
 		<title><function>is_uri_user_e164</function> usage</title>
@@ -659,7 +660,7 @@ if (is_uri_user_e164($avp(uri)) {
 		</para>
 		<para>
 		This function can be used from REQUEST_ROUTE, ONREPLY_ROUTE,
-		FAILURE_ROUTE and BRANCH_ROUTE.
+		FAILURE_ROUTE, BRANCH_ROUTE and LOCAL_ROUTE.
 		</para>
 		<example>
 		<title><function>has_body_part</function> usage</title>
@@ -698,7 +699,7 @@ if(has_body_part("application/sdp"))
 
 		<para>
 		This function can be used from REQUEST_ROUTE, ONREPLY_ROUTE,
-		FAILURE_ROUTE and BRANCH_ROUTE.
+		FAILURE_ROUTE, BRANCH_ROUTE and LOCAL_ROUTE.
 		</para>
 		<example>
 		<title><function>is_audio_on_hold</function> usage</title>
@@ -735,7 +736,7 @@ if(is_audio_on_hold())
 		</para>
    		<para>
 		This function can be used from REQUEST_ROUTE, ONREPLY_ROUTE,
-		FAILURE_ROUTE and BRANCH_ROUTE.
+		FAILURE_ROUTE, BRANCH_ROUTE and LOCAL_ROUTE.
 		</para>
 		<example>
 		<title><function>is_privacy</function> usage</title>

--- a/modules/sipmsgops/sipmsgops.c
+++ b/modules/sipmsgops/sipmsgops.c
@@ -284,10 +284,10 @@ static const cmd_export_t cmds[]={
 
 	{"ruri_del_param", (cmd_function)ruri_del_param, {
 		{CMD_PARAM_STR, 0, 0}, {0, 0, 0}},
-		REQUEST_ROUTE},
+		REQUEST_ROUTE|FAILURE_ROUTE|BRANCH_ROUTE|LOCAL_ROUTE},
 
 	{"ruri_tel2sip", (cmd_function)ruri_tel2sip, {{0, 0, 0}},
-		REQUEST_ROUTE},
+		REQUEST_ROUTE|FAILURE_ROUTE|BRANCH_ROUTE|LOCAL_ROUTE},
 
 	{"is_uri_user_e164", (cmd_function)is_uri_user_e164, {
 		{CMD_PARAM_STR, 0, 0}, {0, 0, 0}},


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!
In order to consider and evaluate your PR, it is mandatory to provide detailed information about (1) what is the issue the PR addresses, (2) how the PR is solving the issue (logic and coding), (3) what are (if any) limitations of the proposed PR and (4) if there are any known side-effects/ backward compatibility issues/SIP interoperability issues.
Note that if the PR is missing information, it might take longer to be merged, as extra resources have to be allocated by the maintainers to reverse engineer the changes, understand them, understand the motivation, etc. That is why it is important to provide as much information as possible.
-->

**Summary**
<!-- Summary of the PR - what the PR is aiming to solve -->
The documentation for the `sipmsgops` module contains a discrepancy between the allowed routes listed under exported functions and the corresponding code. This PR addresses and resolves this issue.

**Details**
<!--
Details about the content of the PR - is it a bug fix, a new feature or perhaps a hack? Explain the **motivation** for making this change.
What existing problem does the pull request solve? Is this a particular problem (i.e. only some particular scenarios are affected, only some UACs, etc) or a generic one?
Do not assume others understand what you're trying to do and provide as much information as you may have.
-->
- In most cases, `LOCAL_ROUTE` is allowed, but the documentation does not indicate this.
- According to the documentation, `ruri_del_param` and `ruri_tel2sip` are allowed on `REQUEST_ROUTE`, `FAILURE_ROUTE`, `BRANCH_ROUTE`, and `LOCAL_ROUTE`. However, at the code level, they are limited to `REQUEST_ROUTE`.

**Solution**
<!-- Explain how your PR fixes the problem. Are there any remaining concerns that might need to be addressed? -->

Synchronizing the documentation with the code.

**Compatibility**
<!-- Does your change break other scenarios, or do they need to be migrated in order to work similarly? -->

It expands the usage scope of `ruri_del_param` and `ruri_tel2sip` without causing any disruptions.

This issue is encountered with OpenSIPS 3.2.x when attempted to use `ruri_del_param` from a `FAILURE_ROUTE`. It may require backporting to other versions as well.

**Closing issues**
<!-- Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). -->

N/A.