### PR TITLE
RTPEngine - Last frame pos

### DIFF
--- a/modules/rtpengine/doc/rtpengine_admin.xml
+++ b/modules/rtpengine/doc/rtpengine_admin.xml
@@ -1025,7 +1025,7 @@ if (is_method("INVITE") &amp;&amp; has_totag()) {
 
 	<section id="func_rtpengine_stop_media" xreflabel="rtpengine_stop_media()">
 		<title>
-		<function moreinfo="none">rtpengine_stop_media(flags, [last_frame_pos[, sock_var[, sockvar]]])</function>
+		<function moreinfo="none">rtpengine_stop_media(flags[, [sock_var[, sockvar]][, last_frame_pos]])</function>
 		</title>
 		<para>
 			This function will stop playing a media file previously started
@@ -1067,7 +1067,7 @@ if (is_method("INVITE") &amp;&amp; has_totag()) {
 		$dlg_val(on_hold = "1";
 		rtpengine_play_media("from-tag=$tt start-pos=$avp(last_frame_pos) file=/path/to/moh_file.wav");
 	} else if ($dlg_val(on_hold) == "1") {
-		rtpengine_stop_media("from-tag=$tt", $avp(last_frame_pos));
+		rtpengine_stop_media("from-tag=$tt", , $avp(last_frame_pos));
 		$dlg_val(on_hold = "0");
 	}
 }

--- a/modules/rtpengine/doc/rtpengine_admin.xml
+++ b/modules/rtpengine/doc/rtpengine_admin.xml
@@ -1025,7 +1025,7 @@ if (is_method("INVITE") &amp;&amp; has_totag()) {
 
 	<section id="func_rtpengine_stop_media" xreflabel="rtpengine_stop_media()">
 		<title>
-		<function moreinfo="none">rtpengine_stop_media(flags[, [sock_var[, sockvar]][, last_frame_pos]])</function>
+		<function moreinfo="none">rtpengine_stop_media(flags[, [sock_var[, sockvar]], [last_frame_pos]])</function>
 		</title>
 		<para>
 			This function will stop playing a media file previously started

--- a/modules/rtpengine/doc/rtpengine_admin.xml
+++ b/modules/rtpengine/doc/rtpengine_admin.xml
@@ -966,7 +966,7 @@ rtpengine_stop_recording();
 		<para>Meaning of the parameters is as follows:</para>
 		<itemizedlist>
 		<listitem><para>
-		<emphasis>flags(string)</emphasis> - a list of flags simialar to
+		<emphasis>flags(string)</emphasis> - a list of flags similar to
 			the other functions. One of the <emphasis>file</emphasis>,
 			<emphasis>blob</emphasis> or <emphasis>db-id</emphasis> parameters
 			is mandatory to indicate the content of the media file to be played.
@@ -1025,7 +1025,7 @@ if (is_method("INVITE") &amp;&amp; has_totag()) {
 
 	<section id="func_rtpengine_stop_media" xreflabel="rtpengine_stop_media()">
 		<title>
-		<function moreinfo="none">rtpengine_stop_media([flags[, sockvar]])</function>
+		<function moreinfo="none">rtpengine_stop_media(flags, [last_frame_pos[, sock_var[, sockvar]]])</function>
 		</title>
 		<para>
 			This function will stop playing a media file previously started
@@ -1035,6 +1035,17 @@ if (is_method("INVITE") &amp;&amp; has_totag()) {
 			<function>rtpengine_play_media()</function> call, otherwise
 			RTPEngine will not be able to stop media playing.
 		</para>
+		<para>Meaning of the parameters is as follows:</para>
+		<itemizedlist>
+		<listitem><para>
+		<emphasis>flags(string)</emphasis> - a list of flags similar to
+			the other functions.
+		</para></listitem>
+		<listitem><para>
+		<emphasis>last_frame_pos(var, optional)</emphasis> - a pseudo variable that
+			will contain the last frame played of the file.
+		</para></listitem>
+		</itemizedlist>
 		<para>
 		This function can be used from any route.
 		</para>

--- a/modules/rtpengine/doc/rtpengine_admin.xml
+++ b/modules/rtpengine/doc/rtpengine_admin.xml
@@ -1062,10 +1062,10 @@ if (is_method("INVITE") &amp;&amp; $rs == 200)
 		<title>Example use of the last-frame-pos parameter <function>rtpengine_stop_media</function></title>
 		<programlisting format="linespecific">
 ...
-if (is_method("INVITE") &amp;&amp; has_totag())
+if (is_method("INVITE") &amp;&amp; has_totag()) {
 	if (is_audio_on_hold()) {
 		$dlg_val(on_hold = "1";
-		rtpengine_play_media("from-tag=$tt start-pos=$avp(last_frame_pos)");
+		rtpengine_play_media("from-tag=$tt start-pos=$avp(last_frame_pos) file=/path/to/moh_file.wav");
 	} else if ($dlg_val(on_hold) == "1") {
 		rtpengine_stop_media("from-tag=$tt", $avp(last_frame_pos));
 		$dlg_val(on_hold = "0");

--- a/modules/rtpengine/doc/rtpengine_admin.xml
+++ b/modules/rtpengine/doc/rtpengine_admin.xml
@@ -1058,6 +1058,23 @@ if (is_method("INVITE") &amp;&amp; $rs == 200)
 ...
 		</programlisting>
 		</example>
+		<example>
+		<title>Example use of the last-frame-pos parameter <function>rtpengine_stop_media</function></title>
+		<programlisting format="linespecific">
+...
+if (is_method("INVITE") &amp;&amp; has_totag())
+	if (is_audio_on_hold()) {
+		$dlg_val(on_hold = "1";
+		rtpengine_play_media("from-tag=$tt start-pos=$avp(last_frame_pos)");
+	} else if ($dlg_val(on_hold) == "1") {
+		rtpengine_stop_media("from-tag=$tt", $avp(last_frame_pos));
+		$dlg_val(on_hold = "0");
+	}
+}
+	rtpengine_stop_media();
+...
+		</programlisting>
+		</example>
 	</section>
 
 	<section id="func_rtpengine_block_media" xreflabel="rtpengine_block_media()">

--- a/modules/rtpengine/rtpengine.c
+++ b/modules/rtpengine/rtpengine.c
@@ -277,7 +277,7 @@ static void free_rtpe_nodes(struct rtpe_set *list);
 static int rtpengine_playmedia_f(struct sip_msg* msg, str *flags,
 		pv_spec_t *duration, pv_spec_t *spvar);
 static int rtpengine_stopmedia_f(struct sip_msg* msg, str *flags,
-		pv_spec_t *last_frame_pos, pv_spec_t *spvar);
+		pv_spec_t *spvar, pv_spec_t *last_frame_pos);
 static int rtpengine_blockmedia_f(struct sip_msg* msg, str *flags, pv_spec_t *spvar);
 static int rtpengine_unblockmedia_f(struct sip_msg* msg, str *flags, pv_spec_t *spvar);
 static int rtpengine_blockdtmf_f(struct sip_msg* msg, str *flags, pv_spec_t *spvar);
@@ -3950,7 +3950,7 @@ static int rtpengine_playmedia_f(struct sip_msg* msg, str *flags,
 }
 
 static int rtpengine_stopmedia_f(struct sip_msg* msg, str *flags,
-		pv_spec_t *last_frame_pos, pv_spec_t *spvar)
+		pv_spec_t *spvar, pv_spec_t *last_frame_pos)
 {
 	bencode_buffer_t bencbuf;
 	bencode_item_t *dict;

--- a/modules/rtpengine/rtpengine.c
+++ b/modules/rtpengine/rtpengine.c
@@ -276,7 +276,8 @@ static int rtpengine_delete_f(struct sip_msg* msg, str *flags, pv_spec_t *spvar)
 static void free_rtpe_nodes(struct rtpe_set *list);
 static int rtpengine_playmedia_f(struct sip_msg* msg, str *flags,
 		pv_spec_t *duration, pv_spec_t *spvar);
-static int rtpengine_stopmedia_f(struct sip_msg* msg, str *flags, pv_spec_t *spvar);
+static int rtpengine_stopmedia_f(struct sip_msg* msg, str *flags,
+		pv_spec_t *last_frame_pos, pv_spec_t *spvar);
 static int rtpengine_blockmedia_f(struct sip_msg* msg, str *flags, pv_spec_t *spvar);
 static int rtpengine_unblockmedia_f(struct sip_msg* msg, str *flags, pv_spec_t *spvar);
 static int rtpengine_blockdtmf_f(struct sip_msg* msg, str *flags, pv_spec_t *spvar);
@@ -460,6 +461,7 @@ static const cmd_export_t cmds[] = {
 		ALL_ROUTES},
 	{"rtpengine_stop_media", (cmd_function)rtpengine_stopmedia_f, {
 		{CMD_PARAM_STR | CMD_PARAM_OPT, 0, 0},
+		{CMD_PARAM_VAR | CMD_PARAM_OPT, 0, 0},
 		{CMD_PARAM_VAR | CMD_PARAM_OPT, 0, 0},
 		{0,0,0}},
 		ALL_ROUTES},
@@ -3947,9 +3949,32 @@ static int rtpengine_playmedia_f(struct sip_msg* msg, str *flags,
 	return 1;
 }
 
-static int rtpengine_stopmedia_f(struct sip_msg* msg, str *flags, pv_spec_t *spvar)
+static int rtpengine_stopmedia_f(struct sip_msg* msg, str *flags,
+		pv_spec_t *last_frame_pos, pv_spec_t *spvar)
 {
-	return rtpe_function_call_simple(msg, OP_STOP_MEDIA, flags, NULL, NULL, spvar);
+	bencode_buffer_t bencbuf;
+	bencode_item_t *dict;
+	pv_value_t val;
+
+	if (set_rtpengine_set_from_avp(msg) == -1)
+		return -1;
+
+	dict = rtpe_function_call_ok(&bencbuf, msg, OP_STOP_MEDIA, flags,
+			NULL, spvar, NULL, NULL, NULL);
+	if (!dict) {
+		LM_ERR("could not start media!\n");
+		return -1;
+	}
+
+	if (last_frame_pos) {
+		memset(&val, 0, sizeof(pv_value_t));
+		val.flags = PV_TYPE_INT|PV_VAL_INT;
+		val.ri = bencode_dictionary_get_integer(dict, "last-frame-pos", -1);
+		if (pv_set_value(msg, last_frame_pos, 0, &val) != 0)
+			LM_ERR("failed to set last-frame-pos after stopping media!\n");
+	}
+	bencode_buffer_free(&bencbuf);
+	return 1;
 }
 
 static int rtpengine_blockmedia_f(struct sip_msg* msg, str *flags, pv_spec_t *spvar)


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!
In order to consider and evaluate your PR, it is mandatory to provide detailed information about (1) what is the issue the PR addresses, (2) how the PR is solving the issue (logic and coding), (3) what are (if any) limitations of the proposed PR and (4) if there are any known side-effects/ backward compatibility issues/SIP interoperability issues.
Note that if the PR is missing information, it might take longer to be merged, as extra resources have to be allocated by the maintainers to reverse engineer the changes, understand them, understand the motivation, etc. That is why it is important to provide as much information as possible.
-->

**Summary**
<!-- Summary of the PR - what the PR is aiming to solve -->
This PR will allow the script writer to optionally store the last-frame-pos when the rtpengine_stop_media() function is called.

RTPEngine returns the last-frame-pos with the last frame played from a previously executed play media command.

**Details**
<!--
Details about the content of the PR - is it a bug fix, a new feature or perhaps a hack? Explain the **motivation** for making this change.
What existing problem does the pull request solve? Is this a particular problem (i.e. only some particular scenarios are affected, only some UACs, etc) or a generic one?
Do not assume others understand what you're trying to do and provide as much information as you may have.
-->

This PR adds an optional parameter to the rtpengine_stop_media() function.

For example: rtpengine_stop_media("from-tag=$tt", ,$avp(last_frame_pos));

**Solution**
<!-- Explain how your PR fixes the problem. Are there any remaining concerns that might need to be addressed? -->

This PR uses the same logic from the rtpengine_play_media() function. This function stores data returned by RTPEngine into a "duration" variable.

**Compatibility**
<!-- Does your change break other scenarios, or do they need to be migrated in order to work similarly? -->

There should be no compatibility issues because the existing rtpengine_stop_media() function does not handle any values returned by RTPEngine.

**Closing issues**
<!-- Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). -->
