### PR TITLE
sql_cacher: adding support for returning bigint in string format

### DIFF
--- a/modules/sql_cacher/doc/sql_cacher_admin.xml
+++ b/modules/sql_cacher/doc/sql_cacher_admin.xml
@@ -1,7 +1,7 @@
 <!-- SQL Cacher Module User's Guide -->
 
 <chapter>
-    
+
     <title>&adminguide;</title>
 
     <section id="overview" xreflabel="Overview">
@@ -133,7 +133,7 @@
 		<example>
 		<title><varname>cache_table</varname> parameter usage</title>
 		<programlisting format="linespecific">
-   
+
 modparam("sql_cacher", "cache_table",
 "id=caching_name
 db_url=mysql://root:opensips@localhost/opensips_2_2
@@ -142,7 +142,7 @@ table=table_name
 key=column_name_0
 columns=column_name_1 column_name_2 column_name_3
 on_demand=0")
-   
+
 </programlisting>
 	    </example>
 	</section>
@@ -160,9 +160,9 @@ on_demand=0")
 		<example>
 		<title><varname>spec_delimiter</varname> parameter usage</title>
 		<programlisting format="linespecific">
-   
+
 modparam("sql_cacher", "spec_delimiter", "\n")
-   
+
 </programlisting>
 	    </example>
 	</section>
@@ -180,9 +180,9 @@ modparam("sql_cacher", "spec_delimiter", "\n")
 		<example>
 		<title><varname>pvar_delimiter</varname> parameter usage</title>
 		<programlisting format="linespecific">
-   
+
 modparam("sql_cacher", "pvar_delimiter", " ")
-   
+
 </programlisting>
 	    </example>
 	</section>
@@ -200,9 +200,9 @@ modparam("sql_cacher", "pvar_delimiter", " ")
 		<example>
 		<title><varname>columns_delimiter</varname> parameter usage</title>
 		<programlisting format="linespecific">
-   
+
 modparam("sql_cacher", "columns_delimiter", ",")
-   
+
 </programlisting>
 	    </example>
 	</section>
@@ -212,7 +212,7 @@ modparam("sql_cacher", "columns_delimiter", ",")
 		<para>
 		The number of rows to be fetched into &osips; private memory in one chunk from
 		the SQL database driver. When querying large tables, adjust this parameter
-		accordingly to avoid the filling of &osips; private memory. 
+		accordingly to avoid the filling of &osips; private memory.
 		</para>
 		<para>
 		The default value is <quote>100</quote>.
@@ -220,9 +220,9 @@ modparam("sql_cacher", "columns_delimiter", ",")
 		<example>
 		<title><varname>sql_fetch_nr_rows</varname> parameter usage</title>
 		<programlisting format="linespecific">
-   
+
 modparam("sql_cacher", "sql_fetch_nr_rows", 1000)
-   
+
 </programlisting>
 	    </example>
 	</section>
@@ -240,9 +240,9 @@ modparam("sql_cacher", "sql_fetch_nr_rows", 1000)
 		<example>
 		<title><varname>full_caching_expire</varname> parameter usage</title>
 		<programlisting format="linespecific">
-   
+
 modparam("sql_cacher", "full_caching_expire", 3600)
-   
+
 </programlisting>
 	    </example>
 	</section>
@@ -259,9 +259,9 @@ modparam("sql_cacher", "full_caching_expire", 3600)
 		<example>
 		<title><varname>reload_interval</varname> parameter usage</title>
 		<programlisting format="linespecific">
-   
+
 modparam("sql_cacher", "reload_interval", 5)
-   
+
 </programlisting>
 	    </example>
 	</section>
@@ -348,7 +348,7 @@ $avp(a) = $sql_cached_value(caching_name:column_name_1:key1);
 	This section provides an usage example for the caching of an SQL table.
 	</para>
 	<para>
-	Suppose one in interested in caching the columns: <quote>host_name</quote>, 
+	Suppose one in interested in caching the columns: <quote>host_name</quote>,
 	<quote>reply_code</quote>, <quote>flags</quote> and <quote>next_domain</quote>
 	 from the <quote>carrierfailureroute</quote> table of the &osips; database.
 	</para>
@@ -368,7 +368,7 @@ $avp(a) = $sql_cached_value(caching_name:column_name_1:key1);
 		</programlisting>
 	</example>
 	<para>
-		In the first place, the details of the caching must be provided by setting 
+		In the first place, the details of the caching must be provided by setting
 		the module parameter <quote>cache_table</quote> in the &osips; configuration script.
 	</para>
 	<example>
@@ -414,7 +414,7 @@ xlog("host name is: $sql_cached_value(carrier_fr_caching:host_name:2)");
 	<section id="sr_id_cache_entry_id" xreflabel="cache_entry_id">
 	<title><varname>[cache_entry_id]</varname></title>
 	<para>
-	The status of these identifiers reflects the readiness/status of the 
+	The status of these identifiers reflects the readiness/status of the
 	cached data (if available or not when being loaded from DB):
 	</para>
 	<itemizedlist>

--- a/modules/sql_cacher/doc/sql_cacher_admin.xml
+++ b/modules/sql_cacher/doc/sql_cacher_admin.xml
@@ -265,6 +265,29 @@ modparam("sql_cacher", "reload_interval", 5)
 </programlisting>
 	    </example>
 	</section>
+
+	<section id="bigint_to_str" xreflabel="bigint_to_str">
+		<title><varname>bigint_to_str</varname> (integer)</title>
+		<para>
+		Controls bigint conversion.
+		By default bigint values are returned as int.
+		If the value stored in bigint is out of the int range,
+		by enabling bigint to string conversion,
+		the bigint value will be returned as string.
+		</para>
+		<para>
+		The default value is <quote>0</quote>.
+		</para>
+		<example>
+		<title><varname>bigint_to_str</varname> parameter usage</title>
+		<programlisting format="linespecific">
+
+modparam("sql_cacher", "bigint_to_str", 1)
+
+</programlisting>
+	    </example>
+	</section>
+
 </section>
 
 <section id="exported_functions" xreflabel="exported_functions">

--- a/modules/sql_cacher/sql_cacher.c
+++ b/modules/sql_cacher/sql_cacher.c
@@ -57,6 +57,7 @@ static str columns_delimiter = str_init(DEFAULT_COLUMNS_DELIM);
 static int fetch_nr_rows = DEFAULT_FETCH_NR_ROWS;
 static int full_caching_expire = DEFAULT_FULL_CACHING_EXPIRE;
 static int reload_interval = DEFAULT_RELOAD_INTERVAL;
+static int sql_cacher_bigint2str = DEFAULT_BIGINT2STR;
 
 static cache_entry_t **entry_list;
 static struct queried_key **queries_in_progress;
@@ -77,6 +78,7 @@ static const param_export_t mod_params[] = {
 	{"full_caching_expire", INT_PARAM, &full_caching_expire},
 	{"reload_interval", INT_PARAM, &reload_interval},
 	{"cache_table", STR_PARAM|USE_FUNC_PARAM, (void *)&parse_cache_entry},
+	{"bigint_to_str", INT_PARAM, &sql_cacher_bigint2str},
 	{0,0,0}
 };
 
@@ -479,9 +481,17 @@ static int get_column_types(cache_entry_t *c_entry, db_val_t *values, int nr_col
 		val_type = VAL_TYPE(values + i);
 		switch (val_type) {
 			case DB_INT:
-			case DB_BIGINT:
 				c_entry->nr_ints++;
 				c_entry->column_types &= ~(1LL << i);
+				break;
+			case DB_BIGINT:
+				if (sql_cacher_bigint2str) {
+					c_entry->nr_strs++;
+					c_entry->column_types |= (1LL << i);
+				} else {
+					c_entry->nr_ints++;
+					c_entry->column_types &= ~(1LL << i);
+				}
 				break;
 			case DB_STRING:
 			case DB_STR:
@@ -515,9 +525,17 @@ static int build_column_types(cache_entry_t *c_entry, db_key_t *names, db_type_t
 		val_type = types[i];
 		switch (val_type) {
 			case DB_INT:
-			case DB_BIGINT:
 				c_entry->nr_ints++;
 				c_entry->column_types &= ~(1LL << i);
+				break;
+			case DB_BIGINT:
+				if (sql_cacher_bigint2str) {
+					c_entry->nr_strs++;
+					c_entry->column_types |= (1LL << i);
+				} else {
+					c_entry->nr_ints++;
+					c_entry->column_types &= ~(1LL << i);
+				}
 				break;
 			case DB_STRING:
 			case DB_STR:
@@ -560,6 +578,13 @@ static unsigned int get_cdb_val_size(cache_entry_t *c_entry, db_val_t *values, i
 			case DB_DOUBLE:
 				len += DOUBLE2STR_MAX_LEN;
 				break;
+			case DB_BIGINT:
+				if (sql_cacher_bigint2str) {
+					len += BIGINT2STR_MAX_LEN;
+					break;
+				} else {
+					continue;
+				}
 			default: continue;
 		}
 	}
@@ -605,8 +630,12 @@ static int insert_in_cachedb(cache_entry_t *c_entry, db_handlers_t *db_hdls,
 				int_val = VAL_INT(values + i);
 				break;
 			case DB_BIGINT:
-				int_val = (int)VAL_BIGINT(values + i);
-				break;
+				if (!sql_cacher_bigint2str) {
+					int_val = (int)VAL_BIGINT(values + i);
+					break;
+				} else {
+					continue;
+				}
 			default: continue;
 		}
 		if (VAL_NULL(values + i))
@@ -640,6 +669,13 @@ static int insert_in_cachedb(cache_entry_t *c_entry, db_handlers_t *db_hdls,
 			case DB_DOUBLE:
 				str_val.s = double2str(VAL_DOUBLE(values + i), &str_val.len);
 				break;
+			case DB_BIGINT:
+				if (sql_cacher_bigint2str) {
+					str_val.s = bigint2str(VAL_BIGINT(values + i), &str_val.len);
+					break;
+				} else {
+					continue;
+				}
 			default: continue;
 		}
 		if (VAL_NULL(values + i))
@@ -1755,7 +1791,16 @@ static int on_demand_load(pv_name_fix_t *pv_name, str *str_res, int *int_res,
 			*int_res = VAL_INT(values + pv_name->col_nr);
 			break;
 		case DB_BIGINT:
-			*int_res = (int)VAL_BIGINT(values + pv_name->col_nr);
+			if (sql_cacher_bigint2str) {
+				st.s = bigint2str(VAL_BIGINT(values + pv_name->col_nr), &st.len);
+				if (pkg_str_dup(str_res, &st) != 0) {
+					LM_ERR("oom\n");
+					rc = -1;
+					goto out_free_res;
+				}
+			} else {
+				*int_res = (int)VAL_BIGINT(values + pv_name->col_nr);
+			}
 			break;
 		case DB_DOUBLE:
 			st.s = double2str(VAL_DOUBLE(values + pv_name->col_nr), &st.len);

--- a/modules/sql_cacher/sql_cacher.h
+++ b/modules/sql_cacher/sql_cacher.h
@@ -61,6 +61,7 @@
 #define DEFAULT_FULL_CACHING_EXPIRE 86400 /* 24h */
 #define DEFAULT_RELOAD_INTERVAL 60
 #define DEFAULT_FETCH_NR_ROWS 100
+#define DEFAULT_BIGINT2STR 0
 #define TEST_QUERY_STR "sql_cacher_test_query_key"
 #define TEST_QUERY_INT 555666555
 #define CDB_TEST_KEY_STR "sql_cacher_cdb_test_key"


### PR DESCRIPTION
**Summary**
When retrieving bigint from db and the value stored in bigint is outside of int range, `$sql_cached_value` will return invalid values.

**Solution**
A new module parameter will control the output of bigint. By default, bigint will be returned as int (keeping backward compatibility). If the new module parameter bigint_to_str is set to a value different then 0, the bigint will be returned to the script in string format.