### PR TITLE
dispatcher: Add ping_sock as a partition parameter

### DIFF
--- a/modules/dispatcher/README
+++ b/modules/dispatcher/README
@@ -769,7 +769,7 @@ modparam("dispatcher", "partition",
                     ping_sock = udp:public_ip:public_port")
 
 modparam("dispatcher", "partition",
-                "prioxies:
+                "proxies:
                     db_url = mysql://user:passwd@localhost/database;
                     table_name = proxies;
                     ping_sock = udp:private_ip:private_port")

--- a/modules/dispatcher/README
+++ b/modules/dispatcher/README
@@ -710,10 +710,24 @@ modparam("dispatcher", "cluster_probing_mode", "distributed")
 1.3.26. partition (string)
 
    Define a new partition (data source) with the following
-   properties: "db_url", "table_name", "dst_avp", "grp_avp",
+   properties: 
+   
+   "db_url", "table_name", "dst_avp", "grp_avp",
    "cnt_avp", "sock_avp", "attrs_avp", "script_attrs",
-   "ds_define_blacklist". All these properties are optional,
-   having appropriate default values.
+   "ds_define_blacklist", "ping_sock"
+   
+   All these properties are optional, having appropriate default values.
+
+   If the OpenSIPS server has multiple interfaces the "ping_sock" can be
+   used to specify the interface to be used for sending pings.
+   
+   For example, a server acting as an SBC may have a public and a private interface.
+   There can be two partitions defined, one for carriers and the other for proxies.
+   Using the "ping_sock" parameter, the server can send pings to the carriers over
+   the public interface and to the proxies over the private interface. Additional
+   value can be realized when multiple SBCs are able to use the same carriers and
+   proxies tables. In this case, each SBC can use its own public and private
+   interfaces to send pings to the carriers and proxies.
 
    The syntax is: "partition_name: param1 = value1; param2 =
    value2". Each value format is the same as the one used to
@@ -742,6 +756,23 @@ modparam("dispatcher", "partition",
                     table_name = dispatcher_trunks;
                     attrs_avp = $avp(ds_attr_trunks)")
 modparam("dispatcher", "partition", "default: trunks")
+...
+
+   Example 1.29.  Define the 'carriers' and 'proxies' partitions
+   using the 'ping_sock' to specify which interface is to be used
+   to send pings.
+...
+modparam("dispatcher", "partition",
+                "carriers:
+                    db_url = mysql://user:passwd@localhost/database;
+                    table_name = carriers;
+                    ping_sock = udp:public_ip:public_port")
+
+modparam("dispatcher", "partition",
+                "prioxies:
+                    db_url = mysql://user:passwd@localhost/database;
+                    table_name = proxies;
+                    ping_sock = udp:private_ip:private_port")
 ...
 
 1.3.27. table_name (string)

--- a/modules/dispatcher/dispatch.c
+++ b/modules/dispatcher/dispatch.c
@@ -2781,7 +2781,9 @@ void ds_check_timer(unsigned int ticks, void* param)
 							&partition->ping_from:
 							&ds_ping_from),
 			&pack->params.uri, NULL, NULL,
-			pack->sock?pack->sock:probing_sock,
+			pack->sock?pack->sock:(partition->ping_sock.len?
+							partition->ping_sock_info:
+							probing_sock),
 			&dlg) != 0 ) {
 				LM_ERR("failed to create new TM dlg\n");
 					continue;

--- a/modules/dispatcher/dispatch.h
+++ b/modules/dispatcher/dispatch.h
@@ -119,6 +119,9 @@ typedef struct _ds_partition
 	str ping_method;
 	int persistent_state;
 
+	str ping_sock;
+	struct socket_info *ping_sock_info;
+
 	db_con_t **db_handle;
 	db_func_t dbf;
 	ds_data_t **data;      /* dispatching data holder */

--- a/modules/dispatcher/dispatcher.c
+++ b/modules/dispatcher/dispatcher.c
@@ -773,7 +773,7 @@ static int partition_init(ds_db_head_t *db_head, ds_partition_t *partition)
 			LM_ERR("cannot duplicate ping_sock\n");
 			return -1;
 		}
-		partition->ping_sock_info = parse_sock_info(&partition->ping_sock);
+		partition->ping_sock_info = (struct socket_info *)parse_sock_info(&partition->ping_sock);
 		if (partition->ping_sock_info==NULL) {
 			LM_ERR("socket <%.*s> is not local to opensips (we must listen "
 				"on it\n", partition->ping_sock.len, partition->ping_sock.s);

--- a/modules/dispatcher/dispatcher.c
+++ b/modules/dispatcher/dispatcher.c
@@ -769,9 +769,10 @@ static int partition_init(ds_db_head_t *db_head, ds_partition_t *partition)
 	}
 
 	if (db_head->ping_sock.s && db_head->ping_sock.len > 0) {
-		if (pkg_str_dup(&partition->ping_sock, &db_head->ping_sock) < 0)
+		if (pkg_str_dup(&partition->ping_sock, &db_head->ping_sock) < 0) {
 			LM_ERR("cannot duplicate ping_sock\n");
-
+			return -1;
+		}
 		partition->ping_sock_info = parse_sock_info(&partition->ping_sock);
 		if (partition->ping_sock_info==NULL) {
 			LM_ERR("socket <%.*s> is not local to opensips (we must listen "

--- a/modules/dispatcher/dispatcher.c
+++ b/modules/dispatcher/dispatcher.c
@@ -99,6 +99,9 @@ typedef struct _ds_db_head
 	str ping_method;
 	str persistent_state;
 
+	str ping_sock;
+	struct socket_info *ping_sock_info;
+
 	struct _ds_db_head *next;
 } ds_db_head_t;
 
@@ -118,6 +121,9 @@ ds_db_head_t default_db_head = {
 	{NULL, -1},
 	{NULL, -1},
 	{"1", 1},
+
+	{NULL, -1},
+	NULL,
 
 	NULL
 };
@@ -420,6 +426,7 @@ DEF_GETTER_FUNC(script_attrs_avp);
 DEF_GETTER_FUNC(ping_from);
 DEF_GETTER_FUNC(ping_method);
 DEF_GETTER_FUNC(persistent_state);
+DEF_GETTER_FUNC(ping_sock);
 
 static partition_specific_param_t partition_params[] = {
 	{str_init("db_url"), {NULL, 0}, GETTER_FUNC(db_url)},
@@ -433,6 +440,7 @@ static partition_specific_param_t partition_params[] = {
 	PARTITION_SPECIFIC_PARAM (ping_from, ""),
 	PARTITION_SPECIFIC_PARAM (ping_method, ""),
 	PARTITION_SPECIFIC_PARAM (persistent_state, "1"),
+	PARTITION_SPECIFIC_PARAM (ping_sock, ""),
 };
 
 static const unsigned int partition_param_count = sizeof (partition_params) /
@@ -483,7 +491,7 @@ static int split_partition_argument(str *arg, str *partition_name)
 	arg->len -= partition_name->len + 1;
 
 	trim(partition_name);
-	for (;arg->s[0] == ' ' && arg->len; ++arg->s, --arg->len);
+	for (;(arg->s[0] == ' ' || arg->s[0] == '\n')  && arg->len; ++arg->s, --arg->len);
 	return 0;
 }
 
@@ -759,6 +767,19 @@ static int partition_init(ds_db_head_t *db_head, ds_partition_t *partition)
 		if (pkg_str_dup(&partition->ping_method, &db_head->ping_method) < 0)
 			LM_ERR("cannot duplicate ping_method\n");
 	}
+
+	if (db_head->ping_sock.s && db_head->ping_sock.len > 0) {
+		if (pkg_str_dup(&partition->ping_sock, &db_head->ping_sock) < 0)
+			LM_ERR("cannot duplicate ping_sock\n");
+
+		partition->ping_sock_info = parse_sock_info(&partition->ping_sock);
+		if (partition->ping_sock_info==NULL) {
+			LM_ERR("socket <%.*s> is not local to opensips (we must listen "
+				"on it\n", partition->ping_sock.len, partition->ping_sock.s);
+			return -1;
+		}
+	}
+
 	partition->persistent_state = ds_persistent_state;
 	if (str_strcmp(&db_head->persistent_state, const_str("0")) ||
 			str_strcmp(&db_head->persistent_state, const_str("no")) ||


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!
In order to consider and evaluate your PR, it is mandatory to provide detailed information about (1) what is the issue the PR addresses, (2) how the PR is solving the issue (logic and coding), (3) what are (if any) limitations of the proposed PR and (4) if there are any known side-effects/ backward compatibility issues/SIP interoperability issues.
Note that if the PR is missing information, it might take longer to be merged, as extra resources have to be allocated by the maintainers to reverse engineer the changes, understand them, understand the motivation, etc. That is why it is important to provide as much information as possible.
-->

**Summary**
<!-- Summary of the PR - what the PR is aiming to solve -->

This PR enhances the dispatcher module. It adds 'ping_sock' to the partition parameter.
The 'ping_sock' can be used to specify, per partition which interface pings / probes are sent from.

**Details**
<!--
Details about the content of the PR - is it a bug fix, a new feature or perhaps a hack? Explain the **motivation** for making this change.
What existing problem does the pull request solve? Is this a particular problem (i.e. only some particular scenarios are affected, only some UACs, etc) or a generic one?
Do not assume others understand what you're trying to do and provide as much information as you may have.
-->

The 'ping_sock' parameter can be used when the OpenSIPS server has multiple interfaces. For example,
when operating as an SBC, the server may have a public interface to communicate with carriers and a private
interface to communicate with proxies.  In this scenario partition tables for carriers can have pings / probes use the public
interface and proxies can use the private interface.

**Solution**
<!-- Explain how your PR fixes the problem. Are there any remaining concerns that might need to be addressed? -->

The dispatcher module currently uses a global "probing_sock" interface to ping / probe destinations. There is no ability to define which interface is to be used to ping / probe a particular set of destinations. This works ok when there is just one "pool" of destinations all more or less handling one function such as "carriers".  When multiple destination classes exist, and are defined in multiple partitions the 'ping_sock' offers the ability to have each partition ping / probe destinations from a different interface.

The dispatcher tables have a 'sock' column, however this is not used for pinging / probing operations. A future enhancement may be for this 'sock' column to be used for pinging / probing also.

**Compatibility**
<!-- Does your change break other scenarios, or do they need to be migrated in order to work similarly? -->

Since this is a new parameter there are no compatibility problems with existing configurations. If the parameter is not specified, the existing flow will continue to be used.

**Closing issues**
<!-- Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). -->
