### PR TITLE
Add authentication to Cassandra module

### DIFF
--- a/modules/cachedb_cassandra/cachedb_cassandra_dbase.c
+++ b/modules/cachedb_cassandra/cachedb_cassandra_dbase.c
@@ -138,9 +138,12 @@ int cassandra_reopen(cassandra_con *cass_con)
 	return 0;
 }
 
-int cassandra_new_connection(cassandra_con *con, char *host, int port)
+int cassandra_new_connection(cassandra_con *con, char *host, int port, char *username, char *password)
 {
 	con->cluster = cass_cluster_new();
+	if (username && password) {
+	  cass_cluster_set_credentials(con->cluster, username, password);
+	}
 	if (!con->cluster) {
 		LM_ERR("Failed to create Cassandra Cluster object\n");
 		return -1;
@@ -256,7 +259,7 @@ void *cassandra_init_connection(struct cachedb_id *id)
 	con->table = table;
 	con->cnt_table = cnt_table;
 
-	if (cassandra_new_connection(con, id->host, id->port) < 0) {
+	if (cassandra_new_connection(con, id->host, id->port, id->username, id->password) < 0) {
 		LM_ERR("failed to create new connection to Cassandra\n");
 		pkg_free(con);
 		return NULL;


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!
In order to consider and evaluate your PR, it is mandatory to provide detailed information about (1) what is the issue the PR addresses, (2) how the PR is solving the issue (logic and coding), (3) what are (if any) limitations of the proposed PR and (4) if there are any known side-effects/ backward compatibility issues/SIP interoperability issues.
Note that if the PR is missing information, it might take longer to be merged, as extra resources have to be allocated by the maintainers to reverse engineer the changes, understand them, understand the motivation, etc. That is why it is important to provide as much information as possible.
-->

**Summary**
This is to add authentication for the Cassandra module.  the URL already has the ability to provide a username and password, this just implements it back to the driver.    If you Database has authentication enabled, Opensips would not be able to connect to it.

**Details**
New Feature.
Need to use authentication when connecting to the database.
This is a very small change using existing logic in opensips code.
Uses the current db_url provided username:password structure for other DB types and makes it work for cassandra.  Documentation would need to be updated to let others know this is now possible to use.

**Solution**
Simply implemented the Cassandra API to pass username and password if provided.

**Compatibility**
It is unknown to me when Cassandra implemented authentication.  but I know it has been almost 8 years now.

**Closing issues**
I put in an issue, with some other questions related to this pull request.  And questions for how to best offer support for Scylla DB as it's required librariy is different than cassandra, but the API is the same.
https://github.com/OpenSIPS/opensips/issues/3486

