### PR TITLE
Only update the TM UAS if we are in request context and not fake request

### DIFF
--- a/modules/tm/async.c
+++ b/modules/tm/async.c
@@ -249,7 +249,7 @@ int t_handle_async(struct sip_msg *msg, struct action* a,
 	} else {
 		/* update the cloned UAS (from transaction)
 		 * with data from current msg */
-		if (t->uas.request)
+		if ((t->uas.request) && (route_type==REQUEST_ROUTE) && ((msg->msg_flags & FL_TM_FAKE_REQ) == 0))
 			update_cloned_msg_from_msg( t->uas.request, msg);
 	}
 


### PR DESCRIPTION
**Summary**
Fix crashing of OpenSIPS when script writer mistakenly runs async in branch route and/or event route

**Details**
In case of push notifications injecting branches, and if in branch_route the script writer does async() calls, OpenSIPS will update the UAS with information from the fake request ( which might contain new branch lumps and other changes ). In case there are multiple branches, post_print_uac_request will try to free up the new request and find old SHM branches and crash in 

        /* delete inserted branch lumps */
        del_flaged_lumps( &request->add_rm, LUMPFLAG_BRANCH);
        del_flaged_lumps( &request->body_lumps, LUMPFLAG_BRANCH);


**Solution**
Only update the UAS if we are running in request route and we are not having a fake request in hand.

**Compatibility**
Backwards compatible
