### PR TITLE
Fix a corner case causing clusterer to segfault

### DIFF
--- a/modules/clusterer/node_info.c
+++ b/modules/clusterer/node_info.c
@@ -497,7 +497,7 @@ int load_db_info(db_func_t *dr_dbf, db_con_t* db_hdl, str *db_table,
 			} else if (int_vals[INT_VALS_NODE_ID_COL] == current_id) {
 				LM_ERR("Invalid info for local node\n");
 				return -1;
-			} else if (int_vals[INT_VALS_NODE_ID_COL] == current_id && rc == 1) {
+			} else if (int_vals[INT_VALS_NODE_ID_COL] != current_id && rc == 1) {
 				LM_ERR("Invalid info for remote node, this will segfault! [%d] current_id=%d\n",
 				int_vals[INT_VALS_NODE_ID_COL], rc);
 				return -1;

--- a/modules/clusterer/node_info.c
+++ b/modules/clusterer/node_info.c
@@ -497,6 +497,10 @@ int load_db_info(db_func_t *dr_dbf, db_con_t* db_hdl, str *db_table,
 			} else if (int_vals[INT_VALS_NODE_ID_COL] == current_id) {
 				LM_ERR("Invalid info for local node\n");
 				return -1;
+			} else if (int_vals[INT_VALS_NODE_ID_COL] == current_id && rc == 1) {
+				LM_ERR("Invalid info for remote node, this will segfault! [%d] current_id=%d\n",
+				int_vals[INT_VALS_NODE_ID_COL], rc);
+				return -1;
 			} else {
 				return 2;
 			}


### PR DESCRIPTION
Fix a corner case where if the local_node id is higher than the remote node_id and DNS resolution fails opensips would segfault.
<!--
Thanks for submitting a pull request!
In order to consider and evaluate your PR, it is mandatory to provide detailed information about (1) what is the issue the PR addresses, (2) how the PR is solving the issue (logic and coding), (3) what are (if any) limitations of the proposed PR and (4) if there are any known side-effects/ backward compatibility issues/SIP interoperability issues.
Note that if the PR is missing information, it might take longer to be merged, as extra resources have to be allocated by the maintainers to reverse engineer the changes, understand them, understand the motivation, etc. That is why it is important to provide as much information as possible.
-->

**Summary**
<!-- Summary of the PR - what the PR is aiming to solve -->

**Details**
<!--
Details about the content of the PR - is it a bug fix, a new feature or perhaps a hack? Explain the **motivation** for making this change.
What existing problem does the pull request solve? Is this a particular problem (i.e. only some particular scenarios are affected, only some UACs, etc) or a generic one?
Do not assume others understand what you're trying to do and provide as much information as you may have.
-->

**Solution**
<!-- Explain how your PR fixes the problem. Are there any remaining concerns that might need to be addressed? -->

**Compatibility**
<!-- Does your change break other scenarios, or do they need to be migrated in order to work similarly? -->

**Closing issues**
<!-- Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). -->
