### PR TITLE
Ensure VERSIONTYPE is always defined

### DIFF
--- a/Makefile.defs
+++ b/Makefile.defs
@@ -507,6 +507,8 @@ else
   VERSIONTYPE = $(shell [ -f "${TOP_SRCDIR}/.gitrevision" ] && echo "git")
   ifneq ($(VERSIONTYPE),)
     THISREVISION = $(shell cat ${TOP_SRCDIR}/.gitrevision)
+  else
+    VERSIONTYPE = unknown
   endif
   OLDREVISION = "$(THISREVISION)"
 endif

--- a/main.c
+++ b/main.c
@@ -192,9 +192,7 @@ static void print_ct_constants(void)
 		MAX_RECV_BUFFER_SIZE, MAX_LISTEN, MAX_URI_SIZE,
 		BUF_SIZE );
 	printf("poll method support: %s.\n", poll_support);
-#ifdef VERSIONTYPE
 	printf("%s revision: %s\n", core_scm_ver.type, core_scm_ver.rev);
-#endif
 }
 
 static int

--- a/mi/mi_core.c
+++ b/mi/mi_core.c
@@ -138,13 +138,11 @@ static mi_response_t *mi_version_1(const mi_params_t *params,
 		return 0;
 	}
 
-#ifdef VERSIONTYPE
 	if (add_mi_string(resp_obj, MI_SSTR(VERSIONTYPE), MI_SSTR(THISREVISION))<0) {
 		LM_ERR("failed to add mi item\n");
 		free_mi_response(resp);
 		return 0;
 	}
-#endif
 
 	return resp;
 }


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!
In order to consider and evaluate your PR, it is mandatory to provide detailed information about (1) what is the issue the PR addresses, (2) how the PR is solving the issue (logic and coding), (3) what are (if any) limitations of the proposed PR and (4) if there are any known side-effects/ backward compatibility issues/SIP interoperability issues.
Note that if the PR is missing information, it might take longer to be merged, as extra resources have to be allocated by the maintainers to reverse engineer the changes, understand them, understand the motivation, etc. That is why it is important to provide as much information as possible.
-->

**Summary**
If someone downloads tarball from GitHub then this archive won't have .git directoryor .gitrevision (autogenerated) file. Let's ensure we still have VERSIONTYPE macro set.

This also allows us to remove unnecessary guards in two places.

---
Also I'd like to say Merry Christmas and Happy New Year!