### PR TITLE
tm: Add functionality to execute a route, whenever TM creates a request or reply

### DIFF
--- a/modules/rtp_relay/rtp_relay_ctx.c
+++ b/modules/rtp_relay/rtp_relay_ctx.c
@@ -2582,7 +2582,7 @@ mi_response_t *mi_rtp_relay_update_callid(const mi_params_t *params,
 	if (rtp_relay_ctx_pending(ctx)) {
 		RTP_RELAY_CTX_UNLOCK(ctx);
 		lock_stop_read(rtp_relay_contexts_lock);
-		goto error;
+		return 0;
 	}
 
 	ctmp = rtp_relay_new_tmp(ctx, set, node);

--- a/modules/tm/doc/tm_admin.xml
+++ b/modules/tm/doc/tm_admin.xml
@@ -861,6 +861,59 @@ modparam("tm", "cluster_auto_cancel", no)
 		</example>
 	</section>
 
+	<section id="param_local_request_route" xreflabel="local_request_route">
+		<title><varname>local_request_route</varname> (string)</title>
+		<para>
+		This parameter points to a route, which is executed whenever TM creates
+		a new request (e.g., through the B2B modules or through MI).
+		</para>
+		<para>
+		The route is executed with the generated message by TM, incorporating all
+		modifications.
+		</para>
+		<example>
+		<title>Set the <varname>local_request_route</varname> parameter</title>
+		<programlisting format="linespecific">
+...
+# Execute the route "local_request_route" upon sending a request
+modparam("tm", "local_request_route", "tm_local_request")
+
+route[tm_local_request] {
+	if (is_method("INVITE") && $rb(application/sdp) && !has_totag()) {
+		$avp(sdp_request) := $rb(application/sdp);
+	}
+}
+...
+</programlisting>
+		</example>
+	</section>
+
+	<section id="param_local_reply_route" xreflabel="local_reply_route">
+		<title><varname>local_reply_route</varname> (string)</title>
+		<para>
+		This parameter points to a reply-route, which is executed whenever TM creates
+		a reply (e.g., through the B2B modules or through MI).
+		</para>
+
+		<example>
+		<title>Set the <varname>local_reply_route</varname> parameter</title>
+		<programlisting format="linespecific">
+...
+# Execute the route "tm_local_reply" upon sending a request
+modparam("tm", "local_reply_route", "tm_local_reply")
+
+onreply_route[tm_local_reply] {
+	if (is_method("BYE")) {
+		$var(rc) = rest_get("http://localhost/qos/delete",
+					$var(recv_body), $var(recv_ct), $var(rcode));
+	}
+}
+
+...
+</programlisting>
+		</example>
+	</section>
+
 	</section>
 
 

--- a/modules/tm/t_reply.c
+++ b/modules/tm/t_reply.c
@@ -68,6 +68,7 @@
 #include "../../dprint.h"
 #include "../../config.h"
 #include "../../parser/parser_f.h"
+#include "../../parser/msg_parser.h"
 #include "../../ut.h"
 #include "../../timer.h"
 #include "../../error.h"
@@ -119,7 +120,7 @@ static struct script_route_ref *goto_on_reply = NULL;
 /* currently processed branch */
 extern int _tm_branch_index;
 
-
+static struct sip_msg dummy_msg;
 
 /* returns the picked branch */
 int t_get_picked_branch(void)
@@ -442,6 +443,21 @@ static int _reply_light( struct cell *trans, char* buf, unsigned int len,
 
 	if(trans->uas.request && trans->uas.request->flags&tcp_no_new_conn_rplflag)
 		tcp_no_new_conn = 1;
+
+	if(ref_script_route_is_valid(tm_local_reply)) {
+		LM_DBG("Found Local-Reply Route...\n");
+		LM_DBG("Message:\n-----------------\n%.*s\n--------------------\n", len, buf);
+		memset(&dummy_msg, 0, sizeof(struct sip_msg));
+		dummy_msg.buf = buf;
+		dummy_msg.len = len;
+
+		if (parse_msg(buf, len, &dummy_msg) == 0) {
+			LM_DBG("Parsed Message, executing Local-Reply Route with Message...\n");
+			run_top_route(sroutes->onreply[tm_local_reply->idx], &dummy_msg);
+		}
+		free_sip_msg(&dummy_msg);
+	}
+
 
 	if ( SEND_PR_BUFFER( rb, buf, len )==0 ) {
 		LM_DBG("reply sent out. buf=%p: %.9s..., "

--- a/modules/tm/t_reply.h
+++ b/modules/tm/t_reply.h
@@ -30,6 +30,7 @@
 
 extern int restart_fr_on_each_reply;
 extern int onreply_avp_mode;
+extern struct script_route_ref *tm_local_reply;
 
 /* reply processing status */
 enum rps {

--- a/modules/tm/tm.c
+++ b/modules/tm/tm.c
@@ -141,6 +141,12 @@ struct sip_msg* tm_pv_context_reply(struct sip_msg* msg);
 int fr_timeout;
 int fr_inv_timeout;
 
+static char* tm_local_reply_route;
+struct script_route_ref *tm_local_reply = NULL;
+
+static char* tm_local_request_route;
+struct script_route_ref *tm_local_request = NULL;
+
 #define TM_CANCEL_BRANCH_ALL    (1<<0)
 #define TM_CANCEL_BRANCH_OTHERS (1<<1)
 
@@ -340,6 +346,10 @@ static const param_export_t params[]={
 		&tm_cluster_param.s },
 	{ "cluster_auto_cancel",      INT_PARAM,
 		&tm_repl_auto_cancel },
+	{ "local_reply_route",		  STR_PARAM,
+        &tm_local_reply_route },
+	{ "local_request_route",      STR_PARAM,
+        &tm_local_request_route },
 	{0,0,0}
 };
 
@@ -946,6 +956,28 @@ static int mod_init(void)
 		LM_ERR("cannot initialize cluster support for transactions!\n");
 		LM_WARN("running without cluster support for transactions!\n");
 	}
+
+	if (tm_local_reply_route)
+	{
+		tm_local_reply = ref_script_route_by_name( tm_local_reply_route,
+			sroutes->onreply, ONREPLY_RT_NO, ONREPLY_ROUTE, 0);
+		if (!ref_script_route_is_valid(tm_local_reply))
+		{
+			LM_ERR("route <%s> does not exist\n",tm_local_reply_route);
+			return -1;
+		}
+	}       
+
+	if (tm_local_request_route)
+	{
+		tm_local_request = ref_script_route_by_name( tm_local_request_route,
+			sroutes->request, RT_NO, REQUEST_ROUTE, 0);
+		if (!ref_script_route_is_valid(tm_local_request))
+		{
+			LM_ERR("route <%s> does not exist\n",tm_local_request_route);
+			return -1;
+		}
+	}   
 
 	return 0;
 }

--- a/modules/tm/uac.h
+++ b/modules/tm/uac.h
@@ -34,7 +34,7 @@
 
 /* Pass provisional replies to fifo applications */
 extern int pass_provisional_replies;
-
+extern struct script_route_ref *tm_local_request;
 
 /*
  * Function prototypes


### PR DESCRIPTION
**Summary**
We needed to run certain actions, whenever TM creates a request or response. This PR adds the functionality to execute a specific route for requests or replies.

**Details**
This PR adds two new parameters to the TM-Module to define routes, which will be executed upon locally generated requests or replies.

**Solution**
It comes handy, if you for example are using OpenSIPS as a B2BUA and you want to trigger certain actions upon the termination of a session, e.g. when responding to a BYE request.

**Compatibility**
It does not affect any existing deployments, it just adds new functionality.