### PR TITLE
net_tcp_proc: close a socket received for writing when there is an error

### DIFF
--- a/net/net_tcp_proc.c
+++ b/net/net_tcp_proc.c
@@ -303,6 +303,7 @@ again:
 						"handle write, err, state: %d, att: %d",
 						con->state, con->msg_attempts);
 					tcpconn_release_error(con, 1,"Write error");
+					close(s); /* we always close the socket received for writing */
 					break;
 				} else if (resp==1) {
 					sh_log(con->hist, TCP_SEND2MAIN,


### PR DESCRIPTION
**Summary**
We were seeing occasional fd leaks and sockets stuck in CLOSE_WAIT, particularly on TLS connections. This commit makes sure `net_tcp_proc` closes a socket that it was meant to write to even if the write failed with an error.

**Details**
<!--
Details about the content of the PR - is it a bug fix, a new feature or perhaps a hack? Explain the **motivation** for making this change.
What existing problem does the pull request solve? Is this a particular problem (i.e. only some particular scenarios are affected, only some UACs, etc) or a generic one?
Do not assume others understand what you're trying to do and provide as much information as you may have.
-->
I found I could easily reproduce the problem where sockets are stuck in CLOSE_WAIT by making uac_registrant register a user against a TLS server, using "forced_socket", and having the server exit shortly after the registration. `net_tcp_proc` had a comment implying that it was meant to close the socket in all cases when it was writing to it, but there was a surprise `break` statement that meant this was not true.

**Solution**
This PR fixes the problem by making sure `net_tcp_proc` closes the socket in all cases.

**Compatibility**
I don't expect this breaks any other scenarios.

**Closing issues**
<!-- Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). -->
