### PR TITLE
Fix `perl_exec_simple` memory leak

### DIFF
--- a/modules/perl/perlfunc.c
+++ b/modules/perl/perlfunc.c
@@ -81,7 +81,11 @@ int perl_exec_simple(struct sip_msg* _msg, str *_fnc_s, str *_param_s)
 	if (perl_checkfnc(fnc)) {
 		LM_DBG("running perl function \"%s\"\n", fnc);
 
+		ENTER;
+		SAVETMPS;
 		call_argv(fnc, flags, args);
+		FREETMPS;
+		LEAVE;
 		ret = 1;
 	} else {
 		LM_ERR("unknown function '%s' called.\n", fnc);


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!
In order to consider and evaluate your PR, it is mandatory to provide detailed information about (1) what is the issue the PR addresses, (2) how the PR is solving the issue (logic and coding), (3) what are (if any) limitations of the proposed PR and (4) if there are any known side-effects/ backward compatibility issues/SIP interoperability issues.
Note that if the PR is missing information, it might take longer to be merged, as extra resources have to be allocated by the maintainers to reverse engineer the changes, understand them, understand the motivation, etc. That is why it is important to provide as much information as possible.
-->

**Summary**
<!-- Summary of the PR - what the PR is aiming to solve -->
Fix a memory leak in the `perl` module that can accumulate OS `malloc`'d memory over time.  The leak is fairly slow, so unless your configuration makes very heavy use of perl functions, it may go unnoticed for quite a while, but it can eventually result in OS memory exhaustion and the OOM-killer.

**Details**
<!--
Details about the content of the PR - is it a bug fix, a new feature or perhaps a hack? Explain the **motivation** for making this change.
What existing problem does the pull request solve? Is this a particular problem (i.e. only some particular scenarios are affected, only some UACs, etc) or a generic one?
Do not assume others understand what you're trying to do and provide as much information as you may have.
-->
`perl_exec_simple` has a memory leak because `call_argv` doesn't garbage-collect its arguments properly.  This is technically a Perl bug, and is tracked here: https://github.com/Perl/perl5/issues/22255 But, until it is fixed in Perl, we should work around the issue from the OpenSIPS side.

See #3402 for more details on how to reproduce the bug in OpenSIPS and how to validate the fix.

**Solution**
<!-- Explain how your PR fixes the problem. Are there any remaining concerns that might need to be addressed? -->
This PR fixes the problem by applying the appropriate Perl garbage-collection context markers around the function call so that garbage collection of the arguments happens as control returns to the caller.

**Compatibility**
<!-- Does your change break other scenarios, or do they need to be migrated in order to work similarly? -->
No functional change to OpenSIPS.

**Closing issues**
<!-- Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). -->
closes #3402
