### PR TITLE
Presence: Add support for "reg" Event and "tel"-URI's

### DIFF
--- a/cfg.lex
+++ b/cfg.lex
@@ -240,6 +240,7 @@ DNS_SERVERS_NO  dns_servers_no
 DNS_USE_SEARCH  dns_use_search_list
 MAXBUFFER maxbuffer
 CHECK_VIA	check_via
+REPLY_TO_VIA    reply_to_via
 SHM_HASH_SPLIT_PERCENTAGE "shm_hash_split_percentage"
 SHM_SECONDARY_HASH_SIZE "shm_secondary_hash_size"
 MEM_WARMING_ENABLED "mem_warming"|"mem_warming_enabled"
@@ -471,6 +472,7 @@ SPACE		[ ]
 								return MAX_WHILE_LOOPS; }
 <INITIAL>{MAXBUFFER}	{ count(); yylval.strval=yytext; return MAXBUFFER; }
 <INITIAL>{CHECK_VIA}	{ count(); yylval.strval=yytext; return CHECK_VIA; }
+<INITIAL>{REPLY_TO_VIA} { count(); yylval.strval=yytext; return REPLY_TO_VIA; }
 <INITIAL>{SHM_HASH_SPLIT_PERCENTAGE}	{ count(); yylval.strval=yytext; return SHM_HASH_SPLIT_PERCENTAGE; }
 <INITIAL>{SHM_SECONDARY_HASH_SIZE}	{ count(); yylval.strval=yytext; return SHM_SECONDARY_HASH_SIZE; }
 <INITIAL>{MEM_WARMING_ENABLED}	{ count(); yylval.strval=yytext; return MEM_WARMING_ENABLED; }

--- a/cfg.y
+++ b/cfg.y
@@ -321,6 +321,7 @@ extern int cfg_parse_only_routes;
 %token MAX_WHILE_LOOPS
 %token UDP_WORKERS
 %token CHECK_VIA
+%token REPLY_TO_VIA
 %token SHM_HASH_SPLIT_PERCENTAGE
 %token SHM_SECONDARY_HASH_SIZE
 %token MEM_WARMING_ENABLED
@@ -1072,6 +1073,8 @@ assign_stm: LOGLEVEL EQUAL snumber { IFOR();
 		}
 		| CHECK_VIA EQUAL NUMBER { check_via=$3; }
 		| CHECK_VIA EQUAL error { yyerror("boolean value expected"); }
+                | REPLY_TO_VIA EQUAL NUMBER { reply_to_via=$3; }
+                | REPLY_TO_VIA EQUAL error { yyerror("boolean value expected"); }
 		| SHM_HASH_SPLIT_PERCENTAGE EQUAL NUMBER { IFOR();
 			#ifdef HP_MALLOC
 			shm_hash_split_percentage=$3;

--- a/globals.c
+++ b/globals.c
@@ -91,6 +91,8 @@ char *log_name = 0;
 int config_check = 0;
 /* check if reply first via host==us */
 int check_via =  0;
+/* Reply to address indicated in Via */
+int reply_to_via = 0;
 /* debugging level for memory stats */
 int memlog = L_DBG + 11;
 int memdump = L_DBG + 10;

--- a/modules/presence/utils_func.c
+++ b/modules/presence/utils_func.c
@@ -81,7 +81,7 @@ int a_to_i (char *s,int len)
 
 int send_error_reply(struct sip_msg* msg, int reply_code, str reply_str)
 {
-	if(reply_code== BAD_EVENT_CODE)
+	if(reply_code== BAD_EVENT_CODE && EvList != NULL)
 	{
 		str hdr_append;
 		char buffer[256];

--- a/modules/presence/utils_func.h
+++ b/modules/presence/utils_func.h
@@ -53,18 +53,28 @@ static inline int uandd_to_uri(str user,  str domain, str *out)
 		LM_ERR("no more memory\n");
 		return -1;
 	}
-	strcpy(out->s,"sip:");
+
+	if (domain.len != 0)
+		strcpy(out->s,"sip:");
+	else
+		strcpy(out->s,"tel:");
+
 	out->len = 4;
 	if( user.len != 0)
 	{
 		memcpy(out->s+out->len, user.s, user.len);
 		out->len += user.len;
-		out->s[out->len++] = '@';
+		if (domain.len != 0)
+			out->s[out->len++] = '@';
 	}
 
-	memcpy(out->s + out->len, domain.s, domain.len);
-	out->len += domain.len;
+	if (domain.len != 0) {
+		memcpy(out->s + out->len, domain.s, domain.len);
+		out->len += domain.len;
+	}
+	
 	out->s[out->len] = '\0';
+
 
 	return 0;
 }

--- a/modules/sl/sl_funcs.c
+++ b/modules/sl/sl_funcs.c
@@ -154,7 +154,14 @@ int sl_send_reply_helper(struct sip_msg *msg ,int code, const str *text)
 	if ( msg->REQ_METHOD==METHOD_ACK)
 		return 1;
 
-	update_sock_struct_from_ip( &to, msg );
+	if (reply_to_via) {
+		if (update_sock_struct_from_via(&to, msg, msg->via1 )==-1)
+		{
+			LM_ERR("cannot lookup reply dst: %.*s\n",
+					msg->via1->host.len, msg->via1->host.s);
+			goto error;
+		}
+	} else update_sock_struct_from_ip( &to, msg );
 
 	/* if that is a redirection message, dump current message set to it */
 	if (code>=300 && code<400) {

--- a/modules/tm/t_lookup.c
+++ b/modules/tm/t_lookup.c
@@ -942,7 +942,20 @@ int init_rb( struct retr_buf *rb, struct sip_msg *msg)
 {
 	int proto;
 
-	update_sock_struct_from_ip( &rb->dst.to, msg );
+	if (!reply_to_via) {
+		update_sock_struct_from_ip( &rb->dst.to, msg );
+		proto=msg->rcv.proto;
+	} else {
+		/*init retrans buffer*/
+		if (update_sock_struct_from_via( &(rb->dst.to), msg, msg->via1 )==-1) {
+			LM_ERR("cannot lookup reply dst: %.*s\n",
+					msg->via1->host.len, msg->via1->host.s );
+			ser_error=E_BAD_VIA;
+			return 0;
+		}
+		proto=msg->via1->proto;		
+	}	
+	
 	proto=msg->rcv.proto;
 	rb->dst.proto=proto;
 	rb->dst.proto_reserved1=msg->rcv.proto_reserved1;

--- a/parser/parse_event.c
+++ b/parser/parse_event.c
@@ -72,6 +72,9 @@
 #define REFER_STR "refer"
 #define REFER_STR_LEN 5
 
+#define REG_STR "reg"
+#define REG_STR_LEN 3
+
 
 static inline char* skip_token(char* _b, int _l)
 {
@@ -144,6 +147,9 @@ int event_parser(char* _s, int _l, event_t* _e)
 	} else if ((_e->text.len == REFER_STR_LEN) &&
 		   !strncasecmp(REFER_STR, tmp.s, _e->text.len)) {
 		_e->parsed = EVENT_REFER;
+	} else if ((_e->text.len == REG_STR_LEN) &&
+		   !strncasecmp(REG_STR, tmp.s, _e->text.len)) {
+		_e->parsed = EVENT_REG;
 	} else {
 		_e->parsed = EVENT_OTHER;
 	}

--- a/parser/parse_event.h
+++ b/parser/parse_event.h
@@ -44,6 +44,7 @@
 #define EVENT_LINE_SEIZE     9
 #define EVENT_AS_FEATURE     10
 #define EVENT_REFER          11
+#define EVENT_REG			 12
 
 typedef struct event {
 	str text;       /* Original string representation */


### PR DESCRIPTION
**Summary**
In order to deal with "reginfo" events as per RFC 3680, we need to add support for the "reg"-Event into the presence structure. Besides, the current implementation did not work with "tel"-URI's, which is fixed with this PR.

**Details**
- Adds support to the "reg" Event to the Parser
- Adds support for "tel"-URI's

**Compatibility**
It does not affect any existing deployments, it just adds new functionality.