### PR TITLE
json: fix array element deletion

### DIFF
--- a/modules/json/array_del.c
+++ b/modules/json/array_del.c
@@ -31,8 +31,7 @@
 void json_object_array_del(struct json_object* obj, int idx)
 {
 #if JSON_C_VERSION_NUM >= JSON_C_VERSION_013
-	array_list_del_idx(json_object_get_array(obj), idx,
-		json_object_get_array(obj)->length);
+	array_list_del_idx(json_object_get_array(obj), idx, 1);
 #else
 	if(idx >= obj->o.c_array->length)
 		return;


### PR DESCRIPTION
**Summary**
OpenSIPS incorrectly calls the JSON-C array element deletion function by passing the size of the array instead of the desired count of elements to delete. When attempting to delete from index `0`, it results in the deletion of all elements, while specifying an index greater than `0` leads to no deletion due to overindexing.

**Details**
##### Example 1:
```
  $json(obj) := "[ 1, 2, 3 ]";
  $json(obj[0]) = NULL;
  xlog("$json(obj)\n");
```
Result:   `[]`
Expected: `[ 2, 3 ]`

##### Example 2:
```
  $json(obj) := "[ 1, 2, 3 ]";
  $json(obj[1]) = NULL;
  xlog("$json(obj)\n");
```
Result:   `[ 1, 2, 3 ]`
Expected: `[ 1, 3 ]`

**Solution**
Fix the function call.

**Compatibility**
Possibly originates from 57ae84b2d8b2e0af1a66d529e4e94b21f3df319d, Tue Dec 12 15:31:53 2017 +0100. Tested with `master` and `3.2`.

**Closing issues**
N/A
