### PR TITLE
drouting: allow DB_BIGINT for dr_rules.ruleid column

### DIFF
--- a/modules/drouting/dr_load.c
+++ b/modules/drouting/dr_load.c
@@ -641,7 +641,7 @@ rt_data_t* dr_load_routing_info(struct head_db *part,
 			for(i=0; i < RES_ROW_N(res); i++) {
 				row = RES_ROWS(res) + i;
 				/* RULE_ID column */
-				check_val( rule_id_drr_col, ROW_VALUES(row), DB_INT, 1, 0);
+				check_val2( rule_id_drr_col, ROW_VALUES(row), DB_INT, DB_BIGINT, 1, 0);
 				int_vals[INT_VALS_RULE_ID_DRR_COL] = VAL_INT (ROW_VALUES(row));
 				/* GROUP column */
 				check_val( group_drr_col, ROW_VALUES(row)+1, DB_STRING, 1, 1);


### PR DESCRIPTION
**Summary**
Currently the `drouting` module only has support for `DB_INT` type for the **dr_rules.ruleid** column. This PR adds support for the `DB_BIGINT` type as well.

**Details**
I ran into this when trying to integrate the `drouting` module with some custom `VIEW` based schema that was using `BIGINT` for the ID column. The resulting logs are below and the table fails to load.

> ERROR:drouting:dr_load_routing_info: column ruleid has a bad type [1], accepting only [0]

This should be a pretty safe one!