### PR TITLE
Fix comparision of SIP URIs, add GR and PN related params checks

### DIFF
--- a/parser/msg_parser.h
+++ b/parser/msg_parser.h
@@ -208,6 +208,9 @@ struct sip_uri {
 	str pn_prid_val;
 	str pn_param_val;
 	str pn_purr_val;
+	/* XXX - in the future when adding params as special links
+	 * in the list above, make sure to also update compare_uris() function
+	 * to explicitly compare these here */
 
 	/* unknown params */
 	str u_name[URI_MAX_U_PARAMS]; /* Unknown param names */

--- a/parser/parse_uri.c
+++ b/parser/parse_uri.c
@@ -1818,6 +1818,11 @@ int compare_uris(str *raw_uri_a,struct sip_uri* parsed_uri_a,
 	compare_uri_val(method_val,strncasecmp);
 	compare_uri_val(lr_val,strncasecmp);
 	compare_uri_val(r2_val,strncasecmp);
+	compare_uri_val(gr_val,strncasecmp);
+	compare_uri_val(pn_provider_val,strncasecmp);
+	compare_uri_val(pn_prid_val,strncasecmp);
+	compare_uri_val(pn_param_val,strncasecmp);
+	compare_uri_val(pn_purr_val,strncasecmp);
 
 	if (first.u_params_no == 0 || second.u_params_no == 0)
 		/* one URI doesn't have other params,


### PR DESCRIPTION
**Summary**
In the case of multiple push notification devices registering same URI@HOST but with different PN related params, OpenSIPS was not comparing the URIs properly and overriding old registrations with new ones.

**Solution**
Do proper SIP URI comparison.

**Compatibility**
Backwards compatible.
