### PR TITLE
fix: NULL check received MongoDB connections

### DIFF
--- a/modules/cachedb_mongodb/cachedb_mongodb_dbase.c
+++ b/modules/cachedb_mongodb/cachedb_mongodb_dbase.c
@@ -182,6 +182,9 @@ cachedb_con *mongo_con_init(str *url)
 void mongo_free_connection(cachedb_pool_con *con)
 {
 	mongo_con *mcon = (mongo_con *)con;
+	
+	if (!mcon)
+		return;
 
 	mongoc_collection_destroy(mcon->collection);
 	mongoc_database_destroy(mcon->database);
@@ -207,6 +210,9 @@ int mongo_con_get(cachedb_con *con, str *attr, str *val)
 	unsigned long ival;
 	char *p;
 	int ret = 0;
+
+	if (!con)
+		return -1;
 
 	LM_DBG("find %.*s in %s\n", attr->len, attr->s,
 	       MONGO_NAMESPACE(con));
@@ -295,6 +301,9 @@ int mongo_con_set(cachedb_con *con, str *attr, str *val, int expires)
 	struct timeval start;
 	int ret = 0;
 
+	if (!con)
+		return -1;
+
 	query = bson_new();
 	bson_append_utf8(query, MDB_PK, MDB_PKLEN, attr->s, attr->len);
 
@@ -328,6 +337,9 @@ int mongo_con_remove(cachedb_con *con, str *attr)
 	bson_error_t error;
 	struct timeval start;
 	int ret = 0;
+
+	if (!con)
+		return -1;
 
 	doc = bson_new();
 	bson_append_utf8(doc, MDB_PK, MDB_PKLEN, attr->s, attr->len);
@@ -367,6 +379,9 @@ int mongo_raw_find(cachedb_con *con, bson_t *raw_query, bson_iter_t *ns,
 	const bson_t *doc;
 	int i, len, csz = 0, ret = -1;
 	const char *p;
+
+	if (!con)
+		return -1;
 
 	if (bson_iter_type(ns) != BSON_TYPE_UTF8) {
 		LM_ERR("collection name must be a string (%d)!\n", bson_iter_type(ns));
@@ -519,6 +534,9 @@ int mongo_raw_update(cachedb_con *con, bson_t *raw_query, bson_iter_t *ns)
 	const bson_value_t *v;
 	int ret, count = 0;
 
+	if (!con)
+		return -1;
+
 	if (bson_iter_type(ns) != BSON_TYPE_UTF8) {
 		LM_ERR("collection name must be a string (%d)!\n", bson_iter_type(ns));
 		return -1;
@@ -624,6 +642,9 @@ int mongo_raw_insert(cachedb_con *con, bson_t *raw_query, bson_iter_t *ns)
 	const bson_value_t *v;
 	int ret, count = 0;
 
+	if (!con)
+		return -1;
+
 	if (bson_iter_type(ns) != BSON_TYPE_UTF8) {
 		LM_ERR("collection name must be a string (%d)!\n", bson_iter_type(ns));
 		return -1;
@@ -707,6 +728,9 @@ int mongo_raw_remove(cachedb_con *con, bson_t *raw_query, bson_iter_t *ns)
 	struct timeval start;
 	const bson_value_t *v;
 	int ret, count = 0;
+
+	if (!con)
+		return -1;
 
 	if (bson_iter_type(ns) != BSON_TYPE_UTF8) {
 		LM_ERR("collection name must be a string (%d)!\n", bson_iter_type(ns));
@@ -806,6 +830,9 @@ int mongo_con_raw_query(cachedb_con *con, str *qstr, cdb_raw_entry ***reply,
 	int ret = 0;
 	const char *p;
 	int csz = 0, i, len;
+
+	if (!con)
+		return -1;
 
 	LM_DBG("Get operation on namespace %s\n", MONGO_NAMESPACE(con));
 	start_expire_timer(start,mongo_exec_threshold);
@@ -966,6 +993,9 @@ int mongo_con_add(cachedb_con *con, str *attr, int val, int expires, int *new_va
 	struct timeval start;
 	int ret = 0;
 
+	if (!con)
+		return -1;
+
 	cmd = bson_new();
 	bson_append_utf8(cmd, "findAndModify", 13,
 	                 mongoc_collection_get_name(MONGO_COLLECTION(con)), -1);
@@ -1031,6 +1061,9 @@ int mongo_con_get_counter(cachedb_con *con, str *attr, int *val)
 	bson_iter_t iter;
 	struct timeval start;
 	int ret = -2;
+
+	if (!con)
+		return -1;
 
 	query = bson_new();
 #if MONGOC_CHECK_VERSION(1, 5, 0)
@@ -1216,6 +1249,9 @@ int mongo_db_query_trans(cachedb_con *con, const str *table, const db_key_t *_k,
 	mongoc_collection_t *col = NULL;
 	char *strf, *stro;
 	str st;
+
+	if (!con)
+		return -1;
 
 	*_r = NULL;
 
@@ -1516,6 +1552,9 @@ int mongo_db_insert_trans(cachedb_con *con, const str *table,
 	mongoc_collection_t *col = NULL;
 	struct timeval start;
 
+	if (!con)
+		return -1;
+
 	doc = bson_new();
 	if (kvo_to_bson(_k, _v, NULL, _n, doc) != 0) {
 		LM_ERR("failed to build bson\n");
@@ -1564,6 +1603,9 @@ int mongo_db_delete_trans(cachedb_con *con, const str *table,
 	bson_error_t error;
 	mongoc_collection_t *col = NULL;
 	struct timeval start;
+
+	if (!con)
+		return -1;
 
 	doc = bson_new();
 	if (kvo_to_bson(_k, _v, _o, _n, doc) != 0) {
@@ -1614,6 +1656,9 @@ int mongo_db_update_trans(cachedb_con *con, const str *table,
 	bson_error_t error;
 	mongoc_collection_t *col = NULL;
 	struct timeval start;
+
+	if (!con)
+		return -1;
 
 	query = bson_new();
 	if (kvo_to_bson(_k, _v, _o, _n, query) != 0) {
@@ -1676,6 +1721,9 @@ int mongo_truncate(cachedb_con *con)
 	bson_error_t error;
 	struct timeval start;
 	int ret = 0;
+
+	if (!con)
+		return -1;
 
 	start_expire_timer(start, mongo_exec_threshold);
 	if (!mongoc_collection_remove(MONGO_COLLECTION(con),
@@ -1894,6 +1942,9 @@ int mongo_con_query(cachedb_con *con, const cdb_filter_t *filter,
 	const bson_t *doc;
 	struct timeval start;
 
+	if (!con)
+		return -1;
+
 	LM_DBG("find all in %s\n", MONGO_NAMESPACE(con));
 
 	cdb_res_init(res);
@@ -2073,6 +2124,9 @@ int mongo_con_update(cachedb_con *con, const cdb_filter_t *row_filter,
 	char has_set = 0, has_unset = 0;
 	cdb_pair_t *pair;
 	str key;
+
+	if (!con)
+		return -1;
 
 	if (mongo_cdb_filter_to_bson(row_filter, &filter) != 0) {
 		LM_ERR("failed to build bson filter\n");


### PR DESCRIPTION
**Summary**
MongoDB module is crashing if a NULL connection is passed to it

**Solution**
Check for NULL before trying to use a MongoDB connection

**Compatibility**
Backwards compatible.
