### PR TITLE
Support overlapping SIP&HTTP headers in WS HTTP initial requests

### DIFF
--- a/modules/proto_ws/ws_handshake_common.h
+++ b/modules/proto_ws/ws_handshake_common.h
@@ -844,7 +844,7 @@ static int ws_parse_req_handshake(struct tcp_connection *c, char *msg, int len)
 	memset(&tmp_msg, 0, sizeof(struct sip_msg));
 	tmp_msg.len = len;
 	tmp_msg.buf = tmp_msg.unparsed = msg;
-	if (parse_headers(&tmp_msg, HDR_EOH_F, 0) < 0) {
+	if (parse_headers_aux(&tmp_msg, HDR_EOH_F, 0,0) < 0) {
 		LM_ERR("cannot parse headers\n%.*s\n", len, msg);
 		goto error;
 	}
@@ -1122,7 +1122,7 @@ static int ws_parse_rpl_handshake(struct tcp_connection *c, char *msg, int len)
 	memset(&tmp_msg, 0, sizeof(struct sip_msg));
 	tmp_msg.len = len;
 	tmp_msg.buf = tmp_msg.unparsed = msg;
-	if (parse_headers(&tmp_msg, HDR_EOH_F, 0) < 0) {
+	if (parse_headers_aux(&tmp_msg, HDR_EOH_F, 0, 0) < 0) {
 		LM_ERR("cannot parse headers\n%.*s\n", len, msg);
 		goto error;
 	}

--- a/parser/msg_parser.h
+++ b/parser/msg_parser.h
@@ -355,9 +355,13 @@ extern int via_cnt;
 
 int parse_msg(char* buf, unsigned int len, struct sip_msg* msg);
 
-int parse_headers(struct sip_msg* msg, hdr_flags_t flags, int next);
+#define parse_headers(msg, flags,next) 	parse_headers_aux(msg,flags,next, 1)
 
-char* get_hdr_field(char* buf, char* end, struct hdr_field* hdr);
+int parse_headers_aux(struct sip_msg* msg, hdr_flags_t flags, int next, int sip_well_known_parse);
+
+#define get_hdr_field(buf,end,hdr)	get_hdr_field_aux(buf,end,hdr,1)
+
+char* get_hdr_field_aux(char* buf, char* end, struct hdr_field* hdr, int sip_well_known_parse);
 
 void free_sip_msg(struct sip_msg* msg);
 


### PR DESCRIPTION
**Summary**
Support overlapping SIP&HTTP headers in WS HTTP initial requests

**Details**
HTTP proxies can sometimes add VIA header to the HTTP request switching from WS to SIP. Since we are using the SIP parser to go over a HTTP request, that will fail with : 

Oct 30 13:08:01 vlad-x1carbon ./opensips[31764]: ERROR:core:parse_via: bad char <H> on state 100
Oct 30 13:08:01 vlad-x1carbon ./opensips[31764]: ERROR:core:parse_via:  <HTTP/1.1 test@localhost#015#012#015#012>
Oct 30 13:08:01 vlad-x1carbon ./opensips[31764]: ERROR:core:parse_via: via parse failed
Oct 30 13:08:01 vlad-x1carbon ./opensips[31764]: ERROR:core:get_hdr_field: bad via
Oct 30 13:08:01 vlad-x1carbon ./opensips[31764]: INFO:core:parse_headers: bad header field

Steps to reproduce : 
* have OpenSIPS running with a ws listener
* run curl http://127.0.0.1:5060 -H "Host: 127.0.0.1" -H "Origin: 127.0.0.1" -H "Upgrade: websocket" -H "Connection: Upgrade" -H "Sec-Websocket-Protocol: sip" -H "Sec-Websocket-Key: ONdMbIDTYRA5rFwlmqhK5Q==" -H "Sec-Websocket-Version: 13" -H "Via: HTTP/1.1 test@localhost"

**Solution**
Introduce a flag in parser to decide if we want to internally implicit parse well-known SIP headers ( current list is VIA / TO / Content-Length / CSEQ ) & add a define to always parse ( aka. assume SIP context ). From WS HTTP contexts, do not parse those.

**Compatibility**
Should not affect anything

**Closing issues**
Opening PR to make sure we are all in agreement with the solution here.
