### PR TITLE
uac_registrant: make force_register run force_register instead of disable

### DIFF
--- a/modules/uac_registrant/registrant.c
+++ b/modules/uac_registrant/registrant.c
@@ -1534,7 +1534,7 @@ static mi_response_t *mi_reg_force_register(const mi_params_t *params,
 
 	lock_get(&reg_htable[hash_code].lock);
 	rc = slinkedl_traverse(reg_htable[hash_code].p_list,
-					&run_mi_reg_disable, &coords, NULL);
+					&run_mi_reg_force_register, &coords, NULL);
 	lock_release(&reg_htable[hash_code].lock);
 
 	if (rc < 0)


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!
In order to consider and evaluate your PR, it is mandatory to provide detailed information about (1) what is the issue the PR addresses, (2) how the PR is solving the issue (logic and coding), (3) what are (if any) limitations of the proposed PR and (4) if there are any known side-effects/ backward compatibility issues/SIP interoperability issues.
Note that if the PR is missing information, it might take longer to be merged, as extra resources have to be allocated by the maintainers to reverse engineer the changes, understand them, understand the motivation, etc. That is why it is important to provide as much information as possible.
-->

**Summary**
I noticed the `reg_force_register` implementation accidentally calls the `run_mi_reg_disable` callback instead of `run_mi_reg_force_register` callback.
<!-- Summary of the PR - what the PR is aiming to solve -->

**Details**
<!--
Details about the content of the PR - is it a bug fix, a new feature or perhaps a hack? Explain the **motivation** for making this change.
What existing problem does the pull request solve? Is this a particular problem (i.e. only some particular scenarios are affected, only some UACs, etc) or a generic one?
Do not assume others understand what you're trying to do and provide as much information as you may have.
-->
This means "mi reg_force_register" acts the same as "mi reg_disable" - it disables the user instead of registering it.

**Solution**
<!-- Explain how your PR fixes the problem. Are there any remaining concerns that might need to be addressed? -->
My PR fixes the problem by correcting the callback that is invoked.

**Compatibility**
<!-- Does your change break other scenarios, or do they need to be migrated in order to work similarly? -->
This will break any scenarios that depend on "mi reg_force_register" disabling the user instead of forcing a re-registration of the user.

**Closing issues**
<!-- Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). -->
Closes #3395.
