### PR TITLE
Fix stir_shaken_check to align with docs.

### DIFF
--- a/modules/stir_shaken/stir_shaken.c
+++ b/modules/stir_shaken/stir_shaken.c
@@ -2168,6 +2168,8 @@ static int w_stir_check(struct sip_msg *msg)
 		if (rc == -1) {
 			LM_ERR("Failed to parse identity header\n");
 			return -1;
+		} else if (rc == -2) {
+			return -2;
 		} else {
 			LM_INFO("Invalid identity header\n");
 			return -3;


### PR DESCRIPTION
**Summary**
Docs says `-2: No Identity header found`
