### PR TITLE
sqlops: adding support for returning bigint in string format

### DIFF
--- a/modules/sqlops/doc/sqlops_admin.xml
+++ b/modules/sqlops/doc/sqlops_admin.xml
@@ -189,6 +189,31 @@ modparam("sqlops","ps_id_max_buf_len", 2048)
 			</example>
 		</section>
 
+		<section id="bigint_to_str" xreflabel="bigint_to_str">
+			<title><varname>bigint_to_str</varname> (int)</title>
+			<para>
+				Controls bigint conversion.
+				By default bigint values are returned as int.
+				If the value stored in bigint is out of the int range,
+				by enabling bigint to string conversion,
+				the bigint value will be returned as string.
+			</para>
+			<para>
+				<emphasis>Default value is <quote>0</quote>.
+				</emphasis>
+			</para>
+			<example>
+				<title>Set <varname>bigint_to_str</varname> parameter
+				</title>
+				<programlisting format="linespecific">
+...
+# Return bigint as string
+modparam("sqlops","bigint_to_str",1)
+...
+				</programlisting>
+			</example>
+		</section>
+
 		<section id="param_uuid_column" xreflabel="uuid_column">
 			<title><varname>uuid_column</varname> (string)</title>
 			<para>

--- a/modules/sqlops/sqlops.c
+++ b/modules/sqlops/sqlops.c
@@ -256,6 +256,7 @@ static const param_export_t params[] = {
 	{"domain_column",     STR_PARAM, &domain_col.s    },
 	{"db_scheme",         STR_PARAM|USE_FUNC_PARAM, (void*)add_avp_db_scheme },
 	{"ps_id_max_buf_len", INT_PARAM, &query_id_max_len},
+	{"bigint_to_str",     INT_PARAM, &sqlops_bigint2str},
 	{0, 0, 0}
 };
 

--- a/modules/sqlops/sqlops_db.c
+++ b/modules/sqlops/sqlops_db.c
@@ -48,6 +48,8 @@ struct db_url *default_db_url = NULL;
 
 int query_id_max_len = 1024;
 
+int sqlops_bigint2str = 0;
+
 /* array of db urls */
 static struct db_url *db_urls = NULL;  /* array of database urls */
 static unsigned int no_db_urls = 0;
@@ -1069,9 +1071,16 @@ int db_query_print_one_result(struct sip_msg *msg, const db_res_t *db_res,
 						(int)RES_ROWS(db_res)[0].values[j].val.bitmap_val;
 				break;
 				case DB_BIGINT:
-					val.flags = PV_VAL_INT|PV_TYPE_INT;
-					val.ri =
-						(int)RES_ROWS(db_res)[0].values[j].val.bigint_val;
+					if (sqlops_bigint2str) {
+						val.flags = PV_VAL_STR;
+						val.rs.s = bigint2str(
+							RES_ROWS(db_res)[0].values[j].val.bigint_val,
+							&val.rs.len);
+					} else {
+						val.flags = PV_VAL_INT|PV_TYPE_INT;
+						val.ri =
+							(int)RES_ROWS(db_res)[0].values[j].val.bigint_val;
+					}
 				break;
 				case DB_DOUBLE:
 					val.flags = PV_VAL_INT|PV_TYPE_INT;
@@ -1176,8 +1185,15 @@ int db_query_print_results(struct sip_msg *msg, const db_res_t *db_res,
 						(int)RES_ROWS(db_res)[i].values[j].val.bitmap_val;
 				break;
 				case DB_BIGINT:
-					avp_val.n =
-						(int)RES_ROWS(db_res)[i].values[j].val.bigint_val;
+					if (sqlops_bigint2str) {
+						avp_type |= AVP_VAL_STR;
+						avp_val.s.s = bigint2str(
+							RES_ROWS(db_res)[i].values[j].val.bigint_val,
+							&avp_val.s.len);
+					} else {
+						avp_val.n =
+							(int)RES_ROWS(db_res)[i].values[j].val.bigint_val;
+					}
 				break;
 				case DB_DOUBLE:
 					avp_type |= AVP_VAL_STR;

--- a/modules/sqlops/sqlops_db.h
+++ b/modules/sqlops/sqlops_db.h
@@ -36,6 +36,8 @@ extern struct db_url *default_db_url;
 
 extern int query_id_max_len;
 
+extern int sqlops_bigint2str;
+
 struct db_url
 {
 	str url;

--- a/ut.h
+++ b/ut.h
@@ -316,6 +316,17 @@ static inline char* double2str(double d, int* len)
 	return int2str_buf[buf];
 }
 
+#define BIGINT2STR_MAX_LEN  INT2STR_MAX_LEN
+static inline char* bigint2str(long long l, int* len)
+{
+	unsigned int buf;
+
+	buf = getstrbufindex();
+	*len = snprintf(int2str_buf[buf], INT2STR_MAX_LEN - 1, "%lld", l);
+	int2str_buf[buf][*len] = '\0';
+
+	return int2str_buf[buf];
+}
 
 /* faster memchr version */
 static inline char* q_memchr(char* p, int c, unsigned int size)


### PR DESCRIPTION
**Details**
When retrieving bigint from db and the value stored in bigint is outside of int range, `sql_query()` function will return invalid values.

**Solution**
A new module parameter will control the output of bigint. By default, bigint will be returned as int (keeping backward compatibility). If the new module parameter `bigint_to_str` is set to a value different then 0, the bigint will be returned to the script in string format.