### PR TITLE
b2b_logic: pass extra headers in the INVITE sent to the provisional media server

### DIFF
--- a/modules/b2b_logic/bridging.c
+++ b/modules/b2b_logic/bridging.c
@@ -1492,7 +1492,7 @@ int b2bl_bridge(struct sip_msg* msg, b2bl_tuple_t* tuple,
 {
 	b2bl_entity_id_t* bridge_entities[2];
 	b2bl_entity_id_t* entity = NULL;
-	str *hdrs;
+	str *hdrs = NULL;
 	int i;
 
 	memset(bridge_entities, 0, 2*sizeof(b2bl_entity_id_t*));


### PR DESCRIPTION
**Summary**
When bridging a call with a provisional media server, the extra headers are sent only to the transferee (not to the provisional media server too).

**Details**
Here is a script example:
```
    if (is_method("REFER")) { # Process transfer
        ...
        b2b_send_reply(202, "Accepted");
        $avp(hdrs) = "X-1";
        $avp(hdrs_body) = "1";
        $avp(hdrs) = "X-2";
        $avp(hdrs_body) = "2";
        ...
        b2b_client_new($var(client_name), $var(refer_to),,,, $avp(hdrs), $avp(hdrs_body));
        b2b_bridge("peer", $var(client_name), $var(media_uri), "no-late-sdp");
        exit;
    }
````
The patch will ensure that the INVITE that is sent to the provisional media server and the INVITE that is sent to the referee will both contain the extra headers defined in the $avp(hdrs) and $avp(hdrs_body).
