### PR TITLE
cachedb_redis_dbase: Fix the type of port with unsigned short.

### DIFF
--- a/modules/cachedb_redis/cachedb_redis_dbase.h
+++ b/modules/cachedb_redis/cachedb_redis_dbase.h
@@ -37,12 +37,12 @@
 #endif
 
 typedef struct cluster_nodes {
-	char *ip;							/* ip of this cluster node */
-	short port;						/* port of this cluster node */
-	unsigned short start_slot;		/* first slot for this server */
-	unsigned short end_slot;		/* last slot for this server */
+	char *ip;                       /* ip of this cluster node */
+	unsigned short port;            /* port of this cluster node */
+	unsigned short start_slot;      /* first slot for this server */
+	unsigned short end_slot;        /* last slot for this server */
 
-	redisContext *context;			/* actual connection to this node */
+	redisContext *context;          /* actual connection to this node */
 	struct tls_domain *tls_dom;
 
 	struct cluster_nodes *next;


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!
In order to consider and evaluate your PR, it is mandatory to provide detailed information about (1) what is the issue the PR addresses, (2) how the PR is solving the issue (logic and coding), (3) what are (if any) limitations of the proposed PR and (4) if there are any known side-effects/ backward compatibility issues/SIP interoperability issues.
Note that if the PR is missing information, it might take longer to be merged, as extra resources have to be allocated by the maintainers to reverse engineer the changes, understand them, understand the motivation, etc. That is why it is important to provide as much information as possible.
-->

**Summary**
<!-- Summary of the PR - what the PR is aiming to solve -->

**Details**
<!--
Details about the content of the PR - is it a bug fix, a new feature or perhaps a hack? Explain the **motivation** for making this change.
What existing problem does the pull request solve? Is this a particular problem (i.e. only some particular scenarios are affected, only some UACs, etc) or a generic one?
Do not assume others understand what you're trying to do and provide as much information as you may have.
-->
I used the modparam to set the cachedb_url as redis:opensips://:xxxxxx:35454/, and then encountered an error: failed to open redis connection xxxx:35454 - Servname not supported for ai_socktype. Upon inspecting the code, I realized that the cluster_node and redis_con have inconsistent port types, causing 35454 to become a negative value.

**Solution**
<!-- Explain how your PR fixes the problem. Are there any remaining concerns that might need to be addressed? -->

**Compatibility**
<!-- Does your change break other scenarios, or do they need to be migrated in order to work similarly? -->

**Closing issues**
<!-- Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). -->
