### PR TITLE
Getsockopt warnings

### DIFF
--- a/modules/tls_openssl/openssl_conn_ops.c
+++ b/modules/tls_openssl/openssl_conn_ops.c
@@ -756,7 +756,12 @@ again:
 #endif
 				{
 					err_len=sizeof(err);
-					getsockopt(fd, SOL_SOCKET, SO_ERROR, &err, &err_len);
+					if (getsockopt(fd, SOL_SOCKET, SO_ERROR, &err, &err_len) != 0) {
+						LM_WARN("getsockopt error: fd=%d [server=%s:%d]: (%d) %s\n", fd,
+								ip_addr2a(&con->rcv.src_ip), con->rcv.src_port,
+								errno, strerror(errno));
+						goto failure;
+					}
 					if ((err==0) && (poll_err==0))
 						continue; /* retry ssl connect */
 					if (err!=EINPROGRESS && err!=EALREADY){

--- a/modules/tls_wolfssl/wolfssl_conn_ops.c
+++ b/modules/tls_wolfssl/wolfssl_conn_ops.c
@@ -440,7 +440,12 @@ again:
 #endif
 				{
 					err_len=sizeof(err);
-					getsockopt(fd, SOL_SOCKET, SO_ERROR, &err, &err_len);
+					if (getsockopt(fd, SOL_SOCKET, SO_ERROR, &err, &err_len) != 0) {
+						LM_WARN("getsockopt error: fd=%d [server=%s:%d]: (%d) %s\n", fd,
+								ip_addr2a(&con->rcv.src_ip), con->rcv.src_port,
+								errno, strerror(errno));
+						goto failure;
+					}
 					if ((err==0) && (poll_err==0))
 						continue; /* retry ssl connect */
 					if (err!=EINPROGRESS && err!=EALREADY){

--- a/net/tcp_common.c
+++ b/net/tcp_common.c
@@ -113,7 +113,12 @@ again:
 #endif
 		{
 			err_len=sizeof(err);
-			getsockopt(fd, SOL_SOCKET, SO_ERROR, &err, &err_len);
+			if (getsockopt(fd, SOL_SOCKET, SO_ERROR, &err, &err_len) != 0) {
+				get_su_info( servaddr, ip, port);
+				LM_WARN("getsockopt error: fd=%d [server=%s:%d]: (%d) %s\n", fd,
+						ip, port, errno, strerror(errno));
+				goto error;
+			}
 			if ((err==0) && (poll_err==0)) goto end;
 			if (err!=EINPROGRESS && err!=EALREADY){
 				get_su_info( servaddr, ip, port);
@@ -316,7 +321,12 @@ again:
 #endif
 		{
 			err_len=sizeof(err);
-			getsockopt(fd, SOL_SOCKET, SO_ERROR, &err, &err_len);
+			if (getsockopt(fd, SOL_SOCKET, SO_ERROR, &err, &err_len) != 0) {
+				get_su_info(&server->s, ip, port);
+				LM_WARN("getsockopt error: fd=%d [server=%s:%d]: (%d) %s\n", fd,
+						ip, port, errno, strerror(errno));
+				goto error;
+			}
 			if ((err==0) && (poll_err==0)) goto local_connect;
 			if (err!=EINPROGRESS && err!=EALREADY){
 				get_su_info(&server->s, ip, port);


### PR DESCRIPTION
**Summary**
We saw some nonsensical errors from `tls_openssl`, like:

    failed to retrieve SO_ERROR [server=...] (2) No such file or directory

I looked in `openssl_conn_ops.c` and found that the socket error is grabbed via `getsockopt()` of `SO_ERROR`, but I don't think `ENOENT` (No such file or directory) is applicable on a socket.

**Details**
The cause of the problem is that the error value isn't actually being successfully retrieved by `getsockopt()`, instead `getsockopt()` is failing for cause unknown, leaving its argument unchanged, and the argument `err` is also the value of the enclosing `switch`/`case` block, and we're in `case SSL_ERROR_WANT_READ`, and `SSL_ERROR_WANT_READ == ENOENT == 2`. Hence the nonsensical error message.

**Solution**
The solution is to check whether `getsockopt()` returned nonzero, and if so warn with the error that `getsockopt()` returned.

Obviously there is more to it than this (why is `getsockopt()` not working? what has gone wrong?), but logging a warning about the `getsockopt()` error seems strictly preferable to *ignoring* the error.

**Compatibility**
I can't imagine this breaks any scenarios as it doesn't change any logic, it just makes log output less confusing.

**Closing issues**
<!-- Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). -->
