### PR TITLE
Add generate_data_md5 param

### DIFF
--- a/modules/drouting/README
+++ b/modules/drouting/README
@@ -59,6 +59,7 @@ Dynamic Routing Module
               1.3.36. extra_prefix_chars (str)
               1.3.37. extra_id_chars (str)
               1.3.38. rule_tables_query (str)
+              1.3.39. generate_data_md5 (int)
 
         1.4. Exported Functions
 
@@ -168,22 +169,23 @@ Dynamic Routing Module
    1.36. Set extra_prefix_chars parameter
    1.37. Set extra_id_chars parameter
    1.38. Set the rule_tables_query parameter
-   1.39. do_routing usage
-   1.40. route_to_carrier usage
-   1.41. route_to_gw usage
-   1.42. use_next_gw usage
-   1.43. goes_to_gw usage
-   1.44. is_from_gw usage
-   1.45. dr_is_gw usage
-   1.46. dr_disable() usage
-   1.47. dr_match usage
-   1.48. dr_gw_status usage when use_partitions is set to 0
-   1.49. dr_gw_status usage when use_partitionsis set to 1
-   1.50. dr_carrier_status usage when use_partitions is 0
-   1.51. dr_carrier_status usage when use_partitions is 1
-   1.52. dr_reload_status usage when use_partitions is 0
-   1.53. dr_reload_status usage when use_partitions is 1
-   1.54. dr_enable_probing usage
+   1.39. Set the generate_data_md5 parameter
+   1.40. do_routing usage
+   1.41. route_to_carrier usage
+   1.42. route_to_gw usage
+   1.43. use_next_gw usage
+   1.44. goes_to_gw usage
+   1.45. is_from_gw usage
+   1.46. dr_is_gw usage
+   1.47. dr_disable() usage
+   1.48. dr_match usage
+   1.49. dr_gw_status usage when use_partitions is set to 0
+   1.50. dr_gw_status usage when use_partitionsis set to 1
+   1.51. dr_carrier_status usage when use_partitions is 0
+   1.52. dr_carrier_status usage when use_partitions is 1
+   1.53. dr_reload_status usage when use_partitions is 0
+   1.54. dr_reload_status usage when use_partitions is 1
+   1.55. dr_enable_probing usage
 
 Chapter 1. Admin Guide
 
@@ -1072,6 +1074,17 @@ modparam("drouting", "rule_tables_query", "
                 SELECT 'dr_rules_a' UNION SELECT 'dr_rules_b'")
 ...
 
+1.3.39. generate_data_md5 (int)
+
+   If enabled, it will generate MD5 hashes for drouting data,
+   attach that to the reload_status MI command output and to the
+   reload generated status reports
+
+   Example 1.39. Set the generate_data_md5 parameter
+...
+modparam("drouting", "generate_data_md5", 1)
+...
+
 1.4. Exported Functions
 
 1.4.1.  do_routing([groupID], [flags], [gw_whitelist],
@@ -1126,7 +1139,7 @@ modparam("drouting", "rule_tables_query", "
        specifing the name of one partition, you can use the "*"
        wildcard sign to force routing over all partitions.
 
-   Example 1.39. do_routing usage
+   Example 1.40. do_routing usage
 ...
 # all groups, sort on order, use_partitions is 0
 do_routing();
@@ -1182,7 +1195,7 @@ do_routing(2, "F", , , $var(gw_attributes));
        "use_partition" module parameter is turned on. Wildcard
        sign is not accepted by the function.
 
-   Example 1.40. route_to_carrier usage
+   Example 1.41. route_to_carrier usage
 ...
 # use_partitions is not set
 if ( route_to_carrier("my_top_carrier, def_carrier", , $var(carrier_att)
@@ -1237,7 +1250,7 @@ if ( route_to_carrier($var(carrierId), , , $var(my_partition)) ) {
        "use_partition" module parameter is turned on. Wildcard
        sign is not accepted by the function.
 
-   Example 1.41. route_to_gw usage
+   Example 1.42. route_to_gw usage
 ...
 # use_partitions is not set
 if ( route_to_gw("gw_europe") ) {
@@ -1303,7 +1316,7 @@ if ( route_to_gw("gw1,gw2,gw3", $var(gw_attrs), , "my_partition") ) {
        "use_partition" module parameter is turned on. Wildcard
        sign is not accepted by the function.
 
-   Example 1.42. use_next_gw usage
+   Example 1.43. use_next_gw usage
 ...
 # use_partitions is not set
 if (use_next_gw()) {
@@ -1380,7 +1393,7 @@ if (use_next_gw( , ,$var(carrier_attrs), "my_partition")) {
        "use_partition" module parameter is turned on. Wildcard
        sign is accepted by this function.
 
-   Example 1.43. goes_to_gw usage
+   Example 1.44. goes_to_gw usage
 ...
 # use_partitions is not set
 if (goes_to_gw( 1, , $var(gw_attrs))) {
@@ -1440,7 +1453,7 @@ if (goes_to_gw(1, , $var(gw_attrs), , "my_partition")) {
        "use_partition" module parameter is turned on. Wildcard
        sign is accepted by this function.
 
-   Example 1.44. is_from_gw usage
+   Example 1.45. is_from_gw usage
 # use_partitions is not set
 # match the source IP (only) against all gateways
 if (is_from_gw(-1, "n")) {
@@ -1499,7 +1512,7 @@ if (is_from_gw(, "c", , , "outbound")) {
        "use_partition" module parameter is turned on. Wildcard
        sign is accepted by this function.
 
-   Example 1.45. dr_is_gw usage
+   Example 1.46. dr_is_gw usage
 # match the SIP URI host within $var(uac) against all gateways
 if (dr_is_gw( $var(uac), , "n")) {
         ...
@@ -1533,7 +1546,7 @@ if (dr_is_gw( $avp(uac), , "n", , , "partition")) {
        "use_partition" module parameter is turned on. Wildcard
        sign is accepted by this function.
 
-   Example 1.46. dr_disable() usage
+   Example 1.47. dr_disable() usage
 ...
 if (t_check_status("(408)|(5[0-9][0-9])")) {
         dr_disable();
@@ -1575,7 +1588,7 @@ if (t_check_status("(408)|(5[0-9][0-9])")) {
        to be used. This parameter is to be defined ONLY if the
        "use_partition" module parameter is turned on.
 
-   Example 1.47. dr_match usage
+   Example 1.48. dr_match usage
 ...
 if ( dr_match( 1, "L" , $fU, ,"dids") )
         xlog("Full From Username $fU found in group 1 partition DIDS\n")
@@ -1635,7 +1648,7 @@ if ( dr_match( 1, , $var(did) ) )
             GW (0 - disable, 1 - enable). Only makes sense if
             gw_id is provided.
 
-   Example 1.48. dr_gw_status usage when use_partitions is set to
+   Example 1.49. dr_gw_status usage when use_partitions is set to
    0
 $ opensips-cli -x mi dr_gw_status gw_id=2
 State:: Active
@@ -1645,7 +1658,7 @@ Enabled:: Disabled MI
 $ opensips-cli -x mi dr_gw_status gw_id=3
 Enabled:: Inactive
 
-   Example 1.49. dr_gw_status usage when use_partitionsis set to 1
+   Example 1.50. dr_gw_status usage when use_partitionsis set to 1
 $ opensips-cli -x mi dr_gw_status partition_name=part_1 gw_id=my_gw
 State:: Active
 $ opensips-cli -x mi dr_gw_status partition_name=part_1 gw_id=my_gw stat
@@ -1680,14 +1693,14 @@ enabled:: inactive
             carrier (0 - disable, 1 - enable). Only makes sense if
             carrier_id is provided.
 
-   Example 1.50. dr_carrier_status usage when use_partitions is 0
+   Example 1.51. dr_carrier_status usage when use_partitions is 0
 $ opensips-cli -x mi dr_carrier_status carrier_id=CR1
 Enabled:: no
 $ opensips-cli -x mi dr_carrier_status carrier_id=CR1 status=1
 $ opensips-cli -x mi dr_carrier_status carrier_id=CR1
 Enabled:: yes
 
-   Example 1.51. dr_carrier_status usage when use_partitions is 1
+   Example 1.52. dr_carrier_status usage when use_partitions is 1
 $ opensips-cli -x mi dr_carrier_status partition_name=my_partition carri
 er_id=CR1
 Enabled:: no
@@ -1709,11 +1722,11 @@ Enabled:: yes
             every partition. Otherwise, the function will list the
             time of the last reload for the given partition.
 
-   Example 1.52. dr_reload_status usage when use_partitions is 0
+   Example 1.53. dr_reload_status usage when use_partitions is 0
 $ opensips-cli -x mi dr_reload_status
 Date:: Tue Aug 12 12:26:00 2014
 
-   Example 1.53. dr_reload_status usage when use_partitions is 1
+   Example 1.54. dr_reload_status usage when use_partitions is 1
 $ opensips-cli -x mi dr_reload_status
 Partition:: part_test Date=Tue Aug 12 12:24:13 2014
 Partition:: part_2 Date=Tue Aug 12 12:24:13 2014
@@ -1749,7 +1762,7 @@ Partition:: part_test Date=Tue Aug 12 12:24:13 2014
    Parameters:
      * status (optional) - 1 - enable, 0 - disable gateway probing
 
-   Example 1.54. dr_enable_probing usage
+   Example 1.55. dr_enable_probing usage
 $ opensips-cli -x mi dr_enable_probing
 Status:: 1
 $ opensips-cli -x mi dr_enable_probing 0

--- a/modules/drouting/doc/drouting_admin.xml
+++ b/modules/drouting/doc/drouting_admin.xml
@@ -1412,16 +1412,16 @@ modparam("drouting", "rule_tables_query", "
 		</example>
 	</section>
 
-	<section id="param_generate_data_md5" xreflabel="generate_data_md5">
-		<title><varname>generate_data_md5</varname> (int)</title>
+	<section id="param_generate_data_checksum" xreflabel="generate_data_checksum">
+		<title><varname>generate_data_checksum</varname> (int)</title>
 		<para>
-			If enabled, it will generate MD5 hashes for drouting data, attach that to the reload_status MI command output and to the reload generated status reports
+			If enabled, it will generate a checksum ( MD5 ) for drouting loaded data, attach that to the reload_status MI command output and to the reload generated status reports
 		</para>
 		<example>
-		<title>Set the <varname>generate_data_md5</varname> parameter</title>
+		<title>Set the <varname>generate_data_checksum</varname> parameter</title>
 		<programlisting format="linespecific">
 ...
-modparam("drouting", "generate_data_md5", 1)
+modparam("drouting", "generate_data_checksum", 1)
 ...
 		</programlisting>
 		</example>

--- a/modules/drouting/doc/drouting_admin.xml
+++ b/modules/drouting/doc/drouting_admin.xml
@@ -1412,6 +1412,21 @@ modparam("drouting", "rule_tables_query", "
 		</example>
 	</section>
 
+	<section id="param_generate_data_md5" xreflabel="generate_data_md5">
+		<title><varname>generate_data_md5</varname> (int)</title>
+		<para>
+			If enabled, it will generate MD5 hashes for drouting data, attach that to the reload_status MI command output and to the reload generated status reports
+		</para>
+		<example>
+		<title>Set the <varname>generate_data_md5</varname> parameter</title>
+		<programlisting format="linespecific">
+...
+modparam("drouting", "generate_data_md5", 1)
+...
+		</programlisting>
+		</example>
+	</section>
+
 </section>
 
 <section id="exported_functions" xreflabel="exported_functions">

--- a/modules/drouting/dr_load.h
+++ b/modules/drouting/dr_load.h
@@ -33,6 +33,6 @@ int dr_set_gw_sock_filter_mode(char *mode);
 void dr_update_head_cache(struct head_db *head);
 
 rt_data_t* dr_load_routing_info(struct head_db *current_partition,
-		int persistent_state, str *rules_tables, int rules_no);
+		int persistent_state, str *rules_tables, int rules_no, MD5_CTX *hash_ctx);
 
 #endif

--- a/modules/drouting/dr_partitions.h
+++ b/modules/drouting/dr_partitions.h
@@ -40,9 +40,17 @@
 #include "../../parser/parse_uri.h"
 #include "../../mi/mi.h"
 #include "../tm/tm_load.h"
+#include "../../md5global.h"
+#include "../../md5.h"
 
 extern int use_partitions;
 extern rw_lock_t *reload_lock;
+
+#define HASHLEN 16
+typedef char HASH[HASHLEN];
+
+#define HASHHEXLEN 32
+typedef char HASHHEX[HASHHEXLEN+1];
 
 struct head_db {
 	str db_url;
@@ -74,6 +82,7 @@ struct head_db {
 	int carrier_attrs_avp;
 	int restart_persistent;
 	rt_data_t *rdata;
+	HASHHEX md5;
 	rw_lock_t *ref_lock;
 	int ongoing_reload;
 	struct head_db *next;

--- a/modules/drouting/drouting.c
+++ b/modules/drouting/drouting.c
@@ -512,7 +512,7 @@ static const param_export_t params[] = {
 	{"extra_prefix_chars", STR_PARAM, &extra_prefix_chars     },
 	{"extra_id_chars",     STR_PARAM, &extra_id_chars.s       },
 	{"gw_socket_filter_mode", STR_PARAM, &gw_sock_filter_s    },
-	{"generate_data_md5", INT_PARAM, &generate_data_md5       },
+	{"generate_data_checksum", INT_PARAM, &generate_data_md5       },
 	{0, 0, 0}
 };
 

--- a/modules/drouting/drouting.c
+++ b/modules/drouting/drouting.c
@@ -64,6 +64,9 @@
 #define MI_LAST_UPDATE_S "Date"
 #define MI_LAST_UPDATE_LEN (strlen(MI_LAST_UPDATE_S))
 
+#define MI_HASH_S "Hash"
+#define MI_HASH_LEN (strlen(MI_HASH_S))
+
 #define MI_DEFAULT_PROBING_STATE	1
 #define MI_PROBING_DISABLED_S "Gateways probing disabled from script"
 
@@ -87,6 +90,9 @@ struct custom_rule_table *custom_rule_tables;
 
 /* reload controll parametere */
 static int no_concurrent_reload = 0;
+
+/* generate drouting data md5 & attach that to reload status & status reports */
+static int generate_data_md5 = 0;
 
 /*** DB relatede stuff ***/
 /* parameters  */
@@ -505,7 +511,8 @@ static const param_export_t params[] = {
 	{"enable_restart_persistency",INT_PARAM, &dr_rpm_enable   },
 	{"extra_prefix_chars", STR_PARAM, &extra_prefix_chars     },
 	{"extra_id_chars",     STR_PARAM, &extra_id_chars.s       },
-	{"gw_socket_filter_mode", STR_PARAM, &gw_sock_filter_s  },
+	{"gw_socket_filter_mode", STR_PARAM, &gw_sock_filter_s    },
+	{"generate_data_md5", INT_PARAM, &generate_data_md5       },
 	{0, 0, 0}
 };
 
@@ -1094,6 +1101,31 @@ static void dr_state_flusher(struct head_db* hd)
 	return;
 }
 
+static void bin_hash_to_hex(HASH _b, HASHHEX _h)
+{
+	unsigned short i;
+	unsigned char j;
+
+	for (i = 0; i < HASHLEN; i++) {
+		j = (_b[i] >> 4) & 0xf;
+		if (j <= 9) {
+			_h[i * 2] = (j + '0');
+		} else {
+			_h[i * 2] = (j + 'a' - 10);
+		}
+
+		j = _b[i] & 0xf;
+
+		if (j <= 9) {
+			_h[i * 2 + 1] = (j + '0');
+		} else {
+			_h[i * 2 + 1] = (j + 'a' - 10);
+		}
+	};
+
+	_h[HASHHEXLEN] = '\0';
+}
+
 /* Flushes to DB the state of carriers and gateways (if modified)
  * Locking is done to protect the data consistency */
 static void dr_state_timer(unsigned int ticks, void* param)
@@ -1146,6 +1178,9 @@ static inline int dr_reload_data_head(struct head_db *hd,
 	time_t rawtime;
 	struct dr_prepare_part_params pp;
 	int ret = -1;
+	MD5_CTX Md5Ctx, *ctxp=NULL;
+	HASH bin_md5;
+	char hash_report_data[64];
 
 	void **dest;
 	map_iterator_t it;
@@ -1187,7 +1222,13 @@ static inline int dr_reload_data_head(struct head_db *hd,
 			CHAR_INT("data re-loading"), 0);
 
 	if (!uses_rule_table_query(hd, &rule_table_query)) {
-		new_data = dr_load_routing_info(hd, dr_persistent_state, &hd->drr_table, 1);
+
+		if (generate_data_md5) { 
+			MD5Init(&Md5Ctx);
+			ctxp = &Md5Ctx;
+		}
+
+		new_data = dr_load_routing_info(hd, dr_persistent_state, &hd->drr_table, 1, ctxp);
 		if (!new_data) {
 			LM_CRIT("failed to load routing info\n");
 			goto error;
@@ -1240,8 +1281,13 @@ static inline int dr_reload_data_head(struct head_db *hd,
 
 		dr_dbf->free_result(db_hdl, res);
 
+		if (generate_data_md5) { 
+			MD5Init(&Md5Ctx);
+			ctxp = &Md5Ctx;
+		}
+
 		new_data = dr_load_routing_info(hd, dr_persistent_state, rules_tables,
-		                                rules_no);
+		                                rules_no,ctxp);
 		if (!new_data) {
 			LM_CRIT("failed to load routing info\n");
 			goto error;
@@ -1264,6 +1310,11 @@ static inline int dr_reload_data_head(struct head_db *hd,
 	/* update cache head */
 	if (hd->cache)
 		hd->cache->rdata = new_data;
+
+	if (generate_data_md5) {
+		MD5Final(bin_md5, &Md5Ctx);
+		bin_hash_to_hex(bin_md5,hd->md5);
+	}
 
 	lock_stop_write( (hd->ref_lock) );
 
@@ -1312,8 +1363,14 @@ static inline int dr_reload_data_head(struct head_db *hd,
 	populate_dr_bls(hd->rdata->pgw_tree);
 
 success:
-	sr_set_status( dr_srg, STR2CI(hd->partition), SR_STATUS_READY,
-		CHAR_INT("data available"), 0);
+	if (generate_data_md5) {
+		sprintf(hash_report_data,"data available %s",hd->md5);
+		sr_set_status( dr_srg, STR2CI(hd->partition), SR_STATUS_READY,
+			hash_report_data,strlen(hash_report_data), 0);
+	} else {
+		sr_set_status( dr_srg, STR2CI(hd->partition), SR_STATUS_READY,
+			CHAR_INT("data available"), 0);
+	}
 	if (no_concurrent_reload)
 		hd->ongoing_reload = 0;
 	return 0;
@@ -5330,6 +5387,9 @@ static int mi_dr_print_rld_status(mi_item_t *part_item, struct head_db * partiti
 
 	if (add_mi_string(part_item, MI_SSTR(MI_LAST_UPDATE_S),
 		ch_time, strlen(ch_time)-1) < 0)
+		goto error;
+
+	if (generate_data_md5 && add_mi_string(part_item,MI_SSTR(MI_HASH_S),partition->md5,strlen(partition->md5)) < 0)
 		goto error;
 
 	lock_stop_read(partition->ref_lock);

--- a/modules/drouting/routing.h
+++ b/modules/drouting/routing.h
@@ -26,6 +26,8 @@
 #include "../../usr_avp.h"
 #include "../../mem/mem.h"
 #include "../../map.h"
+#include "../../md5global.h"
+#include "../../md5.h"
 
 #include "prefix_tree.h"
 
@@ -98,7 +100,8 @@ add_carrier(
 	int state,
 	rt_data_t *rd,
 	osips_malloc_f mf,
-	osips_free_f ff
+	osips_free_f ff,
+	MD5_CTX *hash_ctx
 	);
 
 /* add a PSTN gw in the list */
@@ -124,7 +127,8 @@ add_dst(
 	/* state */
 	int,
 	osips_malloc_f mf,
-	osips_free_f ff
+	osips_free_f ff,
+	MD5_CTX *hash_ctx
 	);
 
 /* build a routing info list element */
@@ -164,4 +168,7 @@ del_pgw_list(
 
 void
 free_rt_data(rt_data_t*, osips_free_f);
+
+void hash_carrier(pcr_t *pcr,MD5_CTX *hash_ctx); 
+void hash_dst(pgw_t *pgw,MD5_CTX *hash_ctx); 
 #endif


### PR DESCRIPTION

**Summary**
Data loaded in drouting feedback

**Details**
If generate_data_md5 is set, OpenSIPS will compute an MD5 hash for each partition data, and export that MD5 in the reload_status MI command as well as in the reload status reports, for easy comparison between multiple OpenSIPS instances which should have the same dataset loaded.

**Solution**
For clusterer drouting usage, the platform admin can monitor that they are in sync in terms of MD5 hash of loaded data.

**Compatibility**
Backwards-compatible
