### PR TITLE
rest_client: Fix segfault and lock release

### DIFF
--- a/modules/rest_client/rest_methods.c
+++ b/modules/rest_client/rest_methods.c
@@ -631,8 +631,8 @@ void rcl_release_url(char *url_host, int update_conn_ts)
 		void **connected_ts;
 
 		connected_ts = map_get(rcl_connections, host_str);
-		if (connected_ts)
-			*connected_ts = (void *)(unsigned long)get_ticks();
+		if (connected_ts && *connected_ts)
+			*(unsigned long *)(*connected_ts) = (unsigned long)get_ticks();
 	}
 
 	pkg_free(url_host);


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!
In order to consider and evaluate your PR, it is mandatory to provide detailed information about (1) what is the issue the PR addresses, (2) how the PR is solving the issue (logic and coding), (3) what are (if any) limitations of the proposed PR and (4) if there are any known side-effects/ backward compatibility issues/SIP interoperability issues.
Note that if the PR is missing information, it might take longer to be merged, as extra resources have to be allocated by the maintainers to reverse engineer the changes, understand them, understand the motivation, etc. That is why it is important to provide as much information as possible.
-->

**Summary**
- Fix segfault
- Fix lock never released in some cases when using rest_get with async

Should be back ported to supported versions at least 3.5. 

**Closing issues**
closes #3464 

