### PR TITLE
backport the security patch of CVE-2023-28097

### DIFF
--- a/parser/parse_content.c
+++ b/parser/parse_content.c
@@ -242,11 +242,14 @@ char* parse_content_length( char* buffer, char* end, int* length)
 	number = 0;
 	while (p<end && *p>='0' && *p<='9') {
 		number = number*10 + (*p)-'0';
-		if (number<0) {
-			LM_ERR("number overflow at pos %d in len number [%.*s]\n",
+		/* do not actually cause an integer overflow, as it is UB! --liviu */
+		if (number > 214748363) {
+			LM_ERR("integer overflow risk at pos %d in len number [%.*s]\n",
 				(int)(p-buffer),(int)(end-buffer), buffer);
 			return 0;
 		}
+
+		number = number*10 + (*p)-'0';
 		size ++;
 		p++;
 	}


### PR DESCRIPTION
Here is a vulnerability which is fixed in the master branch(https://github.com/OpenSIPS/opensips/commit/7cab422e2fc648f910abba34f3f0dbb3ae171ff5) but is not fixed in the branch of v3.0, maybe it should be backported?