### PR TITLE
Jes/uac registrant null pointer dereference

### DIFF
--- a/modules/uac_registrant/registrant.c
+++ b/modules/uac_registrant/registrant.c
@@ -674,7 +674,8 @@ int run_reg_tm_cback(void *e_data, void *data, void *r_data)
 			goto done;
 		}
 		if (0 == parse_min_expires(msg)) {
-			rec->expires = (unsigned int)(long)msg->min_expires->parsed;
+			if (msg->min_expires)
+				rec->expires = (unsigned int)(long)msg->min_expires->parsed;
 			if(send_register(cb_param->hash_index, rec, NULL)==1)
 				rec->state = REGISTERING_STATE;
 			else


### PR DESCRIPTION
**Summary**
I was seeing segfaults when trying to make opensips register against a server with a much-too-short interval. I traced the problem back to a uac_registrant null pointer dereference of `msg->min_expires`. 

**Details**
This commit makes uac_registrant only try to dereference `msg->min_expires` if it is non-NULL.

**Solution**
I wrapped the dereference of `msg->min_expires` in `if (msg->min_expires)`.

**Compatibility**
It is possible that we would instead want `parse_min_expires()` to return nonzero if `msg->min_expires` is NULL. I couldn't quite work out what logic was intended. I think the code in this PR will fix the segfault, but it may not correct the intended behaviour.

**Closing issues**
<!-- Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). -->
