### PR TITLE
Use makefile openssl everywhere

### DIFF
--- a/Makefile.openssl
+++ b/Makefile.openssl
@@ -4,23 +4,39 @@
 # Needed to build with openssl 3.x
 DEFS += -Wno-deprecated-declarations
 
+# normalize USE_ONLY_CRYPTO value
+ifeq ($(USE_ONLY_CRYPTO),)
+USE_ONLY_CRYPTO=false
+endif
+
 ifeq ($(CROSS_COMPILE),)
+ifeq ($(USE_ONLY_CRYPTO),false)
 SSL_BUILDER=$(shell \
-	if pkg-config --exists libssl; then \
-		echo 'pkg-config libssl'; \
+	if pkg-config --exists libssl libcrypto; then \
+		echo 'pkg-config libssl libcrypto'; \
 	fi)
+else
+SSL_BUILDER=$(shell \
+	if pkg-config --exists libcrypto; then \
+		echo 'pkg-config libcrypto'; \
+	fi)
+endif
 endif
 
 ifneq ($(SSL_BUILDER),)
 	DEFS += $(shell $(SSL_BUILDER) --cflags)
-	LIBS += $(shell $(SSL_BUILDER) --libs) -lcrypto
+	LIBS += $(shell $(SSL_BUILDER) --libs)
 else
 	DEFS += -I$(LOCALBASE)/ssl/include \
 			-I$(LOCALBASE)/include
 	LIBS += -L$(LOCALBASE)/lib -L$(LOCALBASE)/ssl/lib \
 			-L$(LOCALBASE)/lib64 -L$(LOCALBASE)/ssl/lib64 \
-			-lssl -lcrypto
+			-lcrypto
+ifeq ($(USE_ONLY_CRYPTO),false)
+	LIBS += -lssl
 endif
+endif
+
 
 # enable this flag to increase performance by not serializing openssl
 # connect/accept/read/write operations, at the cost of possible crashes

--- a/modules/cachedb_mongodb/Makefile
+++ b/modules/cachedb_mongodb/Makefile
@@ -8,7 +8,6 @@ auto_gen=
 NAME=cachedb_mongodb.so
 
 include ../../lib/json/Makefile.json
-
 ifeq ($(CROSS_COMPILE),)
 MONGOC_BUILDER = $(shell \
 	if pkg-config --exists libmongoc-1.0; then \
@@ -17,8 +16,11 @@ MONGOC_BUILDER = $(shell \
 endif
 
 ifeq ($(MONGOC_BUILDER),)
+
+include ../../Makefile.openssl
+
 	DEFS += -I$(SYSBASE)/include/libmongoc-1.0 -I$(SYSBASE)/include/libbson-1.0
-	LIBS += -L$(LOCALBASE)/lib -lssl -lcrypto -lrt -lmongoc-1.0 -lbson-1.0
+	LIBS += -L$(LOCALBASE)/lib -lrt -lmongoc-1.0 -lbson-1.0
 	LIBS += -dl -Bsymbolic
 else
 	DEFS += $(shell $(MONGOC_BUILDER) --cflags)

--- a/modules/cachedb_redis/Makefile
+++ b/modules/cachedb_redis/Makefile
@@ -12,8 +12,11 @@ NAME=cachedb_redis.so
 HAVE_REDIS_SSL=$(shell if [ -n "`ldconfig -p | grep hiredis_ssl`" ]; \
 	then echo "HAVE_REDIS_SSL"; fi)
 ifeq ($(HAVE_REDIS_SSL), HAVE_REDIS_SSL)
-	LIBS+=-lhiredis_ssl -lssl -lcrypto
-	DEFS+= -DHAVE_REDIS_SSL
+
+include ../../Makefile.openssl
+
+	LIBS += -lhiredis_ssl
+	DEFS += -DHAVE_REDIS_SSL
 endif
 
 ifeq ($(CROSS_COMPILE),)

--- a/modules/stir_shaken/Makefile
+++ b/modules/stir_shaken/Makefile
@@ -2,25 +2,11 @@
 # WARNING: do not run this directly, it should be run by the master Makefile
 
 include ../../Makefile.defs
+
+USE_ONLY_CRYPTO=true
+include ../../Makefile.openssl
+
 auto_gen=
 NAME=stir_shaken.so
-
-ifeq ($(CROSS_COMPILE),)
-SSL_BUILDER=$(shell \
-	if pkg-config --exists libcrypto; then \
-		echo 'pkg-config libcrypto'; \
-	fi)
-endif
-
-ifneq ($(SSL_BUILDER),)
-	DEFS += $(shell $(SSL_BUILDER) --cflags)
-	LIBS += $(shell $(SSL_BUILDER) --libs)
-else
-	DEFS += -I$(LOCALBASE)/ssl/include \
-			-I$(LOCALBASE)/include
-	LIBS += -L$(LOCALBASE)/lib -L$(LOCALBASE)/ssl/lib \
-			-L$(LOCALBASE)/lib64 -L$(LOCALBASE)/ssl/lib64 \
-			-lcrypto
-endif
 
 include ../../Makefile.modules


### PR DESCRIPTION
**Summary**
This PR is aiming to solve the feature request https://github.com/OpenSIPS/opensips/issues/3228

**Details**
One problem arose when I tried to compile my own version of `OpenSSL` for my needs and tried to use it for compiling `OpenSIPS` and its modules (in particular the `stir_shaken` module). I modified the file `Makefile.openssl` for my needs and it happend that the `stir_shaken` module had its own dependencies to `OpenSSL` (not including the file `Makefile.openssl`).

I found two other modules that did not use `Makefile.openssl` but I did not need to use them (but I'm still modifying them in order to use `Makefile.openssl`).

**Solution**
This PR enhances the `Makefile.openssl` to propose linking with either just `libcrypto` (which is standalone) or both `libcrypto` and `libssl` (`libssl` needs `libcrypto`) and make every module depending on `OpenSSL` include `Makefile.openssl`.
