### PR TITLE
[RFC]: Add the statistics for incoming tcp connections handling

### DIFF
--- a/core_stats.c
+++ b/core_stats.c
@@ -79,6 +79,15 @@ const stat_export_t core_stats[] = {
 
 /*************************** NET statistics *********************************/
 
+stat_var* tcp_in_total;
+stat_var* tcp_in_success;
+stat_var* tcp_in_accept_failed;
+stat_var* tcp_in_max_exceeded;
+stat_var* tcp_in_init_sock_opt_failed;
+stat_var* tcp_in_conn_new_failed;
+stat_var* tcp_in_no_workers;
+stat_var* tcp_send_fd_failed;
+
 static unsigned long net_get_wb_udp(unsigned short foo)
 {
 	return get_total_bytes_waiting(PROTO_UDP);
@@ -95,9 +104,17 @@ static unsigned long net_get_wb_tls(unsigned short foo)
 }
 
 const stat_export_t net_stats[] = {
-	{"waiting_udp" ,    STAT_IS_FUNC,  (stat_var**)net_get_wb_udp    },
-	{"waiting_tcp" ,    STAT_IS_FUNC,  (stat_var**)net_get_wb_tcp    },
-	{"waiting_tls" ,    STAT_IS_FUNC,  (stat_var**)net_get_wb_tls    },
+	{"waiting_udp" ,           STAT_IS_FUNC,  (stat_var**)net_get_wb_udp    },
+	{"waiting_tcp" ,           STAT_IS_FUNC,  (stat_var**)net_get_wb_tcp    },
+	{"waiting_tls" ,           STAT_IS_FUNC,  (stat_var**)net_get_wb_tls    },
+	{"tcp_in_total" ,                     0,  &tcp_in_total                 },
+	{"tcp_in_success" ,                   0,  &tcp_in_success               },
+	{"tcp_in_accept_failed",              0,  &tcp_in_accept_failed         },
+	{"tcp_in_max_exceeded",               0,  &tcp_in_max_exceeded          },
+	{"tcp_in_init_sock_opt_failed",       0,  &tcp_in_init_sock_opt_failed  },
+	{"tcp_in_conn_new_failed",            0,  &tcp_in_conn_new_failed       },
+	{"tcp_in_no_workers",                 0,  &tcp_in_no_workers            },
+	{"tcp_send_fd_failed",                0,  &tcp_send_fd_failed           },
 	{0,0,0}
 };
 

--- a/core_stats.h
+++ b/core_stats.h
@@ -74,6 +74,31 @@ extern stat_var* bad_msg_hdr;
 /*! \brief SIP message processing which exceeded 'threshold' duration */
 extern stat_var* slow_msgs;
 
+/*! \brief total handled incoming tcp connections */
+extern stat_var* tcp_in_total;
+
+/*! \brief total incoming tcp connections processed successfully */
+extern stat_var* tcp_in_success;
+
+/*! \brief the accept syscall returned error */
+extern stat_var* tcp_in_accept_failed;
+
+/*! \brief the tcp_max_connections exceeded  */
+extern stat_var* tcp_in_max_exceeded;
+
+/*! \brief the tcp_init_sock_opt for new incoming connection failed */
+extern stat_var* tcp_in_init_sock_opt_failed;
+
+/*! \brief the tcpconn_new for incoming connection failed  */
+extern stat_var* tcp_in_conn_new_failed;
+
+/*! \brief the TCP MAIN sent new incoming conn to a worker unsucceessfully */
+extern stat_var* tcp_in_no_workers;
+
+/*! \brief the TCP MAIN sent the socket to a worker and it failed. */
+extern stat_var* tcp_send_fd_failed;
+
+
 #ifdef PKG_MALLOC
 int init_pkg_stats(int no_procs);
 #endif


### PR DESCRIPTION
These statistics items for NET subsystem was added:

- tcp_in_total - total incoming tcp connections processed.
- tcp_in_success - total incoming tcp connections processed successfully and sent to a worker
- tcp_in_accept_failed - how many times the syscall 'accept' retured error.
- tcp_in_max_exceeded - how many times the incoming connection was closed due by the tcp_max_connection limit was exceeded.
- tcp_in_sock_opt_failed - how many times the incoming connection was closed due by the socket options setting failed.
- tcp_in_conn_new_failed - how many times the incoming connection was closed due by the tcpconn_new retured error.
- tcp_in_no_workers - how many times the incoming connection was closed due by unsuccessfull passing to a worker
- tcp_send_fd_failed - how many times passing to a worker failed.

