### PR TITLE
[clusterer] Added enable_rerouting parameter

### DIFF
--- a/modules/clusterer/clusterer.c
+++ b/modules/clusterer/clusterer.c
@@ -56,6 +56,7 @@ extern int node_timeout;
 extern int ping_timeout;
 extern int seed_fb_interval;
 extern int sync_timeout;
+extern int clusterer_enable_rerouting;
 
 int dispatch_jobs = 1;
 
@@ -1076,6 +1077,10 @@ void bin_rcv_cl_extra_packets(bin_packet_t *packet, int packet_type,
 		lock_release(node->lock);
 
 	if (dest_id != current_id) {
+		if (clusterer_enable_rerouting == 0) {
+			LM_WARN("Received message for destination id [%d] but rerouting disabled\n", dest_id);
+			goto exit;
+		}
 		/* route the message */
 		bin_push_int(packet, cluster_id);
 		bin_push_int(packet, source_id);

--- a/modules/clusterer/clusterer_mod.c
+++ b/modules/clusterer/clusterer_mod.c
@@ -48,6 +48,7 @@ int seed_fb_interval = DEFAULT_SEED_FB_INTERVAL;
 int sync_timeout = DEFAULT_SYNC_TIMEOUT;
 int current_id = -1;
 int db_mode = 1;
+int clusterer_enable_rerouting = 1;
 
 str clusterer_db_url = {NULL, 0};
 str db_table = str_init("clusterer");
@@ -171,6 +172,7 @@ static const param_export_t params[] = {
 		(void*)&shtag_modparam_func},
 	{"sync_packet_size",	INT_PARAM,	&sync_packet_size	},
 	{"dispatch_jobs",		INT_PARAM,	&dispatch_jobs		},
+	{"enable_rerouting",		INT_PARAM,	&clusterer_enable_rerouting	},
 	{0, 0, 0}
 };
 

--- a/modules/clusterer/doc/clusterer_admin.xml
+++ b/modules/clusterer/doc/clusterer_admin.xml
@@ -644,6 +644,29 @@ modparam("clusterer", "enable_stats", 0)
 			</example>
 		</section>
 
+		<section id="param_enable_rerouting" xreflabel="enable_rerouting">
+			<title><varname>enable_rerouting</varname> (integer)</title>
+			<para>
+				If packets should be rerouted via another node if a direct route
+				to destination is unavailible. Disabling may improve stability in
+				two-node topologies.
+				Set it to zero to disable or to non-zero to enable it.
+			</para>
+			<para>
+				<emphasis>
+					Default value is <quote>1 (enabled)</quote>.
+				</emphasis>
+			</para>
+			<example>
+				<title>Set <varname>enable_rerouting</varname> parameter</title>
+				<programlisting format="linespecific">
+...
+modparam("clusterer", "enable_rerouting", 0)
+...
+				</programlisting>
+			</example>
+		</section>
+
         </section>
 
         <section id="exported_functions" xreflabel="exported_functions">


### PR DESCRIPTION
**Summary**
Added a new `enable_rerouting` parameter to the clusterer module. When set to 0 (default 1), nodes will no longer attempt to reroute packets around connectivity issues within the cluster.

**Details**
This is a new feature to allow users to opt-out of the clusterer packet rerouting.

It might be desirable to disable rerouting for simple clusters with only 2 nodes (as rerouting would never be useful in this situation) or when connectivity issues are unlikely (for example if all nodes are running on the same LAN). Disabling the feature reduces the complexity of the cluster logic and the surface area for something to go wrong. It also makes clusterer traffic easier to understand/debug.

**Motivation**
We use OpenSIPS in production at Resilient Plc (we also have a support contract with you). Our SBCs each run as a clustered pair (active/backup), however when we do a deploy there'll briefly be 4 nodes in the cluster (old-active/old-backup/new-active/new-backup) before it drops back down to 2 nodes (active/backup).

We once saw a situation in production where the clusterer rerouting logic got into an unhappy state. There were only two nodes in the cluster (active/backup) but they incorrectly believed that there was a third active phantom node in the setup which could only be routed to via the other node. This phantom node continued to be believed to exist and be healthy and the issue didn't self-resolve (despite neither node being able to ping it - because it didn't exist).

Later one of the 2 nodes got stuck trying to download state from this phantom node (which didn't exist). I've tried at length to replicate this bug but haven't been able to. Further, we don't really benefit from the clusterer rerouting logic as we only really have 2 nodes in each cluster (except very briefly during a deploy).

Therefore we decided to disable this rerouting feature for our SBCs. I'd like to upstream this new feature as it seems plausible other users may benefit from this change too. This feature is of particular relevance if all your nodes share a LAN or if you only have two nodes in your cluster as you're unlikely to benefit from this feature anyway.

Even if we _were_ able to find and fix the initial bug in the rerouting logic, we'd still prefer to opt-out of this rerouting feature as it doesn't benefit us and only adds complexity and the chance of further issues down the line.

**Solution**
Gives users the freedom to opt-out of this rerouting feature if they don't feel like they benefit from it.

**Compatibility**
This defaults to current behaviour, so should not break existing setups.