### PR TITLE
Presence: add "reginfo" module

### DIFF
--- a/modules/presence_reginfo/Makefile
+++ b/modules/presence_reginfo/Makefile
@@ -1,0 +1,47 @@
+#
+# Presence_reginfo Makefile
+# 
+# 
+# WARNING: do not run this directly, it should be run by the main Makefile
+
+include ../../Makefile.defs
+auto_gen=
+NAME=presence_reginfo.so
+
+ifeq ($(CROSS_COMPILE),)
+XML2CFG=$(shell which xml2-config)
+ifeq ($(XML2CFG),)
+XML2CFG=$(shell \
+	if pkg-config --exists libxml-2.0; then \
+		echo 'pkg-config libxml-2.0'; \
+	fi)
+endif
+endif
+
+ifneq ($(XML2CFG),)
+	DEFS += $(shell $(XML2CFG) --cflags )
+	LIBS += $(shell $(XML2CFG) --libs)
+else
+	DEFS+=-I$(LOCALBASE)/include/libxml2 \
+		-I$(LOCALBASE)/include
+	LIBS+=-L$(LOCALBASE)/lib -lxml2
+endif
+
+include ../../Makefile.modules
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/modules/presence_reginfo/add_events.c
+++ b/modules/presence_reginfo/add_events.c
@@ -1,0 +1,64 @@
+/*
+ * presence_reginfo module - Presence Handling of reg events
+ *
+ * Copyright (C) 2011, 2023 Carsten Bock, carsten@ng-voice.com
+ *
+ * This file is part of opensips, a free SIP server.
+ *
+ * opensips is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version
+ *
+ * opensips is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301  USA
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include "../../parser/parse_content.h"
+#include "../presence/event_list.h"
+#include "presence_reginfo.h"
+#include "notify_body.h"
+
+extern int pres_reginfo_aggregate_presentities;
+
+int reginfo_add_events(void)
+{
+	pres_ev_t event;
+
+	/* constructing message-summary event */
+	memset(&event, 0, sizeof(pres_ev_t));
+	event.name.s = "reg";
+	event.name.len = 3;
+
+	event.content_type.s = "application/reginfo+xml";
+	event.content_type.len = 23;
+	event.default_expires = pres_reginfo_default_expires;
+	event.type = PUBL_TYPE;
+	event.req_auth = 0;
+	event.evs_publ_handl = 0;
+	/* modify XML body for each watcher to set the correct "version" */
+	event.aux_body_processing = reginfo_body_setversion;
+	event.aux_free_body= free_xml_body;
+	event.etag_not_new = 0;
+
+	if(pres_reginfo_aggregate_presentities) {
+		/* aggregate XML body and free() function */
+		event.agg_nbody = reginfo_agg_nbody;
+		event.free_body = free_xml_body;
+	}
+
+	if(pres_add_event(&event) < 0) {
+		LM_ERR("failed to add event \"reginfo\"\n");
+		return -1;
+	}
+	return 0;
+}

--- a/modules/presence_reginfo/add_events.h
+++ b/modules/presence_reginfo/add_events.h
@@ -1,0 +1,29 @@
+/*
+ * presence_reginfo module - Presence Handling of reg events
+ *
+ * Copyright (C) 2011, 2023 Carsten Bock, carsten@ng-voice.com
+ *
+ * This file is part of opensips, a free SIP server.
+ *
+ * opensips is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version
+ *
+ * opensips is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301  USA
+ */
+
+
+#ifndef _REGINFO_ADD_EV_H_
+#define _REGINFO_ADD_EV_H_
+
+int reginfo_add_events(void);
+
+#endif

--- a/modules/presence_reginfo/doc/presence_reginfo.xml
+++ b/modules/presence_reginfo/doc/presence_reginfo.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding='ISO-8859-1'?>
+<!DOCTYPE book PUBLIC "-//OASIS//DTD DocBook XML V4.4//EN"
+"http://www.oasis-open.org/docbook/xml/4.4/docbookx.dtd" [
+
+<!-- Include general documentation entities -->
+<!ENTITY % docentities SYSTEM "../../../../doc/docbook/entities.xml">
+%docentities;
+
+]>
+
+<book xmlns:xi="http://www.w3.org/2001/XInclude">
+    <bookinfo>
+	<title>presence_reginfo Module</title>
+	<productname class="trade">&osipsname;</productname>
+	<authorgroup>
+		<author>
+			<firstname>Carsten</firstname>
+			<surname>Bock</surname>
+			<email>carsten@ng-voice.com</email>
+		</author>
+		<editor>
+			<firstname>Carsten</firstname>
+			<surname>Bock</surname>
+			<email>carsten@ng-voice.com</email>
+		</editor>
+	</authorgroup>
+	<copyright>
+	    <year>2011, 2023</year>
+	    <holder>Carsten Bock, carsten@ng-voice.com, http://www.ng-voice.com</holder>
+	</copyright>
+  </bookinfo>
+    <toc></toc>
+    
+    <xi:include href="presence_reginfo_admin.xml"/>
+    
+    
+</book>
+
+

--- a/modules/presence_reginfo/doc/presence_reginfo_admin.xml
+++ b/modules/presence_reginfo/doc/presence_reginfo_admin.xml
@@ -1,0 +1,120 @@
+<?xml version="1.0" encoding='ISO-8859-1'?>
+<!DOCTYPE book PUBLIC "-//OASIS//DTD DocBook XML V4.4//EN"
+"http://www.oasis-open.org/docbook/xml/4.4/docbookx.dtd" [
+
+<!-- Include general documentation entities -->
+<!ENTITY % docentities SYSTEM "../../../../doc/docbook/entities.xml">
+%docentities;
+
+]>
+<!-- Module User's Guide -->
+
+<chapter>
+	
+
+	<title>&adminguide;</title>
+	
+	<section>
+	  <title>Overview</title>
+	    <para> 
+	      The module enables the handling of "Event: reg" (as defined 
+	      in RFC 3680) inside of the presence module. This can be used
+	      distribute the registration-info status to the subscribed watchers.
+	    </para>
+	    <para>
+ 	      The module does not currently implement any authorization
+	      rules.  It assumes that publish requests are only issued by
+	      an authorized application and subscribe requests only by
+	      authorized users.  Authorization can thus be easily done in 
+	      &osips; configuration file before calling handle_publish() 
+	      and handle_subscribe() functions.
+	    </para>
+	    <para>
+	      Note: This module only activates the processing of the "reg" 
+	      in the presence module. To send dialog-info to watchers you also 
+	      need a source which PUBLISH the reg info to the presence module.
+	      For example you can use the pua_reginfo module or any external
+	      component. This approach allows to have the presence server and the
+	      reg-info aware publisher (e.g. the main proxy) on different 
+	      &osips; instances.
+	    </para>
+	</section>
+
+	<section>
+	  <title>Dependencies</title>
+	  <section>
+		<title>&kamailio; Modules</title>
+		<para>
+		The following modules must be loaded before this module:
+			<itemizedlist>
+			<listitem>
+			<para>
+				<emphasis>presence</emphasis>.
+			</para>
+			</listitem>
+			</itemizedlist>
+		</para>
+	  </section>
+
+	  <section>
+		<title>External Libraries or Applications</title>
+		<para>
+		None.
+		</para>
+	  </section>
+	</section>
+
+    <section>
+		<title>Parameters</title>
+        <section id="presence_reginfo.p.default_expires">
+               <title><varname>default_expires</varname> (int)</title>
+               <para>
+               The default expires value used when missing from SUBSCRIBE
+               message (in seconds).
+               </para>
+               <para>
+               <emphasis>Default value is <quote>3600</quote>.
+               </emphasis>
+               </para>
+               <example>
+               <title>Set <varname>default_expires</varname> parameter</title>
+               <programlisting format="linespecific">
+        ...
+        modparam("presence_reginfo", "default_expires", 3600)
+        ...
+        </programlisting>
+            </example>
+        </section>
+
+				<section id="presence_reginfo.p.aggregate_presentities">
+							<title><varname>aggregate_presentities</varname> (int)</title>
+							<para>
+							Whether to aggregate in a single notify body all registration 
+							presentities. Useful to have all registrations on first NOTIFY
+							following initial SUBSCRIBE.
+							</para>
+							<para>
+							<emphasis>Default value is <quote>0</quote> (disabled).
+							</emphasis>
+							</para>
+							<example>
+							<title>Set <varname>aggregate_presentities</varname> parameter</title>
+							<programlisting format="linespecific">
+					...
+					modparam("presence_reginfo", "aggregate_presentities", 1)
+					...
+					</programlisting>
+							</example>
+					</section>
+
+	</section>
+
+
+	<section>
+		<title>Functions</title>
+		<para>
+			None to be used in configuration file.
+		</para>
+	</section>
+
+</chapter>

--- a/modules/presence_reginfo/notify_body.c
+++ b/modules/presence_reginfo/notify_body.c
@@ -1,0 +1,269 @@
+/*
+ * presence_reginfo module - Presence Handling of reg events
+ *
+ * Copyright (C) 2011, 2023 Carsten Bock, carsten@ng-voice.com
+ *
+ * This file is part of opensips, a free SIP server.
+ *
+ * opensips is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version
+ *
+ * opensips is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301  USA
+ */
+
+/*! \file
+ * \brief Kamailio Presence_reginfo :: Notify BODY handling
+ * \ingroup presence_reginfo
+ */
+
+#define MAX_INT_LEN 11 /* 2^32: 10 chars + 1 char sign */
+
+#include <string.h>
+#include <stdlib.h>
+#include <libxml/parser.h>
+
+#include "../../mem/mem.h"
+#include "../presence/hash.h"
+#include "../presence/presence.h"
+
+
+str *aggregate_xmls(str *pres_user, str *pres_domain, str **body_array, int n);
+
+void free_xml_body(char *body)
+{
+	if(body == NULL)
+		return;
+
+	xmlFree(body);
+	body = NULL;
+}
+
+str *reginfo_agg_nbody(str *pres_user, str *pres_domain, str **body_array,
+		int n, int off_index)
+{
+	str *n_body = NULL;
+
+	LM_DBG("[pres_user]=%.*s [pres_domain]= %.*s, [n]=%d\n", pres_user->len,
+			pres_user->s, pres_domain->len, pres_domain->s, n);
+
+	if(body_array == NULL) {
+		return NULL;
+	}
+
+	n_body = aggregate_xmls(pres_user, pres_domain, body_array, n);
+	LM_DBG("[n_body]=%p\n", n_body);
+	if(n_body) {
+		LM_DBG("[*n_body]=%.*s\n", n_body->len, n_body->s);
+	}
+	if(n_body == NULL && n != 0) {
+		LM_ERR("while aggregating body\n");
+	}
+
+	xmlCleanupParser();
+	xmlMemoryDump();
+
+	return n_body;
+}
+
+str *aggregate_xmls(str *pres_user, str *pres_domain, str **body_array, int n)
+{
+	int i, j = 0;
+
+	str *body = NULL;
+
+	xmlDocPtr doc = NULL;
+	xmlNodePtr root_node = NULL;
+	xmlNsPtr namespace = NULL;
+	xmlNodePtr p_root = NULL;
+	xmlDocPtr *xml_array;
+	xmlNodePtr node = NULL;
+	xmlNodePtr next_node = NULL;
+
+	LM_DBG("[pres_user]=%.*s [pres_domain]= %.*s, [n]=%d\n", pres_user->len,
+			pres_user->s, pres_domain->len, pres_domain->s, n);
+
+	xml_array = (xmlDocPtr *)pkg_malloc(n * sizeof(xmlDocPtr));
+	if(xml_array == NULL) {
+		LM_ERR("Error allocating memory\n");
+		return NULL;
+	}
+	memset(xml_array, 0, n * sizeof(xmlDocPtr));
+
+	/* parse all the XML documents into xml_array[] */
+	for(i = 0; i < n; i++) {
+		if(body_array[i] == NULL)
+			continue;
+
+		xml_array[j] = NULL;
+		xml_array[j] = xmlParseMemory(body_array[i]->s, body_array[i]->len);
+		if(xml_array[j] == NULL) {
+			LM_ERR("while parsing xml body message\n");
+			goto error;
+		}
+		j++;
+	}
+
+	if(j == 0) /* no body */
+	{
+		LM_DBG("no body to be built\n");
+		goto error;
+	}
+
+	/* n: number of bodies in total */
+	/* j: number of useful bodies; created XML structures */
+	/* i: loop counter */
+
+	/* create the new NOTIFY body  */
+	doc = xmlNewDoc(BAD_CAST "1.0");
+	if(doc == 0) {
+		LM_ERR("unable to create xml document\n");
+		goto error;
+	}
+
+	root_node = xmlNewNode(NULL, BAD_CAST "reginfo");
+	if(root_node == 0) {
+		goto error;
+	}
+
+	xmlDocSetRootElement(doc, root_node);
+	namespace = xmlNewNs(
+			root_node, BAD_CAST "urn:ietf:params:xml:ns:reginfo", NULL);
+	if(!namespace) {
+		LM_ERR("creating namespace failed\n");
+	}
+	xmlSetNs(root_node, namespace);
+
+	/* The version must be increased for each new document and is a 32bit int.
+	 * As the version is different for each watcher, we can not set here the
+	 * correct value. Thus, we just put here a placeholder which will be
+	 * replaced by the correct value in the aux_body_processing callback.
+	 * Thus we have CPU intensive XML aggregation only once and can use
+	 * quick search&replace in the per-watcher aux_body_processing callback.
+	 * We use 11 chracters as an signed int (although RFC says unsigned int we
+	 * use signed int as presence module stores "version" in DB as
+	 * signed int) has max. 10 characters + 1 character for the sign
+	 */
+	xmlNewProp(root_node, BAD_CAST "version", BAD_CAST "00000000000");
+	xmlNewProp(root_node, BAD_CAST "state", BAD_CAST "full");
+
+	/* loop over all bodies and create the aggregated body */
+	for(i = 0; i < j; i++) {
+		// get the root reginfo element
+		p_root = xmlDocGetRootElement(xml_array[i]);
+		if(p_root == NULL) {
+			LM_ERR("the xml_tree root element is null\n");
+			goto error;
+		}
+
+		// get the children registration elements
+		if(p_root->children) {
+			// loop over registration elements
+			for(node = p_root->children; node; node = next_node) {
+				next_node = node->next;
+				if(node->type != XML_ELEMENT_NODE) {
+					continue;
+				}
+				LM_DBG("node type: Element, name: %s\n", node->name);
+
+				/* we do not copy the node, but unlink it and then add it ot the new node
+				 * this destroys the original document but we do not need it anyway.
+				 */
+				xmlUnlinkNode(node);
+				if(xmlAddChild(root_node, node) == NULL) {
+					xmlFreeNode(node);
+					LM_ERR("while adding child\n");
+					goto error;
+				}
+			} // end of loop over registration elements
+		}
+	} // end of loop over all bodies
+
+	// convert to string & cleanup
+	body = (str *)pkg_malloc(sizeof(str));
+	if(body == NULL) {
+		ERR_MEM(PKG_MEM_STR);
+	}
+
+	xmlDocDumpFormatMemory(doc, (xmlChar **)(void *)&body->s, &body->len, 1);
+
+	for(i = 0; i < j; i++) {
+		if(xml_array[i] != NULL)
+			xmlFreeDoc(xml_array[i]);
+	}
+	if(doc) {
+		xmlFreeDoc(doc);
+	}
+	if(xml_array)
+		pkg_free(xml_array);
+
+	xmlCleanupParser();
+	xmlMemoryDump();
+
+	return body;
+
+	// error handling, cleanup and return NULL
+error:
+	if(xml_array != NULL) {
+		for(i = 0; i < j; i++) {
+			if(xml_array[i] != NULL)
+				xmlFreeDoc(xml_array[i]);
+		}
+		pkg_free(xml_array);
+	}
+	if(body) {
+		pkg_free(body);
+	}
+	if(doc) {
+		xmlFreeDoc(doc);
+	}
+
+	return NULL;
+}
+
+str *reginfo_body_setversion(subs_t *subs, str *body)
+{
+	char *version_start=0;
+	char version[MAX_INT_LEN + 2]; /* +2 becasue of trailing " and \0 */
+	int version_len;
+
+	if (!body) {
+		return NULL;
+	}
+
+	LM_DBG("set version\n");
+	/* xmlDocDumpFormatMemory creates \0 terminated string */
+	/* version parameters starts at minimum at character 34 */
+	if (body->len < 41) {
+		LM_ERR("body string too short!\n");
+		return NULL;
+	}
+	version_start = strstr(body->s + 34, "version=");
+	if (!version_start) {
+	    LM_ERR("version string not found!\n");
+		return NULL;
+	}
+	version_start += 9;
+
+	version_len = snprintf(version, MAX_INT_LEN + 2,"%d\"", subs->version);
+	if (version_len >= MAX_INT_LEN + 2) {
+		LM_ERR("failed to convert 'version' to string\n");
+		return NULL;
+	}
+	/* Replace the placeholder 00000000000 with the version.
+	 * Put the padding behind the ""
+	 */
+	LM_DBG("replace version with \"%s\n",version);
+	memcpy(version_start, version, version_len);
+	memset(version_start + version_len, ' ', MAX_INT_LEN + 2 - version_len);
+
+	return NULL;
+}

--- a/modules/presence_reginfo/notify_body.h
+++ b/modules/presence_reginfo/notify_body.h
@@ -1,0 +1,40 @@
+/*
+ * presence_reginfo module - Presence Handling of reg events
+ *
+ * Copyright (C) 2011, 2023 Carsten Bock, carsten@ng-voice.com
+ *
+ * This file is part of opensips, a free SIP server.
+ *
+ * opensips is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version
+ *
+ * opensips is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301  USA
+ */
+
+/*! \file
+ * \brief Kamailio presence reginfo  ::
+ * \ref notify_body.c
+ * \ingroup presence_reginfo
+ */
+
+
+#ifndef _NBODY_H_
+#define _NBODY_H_
+
+str *reginfo_agg_nbody(str *pres_user, str *pres_domain, str **body_array,
+		int n, int off_index);
+
+str *reginfo_body_setversion(subs_t *subs, str *body);
+
+void free_xml_body(char *body);
+
+#endif

--- a/modules/presence_reginfo/presence_reginfo.c
+++ b/modules/presence_reginfo/presence_reginfo.c
@@ -1,0 +1,135 @@
+/*
+ * presence_reginfo module - Presence Handling of reg events
+ *
+ * Copyright (C) 2011, 2023 Carsten Bock, carsten@ng-voice.com
+ *
+ * This file is part of opensips, a free SIP server.
+ *
+ * opensips is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version
+ *
+ * opensips is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301  USA
+ */
+
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+#include "../../sr_module.h"
+#include "../../dprint.h"
+#include "../../str.h"
+#include "../../parser/msg_parser.h"
+#include "../../mem/mem.h"
+#include "../presence/bind_presence.h"
+#include "add_events.h"
+#include "presence_reginfo.h"
+
+/* module functions */
+static int mod_init(void);
+
+/* module variables */
+add_event_t pres_add_event;
+
+/* module parameters */
+int pres_reginfo_aggregate_presentities = 0;
+unsigned int pres_reginfo_default_expires = 3600;
+
+/* module exported parameters */
+static param_export_t params[] = {
+		{"default_expires", INT_PARAM, &pres_reginfo_default_expires},
+		{"aggregate_presentities", INT_PARAM,
+				&pres_reginfo_aggregate_presentities},
+		{0, 0, 0}};
+
+static const cmd_export_t cmds[] =
+{
+    {0, 0, {{0, 0, 0}}, 0}
+};
+
+/* module exports */
+/* clang-format off */
+static const dep_export_t deps = {
+	{ /* OpenSIPS module dependencies */
+		{ MOD_TYPE_DEFAULT, "presence", DEP_ABORT },
+		{ MOD_TYPE_NULL, NULL, 0 },
+	},
+	{ /* modparam dependencies */
+		{ NULL, NULL },
+	},
+};
+
+/* module exports */
+struct module_exports exports= {
+    "presence_reginfo",		/* module name */
+    MOD_TYPE_DEFAULT,           /* class of this module */
+    MODULE_VERSION,				/* module version */
+    DEFAULT_DLFLAGS,			/* dlopen flags */
+    0,							/* load function */
+    &deps,                      /* OpenSIPS module dependencies */
+    cmds,						/* exported functions */
+    0,							/* exported async functions */
+    params,						/* exported parameters */
+    0,							/* exported statistics */
+    0,							/* exported MI functions */
+    0,							/* exported pseudo-variables */
+    0,			 				/* exported transformations */
+    0,							/* extra processes */
+    0,							/* module pre-initialization function */
+    mod_init,					/* module initialization function */
+    0,							/* response handling function */
+    0,							/* destroy function */
+    0,							/* per-child init function */
+    0							/* reload confirm function */
+};
+/* clang-format on */
+
+/*
+ * init module function
+ */
+static int mod_init(void)
+{
+	presence_api_t pres;
+	bind_presence_t bind_presence;
+
+	bind_presence= (bind_presence_t)find_export("bind_presence", 0);
+	if(!bind_presence) {
+		LM_ERR("can't bind presence\n");
+		return -1;
+	}
+	if(bind_presence(&pres) < 0) {
+		LM_ERR("can't bind presence\n");
+		return -1;
+	}
+
+	if(pres_reginfo_aggregate_presentities != 0
+			&& pres_reginfo_aggregate_presentities != 1) {
+		LM_ERR("invalid aggregate_presentities param value, should be 0 or "
+			   "1\n");
+		return -1;
+	}
+
+	pres_add_event = pres.add_event;
+	if(pres_add_event == NULL) {
+		LM_ERR("could not import add_event\n");
+		return -1;
+	}
+	if(reginfo_add_events() < 0) {
+		LM_ERR("failed to add reginfo-info events\n");
+		return -1;
+	}
+
+	return 0;
+}

--- a/modules/presence_reginfo/presence_reginfo.h
+++ b/modules/presence_reginfo/presence_reginfo.h
@@ -1,0 +1,28 @@
+/*
+ * presence_reginfo module - Presence Handling of reg events
+ *
+ * Copyright (C) 2011, 2023 Carsten Bock, carsten@ng-voice.com
+ *
+ * This file is part of opensips, a free SIP server.
+ *
+ * opensips is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version
+ *
+ * opensips is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301  USA
+ */
+
+#ifndef _PRES_REGINFO_H_
+#define _PRES_REGINFO_H_
+
+extern add_event_t pres_add_event;
+extern unsigned int pres_reginfo_default_expires;
+#endif


### PR DESCRIPTION
**Summary**
In various scenarios, support for the "reg" event as per RFC 2680 is required. This can be for example an application, which wants to get notified when a subscriber gets registered or a device, requesting the status of it's own registration. The "presence_reginfo" module adds support for this.

**Compatibility**
This PR adds new functionality, hence it does not affect any existing deployments.