### PR TITLE
Add MI fetching of keys based on glob

### DIFF
--- a/modules/cachedb_local/README
+++ b/modules/cachedb_local/README
@@ -28,6 +28,7 @@ cachedb_local Module
         1.6. Exported MI Functions
 
               1.6.1. cache_remove_chunk
+              1.6.2. cache_fetch_chunk
 
    2. Frequently Asked Questions
    3. Contributors
@@ -287,6 +288,32 @@ modparam("cachedb_local", "enable_restart_persistency", yes)
 
    MI FIFO Command Format:
 opensips-cli -x mi cache_remove_chunk "keyprefix*" collection
+
+1.6.2.  cache_fetch_chunk
+
+   Fetches all local cache entries that match the provided glob
+   param.
+
+   Parameters :
+     * glob - keys that match glob will be returned
+     * collection(optional) - collection from which the keys shall
+       be retrieved; if no collection set, the default collection
+       will be used;
+
+   MI FIFO Command Format:
+opensips-cli -x mi cache_fetch_chunk "keyprefix*" collection
+{
+    "keys": [
+        {
+            "name": "keyprefix_1",
+            "value": "key 1 data here"
+        },
+        {
+            "name": "keyprefix_2",
+            "value": "key 2 data here"
+        }
+    ]
+}
 
 Chapter 2. Frequently Asked Questions
 

--- a/modules/cachedb_local/doc/cachedb_local_admin.xml
+++ b/modules/cachedb_local/doc/cachedb_local_admin.xml
@@ -339,6 +339,44 @@ modparam("cachedb_local", "enable_restart_persistency", yes)
 opensips-cli -x mi cache_remove_chunk "keyprefix*" collection
 		</programlisting>
 		</section>
+
+		<section id="mi_cache_fetch_chunk" xreflabel="cache_fetch_chunk">
+		<title>
+			<function moreinfo="none">cache_fetch_chunk</function>
+		</title>
+		<para>
+		Fetches all local cache entries that match the provided glob param.
+		</para>
+
+		<para>Parameters :</para>
+		<itemizedlist>
+			<listitem><para>
+				<emphasis>glob</emphasis> - keys that match glob will be returned
+			</para></listitem>
+			<listitem><para>
+				<emphasis>collection(optional)</emphasis> - collection from which the keys shall
+					be retrieved; if no collection set, the default collection will be used;
+			</para></listitem>
+		</itemizedlist>
+		<para>
+		MI FIFO Command Format:
+		</para>
+		<programlisting  format="linespecific">
+opensips-cli -x mi cache_fetch_chunk "keyprefix*" collection
+{
+    "keys": [
+        {
+            "name": "keyprefix_1",
+            "value": "key 1 data here"
+        },
+        {
+            "name": "keyprefix_2",
+            "value": "key 2 data here"
+        }
+    ]
+}
+		</programlisting>
+		</section>
 	</section>
 
 </chapter>


### PR DESCRIPTION
**Summary**
Fetch all cachedb_local keys from mem based on a glob regex

**Details**
New feature to fetch all data based on a global, useful for monitoring

**Solution**
Go through the local cache, match each key against the glob and return it in the reply key-value array