### PR TITLE
sql_cacher: MI/timer initiated table reload error logged on different log level

### DIFF
--- a/modules/sql_cacher/sql_cacher.c
+++ b/modules/sql_cacher/sql_cacher.c
@@ -1226,7 +1226,8 @@ static mi_item_t *mi_reload(const mi_params_t *params, str *key)
 		}
 	} else {
 		if (load_entire_table(db_hdls->c_entry, db_hdls, 1) < 0) {
-			LM_DBG("Failed to reload table\n");
+			LM_ERR("Failed to reload table %.*s\n", db_hdls->c_entry->table.len,
+				db_hdls->c_entry->table.s);
 			return init_mi_error(500, MI_SSTR("ERROR Reloading SQL database"));
 		}
 	}


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!
In order to consider and evaluate your PR, it is mandatory to provide detailed information about (1) what is the issue the PR addresses, (2) how the PR is solving the issue (logic and coding), (3) what are (if any) limitations of the proposed PR and (4) if there are any known side-effects/ backward compatibility issues/SIP interoperability issues.
Note that if the PR is missing information, it might take longer to be merged, as extra resources have to be allocated by the maintainers to reverse engineer the changes, understand them, understand the motivation, etc. That is why it is important to provide as much information as possible.
-->

**Summary**
When reloading a table in `sql_cacher`, the log level for an error is different in the case when the reload is initiated by a timer or by the MI.

**Details**
For timed reload, it’s on error log level: https://github.com/OpenSIPS/opensips/blob/master/modules/sql_cacher/sql_cacher.c#L1137

For MI reload, it’s on debug log level:
https://github.com/OpenSIPS/opensips/blob/master/modules/sql_cacher/sql_cacher.c#L1229

**Solution**
Fix the log level.

**Compatibility**
Noticed in 3.2, but apply to master too.

**Closing issues**
N/A
