### PR TITLE
`tls_wolfssl`: Fix certificate verification in client mode

### DIFF
--- a/modules/tls_wolfssl/wolfssl_config.c
+++ b/modules/tls_wolfssl/wolfssl_config.c
@@ -501,7 +501,7 @@ int _wolfssl_init_tls_dom(struct tls_domain *d, int init_flags)
 		}
 	} else {
 		if (d->verify_cert ) {
-			/* This is turned on by default in wolfSSL */
+			verify_mode = SSL_VERIFY_PEER;
 			LM_INFO("server verification activated.\n");
 		} else {
 			verify_mode = SSL_VERIFY_NONE;


### PR DESCRIPTION
**Summary**
When setting a client domain to `verify_cert=1`, OpenSIPS starts with the log `INFO:tls_wolfssl:_wolfssl_init_tls_dom: server verification activated.` However, it doesn’t actually verify certificates.

**Details**
The `wolfSSL_CTX_set_verify` function `mode` parameter, as per the [wolfSSL documentation](https://github.com/wolfSSL/wolfssl/blob/a4f9ae90d0dbb24047bb7c2edecb62bc98c1be31/wrapper/Ada/wolfssl.adb#L148C19-L149C40), specifies that `SSL_VERIFY_PEER` is the default in client mode. Nevertheless, the `tls_wolfssl` module directly sets it to `SSL_VERIFY_NONE` (`verify_mode` default value: `0`), thus omitting the verification process.

**Solution**
Set the verification mode directly to `SSL_VERIFY_PEER` and do not depend on any default behavior.

**Compatibility**

**Closing issues**
