### PR TITLE
[maxfwd]: Fix bug `is_maxfwd_lt` function limit value

### DIFF
--- a/modules/maxfwd/maxfwd.c
+++ b/modules/maxfwd/maxfwd.c
@@ -52,7 +52,7 @@ static int max_limit = MAXFWD_UPPER_LIMIT;
 
 static int fixup_maxfwd_header(void** param);
 static int w_process_maxfwd_header(struct sip_msg* msg, int* mval);
-static int is_maxfwd_lt(struct sip_msg *msg, char *slimit, char *foo);
+static int is_maxfwd_lt(struct sip_msg *msg, int *limit);
 static int mod_init(void);
 
 
@@ -169,20 +169,18 @@ error:
 
 
 
-static int is_maxfwd_lt(struct sip_msg *msg, char *slimit, char *foo)
+static int is_maxfwd_lt(struct sip_msg *msg, int *limit)
 {
 	str mf_value;
-	int limit;
 	int val;
 
-	limit = (int)(long)slimit;
 	val = is_maxfwd_present( msg, &mf_value);
-	LM_DBG("value = %d \n",val);
+	LM_DBG("value = %d, limit = %d\n", val, *limit);
 
 	if ( val<0 ) {
 		/* error or not found */
 		return val-1;
-	} else if ( val>=limit ) {
+	} else if ( val >= *limit ) {
 		/* greater or equal than/to limit */
 		return -1;
 	}


### PR DESCRIPTION
**Summary**
`is_maxfwd_lt( val )` was using a random value, the ptr address.


**Solution**
Correctly use the int value.

**Compatibility**
Should be backported to all supported versions of opensips.
