### PR TITLE
Fix segfault in siprec srs failover

### DIFF
--- a/modules/siprec/siprec_body.c
+++ b/modules/siprec/siprec_body.c
@@ -394,7 +394,7 @@ int srs_build_body(struct src_sess *sess, str *sdp, str *body)
 	SIPREC_COPY_STR(sdp_content_type, &buf);
 	SIPREC_COPY(CRLF, &buf);
 
-	if (sdp)
+	if (sdp->s && sdp->len > 0)
 		SIPREC_COPY_STR((*sdp), &buf);
 
 	/* add second bondary */

--- a/modules/siprec/siprec_logic.c
+++ b/modules/siprec/siprec_logic.c
@@ -105,7 +105,6 @@ static int srs_do_failover(struct src_sess *sess)
 		LM_BUG("failover without any destination!\n");
 		return -1;
 	}
-	srec_logic_destroy(sess);
 
 	/* pop the first element */
 	node = list_entry(sess->srs.next, struct srs_node, list);


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!
In order to consider and evaluate your PR, it is mandatory to provide detailed information about (1) what is the issue the PR addresses, (2) how the PR is solving the issue (logic and coding), (3) what are (if any) limitations of the proposed PR and (4) if there are any known side-effects/ backward compatibility issues/SIP interoperability issues.
Note that if the PR is missing information, it might take longer to be merged, as extra resources have to be allocated by the maintainers to reverse engineer the changes, understand them, understand the motivation, etc. That is why it is important to provide as much information as possible.
-->

**Summary**
<!-- Summary of the PR - what the PR is aiming to solve -->
Using SIPREC module, while first SRS doesn't respond with 200ok, Opensips encounters with segmentation fault. This bug is solved. Furthermore, rtp data are not recorded in the second SRS because some of the session data are removed after failure of the first one.  This bug is fixed too.

**Details**
<!--
Details about the content of the PR - is it a bug fix, a new feature or perhaps a hack? Explain the **motivation** for making this change.
What existing problem does the pull request solve? Is this a particular problem (i.e. only some particular scenarios are affected, only some UACs, etc) or a generic one?
Do not assume others understand what you're trying to do and provide as much information as you may have.
-->
Explained in issue 3421

**Solution**
<!-- Explain how your PR fixes the problem. Are there any remaining concerns that might need to be addressed? -->
Explained in issue 3421

**Compatibility** 
<!-- Does your change break other scenarios, or do they need to be migrated in order to work similarly? -->
It seems that this change will not break other scenarios. As srec_logic_destroy function is called at the end of the call, memory leakage is not a problem.

**Closing issues**
<!-- `closes #3421`  -->
closes #3421