### PR TITLE
Fix problem with defining custom port for single-instance Redis

### DIFF
--- a/modules/cachedb_redis/cachedb_redis_dbase.c
+++ b/modules/cachedb_redis/cachedb_redis_dbase.c
@@ -371,6 +371,7 @@ redis_con* redis_new_connection(struct cachedb_id* id)
 	redis_con *con, *cons = NULL;
 	csv_record *r, *it;
 	unsigned int multi_hosts;
+  char *host_w_port;
 
 	if (id == NULL) {
 		LM_ERR("null cachedb_id\n");
@@ -382,7 +383,17 @@ redis_con* redis_new_connection(struct cachedb_id* id)
 	else
 		multi_hosts = 0;
 
-	r = parse_csv_record(_str(id->host));
+  LM_DBG("Redis host list: '%.*s' possible port '%d'\n", _str(id->host)->len, _str(id->host)->s, id->port);
+  if (multi_hosts == 0 && id->port != 0) {
+    host_w_port = pkg_malloc(sizeof(id->host) + sizeof((char *)":") + sizeof(id->port) + 1);
+    sprintf(host_w_port, "%s:%d", id->host, id->port);
+  }
+  else {
+    host_w_port = pkg_malloc(sizeof(id->host) + 1);
+    host_w_port = (char *)id->host;
+  }
+
+	r = parse_csv_record(_str(host_w_port));
 	if (!r) {
 		LM_ERR("failed to parse Redis host list: '%s'\n", id->host);
 		return NULL;


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!
In order to consider and evaluate your PR, it is mandatory to provide detailed information about (1) what is the issue the PR addresses, (2) how the PR is solving the issue (logic and coding), (3) what are (if any) limitations of the proposed PR and (4) if there are any known side-effects/ backward compatibility issues/SIP interoperability issues.
Note that if the PR is missing information, it might take longer to be merged, as extra resources have to be allocated by the maintainers to reverse engineer the changes, understand them, understand the motivation, etc. That is why it is important to provide as much information as possible.
-->

**Summary**
<!-- Summary of the PR - what the PR is aiming to solve -->
Fix problem with parsing Redis URL for single-instance servers

**Details**
<!--
Details about the content of the PR - is it a bug fix, a new feature or perhaps a hack? Explain the **motivation** for making this change.
What existing problem does the pull request solve? Is this a particular problem (i.e. only some particular scenarios are affected, only some UACs, etc) or a generic one?
Do not assume others understand what you're trying to do and provide as much information as you may have.
-->
Look at #3168 

**Solution**
<!-- Explain how your PR fixes the problem. Are there any remaining concerns that might need to be addressed? -->
If we know that cachedb_url define single-instance Redis server then get port from basic parser. If port from basic parser is not zero, then redefine string for sub-parser function

**Compatibility**
<!-- Does your change break other scenarios, or do they need to be migrated in order to work similarly? -->

**Closing issues**
<!-- Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). -->
closes #3168 
