### PR TITLE
Feature: add pause recording function to module rtpengine

### DIFF
--- a/modules/rtpengine/doc/rtpengine_admin.xml
+++ b/modules/rtpengine/doc/rtpengine_admin.xml
@@ -1026,6 +1026,39 @@ rtpengine_stop_recording();
 		</example>
 	</section>
 
+	<section id="func_rtpengine_stop_recording" xreflabel="rtpengine_pause_recording()">
+		<title>
+		<function moreinfo="none">rtpengine_pause_recording([flags [, sock_var]])</function>
+		</title>
+		<para>
+		This function will send a signal to the &rtp; proxy to pause
+		recording the RTP stream on the &rtp; proxy.
+		</para>
+		<para>Meaning of the parameters is as follows:</para>
+		<itemizedlist>
+		<listitem><para>
+		<emphasis>flags(string, optional)</emphasis> - flags used to change the behavior
+		of the recorder. An importat value to set is the <emphasis>call-id</emphasis>
+		value, which can be used to start recording a different call than the requested one.
+		</para></listitem>
+		<listitem><para>
+		<emphasis>sock_var(var, optional)</emphasis> - variable used to store the rtpengine
+		socket chosen for this call.
+		</para></listitem>
+		</itemizedlist>
+		<para>
+		This function can be used from any route.
+		</para>
+		<example>
+		<title><function>rtpengine_pause_recording</function> usage</title>
+		<programlisting format="linespecific">
+...
+rtpengine_stop_recording();
+...
+		</programlisting>
+		</example>
+	</section>
+
 	<section id="func_rtpengine_play_media" xreflabel="rtpengine_play_media()">
 		<title>
 		<function moreinfo="none">rtpengine_play_media(flags, [duration_spec[, sock_var[, sockvar]]])</function>

--- a/modules/rtpengine/doc/rtpengine_admin.xml
+++ b/modules/rtpengine/doc/rtpengine_admin.xml
@@ -1026,13 +1026,15 @@ rtpengine_stop_recording();
 		</example>
 	</section>
 
-	<section id="func_rtpengine_stop_recording" xreflabel="rtpengine_pause_recording()">
+	<section id="func_rtpengine_pause_recording" xreflabel="rtpengine_pause_recording()">
 		<title>
 		<function moreinfo="none">rtpengine_pause_recording([flags [, sock_var]])</function>
 		</title>
 		<para>
 		This function will send a signal to the &rtp; proxy to pause
-		recording the RTP stream on the &rtp; proxy.
+		recording the RTP stream on the &rtp; proxy. Identical to stop recording except that it 
+		instructs the recording daemon not to close the recording file, but instead leave it open 
+		so that recording can later be resumed via another start recording message.
 		</para>
 		<para>Meaning of the parameters is as follows:</para>
 		<itemizedlist>

--- a/modules/rtpengine/rtpengine.c
+++ b/modules/rtpengine/rtpengine.c
@@ -3006,7 +3006,7 @@ rtpe_test(struct rtpe_node *node, int isdisabled, int force)
 	}
 
 	if (isdisabled)
-		LM_DBG("rtp proxy <%s> found, support for it %senabled\n",
+		LM_INFO("rtp proxy <%s> found, support for it %senabled\n",
 				node->rn_url.s, force == 0 ? "re-" : "");
 
 	bencode_buffer_free(&bencbuf);

--- a/modules/rtpengine/rtpengine.c
+++ b/modules/rtpengine/rtpengine.c
@@ -152,6 +152,7 @@ enum rtpe_operation {
 	OP_DELETE,
 	OP_START_RECORDING,
 	OP_STOP_RECORDING,
+	OP_PAUSE_RECORDING,
 	OP_QUERY,
 	OP_START_MEDIA,
 	OP_STOP_MEDIA,
@@ -233,6 +234,7 @@ static const char *command_strings[] = {
 	[OP_DELETE]		= "delete",
 	[OP_START_RECORDING]	= "start recording",
 	[OP_STOP_RECORDING]		= "stop recording",
+	[OP_PAUSE_RECORDING]	= "pause recording",
 	[OP_QUERY]		= "query",
 	[OP_START_MEDIA]= "play media",
 	[OP_STOP_MEDIA] = "stop media",
@@ -275,6 +277,8 @@ static char *gencookie();
 static int rtpe_test(struct rtpe_node*, int, int);
 static int start_recording_f(struct sip_msg* msg, str *flags, pv_spec_t *spvar);
 static int stop_recording_f(struct sip_msg* msg, str *flags, pv_spec_t *spvar);
+static int pause_recording_f(struct sip_msg* msg, str *flags, pv_spec_t *spvar);
+static int start_recording_f(struct sip_msg* msg, str *flags, pv_spec_t *spvar);
 static int rtpengine_offer_f(struct sip_msg *msg, str *flags, pv_spec_t *spvar,
 		pv_spec_t *bpvar, str *body);
 static int rtpengine_answer_f(struct sip_msg *msg, str *flags, pv_spec_t *spvar,
@@ -442,6 +446,10 @@ static const cmd_export_t cmds[] = {
 		{CMD_PARAM_VAR | CMD_PARAM_OPT, 0, 0}, {0,0,0}},
 		ALL_ROUTES},
 	{"rtpengine_stop_recording", (cmd_function)stop_recording_f, {
+		{CMD_PARAM_STR | CMD_PARAM_OPT, 0, 0},
+		{CMD_PARAM_VAR | CMD_PARAM_OPT, 0, 0}, {0,0,0}},
+		ALL_ROUTES},
+	{"rtpengine_pause_recording", (cmd_function)pause_recording_f, {
 		{CMD_PARAM_STR | CMD_PARAM_OPT, 0, 0},
 		{CMD_PARAM_VAR | CMD_PARAM_OPT, 0, 0}, {0,0,0}},
 		ALL_ROUTES},
@@ -2998,7 +3006,7 @@ rtpe_test(struct rtpe_node *node, int isdisabled, int force)
 	}
 
 	if (isdisabled)
-		LM_INFO("rtp proxy <%s> found, support for it %senabled\n",
+		LM_DBG("rtp proxy <%s> found, support for it %senabled\n",
 				node->rn_url.s, force == 0 ? "re-" : "");
 
 	bencode_buffer_free(&bencbuf);
@@ -3519,6 +3527,12 @@ static int
 stop_recording_f(struct sip_msg* msg, str *flags, pv_spec_t *spvar)
 {
 	return rtpe_function_call_simple(msg, OP_STOP_RECORDING, flags, NULL, NULL, spvar);
+}
+
+static int
+pause_recording_f(struct sip_msg* msg, str *flags, pv_spec_t *spvar)
+{
+	return rtpe_function_call_simple(msg, OP_PAUSE_RECORDING, flags, NULL, NULL, spvar);
 }
 
 /**


### PR DESCRIPTION
**Summary**
RTPEngine Module: add exported function for `pause recording` operation. Pause recording tells the recording daemon to keep the recording file open so you don't end up with multiple for a single call.
**Details**
Feature to add pause recording functionality to RTPEngine module.
**Solution**
n/a

**Compatibility**
Backwards compatible.

**Closing issues**

