### PR TITLE
Usrloc kv store

### DIFF
--- a/cfg.lex
+++ b/cfg.lex
@@ -240,6 +240,7 @@ DNS_SERVERS_NO  dns_servers_no
 DNS_USE_SEARCH  dns_use_search_list
 MAXBUFFER maxbuffer
 CHECK_VIA	check_via
+REPLY_TO_VIA    reply_to_via
 SHM_HASH_SPLIT_PERCENTAGE "shm_hash_split_percentage"
 SHM_SECONDARY_HASH_SIZE "shm_secondary_hash_size"
 MEM_WARMING_ENABLED "mem_warming"|"mem_warming_enabled"
@@ -471,6 +472,7 @@ SPACE		[ ]
 								return MAX_WHILE_LOOPS; }
 <INITIAL>{MAXBUFFER}	{ count(); yylval.strval=yytext; return MAXBUFFER; }
 <INITIAL>{CHECK_VIA}	{ count(); yylval.strval=yytext; return CHECK_VIA; }
+<INITIAL>{REPLY_TO_VIA} { count(); yylval.strval=yytext; return REPLY_TO_VIA; }
 <INITIAL>{SHM_HASH_SPLIT_PERCENTAGE}	{ count(); yylval.strval=yytext; return SHM_HASH_SPLIT_PERCENTAGE; }
 <INITIAL>{SHM_SECONDARY_HASH_SIZE}	{ count(); yylval.strval=yytext; return SHM_SECONDARY_HASH_SIZE; }
 <INITIAL>{MEM_WARMING_ENABLED}	{ count(); yylval.strval=yytext; return MEM_WARMING_ENABLED; }

--- a/cfg.y
+++ b/cfg.y
@@ -321,6 +321,7 @@ extern int cfg_parse_only_routes;
 %token MAX_WHILE_LOOPS
 %token UDP_WORKERS
 %token CHECK_VIA
+%token REPLY_TO_VIA
 %token SHM_HASH_SPLIT_PERCENTAGE
 %token SHM_SECONDARY_HASH_SIZE
 %token MEM_WARMING_ENABLED
@@ -1072,6 +1073,8 @@ assign_stm: LOGLEVEL EQUAL snumber { IFOR();
 		}
 		| CHECK_VIA EQUAL NUMBER { check_via=$3; }
 		| CHECK_VIA EQUAL error { yyerror("boolean value expected"); }
+                | REPLY_TO_VIA EQUAL NUMBER { reply_to_via=$3; }
+                | REPLY_TO_VIA EQUAL error { yyerror("boolean value expected"); }
 		| SHM_HASH_SPLIT_PERCENTAGE EQUAL NUMBER { IFOR();
 			#ifdef HP_MALLOC
 			shm_hash_split_percentage=$3;

--- a/globals.c
+++ b/globals.c
@@ -91,6 +91,8 @@ char *log_name = 0;
 int config_check = 0;
 /* check if reply first via host==us */
 int check_via =  0;
+/* Reply to address indicated in Via */
+int reply_to_via = 0;
 /* debugging level for memory stats */
 int memlog = L_DBG + 11;
 int memdump = L_DBG + 10;

--- a/modules/sl/sl_funcs.c
+++ b/modules/sl/sl_funcs.c
@@ -154,7 +154,14 @@ int sl_send_reply_helper(struct sip_msg *msg ,int code, const str *text)
 	if ( msg->REQ_METHOD==METHOD_ACK)
 		return 1;
 
-	update_sock_struct_from_ip( &to, msg );
+	if (reply_to_via) {
+		if (update_sock_struct_from_via(&to, msg, msg->via1 )==-1)
+		{
+			LM_ERR("cannot lookup reply dst: %.*s\n",
+					msg->via1->host.len, msg->via1->host.s);
+			goto error;
+		}
+	} else update_sock_struct_from_ip( &to, msg );
 
 	/* if that is a redirection message, dump current message set to it */
 	if (code>=300 && code<400) {

--- a/modules/tm/t_lookup.c
+++ b/modules/tm/t_lookup.c
@@ -942,7 +942,20 @@ int init_rb( struct retr_buf *rb, struct sip_msg *msg)
 {
 	int proto;
 
-	update_sock_struct_from_ip( &rb->dst.to, msg );
+	if (!reply_to_via) {
+		update_sock_struct_from_ip( &rb->dst.to, msg );
+		proto=msg->rcv.proto;
+	} else {
+		/*init retrans buffer*/
+		if (update_sock_struct_from_via( &(rb->dst.to), msg, msg->via1 )==-1) {
+			LM_ERR("cannot lookup reply dst: %.*s\n",
+					msg->via1->host.len, msg->via1->host.s );
+			ser_error=E_BAD_VIA;
+			return 0;
+		}
+		proto=msg->via1->proto;		
+	}	
+	
 	proto=msg->rcv.proto;
 	rb->dst.proto=proto;
 	rb->dst.proto_reserved1=msg->rcv.proto_reserved1;

--- a/modules/usrloc/doc/usrloc_admin.xml
+++ b/modules/usrloc/doc/usrloc_admin.xml
@@ -1475,9 +1475,127 @@ modparam("usrloc", "contact_refresh_timer", true)
 
 	<section id="exported_functions" xreflabel="exported_functions">
 	<title>Exported Functions</title>
-	<para>
-		There are no exported functions that could be used in scripts.
-	</para>
+
+	<section id="func_ul_add_key" xreflabel="ul_add_key(domain, aor, key_name[, key_value])">
+		<title>
+		<function moreinfo="none">ul_add_key(domain, aor, key_name[, key_value])</function>
+		</title>
+		<para>
+		Append a Key/Value to the Key-Value-Store of a Usrloc-Record.
+		</para>
+		<para>
+		Returns false, if no record is found is usrloc.
+		</para>		
+		<para>Meaning of the parameters is as follows:</para>
+		<itemizedlist>
+		<listitem>
+			<para><emphasis>domain (string)</emphasis> - Domain of the
+			        AOR, e.g. "location"
+			</para>
+			<para><emphasis>aor (string)</emphasis> - Address-of-Record,
+			        save the key for a specific (registered) user.
+			</para>
+			<para><emphasis>key (string)</emphasis> - The name of the
+			        key to be stored.
+			</para>
+			<para><emphasis>value (string, optional)</emphasis>
+			        - The value to be stored. Not providing the value or
+			        by providing an empty value, will delete the entry.
+			</para>
+		</listitem>
+		</itemizedlist>
+		<para>
+		This function can be used in ANY route.
+		</para>
+		<example>
+		<title><function>ul_add_key</function> usage</title>
+		<programlisting format="linespecific">
+...
+ul_add_key("location", "$tU@$td", "service_route", "$hdr(Service-Route)");
+...
+</programlisting>
+		</example>
+	</section>
+
+	<section id="func_ul_get_key" xreflabel="ul_get_key(domain, aor, key_name, destination)">
+		<title>
+		<function moreinfo="none">ul_get_key(domain, aor, key_name, destination)</function>
+		</title>
+		<para>
+		Retrieve a Key/Value from the Key-Value-Store of a Usrloc-Record.
+		</para>
+		<para>
+		Returns false, if no record is found is usrloc or no according key is found.
+		</para>	
+		<para>Meaning of the parameters is as follows:</para>
+		<itemizedlist>
+		<listitem>
+			<para><emphasis>domain (string)</emphasis> - Domain of the
+			        AOR, e.g. "location"
+			</para>
+			<para><emphasis>aor (string)</emphasis> - Address-of-Record,
+			        save the key for a specific (registered) user.
+			</para>
+			<para><emphasis>key (string)</emphasis> - The name of the
+			        key to be retrieved.
+			</para>
+			<para><emphasis>destination (variable)</emphasis>
+			        - A variable, where to store the retrieved key.
+			</para>
+		</listitem>
+		</itemizedlist>
+		<para>
+		This function can be used in ANY route.
+		</para>
+		<example>
+		<title><function>ul_get_key</function> usage</title>
+		<programlisting format="linespecific">
+...
+if (ul_get_key("location", "$tU@$td", "service_route", "$avp(service_route)")) {
+        append_to_reply("Service-Route: $avp(service_route)\r\n");
+}
+...
+</programlisting>
+		</example>
+	</section>
+
+	<section id="func_ul_del_key" xreflabel="ul_del_key(domain, aor, key_name)">
+		<title>
+		<function moreinfo="none">ul_del_key(domain, aor, key_name)</function>
+		</title>
+		<para>
+		Deletes a Key/Value from the Key-Value-Store of a Usrloc-Record.
+		</para>
+		<para>
+		Returns false, if no record is found is usrloc.
+		</para>	
+		<para>Meaning of the parameters is as follows:</para>
+		<itemizedlist>
+		<listitem>
+			<para><emphasis>domain (string)</emphasis> - Domain of the
+			        AOR, e.g. "location"
+			</para>
+			<para><emphasis>aor (string)</emphasis> - Address-of-Record,
+			        save the key for a specific (registered) user.
+			</para>
+			<para><emphasis>key (string)</emphasis> - The name of the
+			        key to be deleted.
+			</para>
+		</listitem>
+		</itemizedlist>
+		<para>
+		This function can be used in ANY route.
+		</para>
+		<example>
+		<title><function>ul_del_key</function> usage</title>
+		<programlisting format="linespecific">
+...
+ul_del_key("location", "$tU@$td", "service_route");
+...
+</programlisting>
+		</example>
+	</section>
+
 	</section>
 
 

--- a/modules/usrloc/kv_store.c
+++ b/modules/usrloc/kv_store.c
@@ -26,6 +26,7 @@
 
 #include "../../lib/cJSON.h"
 #include "../../lib/osips_malloc.h"
+#include "urecord.h"
 
 int_str_t *kv_get(map_t _store, const str* _key)
 {
@@ -237,4 +238,94 @@ void store_destroy(map_t _store)
 {
 	if (_store)
 		map_destroy(_store, destroy_kv_store_val);
+}
+
+
+int w_add_key(struct sip_msg* _m, void* _d, str* aor, str* key, str* value) {
+	urecord_t *r;
+	udomain_t *domain = (udomain_t*)_d;
+	int_str_t insert_value;
+	lock_udomain(domain, aor);
+	get_urecord(domain, aor, &r);
+	if (r) {
+		if (value->len > 0) {
+			insert_value.is_str = 1;
+			insert_value.s.s = value->s;
+			insert_value.s.len = value->len;
+			kv_put(r->kv_storage, key, &insert_value);
+		} else {
+			kv_del(r->kv_storage, key);
+		}
+	} else {
+		LM_WARN("No record found - not inserting key into KV store - user not registered?\n");
+		unlock_udomain(domain, aor);
+		return -1;
+	}
+
+	unlock_udomain(domain, aor);
+	return 1;
+}
+
+int w_get_key(struct sip_msg* _m, void* _d, str* aor, str* key, pv_spec_t* destination) {
+	urecord_t *r;
+	udomain_t *domain = (udomain_t*)_d;
+	int_str_t * key_value;
+	pv_value_t out_val;
+
+	lock_udomain(domain, aor);
+	get_urecord(domain, aor, &r);
+
+	if (r) {
+		key_value = kv_get(r->kv_storage, key);
+		if (key_value) {
+			if (key_value->is_str) {
+				out_val.flags = PV_VAL_STR;
+				out_val.rs = key_value->s;
+				if (pv_set_value(_m, destination, 0, &out_val) != 0) {
+					LM_ERR("failed to write to destination variable.\n");
+					unlock_udomain(domain, aor);
+					return -1;
+				}
+			} else {
+				out_val.flags = PV_VAL_INT;
+				out_val.ri = key_value->i;
+				if (pv_set_value(_m, destination, 0, &out_val) != 0) {
+					LM_ERR("failed to write to destination variable.\n");
+					unlock_udomain(domain, aor);
+					return -1;
+				}
+			}
+		} else {
+			LM_WARN("Key not found in record - unable to retrieve value from KV store\n");
+			unlock_udomain(domain, aor);
+			return -1;
+		}
+	} else {
+		LM_WARN("No record found - unable to retrieve value from KV store - user not registered?\n");
+		unlock_udomain(domain, aor);
+		return -1;
+	}
+
+
+	unlock_udomain(domain, aor);
+	return 1;
+}
+
+int w_delete_key(struct sip_msg* _m, void* _d, str* aor, str* key) {
+	urecord_t *r;
+	udomain_t *domain = (udomain_t*)_d;
+
+
+	lock_udomain(domain, aor);
+	get_urecord(domain, aor, &r);
+	if (r) {
+		kv_del(r->kv_storage, key);
+	} else {
+		LM_WARN("No record found - not deleting value from  KV store - user not registered?\n");
+		unlock_udomain(domain, aor);
+		return -1;
+	}
+
+	unlock_udomain(domain, aor);
+	return 1;
 }

--- a/modules/usrloc/kv_store.h
+++ b/modules/usrloc/kv_store.h
@@ -24,6 +24,7 @@
 #define __KV_STORE_H__
 
 #include "../../map.h"
+#include "../../pvar.h"
 
 int_str_t *kv_get(map_t _store, const str* _key);
 int_str_t *kv_put(map_t _store, const str* _key, const int_str_t* _val);
@@ -45,5 +46,9 @@ void store_free_buffer(str *serialized);
 map_t store_deserialize(const str *input);
 
 void store_destroy(map_t _store);
+
+int w_add_key(struct sip_msg* _m, void* _d, str* aor, str* key, str* value);
+int w_get_key(struct sip_msg* _m, void* _d, str* aor, str* key, pv_spec_t* destination);
+int w_delete_key(struct sip_msg* _m, void* _d, str* aor, str* key);
 
 #endif /* __KV_STORE_H__ */


### PR DESCRIPTION
**Summary**
Expose functions to store/retrieve/delete values from the Key-Value-Store of Usrloc to the script-writer

**Details**
In some situations it becomes quite useful to store and retrieve keys and values from usrloc, which, for example, are learned during registration. As an example, a subscriber may learn it's possible identities in a P-Associated-URI-Header, which may at a later stage be used to verify a P-Preferred-Identity-header and to add a P-Asserted-Identity-Header.

**Compatibility**
This PR adds new functionality, without affecting any existing functionality.