### PR TITLE
STIR SHAKEN CA/CRL reload - disengagement token

### DIFF
--- a/modules/stir_shaken/doc/stir_shaken_admin.xml
+++ b/modules/stir_shaken/doc/stir_shaken_admin.xml
@@ -508,6 +508,42 @@ if (!stir_shaken_check_cert($var(cert))) {
 	    </example>
 	</section>
 
+	<section id="stir_shaken_disengagement" xreflabel="stir_shaken_disengagement()">
+	    <title>
+		<function moreinfo="none">stir_shaken_disengagement(token)</function>
+	    </title>
+	    <para>
+		This function add P-Identity-Bypass header with token value at the end of SIP headers.
+		</para>
+		<para>Meaning of the parameters is as follows:</para>
+	    <itemizedlist>
+	    <listitem>
+			<para><emphasis>token (string)</emphasis> - The token provided by the authority during outage.
+			</para>
+		</listitem>
+	    </itemizedlist>
+		<para>The function returns the following values:</para>
+		<itemizedlist>
+		<listitem>
+		    <para>1: Success</para>
+		</listitem>
+		<listitem>
+		    <para>0: Failed to add P-Identity-Bypass header</para>
+		</listitem>
+	    </itemizedlist>
+	    <para>This function can be used from REQUEST_ROUTE.</para>
+	    <example>
+		<title><function>stir_shaken_disengagement()</function> usage</title>
+		<programlisting format="linespecific">
+...
+if ( is_method("INVITE") &amp;&amp; !has_totag()) {
+	stir_shaken_disengagement("OSIP99-1234567890ABCDEF");
+}
+...
+</programlisting>
+	    </example>
+	</section>
+
     </section>
 
     <section id="exported_pseudo_variables">
@@ -570,6 +606,69 @@ if (!stir_shaken_check_cert($var(cert))) {
 ...
 	</programlisting>
 	</example>
+	</section>
+
+	<section id="exported_mi_functions" xreflabel="Exported MI Functions">
+		<title>Exported MI Functions</title>
+
+		<section id="mi_stir_shaken_ca_reload" xreflabel="stir_shaken_ca_reload">
+			<title>
+				<function moreinfo="none">stir_shaken_ca_reload</function>
+			</title>
+
+			<para>
+				Reload the file containing trusted CA certificates for the verifier
+				and the directory containing trusted CA certificates for the verifier.
+			</para>
+
+			<para>
+				Name: <emphasis>stir_shaken_ca_reload</emphasis>
+			</para>
+
+			<para>Parameters: <emphasis>none</emphasis></para>
+
+			<para>
+				MI FIFO Command Format:
+			</para>
+
+<programlisting  format="linespecific">
+...
+opensips-cli -x mi stir_shaken_ca_reload
+"OK"
+...
+</programlisting>
+
+		</section>
+
+		<section id="mi_stir_shaken_crl_reload" xreflabel="stir_shaken_crl_reload">
+			<title>
+				<function moreinfo="none">stir_shaken_crl_reload</function>
+			</title>
+
+			<para>
+				Reload the file containing certificate revocation lists (CRLs) for the verifier
+				and the directory containing certificate revocation lists for the verifier.
+			</para>
+
+			<para>
+				Name: <emphasis>stir_shaken_crl_reload</emphasis>
+			</para>
+
+			<para>Parameters: <emphasis>none</emphasis></para>
+
+			<para>
+				MI FIFO Command Format:
+			</para>
+
+<programlisting  format="linespecific">
+...
+opensips-cli -x mi stir_shaken_crl_reload
+"OK"
+...
+</programlisting>
+
+		</section>
+
 	</section>
 
 	</section>

--- a/modules/stir_shaken/doc/stir_shaken_admin.xml
+++ b/modules/stir_shaken/doc/stir_shaken_admin.xml
@@ -537,6 +537,7 @@ if (!stir_shaken_check_cert($var(cert))) {
 		<programlisting format="linespecific">
 ...
 if ( is_method("INVITE") &amp;&amp; !has_totag()) {
+	# equivalent to sipmsgops module: append_hf("P-Identity-Bypass: OSIP99-1234567890ABCDEF\r\n");
 	stir_shaken_disengagement("OSIP99-1234567890ABCDEF");
 }
 ...

--- a/modules/stir_shaken/stir_shaken.c
+++ b/modules/stir_shaken/stir_shaken.c
@@ -130,7 +130,6 @@ mi_response_t *mi_stir_shaken_crl_reload(const mi_params_t *params, struct mi_ha
  */
 static int auth_date_freshness = DEFAULT_AUTH_FRESHNESS;
 static int verify_date_freshness = DEFAULT_VERIFY_FRESHNESS;
-static char *token;
 static char *ca_list;
 static char *ca_dir;
 static char *crl_list;

--- a/modules/stir_shaken/stir_shaken.c
+++ b/modules/stir_shaken/stir_shaken.c
@@ -150,7 +150,6 @@ static X509_STORE *store;
 static const param_export_t params[] = {
 	{"auth_date_freshness", INT_PARAM, &auth_date_freshness},
 	{"verify_date_freshness", INT_PARAM, &verify_date_freshness},
-	{"token", INT_PARAM, &token},
 	{"ca_list", STR_PARAM, &ca_list},
 	{"ca_dir", STR_PARAM, &ca_dir},
 	{"crl_list", STR_PARAM, &crl_list},


### PR DESCRIPTION
- add init_cert_ca_reload function (derivative init_cert_validation)
- add init_cert_crl_reload function (derivative init_cert_validation)
- export stir_shaken_ca_reload to opensips-cli
- export stir_shaken_crl_reload to opensips-cli

**Summary**
hot reload request : https://github.com/OpenSIPS/opensips/issues/3139

**Details**
Use derivative init_cert_validation function to scope CA or CRL not only during OpenSIPS start.
Then export to MI for hot reload.

**Solution**
<!-- Explain how your PR fixes the problem. Are there any remaining concerns that might need to be addressed? -->

**Compatibility**
Compiled under 3.4

**Closing issues**
https://github.com/OpenSIPS/opensips/issues/3139
