### PR TITLE
siprec: fill stream object in metadata

### DIFF
--- a/doc/build-contrib.sh
+++ b/doc/build-contrib.sh
@@ -174,6 +174,7 @@ github_handles=(
   ["Sergey Khripchenko"]="shripchenko"
   ["Stefan Pologov"]="sisoftrg"
   ["Stéphane Alnet"]="shimaore"
+  ["Seyed Mehran Siadati"]="siadatism"
   ["Victor Ciurel <victor.ciurel@gmail.com>"]="victor-ciurel"
   ["Vlad Paiu"]="vladpaiu"
   ["Vlad Patrascu"]="rvlad-patrascu"

--- a/modules/siprec/siprec.c
+++ b/modules/siprec/siprec.c
@@ -248,7 +248,17 @@ static int siprec_start_rec(struct sip_msg *msg, str *srs)
 		LM_ERR("cannot add caller participant!\n");
 		goto session_cleanup;
 	}
-	/* caller info */
+
+	siprec_uuid caller_uuid;
+	siprec_build_uuid(caller_uuid);
+	int caller_label = 0;
+	int caller_medianum = 0;
+	if (srs_add_raw_sdp_stream(caller_label, caller_medianum, &caller_uuid, ss, &ss->participants[0]) < 0) {
+		LM_ERR("cannot add new media stream!\n");
+		goto session_cleanup;
+	}
+
+	/* callee info */
 	if (var && var->callee.len) {
 		xml_val = &var->callee;
 	} else {
@@ -263,6 +273,15 @@ static int siprec_start_rec(struct sip_msg *msg, str *srs)
 
 	if (src_add_participant(ss, aor, display, xml_val, NULL, NULL) < 0) {
 		LM_ERR("cannot add callee pariticipant!\n");
+		goto session_cleanup;
+	}
+
+	siprec_uuid callee_uuid;
+	siprec_build_uuid(callee_uuid);
+	int callee_label = 1;
+	int callee_medianum = 0;
+	if (srs_add_raw_sdp_stream(callee_label, callee_medianum, &callee_uuid, ss, &ss->participants[1]) < 0) {
+		LM_ERR("cannot add new media stream!\n");
 		goto session_cleanup;
 	}
 

--- a/modules/siprec/siprec_logic.c
+++ b/modules/siprec/siprec_logic.c
@@ -573,7 +573,6 @@ int srs_handle_media(struct sip_msg *msg, struct src_sess *sess)
 	return 0;
 }
 
-
 static void srs_send_update_invite(struct src_sess *sess, str *body)
 {
 	struct b2b_req_data req;


### PR DESCRIPTION
**Summary**

Currently stream object in not exists in generated metadata in SIPREC sessions. This PR is aiming to fill this object so it could be added in metadata.

**Details**

SIPREC metadata includes stream object to identify owner of each stream by adding its label.

Additional information is provided in feature request #3287.

**Solution**

The stream object is already implemented but it is not being filled. For each stream, an stream uuid should be generated, and its label should be extracted from SDP. My current solution is primitive, it assumes the caller's stream label is 0 and the callee's stream label is 1. I don't know if this assumption is current in all cases or not. Someone else's opinion would be great.

**Compatibility**

No compatibility problem should be observed.

**Closing issues**

Closes #3287.