### PR TITLE
#1923 - New option flag

### DIFF
--- a/help_msg.h
+++ b/help_msg.h
@@ -108,7 +108,8 @@ Options:\n\
                   shall receive input via stdin and it must output the\n\
                   result to stdout\n\
     -P file      Create a pid file\n\
-    -G file      Create a pgid file\n"
+    -G file      Create a pgid file\n\
+    -A address   Set the globally advertised addres\n"
 #ifdef UNIT_TESTS
 "    -T           Fork, run unit tests and exit.\n"
 #endif

--- a/main.c
+++ b/main.c
@@ -408,7 +408,7 @@ int main(int argc, char** argv)
 	/* process pkg mem size from command line */
 	opterr=0;
 
-	options="f:cCm:M:b:l:n:N:rRvdDFEVhw:t:u:g:p:P:G:W:o:a:k:s:"
+	options="A:f:cCm:M:b:l:n:N:rRvdDFEVhw:t:u:g:p:P:G:W:o:a:k:s:"
 #ifdef UNIT_TESTS
 	"T:"
 #endif
@@ -619,6 +619,10 @@ int main(int argc, char** argv)
 			case 'o':
 					if (add_arg_var(optarg) < 0)
 						LM_ERR("cannot add option %s\n", optarg);
+					break;
+			case 'A':
+					default_global_address->s = optarg;
+					default_global_address->len = strlen(optarg);
 					break;
 #ifdef UNIT_TESTS
 			case 'T':


### PR DESCRIPTION
**Summary**
This PR is aiming to add a new option in the command line that specifies the advertised address in Via Headers. It is a solution to the issue and feature request #1923.

**Details**
This PR is a new feature that allow users to define the advertised address with an option directly from the command line. The feature request was made in the issue #1923.

**Solution**
I defined a new option parameter : `-A [string]` and updated the help message.
If the parameter `-A [string]`is defined the `default_global_address` variable is set.
The advertised address parameter of the configuration, if defined, will overrides the one provided in the command line.

**Compatibility**
No compatibility problem should be observed. 

**Closing issues**
closes #1923.