### PR TITLE
REGEX add pcres_match and pcres_match_group to opensips-cli

### DIFF
--- a/modules/regex/doc/regex_admin.xml
+++ b/modules/regex/doc/regex_admin.xml
@@ -359,9 +359,80 @@ if (pcre_match_group($rU, 2)) {
 			</para>
 
 <programlisting  format="linespecific">
+...
 opensips-cli -x mi regex_reload
+...
 </programlisting>
+		</section>
 
+		<section id="mi_regex_match" xreflabel="regex_match">
+			<title>
+				<function moreinfo="none">regex_match</function>
+			</title>
+
+			<para>
+				Matches the given string parameter against the regular expression pcre_regex.
+				Returns "Match" if it matches, "Not Match" otherwise.
+			</para>
+
+			<para>
+				Name: <emphasis>regex_match</emphasis>
+			</para>
+
+			<para>Parameters:</para>
+				<itemizedlist>
+					<listitem><para>string</para></listitem>
+
+					<listitem><para>pcre_regex</para></listitem>
+				</itemizedlist>
+
+			<para>
+				MI FIFO Command Format:
+			</para>
+
+<programlisting  format="linespecific">
+...
+opensips-cli -x mi regex_match string="1234" pcre_regex="^1234$"
+"Match"
+opensips-cli -x mi regex_match string="1234" pcre_regex="^1235$"
+"Not Match"
+...
+</programlisting>
+		</section>
+
+		<section id="mi_regex_match_group" xreflabel="regex_match_group">
+			<title>
+				<function moreinfo="none">regex_match_group</function>
+			</title>
+
+			<para>
+				It uses the groups readed from the text file to match the given string parameter against the compiled
+				regular expression in group number group. Returns "Match" if it matches, "Not Match" otherwise.
+			</para>
+
+			<para>
+				Name: <emphasis>regex_match_group</emphasis>
+			</para>
+
+			<para>Parameters:</para>
+				<itemizedlist>
+					<listitem><para>string</para></listitem>
+
+					<listitem><para>group</para></listitem>
+				</itemizedlist>
+
+			<para>
+				MI FIFO Command Format:
+			</para>
+
+<programlisting  format="linespecific">
+...
+opensips-cli -x mi regex_match_group string="1234" group="0"
+"Match"
+opensips-cli -x mi regex_match_group string="1234" group="1"
+"Not Match"
+...
+</programlisting>
 		</section>
 
 	</section>

--- a/modules/regex/regex_mod.c
+++ b/modules/regex/regex_mod.c
@@ -22,6 +22,8 @@
  * History:
  * --------
  *  2009-01-14  initial version (Iñaki Baz Castillo)
+ *  2023-08-12  export pcres_match to MI (Fabien Aunay)
+ *  2023-08-12  export pcres_match_group to MI (Fabien Aunay)
  */
 
 
@@ -46,8 +48,6 @@
 #include "../../locking.h"
 #include "../../mod_fix.h"
 #include "../../mi/mi.h"
-
-
 
 #define START 0
 #define RELOAD 1
@@ -108,8 +108,9 @@ static int w_pcre_match_group(struct sip_msg* _msg, str* string, int* _num_pcre)
 /*
  * MI functions
  */
-mi_response_t *mi_pcres_reload(const mi_params_t *params,
-								struct mi_handler *async_hdl);
+mi_response_t *mi_pcres_reload(const mi_params_t *params, struct mi_handler *async_hdl);
+mi_response_t *mi_pcres_match(const mi_params_t *params, struct mi_handler *async_hdl);
+mi_response_t *mi_pcres_match_group(const mi_params_t *params, struct mi_handler *async_hdl);
 
 
 /*
@@ -149,8 +150,16 @@ static const param_export_t params[] = {
  * Exported MI functions
  */
 static const mi_export_t mi_cmds[] = {
-	{ "regex_reload", 0, 0, 0, {
-		{mi_pcres_reload, {0}},
+	{ "regex_reload", "Causes regex module to re-read the content of the text file and re-compile the regular expressions", 0, 0, 
+		{{mi_pcres_reload, {0}},
+		{EMPTY_MI_RECIPE}}
+	},
+	{ "regex_match", "Matches the given string parameter against the regular expression pcre_regex", 0, 0, {
+		{mi_pcres_match, {"string", "pcre_regex", 0}},
+		{EMPTY_MI_RECIPE}}
+	},
+	{ "regex_match_group", "It uses the groups readed from the text file to match the given string parameter against the compiled regular expression in group number group", 0, 0, {
+		{mi_pcres_match_group, {"string", "group", 0}},
 		{EMPTY_MI_RECIPE}}
 	},
 	{EMPTY_MI_EXPORT}
@@ -181,7 +190,6 @@ struct module_exports exports = {
 	0,                         /*!< per-child init function */
 	0                          /* reload confirm function */
 };
-
 
 
 /*! \brief
@@ -249,9 +257,9 @@ static int mod_init(void)
 
 	return 0;
 
-err:
-	free_shared_memory();
-	return -1;
+	err:
+		free_shared_memory();
+		return -1;
 }
 
 
@@ -654,8 +662,7 @@ static int w_pcre_match_group(struct sip_msg* _msg, str* string, int* _num_pcre)
  */
 
 /*! \brief Reload pcres by reading the file again */
-mi_response_t *mi_pcres_reload(const mi_params_t *params,
-								struct mi_handler *async_hdl)
+mi_response_t *mi_pcres_reload(const mi_params_t *params, struct mi_handler *async_hdl)
 {
 	/* Check if group matching feature is enabled */
 	if (file == NULL) {
@@ -668,6 +675,99 @@ mi_response_t *mi_pcres_reload(const mi_params_t *params,
 		LM_ERR("failed to reload pcres\n");
 		return init_mi_error(500, MI_SSTR("Internal error"));
 	}
+
 	LM_NOTICE("reload success\n");
 	return init_mi_result_ok();
+}
+
+
+/*! \brief Matches the given string parameter against the regular expression pcre_regex */
+mi_response_t *mi_pcres_match(const mi_params_t *params, struct mi_handler *async_hdl)
+{
+	str string, pcre_regex;
+	int rc;
+
+	if ( get_mi_string_param(params, "string", &string.s, &string.len ) < 0) {
+		LM_DBG("mi_pcres_match string param error\n");
+		return init_mi_param_error();
+	}
+	if ( get_mi_string_param(params, "pcre_regex", &pcre_regex.s, &pcre_regex.len) < 0) {
+		LM_DBG("mi_pcres_match pcre_regex param error\n");
+		return init_mi_param_error();
+	}
+
+	/* handle call back function result */
+	rc = w_pcre_match(NULL, &string.s, &pcre_regex.s);
+	LM_DBG("w_pcre_match: string<%s>, pcre_regex=<%s>, result:<%i>\n", string.s, pcre_regex.s, rc);
+	
+	switch(rc) {
+		case -4:
+			/* Compilation error */
+			return init_mi_error(500, MI_SSTR("Error pcre_re compilation"));
+			break;
+		case -1:
+			/* Not Match */
+			return init_mi_result_string(MI_SSTR("Not Match"));
+			break;
+		case 1:
+			/* Match */
+			return init_mi_result_string(MI_SSTR("Match"));
+			break;
+		default:
+			/* Any other case */
+			return init_mi_error(500, MI_SSTR("Error"));
+	}
+}
+
+mi_response_t *mi_pcres_match_group(const mi_params_t *params, struct mi_handler *async_hdl)
+{
+	str string, group;
+	int _group;
+	int rc;
+
+	if ( get_mi_string_param(params, "string", &string.s, &string.len ) < 0) {
+		LM_DBG("mi_pcres_match_group string param error\n");
+		return init_mi_param_error();
+	}
+	if ( get_mi_string_param(params, "group", &group.s, &group.len) < 0) {
+		LM_DBG("mi_pcres_match_group group param error\n");
+		return init_mi_param_error();
+	}
+
+	/* 
+		type casting MI Param -> int(group) function.
+		L.616 already test if group is an integer, if not, default 0 is set.
+	*/
+	_group = atoi(group.s);
+
+	/* No possible negative index */
+	if ( _group < 0 ) {
+		return init_mi_error(500, MI_SSTR("Error invalid pcre index"));
+	}
+
+	/* handle call back function result */
+	rc = w_pcre_match_group(NULL, &string.s, &_group);
+	LM_DBG("w_pcre_match_group: string<%s>, _group=<%i>, result:<%i>\n", string.s, _group, rc);
+
+	switch(rc) {
+		case -4:
+			/* Compilation error */
+			return init_mi_error(500, MI_SSTR("Error invalid pcre index"));
+			break;
+		case -2:
+			/* group is disabled*/
+			return init_mi_error(500, MI_SSTR("Error group matching is disabled"));
+			break;
+		case -1:
+			/* Not Match */
+			return init_mi_result_string(MI_SSTR("Not Match"));
+			break;
+		case 1:
+			/* Match */
+			return init_mi_result_string(MI_SSTR("Match"));
+			break;
+		default:
+			/* Any other case */
+			return init_mi_error(500, MI_SSTR("Error"));
+	}
 }

--- a/modules/regex/regex_mod.c
+++ b/modules/regex/regex_mod.c
@@ -257,9 +257,9 @@ static int mod_init(void)
 
 	return 0;
 
-	err:
-		free_shared_memory();
-		return -1;
+err:
+	free_shared_memory();
+	return -1;
 }
 
 
@@ -719,6 +719,9 @@ mi_response_t *mi_pcres_match(const mi_params_t *params, struct mi_handler *asyn
 	}
 }
 
+/*! \brief It uses the groups readed from the text file to match the given string parameter against
+ * the compiled regular expression in group number group
+ */
 mi_response_t *mi_pcres_match_group(const mi_params_t *params, struct mi_handler *async_hdl)
 {
 	str string, group;
@@ -735,9 +738,9 @@ mi_response_t *mi_pcres_match_group(const mi_params_t *params, struct mi_handler
 	}
 
 	/* 
-		type casting MI Param -> int(group) function.
-		L.616 already test if group is an integer, if not, default 0 is set.
-	*/
+	 *	type casting MI Param -> int(group) function.
+	 *	L.616 already test if group is an integer, if not, default 0 is set.
+	 */
 	_group = atoi(group.s);
 
 	/* No possible negative index */
@@ -755,7 +758,7 @@ mi_response_t *mi_pcres_match_group(const mi_params_t *params, struct mi_handler
 			return init_mi_error(500, MI_SSTR("Error invalid pcre index"));
 			break;
 		case -2:
-			/* group is disabled*/
+			/* group is disabled */
 			return init_mi_error(500, MI_SSTR("Error group matching is disabled"));
 			break;
 		case -1:


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!
In order to consider and evaluate your PR, it is mandatory to provide detailed information about (1) what is the issue the PR addresses, (2) how the PR is solving the issue (logic and coding), (3) what are (if any) limitations of the proposed PR and (4) if there are any known side-effects/ backward compatibility issues/SIP interoperability issues.
Note that if the PR is missing information, it might take longer to be merged, as extra resources have to be allocated by the maintainers to reverse engineer the changes, understand them, understand the motivation, etc. That is why it is important to provide as much information as possible.
-->

**Summary**
Add pcres_match and pcres_match_group to opensips-cli.

**Details**
Test your regex on a fly whithout script implementation nor external tool.

**Solution**
Perform live test like reload, test string regex against the regular expression pcre_regex or by using the groups readed from the text file.

Exported MI function :
- mi_pcres_match (exported from pcre_match)
- mi_pcres_match_group (exported from pcre_match_group)

**Compatibility**
Compiled under 3.4

**Closing issues**
Feature request : https://github.com/OpenSIPS/opensips/issues/3112
