### PR TITLE
[db_postgres] fix the SSL control over the "use_tls" parameter

### DIFF
--- a/modules/db_postgres/doc/db_postgres_admin.xml
+++ b/modules/db_postgres/doc/db_postgres_admin.xml
@@ -119,6 +119,34 @@ modparam("db_postgres", "timeout", 2)
         <section id="param_use_tls" xreflabel="use_tls">
 		<title><varname>use_tls</varname> (integer)</title>
 		<para>
+		Parameter to control the way the SSL support is used when connecting
+		to the Postgres server, as follows:
+		</para>
+		<itemizedlist>
+			<listitem>
+			<para>
+				<emphasis>use_tls=0</emphasis> (default) - the SSL support
+				is disabled and there is no attempt to use it;
+			</para>
+			</listitem>
+			<listitem>
+			<para>
+				<emphasis>use_tls=1</emphasis> with "tls_domain" present
+				in the DB URL - the SSL support is enabled, either 
+				"require", either "verify-ca", depending on the certificate
+				settings;
+			</para>
+			</listitem>
+			<listitem>
+			<para>
+				<emphasis>use_tls=1</emphasis> with no "tls_domain" present
+				in the DB URL - the SSL support is enabled in best effort mode
+				(or "prefer"); if supported by the server, it will be used,
+				otherwise it will fall back to non-SSL.
+			</para>
+			</listitem>
+		</itemizedlist>
+		<para>
 		Warning: the <emphasis>tls_openssl</emphasis> module cannot be used
 		when setting this parameter. Use the <emphasis>tls_wolfssl</emphasis>
 		module instead if a TLS/SSL Library is required.

--- a/modules/db_postgres/pg_con.c
+++ b/modules/db_postgres/pg_con.c
@@ -152,28 +152,38 @@ int db_postgres_connect(struct pg_con* ptr)
 
 	/* If use_tls is specified and tls_domain=[dom] was found in the parameter list */
 	/* configure the SSL connection parameters */
-	if (use_tls && tls_domain_name.len) {
-		/* the connection should use TLS */
-		if (!ptr->tls_dom) {
-			ptr->tls_dom = tls_api.find_client_domain_name(&tls_domain_name);
+	if (use_tls) {
+		if (tls_domain_name.len) {
+		/* the connection must use TLS */
 			if (!ptr->tls_dom) {
-				LM_ERR("TLS domain: %.*s not found\n", tls_domain_name.len, tls_domain_name.s);
-				return -1;
+				ptr->tls_dom = tls_api.find_client_domain_name(&tls_domain_name);
+				if (!ptr->tls_dom) {
+					LM_ERR("TLS domain: %.*s not found\n", tls_domain_name.len, tls_domain_name.s);
+					return -1;
+				}
 			}
+
+			LM_DBG("SSL key file: %.*s\n", ptr->tls_dom->pkey.len, ptr->tls_dom->pkey.s);
+			LM_DBG("SSL cert file: %.*s\n", ptr->tls_dom->cert.len, ptr->tls_dom->cert.s);
+			LM_DBG("SSL ca file: %.*s\n", ptr->tls_dom->ca.len, ptr->tls_dom->ca.s);
+			LM_DBG("SSL verify_cert: %d\n", ptr->tls_dom->verify_cert);
+
+			if (ptr->tls_dom->verify_cert == 1) {
+				PSQL_PARAM("sslmode", "verify-ca");
+			} else {
+				PSQL_PARAM("sslmode", "require");
+			}
+
+			PSQL_PARAM("sslkey", ptr->tls_dom->pkey.s);
+			PSQL_PARAM("sslcert", ptr->tls_dom->cert.s);
+			PSQL_PARAM("sslrootcert", ptr->tls_dom->ca.s);
+		} else {
+			/* try SSL if available, fallback to non-SSL */
+			PSQL_PARAM("sslmode", "prefer");
 		}
-
-		LM_DBG("SSL key file: %.*s\n", ptr->tls_dom->pkey.len, ptr->tls_dom->pkey.s);
-		LM_DBG("SSL cert file: %.*s\n", ptr->tls_dom->cert.len, ptr->tls_dom->cert.s);
-		LM_DBG("SSL ca file: %.*s\n", ptr->tls_dom->ca.len, ptr->tls_dom->ca.s);
-		LM_DBG("SSL verify_cert: %d\n", ptr->tls_dom->verify_cert);
-
-		if (ptr->tls_dom->verify_cert == 1) {
-			PSQL_PARAM("sslmode", "verify-ca");
-		}
-
-		PSQL_PARAM("sslkey", ptr->tls_dom->pkey.s);
-		PSQL_PARAM("sslcert", ptr->tls_dom->cert.s);
-		PSQL_PARAM("sslrootcert", ptr->tls_dom->ca.s);
+	} else {
+		/* do not try SSL at all*/
+		PSQL_PARAM("sslmode", "disable");
 	}
 
 	/* force the default timeout */


### PR DESCRIPTION
Fix how the `use_tls` controls the SSL usage when connecting to the server. The main issue here is that the SSL may be used even if the `use_tls` is not set (as the "prefer" mode is by default used).
Now we have:

- use_tls=0 (default) - the SSL support is disabled and there is no attempt to use it;
- use_tls=1 with "tls_domain" present in the DB URL - the SSL support is enabled, either "require", either "verify-ca", depending on the certificate settings;
- use_tls=1 with no "tls_domain" present in the DB URL - the SSL support is enabled in best effort mode (or "prefer"); if supported by the server, it will be used, otherwise it will fall back to non-SSL.
