### PR TITLE
uac_registrant: compare Contact URI case-insensitively

### DIFF
--- a/modules/uac_registrant/registrant.c
+++ b/modules/uac_registrant/registrant.c
@@ -482,7 +482,7 @@ int run_reg_tm_cback(void *e_data, void *data, void *r_data)
 		while (contact) {
 			/* Check for binding */
 			if (contact->uri.len==rec->contact_uri.len &&
-				strncmp(contact->uri.s,rec->contact_uri.s,contact->uri.len)==0){
+				strncasecmp(contact->uri.s,rec->contact_uri.s,contact->uri.len)==0){
 				if (contact->expires && contact->expires->body.len) {
 					if (str2int(&contact->expires->body, &exp)<0) {
 						LM_ERR("Unable to extract expires from [%.*s]"


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!
In order to consider and evaluate your PR, it is mandatory to provide detailed information about (1) what is the issue the PR addresses, (2) how the PR is solving the issue (logic and coding), (3) what are (if any) limitations of the proposed PR and (4) if there are any known side-effects/ backward compatibility issues/SIP interoperability issues.
Note that if the PR is missing information, it might take longer to be merged, as extra resources have to be allocated by the maintainers to reverse engineer the changes, understand them, understand the motivation, etc. That is why it is important to provide as much information as possible.
-->

**Summary**
<!-- Summary of the PR - what the PR is aiming to solve -->
We had an issue where the response Contact URI had ";transport=udp" changed to ";transport=UDP".

**Details**
<!--
Details about the content of the PR - is it a bug fix, a new feature or perhaps a hack? Explain the **motivation** for making this change.
What existing problem does the pull request solve? Is this a particular problem (i.e. only some particular scenarios are affected, only some UACs, etc) or a generic one?
Do not assume others understand what you're trying to do and provide as much information as you may have.
-->
The unequal casing of "UDP" meant that `uac_registrant` did not recognise the Contact header, and therefore ignored the `;expires=...` value on the header, leading to OpenSIPS failing to re-register the user at the correct interval.

**Solution**
<!-- Explain how your PR fixes the problem. Are there any remaining concerns that might need to be addressed? -->

This commit solves the problem by comparing the Contact URI case-insensitively.

**Compatibility**
<!-- Does your change break other scenarios, or do they need to be migrated in order to work similarly? -->
I doubt this breaks any scenarios.

**Closing issues**
<!-- Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). -->
