### PR TITLE
tls_openssl: fix openssl_tls_async_connect

### DIFF
--- a/modules/tls_openssl/openssl_conn_ops.c
+++ b/modules/tls_openssl/openssl_conn_ops.c
@@ -657,7 +657,6 @@ int openssl_tls_async_connect(struct tcp_connection *con, int fd,
 	poll_err=0;
 	elapsed = 0;
 	to = timeout*1000;
-	fd = con->fd;
 
 #if defined(HAVE_SELECT) && defined(BLOCKING_USE_SELECT)
 	FD_ZERO(&orig_set);


### PR DESCRIPTION
The `fd` value here is used with `poll()`/`select()` in the event that `SSL_connect()` gives an `SSL_ERROR_WANT_WRITE` error. So we need to be polling/selecting on the fd that is used by the underlying socket, which is the fd passed as an argument to the function, rather than `con->fd`.

So the fix is to let `fd` keep the value that was passed in the function argument rather than overwrite it with `con->fd`.

It seems to me that `handle_io()` updates `con->fd` to match the received fd number only when the socket wants reading and not when it wants writing. When the socket wants writing the correct fd to use is the one that is passed in the function argument, not the one that is in `con->fd`.

The reasons this mostly worked before are:

1.  on a box that is not heavily-loaded you often end up with the same worker setting up the TLS session as opened the socket in the first place, so the fd in `con->fd happens to be correct.
2.  if `SSL_connect()` happily connects straight away, without an `SSL_ERROR_WANT_WRITE`, then you never run into a code path that uses the value in `fd` anyway.

<!--
Thanks for submitting a pull request!
In order to consider and evaluate your PR, it is mandatory to provide detailed information about (1) what is the issue the PR addresses, (2) how the PR is solving the issue (logic and coding), (3) what are (if any) limitations of the proposed PR and (4) if there are any known side-effects/ backward compatibility issues/SIP interoperability issues.
Note that if the PR is missing information, it might take longer to be merged, as extra resources have to be allocated by the maintainers to reverse engineer the changes, understand them, understand the motivation, etc. That is why it is important to provide as much information as possible.
-->

**Summary**
This fixes an issue we were seeing where TLS connections would sometimes fail, particularly on highly-loaded boxes.

**Details**
This code has been there since `openssl_tls_async_connect()` was first created ( https://github.com/OpenSIPS/opensips/commit/806221f8ede4b063885df1aa73e895a60b1724f5 ) so I'm surprised nobody else has noticed this problem. (Could the issue actually be something else? Should `handle_io()` be setting `con->fd` in the write path as well? But then why pass it as a function argument? I don't fully understand this).

Empirically this fix works.

**Compatibility**
I don't think this change will break any scenarios.