### PR TITLE
usrloc: simplify processing of the refresh events

### DIFF
--- a/modules/usrloc/ul_evi.h
+++ b/modules/usrloc/ul_evi.h
@@ -52,9 +52,10 @@
 #define UL_EV_PARAM_CT_RCLID  "req_callid"
 
 struct ct_refresh_event_data {
-	ucontact_t *ct;
+	const ucontact_t *ct;
 	str reason;
 	str req_callid;
+	str sock_str;
 };
 
 /* AoR event IDs */


### PR DESCRIPTION
**Summary**

usrloc: simplify processing of the refresh events

**Details**

The code that generates refresh event tries to use sock_info* available in the contact structure to pass sock_str over. This requires allocating sock_info as well as setting up appropriate pointers. 

**Solution**

Do not abuse "struct socket_info" just to pass sock_str over. Instead, add str to the refresh event data and pass that alone. Not only it reduces amount of data to pass, but also makes code much easier to read and understand.

**Compatibility**

None

**Closing issues**

Nope