### PR TITLE
Fix `rtpengine_manage()` SDP existence check with custom body

### DIFF
--- a/modules/rtpengine/rtpengine.c
+++ b/modules/rtpengine/rtpengine.c
@@ -3343,7 +3343,7 @@ rtpengine_manage(struct sip_msg *msg, str *flags, pv_spec_t *spvar,
 		return rtpengine_delete(msg, flags, NULL, NULL, spvar);
 
 	if (body)
-		nosdp = body->len != 0;
+		nosdp = body->len == 0;
 	else if(has_body_part(msg, TYPE_APPLICATION, SUBTYPE_SDP))
 		nosdp = 0;
 	else


### PR DESCRIPTION
Correct the logic for checking the presence of SDP body when body var is provided. Previously, the condition was inverted, leading to incorrect handling of messages.

If possible to backport to 3.5.