### PR TITLE
fix: Populate last dst leg for internally generated sequentials

### DIFF
--- a/modules/dialog/dlg_req_within.c
+++ b/modules/dialog/dlg_req_within.c
@@ -622,6 +622,8 @@ int send_leg_msg(struct dlg_cell *dlg,str *method,int src_leg,int dst_leg,
 	if (push_new_processing_context( dlg, &old_ctx, &new_ctx, NULL)!=0)
 		return -1;
 
+	ctx_lastdstleg_set(dst_leg);
+
 	dialog_info->T_flags=T_NO_AUTOACK_FLAG;
 
 	result = d_tmb.t_request_within


### PR DESCRIPTION
**Summary**
For internally generated requests ( like Options/Reinvites from the pPrR flags, or sent by dlg_send_sequential MI or script ), local_route does not hold correct $DLG_dir values.

**Solution**
Populate last dst leg, so $DLG_dir has the correct value in the script

**Compatibility**
Backwards compatible

