### PR TITLE
Add xml group and session custom extensions in metadata for siprec module.

### DIFF
--- a/modules/siprec/siprec.c
+++ b/modules/siprec/siprec.c
@@ -83,7 +83,6 @@ static const pv_export_t vars[] = {
 	{ {0, 0}, 0, 0, 0, 0, 0, 0, 0 }
 };
 
-
 /* module exports */
 struct module_exports exports = {
 	"siprec",						/* module name */
@@ -142,7 +141,6 @@ static int mod_preinit(void)
 
 	return 0;
 }
-
 
 /**
  * init module function

--- a/modules/siprec/siprec_sess.h
+++ b/modules/siprec/siprec_sess.h
@@ -94,6 +94,8 @@ struct src_sess {
 	struct list_head srs;
 	str group;
 	struct socket_info *socket; /* socket used towards SRS */
+	str group_custom_extension;
+	str session_custom_extension;
 
 	/* siprec */
 	siprec_uuid uuid;

--- a/modules/siprec/siprec_var.c
+++ b/modules/siprec/siprec_var.c
@@ -22,13 +22,15 @@
 #include "../../ut.h"
 #include "../../context.h"
 
-#define SIPREC_VAR_INVAID_ID	(-1)
-#define SIPREC_VAR_GROUP_ID		(1 << 0)
-#define SIPREC_VAR_CALLER_ID	(1 << 1)
-#define SIPREC_VAR_CALLEE_ID	(1 << 2)
-#define SIPREC_VAR_HEADERS_ID	(1 << 3)
-#define SIPREC_VAR_MEDIA_ID		(1 << 4)
-#define SIPREC_VAR_SOCKET_ID	(1 << 5)
+#define SIPREC_VAR_INVAID_ID				(-1)
+#define SIPREC_VAR_GROUP_ID					(1 << 0)
+#define SIPREC_VAR_CALLER_ID				(1 << 1)
+#define SIPREC_VAR_CALLEE_ID				(1 << 2)
+#define SIPREC_VAR_HEADERS_ID				(1 << 3)
+#define SIPREC_VAR_MEDIA_ID					(1 << 4)
+#define SIPREC_VAR_SOCKET_ID				(1 << 5)
+#define SIPREC_GROUP_CUSTOM_EXTENSION_ID	(1 << 6)
+#define SIPREC_SESSION_CUSTOM_EXTENSION_ID	(1 << 7)
 
 struct {
 	const char *name;
@@ -41,6 +43,8 @@ struct {
 	{"media_ip", SIPREC_VAR_MEDIA_ID},
 	{"headers", SIPREC_VAR_HEADERS_ID},
 	{"socket", SIPREC_VAR_SOCKET_ID},
+	{"group_custom_extension", SIPREC_GROUP_CUSTOM_EXTENSION_ID},
+	{"session_custom_extension", SIPREC_SESSION_CUSTOM_EXTENSION_ID},
 };
 
 static int srec_msg_idx;
@@ -82,6 +86,10 @@ static void free_srec_var(void *v)
 		pkg_free(sv->media.s);
 	if (sv->headers.s)
 		pkg_free(sv->headers.s);
+	if (sv->group_custom_extension.s)
+		pkg_free(sv->group_custom_extension.s);
+	if (sv->session_custom_extension.s)
+		pkg_free(sv->session_custom_extension.s);
 	pkg_free(sv);
 }
 
@@ -121,7 +129,6 @@ static int pv_parse_siprec_get_name(struct sip_msg *msg, pv_param_t *p)
 
 	return pv_parse_siprec_name(&tv.rs);
 }
-
 
 int pv_parse_siprec(pv_spec_p sp, const str *in)
 {
@@ -185,6 +192,12 @@ int pv_get_siprec(struct sip_msg *msg,  pv_param_t *param,
 				return pv_get_null(msg, param, val);
 			field = get_socket_real_name(sv->si);
 			break;
+		case SIPREC_GROUP_CUSTOM_EXTENSION_ID:
+			field = &sv->group_custom_extension;
+			break;
+		case SIPREC_SESSION_CUSTOM_EXTENSION_ID:
+			field = &sv->session_custom_extension;
+			break;
 		default:
 			LM_BUG("unknown field!\n");
 		case SIPREC_VAR_INVAID_ID:
@@ -241,6 +254,12 @@ int pv_set_siprec(struct sip_msg* msg, pv_param_t *param,
 				return -1;
 			}
 			return 1;
+		case SIPREC_GROUP_CUSTOM_EXTENSION_ID:
+			field = &sv->group_custom_extension;
+			break;
+		case SIPREC_SESSION_CUSTOM_EXTENSION_ID:
+			field = &sv->session_custom_extension;
+			break;
 		default:
 			LM_BUG("unknown field %d!\n", pv_parse_siprec_get_name(msg, param));
 		case SIPREC_VAR_INVAID_ID:

--- a/modules/siprec/siprec_var.h
+++ b/modules/siprec/siprec_var.h
@@ -26,7 +26,7 @@
 #include "../../socket_info.h"
 
 struct srec_var {
-	str group, caller, callee, media, headers;
+	str group, caller, callee, media, headers, group_custom_extension, session_custom_extension;
 	struct socket_info *si;
 };
 


### PR DESCRIPTION
**Summary**

This PR is aiming to add two new options in the SIPREC configuration:

- Group Custom Extension
- Session Custom Extension

These options could be used to inject custom XML extensions in SIPREC metadata. This PR is a solution to the issue and feature request [#3251](https://github.com/OpenSIPS/opensips/issues/3251).

**Details**

SIPREC metadata can have custom XML extensions in `group` and `session` tags. An example is provided in [RFC 7865](https://datatracker.ietf.org/doc/rfc7865/). Currently Opensips has no way to add such data in SIPREC metadata. This PR add two options in SIPREC configuration to enable adding custom data in those two tags.

Additional information is provided in feature request [#3251](https://github.com/OpenSIPS/opensips/issues/3251).

**Solution**

SIPREC module supports some options like `media` and `group`. Like those two options I added two more options, changed corressponding files and tested in a SRC/SRS lab.

**Compatibility**

No compatibility problem should be observed.

**Closing issues**

Closes [#3251](https://github.com/OpenSIPS/opensips/issues/3251).
