### PR TITLE
Update stir_shaken.c - enforce stir_shaken_verify pvar generic error reason

### DIFF
--- a/modules/stir_shaken/stir_shaken.c
+++ b/modules/stir_shaken/stir_shaken.c
@@ -1999,7 +1999,7 @@ static int w_stir_verify(struct sip_msg *msg, str *cert_buf,
 	if ((rc = get_parsed_identity( msg, &parsed)) < 0) {
 		if (rc == -1) {
 			LM_ERR("Failed to parse identity header\n");
-			SET_VERIFY_ERR_VARS(IERROR_CODE, IERROR_REASON);
+			SET_VERIFY_ERR_VARS(IERROR_CODE, IERROR_REASON_PARSE_IDENTITY);
 		} else {  /* rc == -4 */
 			LM_INFO("Invalid identity header\n");
 			SET_VERIFY_ERR_VARS(INVALID_IDENTITY_CODE, INVALID_IDENTITY_REASON);
@@ -2028,7 +2028,7 @@ static int w_stir_verify(struct sip_msg *msg, str *cert_buf,
 
 	if ((now = time(0)) == -1) {
 		LM_ERR("Failed to get current time\n");
-		SET_VERIFY_ERR_VARS(IERROR_CODE, IERROR_REASON);
+		SET_VERIFY_ERR_VARS(IERROR_CODE, IERROR_REASON_GET_CURRENT_TIME);
 		rc = -1;
 		goto error;
 	}
@@ -2045,7 +2045,7 @@ static int w_stir_verify(struct sip_msg *msg, str *cert_buf,
 
 		if (get_date_ts(date_hf, &date_ts) < 0) {
 			LM_ERR("Failed to get UNIX time from Date header\n");
-			SET_VERIFY_ERR_VARS(IERROR_CODE, IERROR_REASON);
+			SET_VERIFY_ERR_VARS(IERROR_CODE, IERROR_REASON_GET_TIME_FROM_DATE_HEADER);
 			rc = -1;
 			goto error;
 		}
@@ -2095,7 +2095,7 @@ static int w_stir_verify(struct sip_msg *msg, str *cert_buf,
 
 	if (load_cert(&cert, &certchain, cert_buf) < 0) {
 		LM_ERR("Failed to load certificate\n");
-		SET_VERIFY_ERR_VARS(IERROR_CODE, IERROR_REASON);
+		SET_VERIFY_ERR_VARS(IERROR_CODE, IERROR_REASON_LOAD_CERTIFICATE);
 		rc = -1;
 		goto error;
 	}
@@ -2119,7 +2119,7 @@ static int w_stir_verify(struct sip_msg *msg, str *cert_buf,
 	if ((rc = validate_certificate(cert, certchain)) < 0) {
 		if (rc == -1) {
 			LM_ERR("Error validating certificate\n");
-			SET_VERIFY_ERR_VARS(IERROR_CODE, IERROR_REASON);
+			SET_VERIFY_ERR_VARS(IERROR_CODE, IERROR_REASON_VALIDATE_CERTIFICATE);
 			goto error;
 		} else {  /* rc == -8 */
 			LM_INFO("Invalid certificate\n");
@@ -2135,7 +2135,7 @@ static int w_stir_verify(struct sip_msg *msg, str *cert_buf,
 	if ((rc = verify_signature(cert, parsed, iat_ts, orig_tn_p, dest_tn_p)) <= 0) {
 		if (rc < 0) {
 			LM_ERR("Error while verifying signature\n");
-			SET_VERIFY_ERR_VARS(IERROR_CODE, IERROR_REASON);
+			SET_VERIFY_ERR_VARS(IERROR_CODE, IERROR_REASON_VERIFY_SIGNATURE);
 			rc = -1;
 			goto error;
 		} else {

--- a/modules/stir_shaken/stir_shaken.h
+++ b/modules/stir_shaken/stir_shaken.h
@@ -88,6 +88,13 @@
 #define INVALID_IDENTITY_REASON "Invalid Identity Header"
 #define IERROR_CODE 500
 #define IERROR_REASON "Internal Server Error"
+#define IERROR_REASON_PARSE_HEADERS "Failed to parse headers"
+#define IERROR_REASON_PARSE_IDENTITY "Failed to parse identity header"
+#define IERROR_REASON_GET_CURRENT_TIME "Failed to get current time"
+#define IERROR_REASON_GET_TIME_FROM_DATE_HEADER "Failed to get UNIX time from Date header"
+#define IERROR_REASON_LOAD_CERTIFICATE "Failed to load certificate"
+#define IERROR_REASON_VALIDATE_CERTIFICATE "Error validating certificate"
+#define IERROR_REASON_VERIFY_SIGNATURE "Error while verifying signature"
 
 #define TN_AUTH_LIST_OID "1.3.6.1.5.5.7.1.26"
 #define TN_AUTH_LIST_LN "TNAuthorizationList"


### PR DESCRIPTION
- more explicit SET_VERIFY_ERR_VARS.
- stir_shaken_verify generic err_reason pvar is now more explicit to easily reflect the real reason.

- replace generic "Internal Server Error" by dedicated internal error like "Failed to parse headers", "Failed to parse identity header", "Failed to get current time", "Failed to get UNIX time from Date header", "Failed to load certificate", "Error validating certificate", "Error while verifying signature".