### PR TITLE
Move main builds into a docker container

### DIFF
--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -18,7 +18,7 @@ jobs:
         fuzz-seconds: 600
         dry-run: false
     - name: Upload Crash
-      uses: actions/upload-artifact@v1
+      uses: actions/upload-artifact@v4
       if: failure() && steps.build.outcome == 'success'
       with:
         name: artifacts

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,7 +2,7 @@
 
 name: Main CI
 
-# Controls when the action will run. 
+# Controls when the action will run.
 on:
   # Triggers the workflow on all push or pull request events
   push:
@@ -16,41 +16,57 @@ jobs:
   # This workflow contains a single job called "build"
   build:
     # The type of runner that the job will run on
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     continue-on-error: true
+    container:
+      image: ubuntu:${{ matrix.os }}
     env:
       COMPILER: ${{ matrix.compiler }}
-      BUILD_OS: ${{ matrix.os }}
+      BUILD_OS: ubuntu-${{ matrix.os }}
 
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04]
-        compiler: ['gcc', 'clang', 'gcc-9', 'gcc-10', 'clang-9', 'clang-10']
+        os: [20.04, 22.04, 24.04]
+        compiler: ['gcc', 'clang']
         include:
-          - os: ubuntu-22.04
-            compiler: 'gcc'
-          - os: ubuntu-22.04
-            compiler: 'clang'
-          - os: ubuntu-22.04
+          - os: 20.04
+            compiler: 'gcc-9'
+          - os: 20.04
+            compiler: 'gcc-10'
+          - os: 20.04
+            compiler: 'clang-9'
+          - os: 20.04
+            compiler: 'clang-10'
+          - os: 22.04
             compiler: 'gcc-11'
-          - os: ubuntu-22.04
+          - os: 22.04
             compiler: 'gcc-12'
-          - os: ubuntu-22.04
+          - os: 22.04
             compiler: 'clang-11'
-          - os: ubuntu-22.04
+          - os: 22.04
             compiler: 'clang-12'
-          - os: ubuntu-22.04
+          - os: 22.04
             compiler: 'clang-13'
-          - os: ubuntu-22.04
+          - os: 22.04
             compiler: 'clang-14'
-          - os: ubuntu-22.04
+          - os: 22.04
             compiler: 'clang-15'
+          - os: 24.04
+            compiler: 'clang-16'
+          - os: 24.04
+            compiler: 'clang-17'
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v3
+      - name: Install git
+        run: |
+          apt-get update
+          apt-get install -y git lsb-release gnupg2 wget
+
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
 

--- a/.github/workflows/multiarch.yml
+++ b/.github/workflows/multiarch.yml
@@ -31,13 +31,13 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
 
       # Cache the compiler cache
       - name: Cache the compiler cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         if: endsWith(matrix.compiler, '-qemu-cross')
         with:
           path: ccache

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -58,12 +58,12 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
 
       - name: Cache the compiler cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         if: endsWith(matrix.compiler, '-qemu-cross')
         with:
           path: ccache
@@ -103,7 +103,7 @@ jobs:
         run: script -e unit_tests.log -c 'sh -x scripts/build/do_build.sh DEFS_EXTRA_OPTS="-DUNIT_TESTS -fPIE -fPIC"'
 
       - name: Collect test logs
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: unit_tests-logs_${{ matrix.os }}_${{ matrix.compiler }}
           path: |

--- a/scripts/build/build.conf.sub
+++ b/scripts/build/build.conf.sub
@@ -1,6 +1,6 @@
 enable_ubuntu_toolchain_test() {
-	sudo apt install software-properties-common
-	sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
+	${SUDO} env DEBIAN_FRONTEND=noninteractive apt-get install -y software-properties-common
+	${SUDO} add-apt-repository -y ppa:ubuntu-toolchain-r/test
 }
 
 setup_qemu() {

--- a/scripts/build/install_depends.sh
+++ b/scripts/build/install_depends.sh
@@ -11,7 +11,7 @@ PKGS=$(cat "$(dirname $0)/apt_requirements.txt")
 _PKGS=""
 for pkg in ${PKGS}
 do
-  if [ "${BUILD_OS}" = ubuntu-22.04 -a "${pkg}" = python-dev ]
+  if [ "${BUILD_OS}" != ubuntu-20.04 -a "${BUILD_OS}" != ubuntu-18.04 -a "${pkg}" = python-dev ]
   then
     pkg="python-dev-is-python3"
   fi
@@ -29,7 +29,7 @@ ${SUDO} apt-get -y remove libmemcached11 libpq5
 ${SUDO} apt-get -y autoremove
 
 PKGS="$PKGS $(. "$(dirname $0)/apt_requirements_postupdate.sh")"
-${SUDO} apt-get -y --allow-downgrades install ${PKGS}
+${SUDO} env DEBIAN_FRONTEND=noninteractive apt-get -y --allow-downgrades install ${PKGS}
 
 if [ ! -z "${POST_INSTALL_CMD}" ]
 then

--- a/scripts/build/reset_sources.sh
+++ b/scripts/build/reset_sources.sh
@@ -1,8 +1,16 @@
 #!/bin/sh
 
+. $(dirname $0)/build.conf.sub
+
 RELEASE="$(lsb_release -cs)"
+if [ "${RELEASE}" = "bookworm" ]
+then
+  RELEASE="jammy"
+fi
 URL="http://archive.ubuntu.com/ubuntu"
 
 echo "deb $URL $RELEASE main universe
 deb $URL $RELEASE-updates main universe
-deb $URL $RELEASE-security main universe" | sudo tee /etc/apt/sources.list > /dev/null
+deb $URL $RELEASE-security main universe" | ${SUDO} tee /etc/apt/sources.list > /dev/null
+gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 871920D1991BC93C
+gpg --export 871920D1991BC93C | ${SUDO} tee /etc/apt/trusted.gpg.d/ubuntu-keyring-2018-archive.gpg > /dev/null


### PR DESCRIPTION
**Summary**

Move main builds into a docker container, add four new OS/compiler flavours (ubuntu 24.04 + stock clang/gcc, clang-16 and clang-17).

**Details**

This PR is to fix various transient failures running CI in GH-supplied containers, which have lot of various junk junk pre-installed often in conflict in packages that OpenSIPS expects. This also allows us to build/test in various weird environments (RHEL?) and OS versions that are not yet supported by the GH directly (Ubuntu 24.x at this time).

**Solution**

Adjust pipeline, fix few scripts.

**Compatibility**

None

