### PR TITLE
The proxy address does not specify the protocol to give an error mess…

### DIFF
--- a/modules/rtpengine/rtpengine.c
+++ b/modules/rtpengine/rtpengine.c
@@ -1034,6 +1034,9 @@ static int add_rtpengine_socks(struct rtpe_set * rtpe_list,
 		} else if (strncasecmp(pnode->rn_address, "unix:", 5) == 0) {
 			pnode->rn_umode = 0;
 			pnode->rn_address += 5;
+		} else {
+			LM_ERR("no protocol is specified for the proxy address <%s>\n", pnode->rn_address);
+			continue;
 		}
 
 		if (rtpe_list->rn_first == NULL) {


### PR DESCRIPTION
…age and is not added to the node list

**Summary**
The proxy address does not specify the protocol to give an error message and not added to the node list

**Details**
Configure the RTP Proxy address without the protocol part. you will see an error log: "ERROR:rtpengine:send_rtpe_command: proxy <ip:port> does not respond, disable it". but it is not easy to see what is the problem

**Solution**
The proxy address does not specify the protocol to give an error message and not added to the node list

**Compatibility**
<!-- Does your change break other scenarios, or do they need to be migrated in order to work similarly? -->

**Closing issues**
<!-- Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). -->
