### PR TITLE
Fix HP_MALLOC build flag - DBG_MALLOC is not necessary for it

### DIFF
--- a/mem/shm_mem.h
+++ b/mem/shm_mem.h
@@ -301,6 +301,7 @@ inline static void shm_threshold_check(void)
 				lock_release(mem_lock); \
 		} while (0)
 	#endif
+	extern unsigned long long *shm_hash_usage;
 #else
 #define shm_lock()    lock_get(mem_lock)
 #define shm_unlock()  lock_release(mem_lock)
@@ -628,8 +629,6 @@ inline static void _shm_free_bulk(void *ptr,
 #define shm_free_bulk_func _shm_free_bulk
 #define shm_free_bulk( _ptr ) _shm_free_bulk( (_ptr), \
 	__FILE__, __FUNCTION__, __LINE__ )
-
-extern unsigned long long *shm_hash_usage;
 
 #else /*DBG_MALLOC*/
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!
In order to consider and evaluate your PR, it is mandatory to provide detailed information about (1) what is the issue the PR addresses, (2) how the PR is solving the issue (logic and coding), (3) what are (if any) limitations of the proposed PR and (4) if there are any known side-effects/ backward compatibility issues/SIP interoperability issues.
Note that if the PR is missing information, it might take longer to be merged, as extra resources have to be allocated by the maintainers to reverse engineer the changes, understand them, understand the motivation, etc. That is why it is important to provide as much information as possible.
-->

**Summary**
Fix building of OpenSIPS with HP_MALLOC

**Details**
I found that if I doesn't want turn on DBG_MALLOC flag, but I want do some experiments with HP_MALLOC when building OpenSIPS from source - I cannot do that, because in that case shm_hash_usage will be undefined.

**Solution**
Move definition of shm_hash_usage to the ifdef block of HP_MALLOC.

**Compatibility**
This change doesn't looks like breaking.

**Closing issues**
No any opened issue.
