### PR TITLE
ldap: Fix memory leak

### DIFF
--- a/modules/ldap/ldap_mod.c
+++ b/modules/ldap/ldap_mod.c
@@ -59,6 +59,7 @@ static int child_init(int rank);
 */
 static int fixup_result_avp_type(void **param);
 static int fixup_substre(void** param);
+static int fixup_free_substre(void** param);
 
 /*
 * exported functions
@@ -102,7 +103,7 @@ static const cmd_export_t cmds[] = {
 		{CMD_PARAM_STR, 0, 0},
 		{CMD_PARAM_VAR, 0, 0},
 		{CMD_PARAM_STR | CMD_PARAM_OPT, fixup_result_avp_type, 0},
-		{CMD_PARAM_STR | CMD_PARAM_OPT, fixup_substre, 0}, {0,0,0}},
+		{CMD_PARAM_STR | CMD_PARAM_OPT, fixup_substre, fixup_free_substre}, {0,0,0}},
 		REQUEST_ROUTE|FAILURE_ROUTE|BRANCH_ROUTE|
 		ONREPLY_ROUTE|LOCAL_ROUTE|STARTUP_ROUTE|TIMER_ROUTE|EVENT_ROUTE},
 	{"ldap_result_next", (cmd_function)w_ldap_result_next, {{0,0,0}},
@@ -111,7 +112,7 @@ static const cmd_export_t cmds[] = {
 	{"ldap_result_check", (cmd_function)w_ldap_result_check, {
 		{CMD_PARAM_STR, 0, 0},
 		{CMD_PARAM_STR, 0, 0},
-		{CMD_PARAM_STR | CMD_PARAM_OPT, fixup_substre, 0}, {0,0,0}},
+		{CMD_PARAM_STR | CMD_PARAM_OPT, fixup_substre, fixup_free_substre}, {0,0,0}},
 		REQUEST_ROUTE|FAILURE_ROUTE|
 		BRANCH_ROUTE|ONREPLY_ROUTE|LOCAL_ROUTE|STARTUP_ROUTE|TIMER_ROUTE|EVENT_ROUTE},
 	{"ldap_filter_url_encode", (cmd_function)w_ldap_filter_url_encode, {
@@ -342,5 +343,11 @@ static int fixup_substre(void** param)
 	}
 
 	*param=se;
+	return 0;
+}
+
+static int fixup_free_substre(void** param)
+{
+	subst_expr_free(*param);
 	return 0;
 }


### PR DESCRIPTION
**Summary**
This PR is aiming to solve a memory leak that happens to be located in the LDAP module (see bug https://github.com/OpenSIPS/opensips/issues/3190).

**Details**
The memory leak concerns the exported methods ldap_write_result and ldap_result_check when a regexp is used for substringing the result.

**Solution**
The subst_expr* that is allocated for the methods ldap_write_result and ldap_result_check is never freed.

In order to fix it, we declare the fixup_free_substre function that is used in the definition of the "free_fixup" function for the subst_expr parameter of these two functions.

**Compatibility**
This change is not compatible with versions prior to the commit 4137c5a09299012a3c3ae2e6085c140790f4403d ldap: port script functions to new param interface

**Additional data**
Hereafter is the memory allocation table that led me to discover this leak :
```
Sep 14 09:54:36 [17775] Memory status (pkg):
Sep 14 09:54:36 [17775] fm_status (0x7fc08aa26010):
Sep 14 09:54:36 [17775]  heap size= 16777216
Sep 14 09:54:36 [17775]  used= 9898328, used+overhead=16772880, free=6878888
Sep 14 09:54:36 [17775]  max used (+overhead)= 16777216
Sep 14 09:54:36 [17775]  dumping summary of all alloc'ed. fragments:
Sep 14 09:54:36 [17775] ------------+---------------------------------------
Sep 14 09:54:36 [17775] total_bytes | num_allocations x [file: func, line]
Sep 14 09:54:36 [17775] ------------+---------------------------------------
Sep 14 09:54:36 [17775]          48 : 4 x [script_var.c: set_var_value, line 101]
Sep 14 09:54:36 [17775]         112 : 1 x [stir_shaken.c: fixup_auth_out, line 956]
Sep 14 09:54:36 [17775]         264 : 11 x [socket_info.c: fix_socket_list, line 802]
Sep 14 09:54:36 [17775]          48 : 1 x [db/db_res.c: db_new_result, line 92]
Sep 14 09:54:36 [17775]          16 : 1 x [dbt_res.c: dbt_result_new, line 68]
Sep 14 09:54:36 [17775]         520 : 34 x [script_var.c: add_var, line 59]
Sep 14 09:54:36 [17775]         312 : 3 x [transformations.c: tr_parse_sparam, line 2746]
Sep 14 09:54:36 [17775]      140112 : 1 x [pvar.c: init_pvar_support, line 134]
Sep 14 09:54:36 [17775]        8192 : 1 x [io_wait.c: init_io_wait, line 568]
Sep 14 09:54:36 [17775]         528 : 4 x [dlg_vals.c: fetch_dlg_value, line 176]
Sep 14 09:54:36 [17775]          96 : 3 x [rr_cb.c: register_rrcb, line 57]
Sep 14 09:54:36 [17775]         912 : 1 x [parser/msg_parser.c: get_hdr_field, line 156]
Sep 14 09:54:36 [17775]         144 : 3 x [sr_module_deps.c: _alloc_module_dep, line 60]
Sep 14 09:54:36 [17775]          64 : 1 x [sdp_mangler.c: compile_expressions, line 499]
Sep 14 09:54:36 [17775]         144 : 2 x [context.c: context_alloc, line 120]
Sep 14 09:54:36 [17775]          32 : 1 x [db/db_res.c: db_allocate_columns, line 130]
Sep 14 09:54:36 [17775]         664 : 35 x [map.c: map_get, line 155]
Sep 14 09:54:36 [17775]          40 : 1 x [dbt_res.c: dbt_result_new, line 55]
Sep 14 09:54:36 [17775]        8008 : 143 x [route_struct.c: mk_exp, line 53]
Sep 14 09:54:36 [17775]          32 : 1 x [rtpproxy.c: rtpp_init_extra_stats, line 4361]
Sep 14 09:54:36 [17775]       32768 : 1 x [io_wait.c: init_io_wait, line 559]
Sep 14 09:54:36 [17775]          48 : 1 x [ipc.c: ipc_register_handler, line 154]
Sep 14 09:54:36 [17775]          40 : 1 x [mod_options.c: mod_init, line 139]
Sep 14 09:54:36 [17775]        6400 : 80 x [pvar.c: pv_add_extra, line 5190]
Sep 14 09:54:36 [17775]          64 : 4 x [script_var.c: set_var_value, line 112]
Sep 14 09:54:36 [17775]         504 : 46 x [cfg.y: yyparse, line 1404]
Sep 14 09:54:36 [17775]           8 : 1 x [ld_session.c: add_ld_session, line 134]
Sep 14 09:54:36 [17775]        1632 : 34 x [script_var.c: add_var, line 52]
Sep 14 09:54:36 [17775]         376 : 17 x [name_alias.c: add_alias, line 59]
Sep 14 09:54:36 [17775]          32 : 1 x [map.c: map_create, line 84]
Sep 14 09:54:36 [17775]          16 : 1 x [cfg.y: yyparse, line 513]
Sep 14 09:54:36 [17775]          24 : 1 x [rtpproxy.c: mod_init, line 1287]
Sep 14 09:54:36 [17775]         104 : 1 x [pg_con.c: db_postgres_new_connection, line 273]
Sep 14 09:54:36 [17775]          96 : 1 x [mi/mi_trace.c: try_load_trace_api, line 53]
Sep 14 09:54:36 [17775]         192 : 1 x [net/net_tcp.c: tcp_init, line 1753]
Sep 14 09:54:36 [17775]         232 : 1 x [cachedb/cachedb.c: register_cachedb, line 173]
Sep 14 09:54:36 [17775]          40 : 1 x [dns_cache.c: deserialize_he_rdata, line 282]
Sep 14 09:54:36 [17775]         376 : 17 x [cfg.y: yyparse, line 523]
Sep 14 09:54:36 [17775]         192 : 6 x [transformations.c: tr_parse_sparam, line 2784]
Sep 14 09:54:36 [17775]           8 : 1 x [ld_session.c: add_ld_session, line 160]
Sep 14 09:54:36 [17775]          48 : 2 x [script_cb.c: insert_raw_processing_cb, line 220]
Sep 14 09:54:36 [17775]           8 : 1 x [pvar.c: pv_init_extra_list, line 5126]
Sep 14 09:54:36 [17775]          24 : 2 x [cachedb/cachedb_id.c: dupl_string, line 45]
Sep 14 09:54:36 [17775]      192512 : 1503 x [cfg.lex: addstr, line 794]
Sep 14 09:54:36 [17775]          80 : 4 x [avpops_parse.c: parse_intstr_value, line 352]
Sep 14 09:54:36 [17775]         192 : 3 x [avpops.c: fixup_check_avp, line 1017]
Sep 14 09:54:36 [17775]         240 : 5 x [sr_module_deps.c: solve_module_dependencies, line 293]
Sep 14 09:54:36 [17775]         192 : 3 x [mod_fix.c: fixup_regcomp, line 55]
Sep 14 09:54:36 [17775]          96 : 2 x [sr_module_deps.c: solve_module_dependencies, line 275]
Sep 14 09:54:36 [17775]          32 : 1 x [dbt_res.c: dbt_result_new, line 52]
Sep 14 09:54:36 [17775]           8 : 1 x [ld_session.c: add_ld_session, line 147]
Sep 14 09:54:36 [17775]         480 : 4 x [avpops_parse.c: parse_intstr_value, line 320]
Sep 14 09:54:36 [17775]        1152 : 16 x [route.c: fix_expr, line 1059]
Sep 14 09:54:36 [17775]       12288 : 1 x [io_wait.c: init_io_wait, line 621]
Sep 14 09:54:36 [17775]          56 : 1 x [dlg_db_handler.c: dlg_timer_remove_from_db, line 846]
Sep 14 09:54:36 [17775]          56 : 1 x [dlg_db_handler.c: dlg_timer_remove_from_db, line 838]
Sep 14 09:54:36 [17775]       32144 : 574 x [route_struct.c: mk_elem, line 69]
Sep 14 09:54:36 [17775]         440 : 25 x [sipmsgops.c: fixup_method, line 737]
Sep 14 09:54:36 [17775]         384 : 5 x [parser/msg_parser.c: parse_headers, line 325]
Sep 14 09:54:36 [17775]          24 : 1 x [ld_session.c: add_ld_session, line 67]
Sep 14 09:54:36 [17775]         896 : 28 x [transformations.c: tr_parse_string, line 2983]
Sep 14 09:54:36 [17775]          32 : 1 x [transformations.c: tr_eval_paramlist, line 2165]
Sep 14 09:54:36 [17775]         104 : 2 x [rtpproxy.c: rtpp_init_extra_stats, line 4374]
Sep 14 09:54:36 [17775]        2480 : 1 x [action.c: get_dummy_sip_msg, line 1321]
Sep 14 09:54:36 [17775]         240 : 6 x [flags.c: get_flag_id_by_name, line 202]
Sep 14 09:54:36 [17775]         240 : 2 x [db/db.c: db_do_init, line 314]
Sep 14 09:54:36 [17775]     2508896 : 38962 x [re.c: subst_parser, line 291]
Sep 14 09:54:36 [17775]         528 : 3 x [db/db.c: db_do_init, line 352]
Sep 14 09:54:36 [17775]          40 : 1 x [dns_cache.c: serialize_he_rdata, line 192]
Sep 14 09:54:36 [17775]         120 : 1 x [socket_info.c: get_socket_list_from_proto, line 955]
Sep 14 09:54:36 [17775]         296 : 1 x [parser/msg_parser.c: get_hdr_field, line 110]
Sep 14 09:54:36 [17775]         656 : 11 x [socket_info.c: new_sock_info, line 127]
Sep 14 09:54:36 [17775]       10456 : 1 x [route.c: new_sroutes_holder, line 106]
Sep 14 09:54:36 [17775]        4104 : 1 x [xlog.c: buf_init, line 124]
Sep 14 09:54:36 [17775]           8 : 1 x [ld_session.c: add_ld_session, line 173]
Sep 14 09:54:36 [17775]          64 : 2 x [permissions.c: get_pathname, line 328]
Sep 14 09:54:36 [17775]          88 : 1 x [ut.h: pkg_str_extend, line 964]
Sep 14 09:54:36 [17775]          24 : 1 x [dlg_hash.c: state_changed_event_init, line 1043]
Sep 14 09:54:36 [17775]         256 : 1 x [rtpproxy.c: connect_rtpproxies, line 1471]
Sep 14 09:54:36 [17775]         200 : 5 x [script_cb.c: add_callback, line 60]
Sep 14 09:54:36 [17775]        3840 : 80 x [transformations.c: parse_transformation, line 2568]
Sep 14 09:54:36 [17775]          32 : 1 x [transformations.c: tr_eval_uri, line 1105]
Sep 14 09:54:36 [17775]         424 : 1 x [ld_session.c: add_ld_session, line 49]
Sep 14 09:54:36 [17775]         784 : 15 x [sr_module_deps.c: solve_module_dependencies, line 335]
Sep 14 09:54:36 [17775]        6248 : 1 x [mi/mi.c: register_mi_cmd, line 146]
Sep 14 09:54:36 [17775]          24 : 1 x [cfg.y: yyparse, line 1327]
Sep 14 09:54:36 [17775]         904 : 28 x [transformations.c: tr_parse_nparam, line 2706]
Sep 14 09:54:36 [17775]      335184 : 38962 x [re.c: subst_parser, line 315]
Sep 14 09:54:36 [17775]       15448 : 478 x [mod_fix.c: alloc_gp, line 72]
Sep 14 09:54:36 [17775]         176 : 11 x [socket_info.c: fix_socket_list, line 690]
Sep 14 09:54:36 [17775]          48 : 1 x [dauth_nonce.c: dauth_noncer_new, line 290]
Sep 14 09:54:36 [17775]          32 : 2 x [avpops.c: fixup_subst, line 1095]
Sep 14 09:54:36 [17775]          64 : 1 x [dlg_db_handler.c: dlg_timer_remove_from_db, line 859]
Sep 14 09:54:36 [17775]          80 : 1 x [cachedb/cachedb_id.c: new_cachedb_id, line 386]
Sep 14 09:54:36 [17775]         144 : 11 x [socket_info.c: fix_socket_list, line 639]
Sep 14 09:54:36 [17775]        1096 : 19 x [sr_module_deps.c: add_module_dependency, line 135]
Sep 14 09:54:36 [17775]         640 : 20 x [transformations.c: tr_parse_nparam, line 2682]
Sep 14 09:54:36 [17775]         544 : 17 x [name_alias.c: add_alias, line 57]
Sep 14 09:54:36 [17775]          72 : 1 x [db/db_id.c: new_db_id, line 272]
Sep 14 09:54:36 [17775]          56 : 1 x [parser/parse_param.c: parse_params, line 370]
Sep 14 09:54:36 [17775]       43264 : 416 x [cfg.y: yyparse, line 1597]
Sep 14 09:54:36 [17775]        2080 : 20 x [transformations.c: tr_parse_nparam, line 2668]
Sep 14 09:54:36 [17775]          32 : 1 x [ld_session.c: add_ld_session, line 122]
Sep 14 09:54:36 [17775]        5160 : 43 x [avpops_parse.c: avpops_parse_pvar, line 126]
Sep 14 09:54:36 [17775]          32 : 1 x [cachedb_local.c: lcache_new_connection, line 283]
Sep 14 09:54:36 [17775]         248 : 1 x [address.c: init_address_part, line 354]
Sep 14 09:54:36 [17775]         624 : 13 x [evi/evi_params.c: evi_param_create, line 43]
Sep 14 09:54:36 [17775]      206832 : 834 x [route_struct.c: mk_action, line 105]
Sep 14 09:54:36 [17775]          80 : 1 x [context.c: register_context_destroy, line 66]
Sep 14 09:54:36 [17775]        1960 : 35 x [map.c: map_get, line 144]
Sep 14 09:54:36 [17775]        3168 : 11 x [socket_info.c: new_sock_info, line 120]
Sep 14 09:54:36 [17775]        1152 : 18 x [cfg.y: mk_listen_id, line 2319]
Sep 14 09:54:36 [17775]           8 : 1 x [ld_session.c: add_ld_session, line 186]
Sep 14 09:54:36 [17775]          64 : 2 x [cachedb/cachedb.c: cachedb_do_init, line 646]
Sep 14 09:54:36 [17775]        1296 : 27 x [ip_addr.c: mk_net, line 55]
Sep 14 09:54:36 [17775]          64 : 1 x [parser/parse_via.c: parse_via, line 2117]
Sep 14 09:54:36 [17775]        3376 : 77 x [sipmsgops.c: fixup_parse_hname, line 679]
Sep 14 09:54:36 [17775]     6245264 : 38962 x [re.c: subst_parser, line 306]
Sep 14 09:54:36 [17775]          16 : 1 x [io_wait.c: init_io_wait, line 576]
Sep 14 09:54:36 [17775]          80 : 5 x [db/db_id.c: dupl_string, line 47]
Sep 14 09:54:36 [17775]        2368 : 37 x [sr_module.c: register_module, line 151]
Sep 14 09:54:36 [17775]          48 : 1 x [parser/msg_parser.c: get_hdr_field, line 132]
Sep 14 09:54:36 [17775]          80 : 2 x [pvar.c: new_pv_context, line 5265]
Sep 14 09:54:36 [17775]        4032 : 36 x [route.c: fix_actions, line 1358]
Sep 14 09:54:36 [17775]         768 : 1 x [hashTable.c: createHashTable, line 107]
Sep 14 09:54:36 [17775]       36608 : 286 x [pvar.c: pv_parse_format, line 4620]
Sep 14 09:54:36 [17775]          64 : 1 x [sdp_mangler.c: compile_expressions, line 483]
Sep 14 09:54:36 [17775]          96 : 3 x [transformations.c: tr_parse_sparam, line 2760]
Sep 14 09:54:36 [17775] ----------------------------------------------------
Sep 14 09:54:36 [17775] dumping free list:
Sep 14 09:54:36 [17775] hash =   7 fragments no.:     1, unused:     0
Sep 14 09:54:36 [17775] hash =   9 fragments no.:     9, unused:     0
Sep 14 09:54:36 [17775] hash =  30 fragments no.:     1, unused:     0
Sep 14 09:54:36 [17775] hash = 114 fragments no.:     1, unused:     0
Sep 14 09:54:36 [17775] hash = 310 fragments no.:     1, unused:     0
Sep 14 09:54:36 [17775] TOTAL:     13 free fragments =   4336 free bytes
Sep 14 09:54:36 [17775] TOTAL: 56 overhead
Sep 14 09:54:36 [17775] -----------------------------
```
