### PR TITLE
tls_openssl: only verify client certs if configured to require them

### DIFF
--- a/modules/tls_openssl/openssl_config.c
+++ b/modules/tls_openssl/openssl_config.c
@@ -202,15 +202,10 @@ static void get_ssl_ctx_verify_mode(struct tls_domain *d, int *verify_mode)
 		 *   SSL_VERIFY_PEER.
 		 */
 
-		if( d->verify_cert ) {
-			*verify_mode = SSL_VERIFY_PEER;
-			if( d->require_client_cert ) {
-				LM_INFO("client verification activated. Client "
-						"certificates are mandatory.\n");
-				*verify_mode |= SSL_VERIFY_FAIL_IF_NO_PEER_CERT;
-			} else
-				LM_INFO("client verification activated. Client "
-						"certificates are NOT mandatory.\n");
+		if( d->require_client_cert ) {
+			LM_INFO("client verification activated. Client "
+					"certificates are mandatory.\n");
+			*verify_mode = SSL_VERIFY_PEER | SSL_VERIFY_FAIL_IF_NO_PEER_CERT;
 		} else {
 			*verify_mode = SSL_VERIFY_NONE;
 			LM_INFO("client verification NOT activated. Weaker security.\n");


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!
In order to consider and evaluate your PR, it is mandatory to provide detailed information about (1) what is the issue the PR addresses, (2) how the PR is solving the issue (logic and coding), (3) what are (if any) limitations of the proposed PR and (4) if there are any known side-effects/ backward compatibility issues/SIP interoperability issues.
Note that if the PR is missing information, it might take longer to be merged, as extra resources have to be allocated by the maintainers to reverse engineer the changes, understand them, understand the motivation, etc. That is why it is important to provide as much information as possible.
-->

**Summary**
If you want opensips to verify server certs you have to enable `verify_cert`, but this also implicitly makes it verify *client* certs, when presented, even if you don't have `require_client_cert` enabled.



**Details**
<!--
Details about the content of the PR - is it a bug fix, a new feature or perhaps a hack? Explain the **motivation** for making this change.
What existing problem does the pull request solve? Is this a particular problem (i.e. only some particular scenarios are affected, only some UACs, etc) or a generic one?
Do not assume others understand what you're trying to do and provide as much information as you may have.
-->
There was previously no way to configure opensips to verify server certs without having it also verify client certs, even if you configured it to make client certs optional!

**Solution**
<!-- Explain how your PR fixes the problem. Are there any remaining concerns that might need to be addressed? -->
This PR makes `verify_cert` only apply in the case of opensips connecting out to a server, and `require_client_cert` only apply in the case of a client connecting into opensips.

**Compatibility**
<!-- Does your change break other scenarios, or do they need to be migrated in order to work similarly? -->
The only scenario I can imagine it breaking is if you have `require_client_cert` but *not* `verify_cert`, in which case formerly it would allow any client cert (but require *some* client cert to be presented), but now it would verify the client certificate. I don't expect this to be a problem because what is the point in requiring a client cert if you don't verify it?

**Closing issues**
<!-- Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). -->
