### PR TITLE
Fix Cluster Master-Slave detection

### DIFF
--- a/modules/cachedb_redis/cachedb_redis_dbase.c
+++ b/modules/cachedb_redis/cachedb_redis_dbase.c
@@ -273,7 +273,7 @@ int redis_connect(redis_con *con)
 		/* cluster instance mode */
 		con->flags |= REDIS_CLUSTER_INSTANCE;
 		con->slots_assigned = 0;
-		LM_DBG("cluster instance mode\n");
+		LM_DBG("cluster instance mode on %p\n",con);
 		if (build_cluster_nodes(con,rpl->str,rpl->len) < 0) {
 			LM_ERR("failed to parse Redis cluster info\n");
 			freeReplyObject(rpl);


### PR DESCRIPTION
**Summary**
Fix Cluster Master-Slave detection

**Details**
When using an Redis Based AWS Elasticache setup, in a master-slave fashion, when connecting via the global URL for the cluster ( which has multiple A records for all masters & slaves ), OpenSIPS would wrongly connect to the Slave ( via the global URL ) in case the initial DNS resolved to the slave, leading to run-time queries to get 'redirected' by redis with MOVED, which is currently not handled by OpenSIPS.


**Solution**
Only use the global cluster config URL as host if "CLUSTER NODES" did not report a hostname for the master. if it did, use that.

Nov 19 06:43:07 [27] DBG:cachedb_redis:build_cluster_nodes: Nodes : 0ba237ec8968c34ec0f6cc0875e4b6e0982054bb dev-redis-0001-002.cache.amazon.aws.com:6379@1122 slave 3e8bff7e0084066c0121220b9b9de720f30206da 0 1731998587073 0 connected
Nov 19 06:43:07 [27] DBG:cachedb_redis:build_cluster_nodes: Nodes : 3e8bff7e0084066c0121220b9b9de720f30206da dev-redis-0001-001..cache.amazon.aws.com:6379@1122 myself,master - 0 0 0 connected 0-16383
Nov 19 06:43:07 [27] DBG:cachedb_redis:build_cluster_nodes: Master already discovered to not be myself, not going to main host 

**Compatibility**
Backwards compatible
