### PR TITLE
Presence add pua reginfo

### DIFF
--- a/modules/pua/add_events.c
+++ b/modules/pua/add_events.c
@@ -62,6 +62,13 @@ int pua_add_events(void)
 		LM_ERR("while adding event presence\n");
 		return -1;
 	}
+	/* add application/reginfo+xml */
+	if(add_pua_event(REGINFO_EVENT, "reg", "application/reginfo+xml", 0)< 0)
+	{
+		LM_ERR("while adding event application/reginfo+xml with version "
+				"increase\n");
+		return -1;
+	}
 
 	return 0;
 }

--- a/modules/pua/hash.h
+++ b/modules/pua/hash.h
@@ -42,6 +42,7 @@
 #define XCAPDIFF_EVENT      1<<5
 #define DIALOG_EVENT        1<<6
 #define CALLINFO_EVENT      1<<7
+#define REGINFO_EVENT       1<<8
 
 #define UL_PUBLISH          1<<0
 #define BLA_PUBLISH         1<<1
@@ -55,6 +56,8 @@
 #define RLS_SUBSCRIBE       1<<9
 #define DIALOG_PUBLISH      1<<10
 #define CALLINFO_PUBLISH    1<<11
+#define REGINFO_SUBSCRIBE   1<<12
+#define REGINFO_PUBLISH     1<<13
 
 #define NO_UPDATEDB_FLAG    0
 #define UPDATEDB_FLAG       1

--- a/modules/pua_reginfo/Makefile
+++ b/modules/pua_reginfo/Makefile
@@ -1,0 +1,29 @@
+# PUA_REGINFO
+#
+#
+# WARNING: do not run this directly, it should be run by the main Makefile
+
+include ../../Makefile.defs
+auto_gen=
+NAME=pua_reginfo.so
+LIBS=
+
+ifeq ($(CROSS_COMPILE),)
+XML2CFG=$(shell which xml2-config)
+ifeq ($(XML2CFG),)
+XML2CFG=$(shell \
+	if pkg-config --exists libxml-2.0; then \
+		echo 'pkg-config libxml-2.0'; \
+	fi)
+endif
+endif
+
+ifneq ($(XML2CFG),)
+	DEFS += $(shell $(XML2CFG) --cflags )
+	LIBS += $(shell $(XML2CFG) --libs)
+else
+	DEFS+=-I$(LOCALBASE)/include/libxml2 -I$(LOCALBASE)/include
+	LIBS+=-L$(LOCALBASE)/lib -lxml2
+endif
+
+include ../../Makefile.modules

--- a/modules/pua_reginfo/doc/pua_reginfo.xml
+++ b/modules/pua_reginfo/doc/pua_reginfo.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding='ISO-8859-1'?>
+<!DOCTYPE book PUBLIC "-//OASIS//DTD DocBook XML V4.4//EN"
+"http://www.oasis-open.org/docbook/xml/4.4/docbookx.dtd" [
+
+<!-- Include general documentation entities -->
+<!ENTITY % docentities SYSTEM "../../../../doc/docbook/entities.xml">
+%docentities;
+
+]>
+
+<book xmlns:xi="http://www.w3.org/2001/XInclude">
+    <bookinfo>
+	<title>pua_reginfo Module</title>
+	<productname class="trade">&osipsname;</productname>
+	<authorgroup>
+		<author>
+			<firstname>Carsten</firstname>
+			<surname>Bock</surname>
+			<email>carsten@ng-voice.com</email>
+		</author>
+		<editor>
+			<firstname>Carsten</firstname>
+			<surname>Bock</surname>
+			<email>carsten@ng-voice.com</email>
+		</editor>
+	</authorgroup>
+	<copyright>
+	    <year>2011, 2023</year>
+	    <holder>Carsten Bock, carsten@ng-voice.com, http://www.ng-voice.com</holder>
+	</copyright>
+  </bookinfo>
+    <toc></toc>
+    
+    <xi:include href="pua_reginfo_admin.xml"/>
+    
+    
+</book>
+
+

--- a/modules/pua_reginfo/doc/pua_reginfo_admin.xml
+++ b/modules/pua_reginfo/doc/pua_reginfo_admin.xml
@@ -1,0 +1,329 @@
+<?xml version="1.0" encoding='ISO-8859-1'?>
+<!DOCTYPE book PUBLIC "-//OASIS//DTD DocBook XML V4.4//EN"
+"http://www.oasis-open.org/docbook/xml/4.4/docbookx.dtd" [
+
+<!-- Include general documentation entities -->
+<!ENTITY % docentities SYSTEM "../../../../doc/docbook/entities.xml">
+%docentities;
+
+]>
+<!-- Module User's Guide -->
+
+<chapter>
+	
+
+	<title>&adminguide;</title>
+	
+	<section>
+	  <title>Overview</title>
+	    <para> 
+	      This module publishes information about "reg"-events according to
+              to RFC 3680. This can be used distribute the registration-info
+              status to the subscribed watchers.
+	    </para>
+	    <para>
+ 	      This module "PUBLISH"es information when a new user registers
+              at this server (e.g. when "save()" is called) to users, which have
+              subscribed for the reg-info for this user.
+	    </para>
+	    <para>
+ 	      This module can "SUBSCRIBE" for information at another server, so it
+              will receive "NOTIFY"-requests, when the information about a user
+              changes.
+	    </para>
+	    <para>
+ 	      And finally, it can process received "NOTIFY" requests and it will 
+              update the local registry accordingly.
+	    </para>
+	    <para>
+ 	      Use cases for this might be:
+		<itemizedlist>
+		<listitem>Keeping different Servers in Sync regarding
+		the location database
+		</listitem>
+		<listitem>Get notified, when a user registers: A presence-server,
+		which handles offline message storage for an account, would get
+		notified, when the user comes online.
+		</listitem>
+		<listitem>A client could subscribe to its own registration-status,
+		so he would get notified as soon as his account gets administratively
+		unregistered.
+		</listitem>
+		<listitem>...</listitem>
+		</itemizedlist>
+	    </para>
+
+	</section>
+
+	<section>
+	  <title>Dependencies</title>
+	  <section>
+		<title>&kamailio; Modules</title>
+		<para>
+		The following modules must be loaded before this module:
+			<itemizedlist>
+			<listitem>
+			<para>
+				<emphasis>pua</emphasis>.
+			</para>
+			</listitem>
+			<listitem>
+			<para>
+				<emphasis>usrloc</emphasis>.
+			</para>
+			</listitem>
+			</itemizedlist>
+		</para>
+	  </section>
+
+	  <section>
+		<title>External Libraries or Applications</title>
+		<para>
+		None.
+		</para>
+	  </section>
+	</section>
+	<section>
+	<title>Parameters</title>
+	<section>
+		<title><varname>default_domain</varname>(str)</title>
+		<para>
+		The default domain for the registered users to be used when
+		constructing the uri for the registrar callback. 
+		</para>
+		<para>
+		<emphasis>	Default value is <quote>NULL</quote>.	
+		</emphasis>
+		</para>
+		<example>
+		<title>Set <varname>default_domain</varname> parameter</title>
+		<programlisting format="linespecific">
+...
+modparam("pua_reginfo", "default_domain", "kamailio.org")
+...
+</programlisting>
+		</example>
+	</section>
+	<section>
+		<title><varname>publish_reginfo</varname>(int)</title>
+		<para>
+		Whether or not to generate PUBLISH requests.
+		</para>
+		<para>
+		<emphasis>	Default value is <quote>1</quote> (enabled).	
+		</emphasis>
+		</para>
+		<example>
+		<title>Set <varname>publish_reginfo</varname> parameter</title>
+		<programlisting format="linespecific">
+...
+modparam("pua_reginfo", "publish_reginfo", 0)
+...
+</programlisting>
+		</example>
+	</section>
+	<section>
+		<title><varname>outbound_proxy</varname>(str)</title>
+		<para>
+		The outbound_proxy uri to be used when sending Subscribe and Publish requests.
+		</para>
+		<para>
+		<emphasis>	Default value is <quote>NULL</quote>.	
+		</emphasis>
+		</para>
+		<example>
+		<title>Set <varname>outbound_proxy</varname> parameter</title>
+		<programlisting format="linespecific">
+...
+modparam("pua_reginfo", "outbound_proxy", "sip:proxy@kamailio.org")
+...
+</programlisting>
+		</example>
+	</section>
+	<section>
+		<title><varname>server_address</varname>(str)</title>
+		<para>
+		The IP address of the server.
+		</para>
+		<example>
+		<title>Set <varname>server_address</varname> parameter</title>
+		<programlisting format="linespecific">
+...
+modparam("pua_reginfo", "server_address", "sip:reginfo@160.34.23.12")
+...
+</programlisting>
+		</example>
+	</section>
+	<section>
+		<title><varname>ul_domain</varname>(str)</title>
+		<para>
+		The domain for for querying the usrloc-database.
+		</para>
+		<para>
+		<emphasis>	Default value is <quote>NULL</quote> (not set).	
+		</emphasis>
+		</para>
+		<example>
+		<title>Set <varname>ul_domain</varname> parameter</title>
+		<programlisting format="linespecific">
+...
+modparam("pua_reginfo", "ul_domain", "location")
+...
+</programlisting>
+		</example>
+	</section>
+	<section>
+		<title><varname>ul_identities_key</varname>(str)</title>
+		<para>
+		The Key, which may be used for retrieving multiple public identies
+		for a user.
+		</para>
+		<para>
+		<emphasis>	Default value is <quote>NULL</quote> (not set).	
+		</emphasis>
+		</para>
+		<example>
+		<title>Set <varname>ul_identities_key</varname> parameter</title>
+		<programlisting format="linespecific">
+...
+modparam("pua_reginfo", "ul_identities_key", "identities")
+...
+onreply_route[register_reply] {
+	if (t_check_status("200") && $hdr(P-Associated-URI)) {
+        ul_add_key("location", "$tU@$td", "identities", "$hdr(P-Associated-URI)");
+        reginfo_update("$tU@$td");
+	}
+}
+
+...
+		</programlisting>
+		</example>
+	</section>
+	</section>	
+	<section>
+		<title>Functions</title>
+		<section id="pua_reginfo.f.reginfo_handle_notify">
+			<title>
+				<function moreinfo="none">reginfo_handle_notify(uldomain)</function>
+			</title>
+			<para>
+				This function processes received "NOTIFY"-requests and updates
+				the local registry accordingly.
+			</para>
+			<para>
+				This method does not create any SIP-Response, this has to be done
+				by the script-writer.
+			</para>
+			<para>
+				The parameter has to correspond to user location table (domain)
+				where to store the record.
+			</para>
+			<para>Return codes:</para>
+			<itemizedlist>
+			<listitem>
+				<para>
+				<emphasis>2</emphasis> - contacts successfully updated,
+				but no more contacts online now.
+				</para>
+				<para>
+				<emphasis>1</emphasis> - contacts successfully updated and at
+				at least one contact still registered.
+				</para>
+				<para>
+				<emphasis>-1</emphasis> - Invalid NOTIFY or other error (see log-file)
+				</para>
+			</listitem>
+			</itemizedlist>
+
+			<example>
+				<title><function>reginfo_handle_notify</function> usage</title>
+				<programlisting format="linespecific">
+...
+if(is_method("NOTIFY")) 
+	if (reginfo_handle_notify("location"))
+		send_reply("202", "Accepted");
+...
+				</programlisting>
+			</example>
+		</section>
+		<section>
+			<title>
+				<function moreinfo="none">reginfo_subscribe(uri[, expires])</function>
+			</title>
+			<para>
+				This function will subscribe for reginfo-information at the given
+				server URI.
+			</para>
+			<para>Meaning of the parameters is as follows:</para>
+			<itemizedlist>
+			<listitem>
+				<para>
+				<emphasis>uri</emphasis> - SIP-URI of the server, where to subscribe,
+				may contain pseudo-variables.
+				</para>
+				<para>
+				<emphasis>expires</emphasis> - Expiration date for this subscription, in seconds (default 3600)
+				</para>
+			</listitem>
+			</itemizedlist>
+			<example>
+				<title><function>reginfo_subscribe</function> usage</title>
+				<programlisting format="linespecific">
+...
+route {
+	t_on_reply("1");
+	t_relay();
+}
+
+reply_route[1] {
+	if (t_check_status("200")) 
+		reginfo_subscribe("$ru");		
+}
+...
+				</programlisting>
+			</example>
+		</section>
+		<section>
+			<title>
+				<function moreinfo="none">reginfo_update(aor)</function>
+			</title>
+			<para>
+				Explicitly update the presence status, e.g., when new information
+				is learned. This may trigger a new NOTIFY towards subscribed
+				entities; at least it will update the internal information for
+				subsequent subscribe and notifies.
+			</para>
+			<para>
+				This is done implicitly, when a registration is updated. However,
+				when a registration was just updated with additional information like
+				identities, this is not triggered automatically.
+			</para>
+			<para>Meaning of the parameters is as follows:</para>
+			<itemizedlist>
+			<listitem>
+				<para>
+				<emphasis>aor</emphasis> - The AOR to be updated.
+				</para>
+			</listitem>
+			</itemizedlist>
+			<example>
+				<title><function>reginfo_subscribe</function> usage</title>
+				<programlisting format="linespecific">
+...
+modparam("pua_reginfo", "ul_domain", "location")
+modparam("pua_reginfo", "ul_identities_key", "identities")
+...
+onreply_route[register_reply] {
+	if (t_check_status("200") && $hdr(P-Associated-URI)) {
+        ul_add_key("location", "$tU@$td", "identities", "$hdr(P-Associated-URI)");
+        reginfo_update("$tU@$td");
+	}
+}
+
+...
+				</programlisting>
+			</example>
+		</section>
+	</section>
+
+</chapter>

--- a/modules/pua_reginfo/notify.c
+++ b/modules/pua_reginfo/notify.c
@@ -1,0 +1,546 @@
+/*
+ * pua_reginfo module - Presence-User-Agent Handling of reg events
+ *
+ * Copyright (C) 2011, 2023 Carsten Bock, carsten@ng-voice.com
+ *
+ * This file is part of opensips, a free SIP server.
+ *
+ * opensips is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version
+ *
+ * opensips is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301  USA
+ */
+
+#include "notify.h"
+#include "../../parser/parse_from.h"
+#include "../../parser/parse_content.h"
+#include "../../parser/parse_uri.h"
+#include "../../modules/usrloc/usrloc.h"
+#include <libxml/parser.h>
+#include "usrloc_cb.h"
+#include "pua_reginfo.h"
+
+/*<?xml version="1.0"?>
+<reginfo xmlns="urn:ietf:params:xml:ns:reginfo" version="0" state="full">
+.<registration aor="sip:carsten@ng-voice.com" id="0xb33fa860" state="active">
+..<contact id="0xb33fa994" state="active" event="registered" expires="3600">
+...<uri>sip:carsten@10.157.87.36:43582;transport=udp</uri>
+...<unknown-param name="+g.3gpp.cs-voice"></unknown-param>
+...<unknown-param name="+g.3gpp.icsi-ref">urn0X0.0041FB74E7B54P-1022urn-70X0P+03gpp-application.ims.iari.gsma-vs</unknown-param>
+...<unknown-param name="audio"></unknown-param>
+...<unknown-param name="+g.oma.sip-im.large-message"></unknown-param>
+...<unknown-param name="+g.3gpp.smsip"></unknown-param>
+...<unknown-param name="language">en,fr</unknown-param>
+...<unknown-param name="+g.oma.sip-im"></unknown-param>
+...<unknown-param name="expires">600000</unknown-param>
+..</contact>
+.</registration>
+</reginfo> */
+
+#define STATE_ACTIVE 1
+#define STATE_TERMINATED 0
+#define STATE_UNKNOWN -1
+
+#define EVENT_UNKNOWN -1
+#define EVENT_REGISTERED 0
+#define EVENT_UNREGISTERED 1
+#define EVENT_TERMINATED 2
+#define EVENT_CREATED 3
+#define EVENT_REFRESHED 4
+#define EVENT_EXPIRED 5
+
+#define RESULT_ERROR -1
+#define RESULT_CONTACTS_FOUND 1
+#define RESULT_NO_CONTACTS 2
+
+int process_contact(udomain_t *domain, urecord_t **ul_record, str aor,
+		str callid, int cseq, int expires, int event, str contact_uri)
+{
+	static str no_ua = str_init("n/a");
+	static ucontact_info_t ci;
+	ucontact_t *ul_contact;
+	int ret;
+
+	struct ct_match cmatch;
+	memset(&cmatch, 0, sizeof(struct ct_match));
+	cmatch.mode = CT_MATCH_NONE;
+
+	pua_reginfo_update_self_op(1);
+	if(*ul_record == NULL) {
+		switch(event) {
+			case EVENT_REGISTERED:
+			case EVENT_CREATED:
+			case EVENT_REFRESHED:
+				/* In case, no record exists and new one should be created,
+				 * create a new entry for this user in the usrloc-DB */
+				if(ul.insert_urecord(domain, &aor, ul_record, 0) < 0) {
+					LM_ERR("failed to insert new user-record\n");
+					ret = RESULT_ERROR;
+					goto done;
+				}
+				break;
+			default:
+				/* No entry in usrloc and the contact is expired, deleted, unregistered, whatever:
+				 * We do not need to do anything. */
+				ret = RESULT_NO_CONTACTS;
+				goto done;
+		}
+	}
+
+	/* Make sure, no crap is in the structure: */
+	memset(&ci, 0, sizeof(ucontact_info_t));
+	/* Get callid of the message */
+	ci.callid = &callid;
+	/* Get CSeq number of the message */
+	ci.cseq = cseq;
+	ci.sock = NULL;
+	/* additional info from message */
+	ci.user_agent = &no_ua;
+	ci.last_modified = time(0);
+
+	/* set expire time */
+	ci.expires = time(0) + expires;
+
+	/* Now we start looking for the contact: */
+	if(((*ul_record)->contacts == 0)
+			|| (ul.get_ucontact(*ul_record, &contact_uri, &callid, cseq + 1, &cmatch, &ul_contact)
+					!= 0)) {
+		if(ul.insert_ucontact(*ul_record, &contact_uri, &ci, &cmatch, 0, &ul_contact) < 0) {
+			LM_ERR("failed to insert new contact\n");
+			ret = RESULT_ERROR;
+			goto done;
+		}
+	} else {
+		if(ul.update_ucontact(*ul_record, ul_contact, &ci, &cmatch, 0) < 0) {
+			LM_ERR("failed to update contact\n");
+			ret = RESULT_ERROR;
+			goto done;
+		}
+	}
+	ul_contact = (*ul_record)->contacts;
+	while(ul_contact) {
+		if(VALID_CONTACT(ul_contact, time(0)))
+			return RESULT_CONTACTS_FOUND;
+		ul_contact = ul_contact->next;
+	}
+
+	ret = RESULT_NO_CONTACTS;
+done:
+	pua_reginfo_update_self_op(0);
+	return ret;
+}
+
+xmlNodePtr xmlGetNodeByName(xmlNodePtr parent, const char *name)
+{
+	xmlNodePtr cur = parent;
+	xmlNodePtr match = NULL;
+	while(cur) {
+		if(xmlStrcasecmp(cur->name, (unsigned char *)name) == 0)
+			return cur;
+		match = xmlGetNodeByName(cur->children, name);
+		if(match)
+			return match;
+		cur = cur->next;
+	}
+	return NULL;
+}
+
+char *xmlGetAttrContentByName(xmlNodePtr node, const char *name)
+{
+	xmlAttrPtr attr = node->properties;
+	while(attr) {
+		if(xmlStrcasecmp(attr->name, (unsigned char *)name) == 0)
+			return (char *)xmlNodeGetContent(attr->children);
+		attr = attr->next;
+	}
+	return NULL;
+}
+
+int reginfo_parse_state(char *s)
+{
+	if(s == NULL) {
+		return STATE_UNKNOWN;
+	}
+	switch(strlen(s)) {
+		case 6:
+			if(strncmp(s, "active", 6) == 0)
+				return STATE_ACTIVE;
+			break;
+		case 10:
+			if(strncmp(s, "terminated", 10) == 0)
+				return STATE_TERMINATED;
+			break;
+		default:
+			LM_ERR("Unknown State %s\n", s);
+			return STATE_UNKNOWN;
+	}
+	LM_ERR("Unknown State %s\n", s);
+	return STATE_UNKNOWN;
+}
+
+int reginfo_parse_event(char *s)
+{
+	if(s == NULL) {
+		return EVENT_UNKNOWN;
+	}
+	switch(strlen(s)) {
+		case 7:
+			if(strncmp(s, "created", 7) == 0)
+				return EVENT_CREATED;
+			if(strncmp(s, "expired", 7) == 0)
+				return EVENT_EXPIRED;
+			break;
+		case 9:
+			if(strncmp(s, "refreshed", 9) == 0)
+				return EVENT_CREATED;
+			break;
+		case 10:
+			if(strncmp(s, "registered", 10) == 0)
+				return EVENT_REGISTERED;
+			if(strncmp(s, "terminated", 10) == 0)
+				return EVENT_TERMINATED;
+			break;
+		case 12:
+			if(strncmp(s, "unregistered", 12) == 0)
+				return EVENT_UNREGISTERED;
+			break;
+		default:
+			LM_ERR("Unknown Event %s\n", s);
+			return EVENT_UNKNOWN;
+	}
+	LM_ERR("Unknown Event %s\n", s);
+	return EVENT_UNKNOWN;
+}
+
+int process_body(str notify_body, udomain_t *domain)
+{
+	xmlDocPtr doc = NULL;
+	xmlNodePtr doc_root = NULL, registrations = NULL, contacts = NULL,
+			   uris = NULL, params = NULL;
+	char uri[MAX_URI_SIZE];
+	str aor_key = {0, 0};
+	str aor = {0, 0};
+	str callid = {0, 0};
+	str contact = {0, 0};
+	str contact_uri = {0, 0};
+	str contact_params = {0, 0};
+	str param = {0, 0};
+	str received = {0, 0};
+	str path = {0, 0};
+	str user_agent = {0, 0};
+	int state, event, expires, result, final_result = RESULT_ERROR;
+	char *expires_char, *cseq_char;
+	int cseq = 0;
+	int len;
+	urecord_t *ul_record = NULL;
+	ucontact_t *ul_contact = NULL;
+	struct sip_uri parsed_aor;
+
+	/* Temporary */
+	int mem_only = 1;
+
+	uri[0] = '\0';
+	doc = xmlParseMemory(notify_body.s, notify_body.len);
+	if(doc == NULL) {
+		LM_ERR("Error while parsing the xml body message, Body is:\n%.*s\n",
+				notify_body.len, notify_body.s);
+		return -1;
+	}
+	doc_root = xmlGetNodeByName(doc->children, "reginfo");
+	if(doc_root == NULL) {
+		LM_ERR("while extracting the reginfo node\n");
+		goto error;
+	}
+	registrations = doc_root->children;
+	while(registrations) {
+		/* Only process registration sub-items */
+		if(xmlStrcasecmp(registrations->name, BAD_CAST "registration") != 0)
+			goto next_registration;
+		state = reginfo_parse_state(
+				xmlGetAttrContentByName(registrations, "state"));
+		if(state == STATE_UNKNOWN) {
+			LM_ERR("No state for this contact!\n");
+			goto next_registration;
+		}
+		aor.s = xmlGetAttrContentByName(registrations, "aor");
+		if(aor.s == NULL) {
+			LM_ERR("No AOR for this contact!\n");
+			goto next_registration;
+		}
+		aor.len = strlen(aor.s);
+		LM_DBG("AOR %.*s has state \"%d\"\n", aor.len, aor.s, state);
+
+		/* Get username part of the AOR, search for @ in the AOR. */
+		if(parse_uri(aor.s, aor.len, &parsed_aor) < 0) {
+			LM_ERR("failed to parse Address of Record (%.*s)\n", aor.len,
+					aor.s);
+			goto next_registration;
+		}
+
+		if(reginfo_use_domain) {
+			aor_key.s = uri;
+		} else {
+			aor_key.s = parsed_aor.user.s;
+		}
+		aor_key.len = strlen(aor_key.s);
+		/* Now let's lock that domain for this AOR: */
+		ul.lock_udomain(domain, &aor_key);
+		/* and retrieve the user-record for this user: */
+		result = ul.get_urecord(domain, &aor_key, &ul_record);
+		if(result < 0) {
+			ul.unlock_udomain(domain, &aor_key);
+			LM_ERR("failed to query usrloc (AOR %.*s)\n", aor_key.len,
+					aor_key.s);
+			goto next_registration;
+		}
+		/* If no contacts found, then set the ul_record to NULL */
+		if(result != 0)
+			ul_record = NULL;
+
+		/* If the state is terminated, we just can delete all bindings */
+		if(state == STATE_TERMINATED) {
+			if(ul_record) {
+				ul_contact = ul_record->contacts;
+				while(ul_contact) {
+					if(mem_only) {
+						ul_contact->flags |= FL_MEM;
+					} else {
+						ul_contact->flags &= ~FL_MEM;
+					}
+					ul_contact = ul_contact->next;
+				}
+
+				if(ul.delete_urecord(domain, &aor_key, ul_record, 0) < 0) {
+					LM_ERR("failed to remove record from usrloc\n");
+				}
+
+				/* Record deleted, and should not be used anymore */
+				ul_record = NULL;
+
+
+				/* If already a registration with contacts was found, then keep that result.
+				   otherwise the result is now "No contacts found" */
+				if(final_result != RESULT_CONTACTS_FOUND)
+					final_result = RESULT_NO_CONTACTS;
+			}
+			/* Otherwise, process the content */
+		} else {
+			/* Now lets process the Contact's from this Registration: */
+			contacts = registrations->children;
+			while(contacts) {
+				if(xmlStrcasecmp(contacts->name, BAD_CAST "contact") != 0)
+					goto next_contact;
+				callid.len = 0;
+				callid.s = xmlGetAttrContentByName(contacts, "callid");
+				// If no CallID present, try the "id"-field instead:
+				if(callid.s == NULL)
+					callid.s = xmlGetAttrContentByName(contacts, "id");
+				callid.len = strlen(callid.s);
+				LM_DBG("Got Call-ID \"%.*s\"\n", callid.len, callid.s);
+				received.s = xmlGetAttrContentByName(contacts, "received");
+				if(received.s == NULL) {
+					LM_DBG("No received for this contact!\n");
+					received.len = 0;
+				} else {
+					received.len = strlen(received.s);
+				}
+
+				path.s = xmlGetAttrContentByName(contacts, "path");
+				if(path.s == NULL) {
+					LM_DBG("No path for this contact!\n");
+					path.len = 0;
+				} else {
+					path.len = strlen(path.s);
+				}
+
+				user_agent.s = xmlGetAttrContentByName(contacts, "user_agent");
+				if(user_agent.s == NULL) {
+					LM_DBG("No user_agent for this contact!\n");
+					user_agent.len = 0;
+				} else {
+					user_agent.len = strlen(user_agent.s);
+				}
+				event = reginfo_parse_event(
+						xmlGetAttrContentByName(contacts, "event"));
+				if(event == EVENT_UNKNOWN) {
+					LM_ERR("No event for this contact!\n");
+					goto next_contact;
+				}
+				expires_char = xmlGetAttrContentByName(contacts, "expires");
+				if(expires_char == NULL) {
+					LM_ERR("No expires for this contact!\n");
+					goto next_contact;
+				}
+				expires = atoi(expires_char);
+				if(expires < 0) {
+					LM_ERR("No valid expires for this contact!\n");
+					goto next_contact;
+				}
+				LM_DBG("%.*s: Event \"%d\", expires %d\n", callid.len, callid.s,
+						event, expires);
+
+				cseq_char = xmlGetAttrContentByName(contacts, "cseq");
+				if(cseq_char == NULL) {
+					LM_DBG("No cseq for this contact!\n");
+				} else {
+					cseq = atoi(cseq_char);
+					if(cseq < 0) {
+						LM_WARN("No valid cseq for this contact!\n");
+					}
+				}
+
+				// <unknown-param name="+g.oma.sip-im"></unknown-param>
+				// <unknown-param name="language">en,fr</unknown-param>
+				/* 1) Iterate through the params, to get the full content-length */
+				params = contacts->children;
+				contact_params.len = 0;
+				len = 0;
+				while(params) {
+					if(xmlStrcasecmp(params->name, BAD_CAST "unknown-param")
+							!= 0)
+						goto next_param;
+					len += 1 /* ; */
+						   + strlen(xmlGetAttrContentByName(params, "name"));
+					param.s = (char *)xmlNodeGetContent(params);
+					param.len = strlen(param.s);
+					if(param.len > 0)
+						len += 1 /* = */ + param.len;
+				next_param:
+					params = params->next;
+				}
+				LM_DBG("Calculated length for params: %i\n", len);
+
+				if(len > 0) {
+					len += 1;
+					if(contact_params.s)
+						pkg_free(contact_params.s);
+					contact_params.s = pkg_malloc(len);
+					params = contacts->children;
+					contact_params.len = 0;
+					while(params) {
+						if(xmlStrcasecmp(params->name, BAD_CAST "unknown-param")
+								!= 0)
+							goto next_param2;
+						contact_params.len += snprintf(
+								contact_params.s + contact_params.len,
+								len - contact_params.len, ";%s",
+								xmlGetAttrContentByName(params, "name"));
+						param.s = (char *)xmlNodeGetContent(params);
+						param.len = strlen(param.s);
+						if(param.len > 0)
+							contact_params.len += snprintf(
+									contact_params.s + contact_params.len,
+									len - contact_params.len, "=%.*s",
+									param.len, param.s);
+
+						LM_DBG("Contact params are: %.*s\n", contact_params.len,
+								contact_params.s);
+
+					next_param2:
+						params = params->next;
+					}
+					LM_DBG("Contact params are: %.*s\n", contact_params.len,
+							contact_params.s);
+				}
+
+				/* Now lets process the URI's from this Contact: */
+				uris = contacts->children;
+				while(uris) {
+					if(xmlStrcasecmp(uris->name, BAD_CAST "uri") != 0)
+						goto next_uri;
+					contact_uri.s = (char *)xmlNodeGetContent(uris);
+					if(contact_uri.s == NULL) {
+						LM_ERR("No URI for this contact!\n");
+						goto next_registration;
+					}
+					contact_uri.len = strlen(contact_uri.s);
+					if(contact_params.len > 0) {
+						if(contact.s)
+							pkg_free(contact.s);
+						contact.s = (char *)pkg_malloc(
+								contact_uri.len + contact_params.len + 1);
+						contact.len = snprintf(contact.s,
+								contact_uri.len + contact_params.len + 1,
+								"%.*s%.*s", contact_uri.len, contact_uri.s,
+								contact_params.len, contact_params.s);
+						LM_DBG("Contact: %.*s\n", contact.len, contact.s);
+
+						/* Add to Usrloc: */
+						result = process_contact(domain, &ul_record, aor_key,
+								callid, cseq, expires, event, contact);
+					} else {
+						LM_DBG("Contact: %.*s\n", contact_uri.len,
+								contact_uri.s);
+
+						/* Add to Usrloc: */
+						result = process_contact(domain, &ul_record, aor_key,
+								callid, cseq, expires, event, contact_uri);
+					}
+
+					/* Process the result */
+					if(final_result != RESULT_CONTACTS_FOUND)
+						final_result = result;
+				next_uri:
+					uris = uris->next;
+				}
+			next_contact:
+				contacts = contacts->next;
+			}
+		}
+	next_registration:
+		if(ul_record)
+			ul.release_urecord(ul_record, 0);
+		/* Unlock the domain for this AOR: */
+		if(aor_key.len > 0)
+			ul.unlock_udomain(domain, &aor_key);
+
+		registrations = registrations->next;
+	}
+error:
+	if(contact.s)
+		pkg_free(contact.s);
+	if(contact_params.s)
+		pkg_free(contact_params.s);
+	/* Free the XML-Document */
+
+	if(doc)
+		xmlFreeDoc(doc);
+	return final_result;
+}
+
+int reginfo_handle_notify(struct sip_msg *msg, char *domain, char *s2)
+{
+	str body;
+	int result = 1;
+
+	/* If not done yet, parse the whole message now: */
+	if(parse_headers(msg, HDR_EOH_F, 0) == -1) {
+		LM_ERR("Error parsing headers\n");
+		return -1;
+	}
+	if(get_content_length(msg) == 0) {
+		LM_DBG("Content length = 0\n");
+		/* No Body? Then there is no published information available, which is ok. */
+		return 1;
+	} else {
+		if (get_body(msg, &body) != 0) {
+			LM_ERR("cannot extract body from msg\n");
+			return -1;
+		}
+	}
+
+	LM_DBG("Body is %.*s\n", body.len, body.s);
+
+	result = process_body(body, (udomain_t *)domain);
+
+	return result;
+}

--- a/modules/pua_reginfo/notify.h
+++ b/modules/pua_reginfo/notify.h
@@ -1,0 +1,30 @@
+/*
+ * pua_reginfo module - Presence-User-Agent Handling of reg events
+ *
+ * Copyright (C) 2011, 2023 Carsten Bock, carsten@ng-voice.com
+ *
+ * This file is part of opensips, a free SIP server.
+ *
+ * opensips is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version
+ *
+ * opensips is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301  USA
+ */
+
+#ifndef NOTIFY_H
+#define NOTIFY_H
+
+#include "../../parser/msg_parser.h"
+
+int reginfo_handle_notify(struct sip_msg *, char *, char *);
+
+#endif

--- a/modules/pua_reginfo/pua_reginfo.c
+++ b/modules/pua_reginfo/pua_reginfo.c
@@ -1,0 +1,253 @@
+/*
+ * pua_reginfo module - Presence-User-Agent Handling of reg events
+ *
+ * Copyright (C) 2011, 2023 Carsten Bock, carsten@ng-voice.com
+ *
+ * This file is part of opensips, a free SIP server.
+ *
+ * opensips is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version
+ *
+ * opensips is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301  USA
+ */
+
+/* Bindings to PUA */
+#include "../pua/pua_bind.h"
+/* Bindings to usrloc */
+#include "../usrloc/usrloc.h"
+/* Bindings to Presence */
+#include "../presence/bind_presence.h"
+
+#include "pua_reginfo.h"
+#include "subscribe.h"
+#include "notify.h"
+#include "usrloc_cb.h"
+
+usrloc_api_t ul; 		/*!< Structure containing pointers to usrloc functions*/
+pua_api_t pua;	 		/*!< Structure containing pointers to PUA functions*/
+presence_api_t pres;	/*!< Structure containing pointers to Presence functions*/
+
+/* Default domain to be added, if none provided. */
+str reginfo_default_domain = {NULL, 0};
+str outbound_proxy = {NULL, 0};
+str server_address = {NULL, 0};
+str uldomain_str = {NULL, 0};
+str ul_identities_key = {NULL, 0};
+
+int publish_reginfo = 0;
+
+udomain_t* ul_domain = 0;
+
+int reginfo_use_domain = 0;
+
+/** Fixup functions */
+static int domain_fixup(void **param);
+
+/** module functions */
+static int mod_init(void);
+
+/* Commands */
+static cmd_export_t cmds[] = {
+		{"reginfo_subscribe", (cmd_function)reginfo_subscribe, {
+				{CMD_PARAM_STR, 0, 0},
+				{CMD_PARAM_INT | CMD_PARAM_OPT, 0, 0},
+				{0,0,0},
+			},
+			REQUEST_ROUTE | ONREPLY_ROUTE},
+		{"reginfo_handle_notify", (cmd_function)reginfo_handle_notify, {
+				{CMD_PARAM_STR|CMD_PARAM_STATIC, domain_fixup, 0},
+				{0,0,0},
+			},
+			REQUEST_ROUTE},
+		{"reginfo_update", (cmd_function)w_reginfo_update, {
+				{CMD_PARAM_STR, 0, 0},
+				{0,0,0},
+			},
+			REQUEST_ROUTE | ONREPLY_ROUTE},
+		{0,0,{{0,0,0}},0}
+	};
+
+static param_export_t params[] = {
+		{"default_domain", STR_PARAM, &reginfo_default_domain.s},
+		{"outbound_proxy", STR_PARAM, &outbound_proxy.s},
+		{"server_address", STR_PARAM, &server_address.s},
+		{"ul_domain", STR_PARAM, &uldomain_str.s},
+		{"ul_identities_key", STR_PARAM, &ul_identities_key.s},
+		{"publish_reginfo", INT_PARAM, &publish_reginfo}, {0, 0, 0}};
+
+/* module exports */
+static const dep_export_t deps = {
+	{ /* OpenSIPS module dependencies */
+		{ MOD_TYPE_DEFAULT, "presence", DEP_ABORT },
+		{ MOD_TYPE_DEFAULT, "pua", DEP_ABORT },
+		{ MOD_TYPE_DEFAULT, "usrloc", DEP_ABORT },
+		{ MOD_TYPE_NULL, NULL, 0 },
+	},
+	{ /* modparam dependencies */
+		{ NULL, NULL },
+	},
+};
+
+/* module exports */
+struct module_exports exports= {
+    "pua_reginfo",		/* module name */
+    MOD_TYPE_DEFAULT,           /* class of this module */
+    MODULE_VERSION,				/* module version */
+    DEFAULT_DLFLAGS,			/* dlopen flags */
+    0,							/* load function */
+    &deps,                      /* OpenSIPS module dependencies */
+    cmds,						/* exported functions */
+    0,							/* exported async functions */
+    params,						/* exported parameters */
+    0,							/* exported statistics */
+    0,							/* exported MI functions */
+    0,							/* exported pseudo-variables */
+    0,			 				/* exported transformations */
+    0,							/* extra processes */
+    0,							/* module pre-initialization function */
+    mod_init,					/* module initialization function */
+    0,							/* response handling function */
+    0,							/* destroy function */
+    0,							/* per-child init function */
+    0							/* reload confirm function */
+};
+
+/**
+ * init module function
+ */
+static int mod_init(void)
+{
+	bind_pua_t bind_pua;
+	bind_usrloc_t bind_usrloc;
+	bind_presence_t bind_presence;
+
+	if(publish_reginfo == 1) {
+		/* Verify the default domain: */
+		if(!reginfo_default_domain.s) {
+			LM_ERR("default domain parameter not set\n");
+			return -1;
+		}
+		reginfo_default_domain.len = strlen(reginfo_default_domain.s);
+	}
+	
+	if(!server_address.s) {
+		LM_ERR("server_address parameter not set\n");
+		return -1;
+	}
+	server_address.len = strlen(server_address.s);
+
+	if(!outbound_proxy.s)
+		LM_DBG("No outbound proxy set\n");
+	else {
+		outbound_proxy.len = strlen(outbound_proxy.s);
+		LM_DBG("Using %.*s as outbound proxy\n", outbound_proxy.len, outbound_proxy.s);
+	}
+
+	/* Bind to Presence: */
+	memset(&pres, 0, sizeof(presence_api_t));
+	bind_presence= (bind_presence_t)find_export("bind_presence", 0);
+	if(!bind_presence) {
+		LM_INFO("can't bind presence\n");
+		return -1;
+	} else {
+		if(bind_presence(&pres) < 0) {
+			LM_ERR("can't bind presence\n");
+			return -1;
+		}
+	}
+
+	/* Bind to PUA: */
+	memset(&pua, 0, sizeof(pua_api_t));
+	bind_pua = (bind_pua_t)find_export("bind_pua", 0);
+	if(!bind_pua) {
+		LM_INFO("Can't bind pua\n");
+		if (pres.update_presentity == NULL) {
+			LM_ERR("Either PUA or Presence required, none found.\n");
+			return -1;
+		}
+		LM_INFO("Disabling sending of PUBLISH\n");
+		publish_reginfo = 0;
+	} else {
+		if(bind_pua(&pua) < 0) {
+			LM_ERR("Can't bind pua\n");
+			return -1;
+		}
+		/* Check for Publish/Subscribe methods */
+		if(pua.send_publish == NULL) {
+			LM_ERR("Could not import send_publish\n");
+			return -1;
+		}
+		if(pua.send_subscribe == NULL) {
+			LM_ERR("Could not import send_subscribe\n");
+			return -1;
+		}
+	}
+
+	/* Bind to URSLOC: */
+	bind_usrloc = (bind_usrloc_t)find_export("ul_bind_usrloc", 0);
+	if(!bind_usrloc) {
+		LM_ERR("Can't bind usrloc\n");
+		return -1;
+	}
+	if(bind_usrloc(&ul) < 0) {
+		LM_ERR("Can't bind usrloc\n");
+		return -1;
+	}
+	if(!uldomain_str.s) {
+		LM_ERR("uldomain parameter not set\n");
+		return -1;
+	}
+	uldomain_str.len = strlen(uldomain_str.s);
+	if (ul.register_udomain(uldomain_str.s, &ul_domain) < 0) {
+		LM_ERR("failed to register domain\n");
+		return E_UNSPEC;
+	}
+	if(ul.register_ulcb == NULL) {
+		LM_ERR("Could not import ul_register_ulcb\n");
+		return -1;
+	}
+	if(ul.register_ulcb(UL_CONTACT_INSERT|UL_CONTACT_UPDATE|UL_CONTACT_DELETE|UL_CONTACT_EXPIRE, reginfo_usrloc_cb) < 0) {
+		LM_ERR("can not register callback for usrloc\n");
+		return -1;
+	}
+
+	ul_identities_key.len = strlen(ul_identities_key.s);
+
+	/*
+	 * Import use_domain parameter from usrloc
+	 */
+	reginfo_use_domain = ul.use_domain;
+
+	return 0;
+}
+
+/*! \brief
+ * Convert char* parameter to udomain_t* pointer
+ */
+static int domain_fixup(void **param)
+{
+	udomain_t* d;
+	str d_nt;
+
+	if (pkg_nt_str_dup(&d_nt, (str*)*param) < 0)
+		return E_OUT_OF_MEM;
+
+	if (ul.register_udomain(d_nt.s, &d) < 0) {
+		LM_ERR("failed to register domain\n");
+		return E_UNSPEC;
+	}
+
+	pkg_free(d_nt.s);
+
+	*param = (void*)d;
+	return 0;
+}

--- a/modules/pua_reginfo/pua_reginfo.h
+++ b/modules/pua_reginfo/pua_reginfo.h
@@ -1,0 +1,43 @@
+/*
+ * pua_reginfo module - Presence-User-Agent Handling of reg events
+ *
+ * Copyright (C) 2011, 2023 Carsten Bock, carsten@ng-voice.com
+ *
+ * This file is part of opensips, a free SIP server.
+ *
+ * opensips is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version
+ *
+ * opensips is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301  USA
+ */
+
+#ifndef _PUA_REGINFO_H
+#define _PUA_REGINFO_H
+
+#include "../pua/pua_bind.h"
+#include "../usrloc/usrloc.h"
+#include "../presence/bind_presence.h"
+
+extern str reginfo_default_domain;
+extern str outbound_proxy;
+extern str server_address;
+extern int publish_reginfo;
+extern udomain_t* ul_domain;
+extern str ul_identities_key;
+
+extern usrloc_api_t ul;     /*!< Structure containing pointers to usrloc functions*/
+extern pua_api_t pua;	    /*!< Structure containing pointers to PUA functions*/
+extern presence_api_t pres; /*!< Structure containing pointers to Presence functions*/
+
+extern int reginfo_use_domain;
+
+#endif

--- a/modules/pua_reginfo/subscribe.c
+++ b/modules/pua_reginfo/subscribe.c
@@ -1,0 +1,62 @@
+/*
+ * pua_reginfo module - Presence-User-Agent Handling of reg events
+ *
+ * Copyright (C) 2011, 2023 Carsten Bock, carsten@ng-voice.com
+ *
+ * This file is part of opensips, a free SIP server.
+ *
+ * opensips is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version
+ *
+ * opensips is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301  USA
+ */
+
+#include "subscribe.h"
+#include "../../pvar.h"
+#include "../../mod_fix.h"
+#include "../pua/send_subscribe.h"
+#include "../pua/pua.h"
+#include "pua_reginfo.h"
+
+int reginfo_subscribe(struct sip_msg *msg, str * uri_str, int expires)
+{
+	subs_info_t subs;
+
+	if(pua.send_subscribe == NULL) {
+		LM_ERR("Not bound to PUA, unable to send SUBSCRIBE\n");
+		return -1;
+	}
+
+	LM_DBG("Subscribing to %.*s\n", uri_str->len, uri_str->s);
+
+	memset(&subs, 0, sizeof(subs_info_t));
+
+	subs.remote_target = uri_str;
+	subs.pres_uri = uri_str;
+	subs.watcher_uri = &server_address;
+	subs.expires = expires;
+
+	subs.source_flag = REGINFO_SUBSCRIBE;
+	subs.event = REGINFO_EVENT;
+	subs.contact = &server_address;
+
+	if(outbound_proxy.s && outbound_proxy.len)
+		subs.outbound_proxy = &outbound_proxy;
+
+	subs.flag |= UPDATE_TYPE;
+
+	if(pua.send_subscribe(&subs) < 0) {
+		LM_ERR("while sending subscribe\n");
+	}
+
+	return 1;
+}

--- a/modules/pua_reginfo/subscribe.h
+++ b/modules/pua_reginfo/subscribe.h
@@ -1,0 +1,30 @@
+/*
+ * pua_reginfo module - Presence-User-Agent Handling of reg events
+ *
+ * Copyright (C) 2011, 2023 Carsten Bock, carsten@ng-voice.com
+ *
+ * This file is part of opensips, a free SIP server.
+ *
+ * opensips is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version
+ *
+ * opensips is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301  USA
+ */
+
+#ifndef PUA_SUBSCRIBE_H
+#define PUA_SUBSCRIBE_H
+
+#include "../../parser/msg_parser.h"
+
+int reginfo_subscribe(struct sip_msg *, str *, int);
+
+#endif

--- a/modules/pua_reginfo/usrloc_cb.c
+++ b/modules/pua_reginfo/usrloc_cb.c
@@ -1,0 +1,536 @@
+/*
+ * pua_reginfo module - Presence-User-Agent Handling of reg events
+ *
+ * Copyright (C) 2011, 2023 Carsten Bock, carsten@ng-voice.com
+ *
+ * This file is part of opensips, a free SIP server.
+ *
+ * opensips is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version
+ *
+ * opensips is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301  USA
+ */
+#include "usrloc_cb.h"
+#include "pua_reginfo.h"
+#include <libxml/parser.h>
+#include "../pua/pua.h"
+#include "../presence/bind_presence.h"
+#include "../../qvalue.h"
+#include "../../lib/csv.h"
+#include "../../trim.h"
+
+/*
+Contact: <sip:carsten@10.157.87.36:44733;transport=udp>;expires=600000;+g.oma.sip-im;language="en,fr";+g.3gpp.smsip;+g.oma.sip-im.large-message;audio;+g.3gpp.icsi-ref="urn%3Aurn-7%3A3gpp-application.ims.iari.gsma-vs";+g.3gpp.cs-voice.
+Call-ID: 9ad9f89f-164d-bb86-1072-52e7e9eb5025.
+*/
+
+/*<?xml version="1.0"?>
+<reginfo xmlns="urn:ietf:params:xml:ns:reginfo" version="0" state="full">
+.<registration aor="sip:carsten@ng-voice.com" id="0xb33fa860" state="active">
+..<contact id="0xb33fa994" state="active" event="registered" expires="3600">
+...<uri>sip:carsten@10.157.87.36:43582;transport=udp</uri>
+...<unknown-param name="+g.3gpp.cs-voice"></unknown-param>
+...<unknown-param name="+g.3gpp.icsi-ref">urn0X0.0041FB74E7B54P-1022urn-70X0P+03gpp-application.ims.iari.gsma-vs</unknown-param>
+...<unknown-param name="audio"></unknown-param>
+...<unknown-param name="+g.oma.sip-im.large-message"></unknown-param>
+...<unknown-param name="+g.3gpp.smsip"></unknown-param>
+...<unknown-param name="language">en,fr</unknown-param>
+...<unknown-param name="+g.oma.sip-im"></unknown-param>
+...<unknown-param name="expires">600000</unknown-param>
+..</contact>
+.</registration>
+</reginfo> */
+
+static int _pua_reginfo_self_op = 0;
+
+static pres_ev_t *reginfo_event = NULL;
+
+void pua_reginfo_update_self_op(int v)
+{
+	_pua_reginfo_self_op = v;
+}
+
+str r_active = str_init("active");
+str r_terminated = str_init("terminated");
+str r_registered = str_init("registered");
+str r_refreshed = str_init("refreshed");
+str r_expired = str_init("expired");
+str r_unregistered = str_init("unregistered");
+#define VERSION_HOLDER "00000000000"
+
+str reginfo_key_etag = str_init("reginfo_etag");
+
+str *build_reginfo_full(urecord_t *record, ucontact_t *contact, str aor[], unsigned int aor_count, int type, int * count)
+{
+	xmlDocPtr doc = NULL;
+	xmlNodePtr root_node = NULL;
+	xmlNodePtr registration_node = NULL;
+	xmlNodePtr contact_node = NULL;
+	xmlNodePtr uri_node = NULL;
+	str *body = NULL;
+	str state = STR_NULL;
+	str event = STR_NULL;
+	ucontact_t *ptr;
+	char buf[512];
+	int reg_active = 0;
+	time_t cur_time = time(0);
+	int expires = 0;
+	int i = 0;
+
+	/* create the XML-Body */
+	doc = xmlNewDoc(BAD_CAST "1.0");
+	if(doc == 0) {
+		LM_ERR("Unable to create XML-Doc\n");
+		return NULL;
+	}
+
+	root_node = xmlNewNode(NULL, BAD_CAST "reginfo");
+	if(root_node == 0) {
+		LM_ERR("Unable to create reginfo-XML-Element\n");
+		xmlFreeDoc(doc);
+		return NULL;
+	}
+	/* This is our Root-Element: */
+	xmlDocSetRootElement(doc, root_node);
+
+	xmlNewProp(root_node, BAD_CAST "xmlns",
+			BAD_CAST "urn:ietf:params:xml:ns:reginfo");
+
+	/* we set the version to 0 but it should be set to the correct value in the pua module */
+	xmlNewProp(root_node, BAD_CAST "version", BAD_CAST VERSION_HOLDER);
+	xmlNewProp(root_node, BAD_CAST "state", BAD_CAST "full");
+
+	for (i = 0; i < aor_count; i++) {
+		/* Registration Node */
+		registration_node =
+				xmlNewChild(root_node, NULL, BAD_CAST "registration", NULL);
+		if(registration_node == NULL) {
+			LM_ERR("while adding child\n");
+			goto error;
+		}
+		reg_active = 0;
+
+		/* Add the properties to this Node for AOR and ID: */
+		xmlNewProp(registration_node, BAD_CAST "aor", BAD_CAST aor[i].s);
+		snprintf(buf, sizeof(buf), "%p.%i", record, i);
+		xmlNewProp(registration_node, BAD_CAST "id", BAD_CAST buf);
+
+		ptr = record->contacts;
+		LM_DBG("Records %p\n", ptr);
+		*count = 0;
+		while(ptr) {
+			expires = (int)(ptr->expires - cur_time);
+			LM_DBG("Contact %.*s (Expires %i, now %i, in %i)\n", ptr->c.len, ptr->c.s, (int)ptr->expires, (int)cur_time, expires);
+			if(ptr == contact) {
+				switch(type) {
+						//richard we only use registered and refreshed and expired and unregistered
+					case UL_CONTACT_INSERT:
+						state = r_active;
+						event = r_registered;
+						reg_active = 1;
+						break;
+					case UL_CONTACT_UPDATE:
+						state = r_active;
+						event = r_refreshed;
+						reg_active = 1;
+						break;
+					case UL_CONTACT_EXPIRE:
+						state = r_terminated;
+						event = r_expired;
+						expires = 0;
+						break;
+					case UL_CONTACT_DELETE:
+						state = r_terminated;
+						event = r_unregistered;
+						expires = 0;
+						break;
+					default:
+						state = r_active;
+						event = r_registered;
+						reg_active = 1;
+				}
+			} else {
+				if (VALID_CONTACT(ptr, cur_time)) {
+					state = r_active;
+					event = r_registered;
+					reg_active = 1;
+				} else {
+					state = r_terminated;
+					event = r_expired;
+					expires = 0;
+				}
+			}
+			*count = *count + 1;
+			LM_DBG("Contact %.*s\n", ptr->c.len, ptr->c.s);
+			/* Contact-Node */
+			contact_node = xmlNewChild(
+					registration_node, NULL, BAD_CAST "contact", NULL);
+			if(contact_node == NULL) {
+				LM_ERR("while adding child\n");
+				goto error;
+			}
+			memset(buf, 0, sizeof(buf));
+			snprintf(buf, sizeof(buf), "%p", ptr);
+			xmlNewProp(contact_node, BAD_CAST "id", BAD_CAST buf);
+			memset(buf, 0, sizeof(buf));
+			snprintf(buf, sizeof(buf), "%.*s", state.len, state.s);
+			xmlNewProp(contact_node, BAD_CAST "state", BAD_CAST buf);
+			memset(buf, 0, sizeof(buf));
+			snprintf(buf, sizeof(buf), "%.*s", event.len, event.s);
+			xmlNewProp(
+					contact_node, BAD_CAST "event", BAD_CAST buf);
+			memset(buf, 0, sizeof(buf));
+			snprintf(
+					buf, sizeof(buf), "%i", (int)expires);
+			xmlNewProp(contact_node, BAD_CAST "expires", BAD_CAST buf);
+			if(ptr->q != Q_UNSPECIFIED) {
+				float q = (float)ptr->q / 1000;
+				memset(buf, 0, sizeof(buf));
+				snprintf(buf, sizeof(buf), "%.3f", q);
+				xmlNewProp(contact_node, BAD_CAST "q", BAD_CAST buf);
+			}
+			/* CallID Attribute */
+			memset(buf, 0, sizeof(buf));
+			snprintf(buf, sizeof(buf), "%.*s", ptr->callid.len, ptr->callid.s);
+			xmlNewProp(contact_node, BAD_CAST "callid", BAD_CAST buf);
+
+			/* CSeq Attribute */
+			memset(buf, 0, sizeof(buf));
+			snprintf(buf, sizeof(buf), "%d", ptr->cseq);
+			xmlNewProp(contact_node, BAD_CAST "cseq", BAD_CAST buf);
+
+			if (ptr->received.len) {
+				/* received Attribute */
+				memset(buf, 0, sizeof(buf));
+				snprintf(buf, sizeof(buf), "%.*s", ptr->received.len,
+						ptr->received.s);
+				xmlNewProp(contact_node, BAD_CAST "received", BAD_CAST buf);
+			}
+
+			if (ptr->path.len) {
+				/* path Attribute */
+				memset(buf, 0, sizeof(buf));
+				snprintf(buf, sizeof(buf), "%.*s", ptr->path.len, ptr->path.s);
+				xmlNewProp(contact_node, BAD_CAST "path", BAD_CAST buf);
+			}
+
+			if (ptr->user_agent.len) {
+				/* user_agent Attribute */
+				memset(buf, 0, sizeof(buf));
+				snprintf(buf, sizeof(buf), "%.*s", ptr->user_agent.len,
+						ptr->user_agent.s);
+				xmlNewProp(contact_node, BAD_CAST "user_agent", BAD_CAST buf);
+			}
+
+			/* URI-Node */
+			memset(buf, 0, sizeof(buf));
+			snprintf(buf, sizeof(buf), "%.*s", ptr->c.len, ptr->c.s);
+			uri_node = xmlNewChild(
+					contact_node, NULL, BAD_CAST "uri", BAD_CAST buf);
+			if(uri_node == NULL) {
+				LM_ERR("while adding child\n");
+				goto error;
+			}
+			ptr = ptr->next;
+		}
+
+		/* add registration state (at least one active contact): */
+		if(reg_active == 0)
+			xmlNewProp(registration_node, BAD_CAST "state", BAD_CAST "terminated");
+		else
+			xmlNewProp(registration_node, BAD_CAST "state", BAD_CAST "active");
+	}
+
+	/* create the body */
+	body = (str *)pkg_malloc(sizeof(str));
+	if(body == NULL) {
+		LM_ERR("while allocating memory\n");
+		return NULL;
+	}
+	memset(body, 0, sizeof(str));
+
+	/* Write the XML into the body */
+	xmlDocDumpFormatMemory(
+			doc, (unsigned char **)(void *)&body->s, &body->len, 1);
+
+	/*free the document */
+	xmlFreeDoc(doc);
+	xmlCleanupParser();
+
+	return body;
+error:
+	if(body) {
+		if(body->s)
+			xmlFree(body->s);
+		pkg_free(body);
+	}
+	if(doc)
+		xmlFreeDoc(doc);
+	return NULL;
+}
+
+void reginfo_usrloc_cb(void *binding, ul_cb_type type, ul_cb_extra *_) {
+	ucontact_t *contact = (ucontact_t*)binding;
+	urecord_t *record = NULL;
+	event_t ev;
+	str *body = NULL;
+	publ_info_t publ;
+	presentity_t presentity;
+	str content_type;
+	str uri = {NULL, 0};
+	struct sip_uri pres_uri;
+	char etag_buf[MD5_LEN];
+	str etag = {NULL, 0};
+	int_str_t * key_value;
+	int_str_t new_value;
+
+	char *at = NULL;
+	char id_buf[512];
+	int id_buf_len;
+	int count = 0, i = 0;
+	str aorlist[20];
+	unsigned int aor_count = 0;
+	csv_record *pai_list = NULL;
+	str s, str_dup;
+
+	/* Get the URecord for the contact */
+	LM_DBG("Searching urecord for contact-AOR %.*s (Contact %.*s)\n",
+		contact->aor->len, contact->aor->s,
+		contact->c.len, contact->c.s);
+	ul.get_urecord(ul_domain, contact->aor, &record);
+	if (record == NULL) {
+		LM_DBG("Unable to get urecord for contact-AOR %.*s (Contact %.*s)\n",
+			contact->aor->len, contact->aor->s,
+			contact->c.len, contact->c.s);
+		return;
+	}
+
+	if(_pua_reginfo_self_op == 1) {
+		LM_DBG("operation triggered by own action for aor: %.*s (%d)\n",
+				record->aor.len, record->aor.s, type);
+		return;
+	}
+
+	/* Debug Output: */
+	LM_DBG("AOR: %.*s (%.*s)\n", record->aor.len, record->aor.s, record->domain->len,
+			record->domain->s);
+	
+	if (ul_identities_key.len > 0) {
+		key_value = ul.get_urecord_key(record, &ul_identities_key);
+		if (key_value && key_value->is_str) {
+			LM_DBG("Got associated identities: %.*s\n", key_value->s.len, key_value->s.s);
+			pai_list = parse_csv_record(&key_value->s);
+			while(pai_list) {
+				str_dup = pai_list->s;
+				trim(&str_dup);
+				if (str_dup.s[0] == '<') {
+					// Strip tags <>:
+					str_dup.s += 1;
+					str_dup.len -= 2;
+				}
+				if (pkg_nt_str_dup(&s, &str_dup) < 0) {
+					LM_ERR("Out of memory\n");
+					goto error;
+				}				
+				LM_DBG("  Identity %.*s\n", s.len, s.s);
+				aorlist[aor_count] = s;
+				aor_count += 1;
+				pai_list = pai_list->next;
+				if (aor_count >= 20) break;
+			}
+		} else {
+			LM_INFO("Looking for identities, but no info found in usrloc - not updating presence\n");
+			return;
+		}
+	}
+
+	/* Create AOR to be published */
+	/* Search for @ in the AOR. In case no domain was provided, we will add the "default_domain" */
+	at = memchr(record->aor.s, '@', record->aor.len);
+	if(!at) {
+		uri.len = record->aor.len + reginfo_default_domain.len + 6;
+		uri.s = (char *)pkg_malloc(sizeof(char) * uri.len);
+		if(uri.s == NULL) {
+			LM_ERR("Error allocating memory for URI!\n");
+			goto error;
+		}
+		memset(uri.s, 0, uri.len);
+		if(record->aor.len > 0)
+			uri.len = snprintf(uri.s, uri.len, "sip:%.*s@%.*s", record->aor.len,
+					record->aor.s, reginfo_default_domain.len, reginfo_default_domain.s);
+		else
+			uri.len = snprintf(uri.s, uri.len, "sip:%.*s", reginfo_default_domain.len,
+					reginfo_default_domain.s);
+	} else {
+		uri.len = record->aor.len + 6;
+		uri.s = (char *)pkg_malloc(sizeof(char) * uri.len);
+		if(uri.s == NULL) {
+			LM_ERR("Error allocating memory for URI!\n");
+			goto error;
+		}
+		uri.len = snprintf(
+				uri.s, uri.len, "sip:%.*s", record->aor.len, record->aor.s);
+	}
+
+	if (parse_uri(uri.s, uri.len, &pres_uri)<0){
+		LM_ERR("bad uri <%.*s>\n", uri.len, uri.s);
+		goto error;
+	}
+	
+	if (aor_count == 0) {
+		aorlist[0] = uri;
+		aor_count = 1;
+	}
+	
+	/* Build the XML-Body: */
+	body = build_reginfo_full(record, contact, aorlist, aor_count, type, &count);
+
+	if(body == NULL || body->s == NULL) {
+		LM_ERR("Error on creating XML-Body for publish\n");
+		goto error;
+	}
+	LM_DBG("XML-Body (%i entries):\n%.*s\n", count, body->len, body->s);
+
+	if (pres.update_presentity != NULL) {
+		if (reginfo_event == NULL) {
+			/* now search it back as we need the internal event structure */
+			memset(&ev, 0, sizeof(event_t));
+			ev.parsed = EVENT_REG;
+			ev.text.s = "reg";
+			ev.text.len = 3;
+			reginfo_event = pres.search_event( &ev );
+			if (reginfo_event==NULL) {
+				LM_CRIT("BUG: failed to get back the registered REG-INFO event!\n");
+				goto error;
+			}		
+		}
+
+		/* now we have all the necessary values */
+		/* fill in the fields of the structure */
+		memset(&presentity, 0, sizeof(presentity_t));
+		presentity.domain = pres_uri.host;
+		presentity.user   = pres_uri.user;
+		presentity.event = reginfo_event;
+		if ((type & (UL_CONTACT_DELETE|UL_CONTACT_EXPIRE)) && (count == 0))	{
+			presentity.expires = 0;
+		} else {
+			presentity.expires = 3600;
+		}
+		presentity.received_time = (int)time(NULL);
+		key_value = ul.get_urecord_key(record, &reginfo_key_etag);
+		if (key_value && key_value->is_str) {
+			presentity.old_etag = key_value->s;
+		} else {
+			id_buf_len = snprintf(id_buf, sizeof(id_buf), "%.*s;%i",
+					record->aor.len, record->aor.s, count);
+			etag.s = id_buf;
+			etag.len = id_buf_len;
+			MD5StringArray(etag_buf, &etag, 1);
+
+			presentity.etag_new = 1;
+			presentity.new_etag.s = etag_buf;
+			presentity.new_etag.len = MD5_LEN;
+		}
+		LM_DBG("etag_new = %i, new_etag %.*s, old_etag %.*s\n", presentity.etag_new,
+		  presentity.new_etag.len, presentity.new_etag.s,
+		  presentity.old_etag.len, presentity.old_etag.s);
+		
+		presentity.body = *body;
+
+		/* query the database and update or insert */
+		if(pres.update_presentity(&presentity) <0)
+		{
+			LM_ERR("when updating presentity\n");
+			goto error;
+		}
+
+		LM_DBG("etag_new = %i, new_etag %.*s, old_etag %.*s\n", presentity.etag_new,
+		  presentity.new_etag.len, presentity.new_etag.s,
+		  presentity.old_etag.len, presentity.old_etag.s);
+
+		memset(&new_value, 0, sizeof(int_str_t));
+		new_value.is_str = 1;
+		new_value.s = presentity.new_etag;
+		ul.put_urecord_key(record, &reginfo_key_etag, &new_value);
+	}
+
+	if (publish_reginfo && pua.send_publish != NULL) {
+		content_type.s = "application/reginfo+xml";
+		content_type.len = 23;
+
+
+		memset(&publ, 0, sizeof(publ_info_t));
+
+		publ.pres_uri = &uri;
+		publ.body = body;
+		id_buf_len = snprintf(id_buf, sizeof(id_buf), "REGINFO_PUBLISH.%.*s@%.*s",
+				record->aor.len, record->aor.s, record->domain->len, record->domain->s);
+		publ.id.s = id_buf;
+		publ.id.len = id_buf_len;
+		publ.content_type = content_type;
+		publ.expires = 3600;
+
+		/* make UPDATE_TYPE, as if this "publish dialog" is not found
+		by pua it will fallback to INSERT_TYPE anyway */
+		publ.flag |= UPDATE_TYPE;
+		publ.source_flag |= REGINFO_PUBLISH;
+		publ.event |= REGINFO_EVENT;
+		publ.extra_headers = NULL;
+
+		if(outbound_proxy.s && outbound_proxy.len)
+			publ.outbound_proxy = outbound_proxy;
+
+		if(pua.send_publish(&publ) < 0) {
+			LM_ERR("Error while sending publish\n");
+		}
+	}
+error:
+	for (i = 0; i < aor_count; i++)
+		pkg_free(aorlist[i].s);
+	if(body) {
+		if(body->s)
+			xmlFree(body->s);
+		pkg_free(body);
+	}
+
+	return;
+}
+
+int w_reginfo_update(struct sip_msg *msg, str * aor) {
+	urecord_t *record = NULL;
+
+	/* Let's lock that domain for this AOR: */
+	ul.lock_udomain(ul_domain, aor);
+	/* Get the URecord for the contact */
+	LM_DBG("Searching urecord for contact-AOR %.*s\n",
+		aor->len, aor->s);
+	ul.get_urecord(ul_domain, aor, &record);
+	if (record == NULL) {
+		LM_DBG("Unable to get urecord for contact-AOR %.*s\n",
+			aor->len, aor->s);
+		/* Let's lock that domain for this AOR: */
+		ul.unlock_udomain(ul_domain, aor);
+		return -1;
+	}
+	if (record->contacts) {
+		if (record->contacts->next)
+			reginfo_usrloc_cb((void*)record->contacts, UL_CONTACT_UPDATE, NULL);
+		else
+			reginfo_usrloc_cb((void*)record->contacts, UL_CONTACT_INSERT, NULL);
+	} else {
+		LM_DBG("Registered, but no contacts. Not updating Reg-Info-State");
+	}
+
+	/* Let's lock that domain for this AOR: */
+	ul.unlock_udomain(ul_domain, aor);
+	return 1;
+}

--- a/modules/pua_reginfo/usrloc_cb.h
+++ b/modules/pua_reginfo/usrloc_cb.h
@@ -1,0 +1,33 @@
+/*
+ * pua_reginfo module - Presence-User-Agent Handling of reg events
+ *
+ * Copyright (C) 2011, 2023 Carsten Bock, carsten@ng-voice.com
+ *
+ * This file is part of opensips, a free SIP server.
+ *
+ * opensips is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version
+ *
+ * opensips is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301  USA
+ */
+
+#ifndef __PUA_REGINFO_USRLOC_CB__
+#define __PUA_REGINFO_USRLOC_CB__
+
+#include "../usrloc/usrloc.h"
+#include "../../str.h"
+
+void reginfo_usrloc_cb(void *binding, ul_cb_type type, ul_cb_extra *_);
+void pua_reginfo_update_self_op(int v);
+int w_reginfo_update(struct sip_msg *msg, str * aor);
+
+#endif


### PR DESCRIPTION
**Summary**
This PR adds a module "pua_reginfo", for locally handling "SUBSCRIBE" to reginfo-events (based on usrloc), for remotely SUBSCRIBE for registration information (and for accordingly handling NOTIFY requests) and for generating "PUBLISH" requests based on usrloc-updates.

**Compatibility**
This module adds new functionality, thus it does not affect any existing deployment.

It requires the following PR to be applied, before it works, as the PR extends the Parser with some functionality:
https://github.com/OpenSIPS/opensips/pull/3331
