### PR TITLE
topology_hiding: fix encoded Contact length calculation

### DIFF
--- a/modules/topology_hiding/topo_hiding_logic.c
+++ b/modules/topology_hiding/topo_hiding_logic.c
@@ -1618,7 +1618,7 @@ static char* build_encoded_contact_suffix(struct sip_msg* msg,int *suffix_len)
 					/* we just iterate over the unknown params */
 					for (i=0;i<ctu.u_params_no;i++) {
 						if (str_match(&el->param_name, &ctu.u_name[i]))
-							suffix_len += topo_ct_param_len(&ctu.u_name[i], &ctu.u_val[i], 0);
+							total_len += topo_ct_param_len(&ctu.u_name[i], &ctu.u_val[i], 0);
 					}
 				}
 			}
@@ -1634,7 +1634,7 @@ static char* build_encoded_contact_suffix(struct sip_msg* msg,int *suffix_len)
 			for (el=th_hdr_param_list;el;el=el->next) {
 				for (it=((contact_body_t *)msg->contact->parsed)->contacts->params;it;it=it->next) {
 					if (str_match(&el->param_name, &it->name))
-						suffix_len += topo_ct_param_len(&it->name, &it->body, 1);
+						total_len += topo_ct_param_len(&it->name, &it->body, 1);
 				}
 			}
 		}


### PR DESCRIPTION


<!--
Thanks for submitting a pull request!
In order to consider and evaluate your PR, it is mandatory to provide detailed information about (1) what is the issue the PR addresses, (2) how the PR is solving the issue (logic and coding), (3) what are (if any) limitations of the proposed PR and (4) if there are any known side-effects/ backward compatibility issues/SIP interoperability issues.
Note that if the PR is missing information, it might take longer to be merged, as extra resources have to be allocated by the maintainers to reverse engineer the changes, understand them, understand the motivation, etc. That is why it is important to provide as much information as possible.
-->

**Summary**
<!-- Summary of the PR - what the PR is aiming to solve -->
OpenSIPS can segfault when topology_hiding's encoded Contact header is too big to fit in its calculated length.

**Details**
<!--
Details about the content of the PR - is it a bug fix, a new feature or perhaps a hack? Explain the **motivation** for making this change.
What existing problem does the pull request solve? Is this a particular problem (i.e. only some particular scenarios are affected, only some UACs, etc) or a generic one?
Do not assume others understand what you're trying to do and provide as much information as you may have.
-->
The calculated length should be accumulated in `total_len`, but instead the assignment is to `suffix_len`, presumably due to a copy and paste error.

This bug was introduced in https://github.com/OpenSIPS/opensips/commit/e23be5d19a4865083971d17dc719a4d4d3436a24 presumably as a copy-and-paste mistake.

**Solution**
<!-- Explain how your PR fixes the problem. Are there any remaining concerns that might need to be addressed? -->
My solution is to accumulate the length in `total_len` instead of in `suffix_len`.

**Compatibility**
<!-- Does your change break other scenarios, or do they need to be migrated in order to work similarly? -->
Probably doesn't break other scenarios.

**Closing issues**
<!-- Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). -->
