### PR TITLE
STIR SHAKEN - Exported Events

### DIFF
--- a/modules/stir_shaken/stir_shaken.h
+++ b/modules/stir_shaken/stir_shaken.h
@@ -88,6 +88,11 @@
 #define INVALID_IDENTITY_REASON "Invalid Identity Header"
 #define IERROR_CODE 500
 #define IERROR_REASON "Internal Server Error"
+#define FAILED_TO_PARSE_IDENTITY "Failed to parse identity header"
+#define FAILED_TO_FIND_IDENTITY "No Identity header found"
+#define FAILED_TO_PARSE_PPT "Unsupported 'ppt' extension"
+#define FAILED_TO_PARSE_ALG "Unsupported 'alg'"
+#define FAILED_TO_PARSE_PASSPORT "Required PASSporT claims are missing or have bad datatypes"
 
 #define TN_AUTH_LIST_OID "1.3.6.1.5.5.7.1.26"
 #define TN_AUTH_LIST_LN "TNAuthorizationList"


### PR DESCRIPTION
**Summary**
Add new exported events E_STIR_AUTH, E_STIR_VERIFY, E_STIR_CHECK, E_STIR_CHECK_CERT.
1/4 PR to link E_STIR_CHECK events.

**Details**
Add new concept events.
Lazier to use and avoids repetition of lines of code inside exported functions.
event_gen_event need level message and mode function to raise an event.

Let suppose you would like raise an event in w_stir_check function linked to the E_STIR_CHECK event to inform it is not possible to find the Identity header.

Just do:
```
// static int event_gen_event(struct sip_msg *msg, int mode, int level)
event_gen_event(msg,2,2);
```
The first 2 mode will point to CHECK event.
The second 2 status will point to FAILED_TO_FIND_IDENTITY state.

**POC**
Core debug:
```
INFO:core:evi_publish_event: Registered event <E_STIR_AUTH(6)>
INFO:core:evi_publish_event: Registered event <E_STIR_VERIFY(7)>
INFO:core:evi_publish_event: Registered event <E_STIR_CHECK(8)>
INFO:core:evi_publish_event: Registered event <E_STIR_CHECK_CERT(9)>
```
opensips.cfg
```
event_route[E_STIR_CHECK] {
	xlog("SCRIPT:DBG: [E_STIR_CHECK] | We got an event from:$param(from), to:$param(to), call-id:$param(callid), state:$param(state)\n");
}
```
syslog
```
NOTICE:SCRIPT:DBG: [E_STIR_CHECK] | We got an event from:"alice"<sip:100@1.1.1.1>;tag=37663030303030313133633401363937303435383034, to:"bob"<sip:101@1.1.1.1>, call-id:887795433350235830738747, state:No Identity header found
```

**Compatibility**
```
version: opensips 3.5.0-dev (x86_64/linux)
```

**Closing issues**
