### PR TITLE
db_oracle: Fix issues#3505 "invalid parameter value" when do sql_query("update ...")

### DIFF
--- a/modules/db_oracle/dbase.c
+++ b/modules/db_oracle/dbase.c
@@ -189,9 +189,13 @@ int db_oracle_free_result(db_con_t* _h, db_res_t* _r)
 {
 	ub4 i;
 
-	if (!_h || !_r) {
+	if (!_h) {
 		LM_ERR("invalid parameter value\n");
 		return -1;
+	}
+
+	if (!_r) {
+		return 0; /* nothing to free */
 	}
 
 	if (RES_NAMES(_r))
@@ -415,7 +419,6 @@ badparam:
 			return -2;
 		}
 #undef _S_DIFF
-		if (_r) goto badparam;
 		cb._rs = NULL;
 	}
 

--- a/modules/db_oracle/res.c
+++ b/modules/db_oracle/res.c
@@ -457,8 +457,13 @@ badparam:
 	    query_data_t *pcb = con->pqdata;
 
 
-	    if (!pcb || !pcb->_rs)
+		if (!pcb)
 		    goto badparam;
+
+		if (!pcb->_rs) {
+			if (_r)	*_r = NULL;
+			return 0; /* No results */
+		}
 
 	    hs = *pcb->_rs;
 	    pcb->_rs = NULL; /* paranoid for next call */

--- a/modules/usrloc/dlist.c
+++ b/modules/usrloc/dlist.c
@@ -151,7 +151,7 @@ static int get_domain_db_ucontacts(udomain_t *d, void *buf, int *len,
 
 	i = snprintf(query_buf, sizeof query_buf, "select %.*s, %.*s, %.*s,"
 #ifdef ORACLE_USRLOC
-	" %.*s, %.*s, %.*s from %s where %.*s > %lu and mod(contact_id, %u) = %u",
+	" %.*s, %.*s, %.*s from %s where %.*s > %lld and mod(contact_id, %u) = %u",
 #else
 	" %.*s, %.*s, %.*s from %s where %.*s > %lld and contact_id %% %u = %u",
 #endif


### PR DESCRIPTION
**Summary**
fix [issues#3505 "invalid parameter value" when do sql_query("update ...")](https://github.com/OpenSIPS/opensips/issues/3505)

**Details**
The sql_query function currently passes a db_res pointer to the url->dbf.raw_query interface to receive query results.
However, the db_oracle_raw_query function expects a NULL value for the parameter used to receive query results when performing insert, delete, or update operations. This mismatch causes the query to fail.

**Solution**
Allow non-NULL parameters to be passed in, and then set the query result to NULL in the db_oracle_store_result function. 
Additionally, the db_oracle_free_result function should also check if the result is not NULL.

**Compatibility**
Backwards compatible

**Closing issues**
closes #3505 
