### PR TITLE
completely disabled state persists over opensips restart

### DIFF
--- a/db/schema/load_balancer.xml
+++ b/db/schema/load_balancer.xml
@@ -58,7 +58,7 @@
 		<type>unsigned int</type>
 		<size>11</size>
 		<default>0</default>
-		<description>Probing mode (0-none, 1-if disabled, 2-all the time)</description>
+		<description>Probing mode (0-none, 1-if disabled, 2-all the time, 12-completly disabled)</description>
 	</column>
 
 	<column id="attrs">

--- a/modules/load_balancer/doc/load_balancer_admin.xml
+++ b/modules/load_balancer/doc/load_balancer_admin.xml
@@ -913,11 +913,23 @@ if (lb_is_destination($si,$sp) ) {
 		<para>
 		Trigers the reload of the load balancing data from the DB.
 		</para>
+		
+		<itemizedlist>
+			<listitem><para><emphasis>inherit_state</emphasis> (optional) : whether inherit old state of the destination , default is y. </para>
+				<itemizedlist>
+					<listitem><para> <quote>n</quote>: no inherit state </para></listitem>
+					<listitem><para> <quote>y</quote>: inherit state </para></listitem>
+				</itemizedlist>
+			</listitem>
+			
+		</itemizedlist>
+
 		<para>
 		MI FIFO Command Format:
 		</para>
 		<programlisting  format="linespecific">
 		opensips-cli -x mi lb_reload
+		opensips-cli -x mi lb_reload inherit_state=n
 		</programlisting>
 		</section>
 
@@ -1028,4 +1040,3 @@ enable:: yes
 
 
 </chapter>
-

--- a/modules/load_balancer/lb_db.c
+++ b/modules/load_balancer/lb_db.c
@@ -176,8 +176,12 @@ int lb_db_load_data( struct lb_data *data)
 			/* PROBING_MODE column */
 			check_val( ROW_VALUES(row)+4, DB_INT, 1, 0);
 			pmode = VAL_INT(ROW_VALUES(row)+4);
+			LM_DBG("id: %d pmode: %d\n", id, pmode);
 			if (pmode==0) {
 				flags |= LB_DST_PING_DSBL_FLAG;
+			} else if (pmode==LB_DST_STAT_MASK) {
+				/* DST is disabled from the db if the PROBING is 12 */
+				flags |= LB_DST_STAT_MASK;
 			} else if (pmode>=2) {
 				flags |= LB_DST_PING_PERM_FLAG;
 			}

--- a/modules/load_balancer/lb_db.c
+++ b/modules/load_balancer/lb_db.c
@@ -176,7 +176,6 @@ int lb_db_load_data( struct lb_data *data)
 			/* PROBING_MODE column */
 			check_val( ROW_VALUES(row)+4, DB_INT, 1, 0);
 			pmode = VAL_INT(ROW_VALUES(row)+4);
-			LM_DBG("id: %d pmode: %d\n", id, pmode);
 			if (pmode==0) {
 				flags |= LB_DST_PING_DSBL_FLAG;
 			} else if (pmode==LB_DST_STAT_MASK) {


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!
In order to consider and evaluate your PR, it is mandatory to provide detailed information about (1) what is the issue the PR addresses, (2) how the PR is solving the issue (logic and coding), (3) what are (if any) limitations of the proposed PR and (4) if there are any known side-effects/ backward compatibility issues/SIP interoperability issues.
Note that if the PR is missing information, it might take longer to be merged, as extra resources have to be allocated by the maintainers to reverse engineer the changes, understand them, understand the motivation, etc. That is why it is important to provide as much information as possible.
-->

**Summary**
<!-- Summary of the PR - what the PR is aiming to solve -->

Calling the lb_status MI command for disabling (on demand) the destination. the destination will be completly disabled。

but once opensips restart, the **completly disabed** state will be lost.

i expect the **completely disabled** will keep persists over opensips restart

**Details**
<!--
Details about the content of the PR - is it a bug fix, a new feature or perhaps a hack? Explain the **motivation** for making this change.
What existing problem does the pull request solve? Is this a particular problem (i.e. only some particular scenarios are affected, only some UACs, etc) or a generic one?
Do not assume others understand what you're trying to do and provide as much information as you may have.
-->

**Solution**
<!-- Explain how your PR fixes the problem. Are there any remaining concerns that might need to be addressed? -->

Add Probing mode  12 (completly disabled)

1. set the probing mode  to 12
2. call lb_reload


**Compatibility**
<!-- Does your change break other scenarios, or do they need to be migrated in order to work similarly? -->

**Closing issues**
<!-- Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). -->
