### PR TITLE
fix: update cloned msg under lock to avoid races with branch injection

### DIFF
--- a/modules/tm/tm.c
+++ b/modules/tm/tm.c
@@ -1333,11 +1333,6 @@ static int w_t_relay( struct sip_msg  *p_msg , void *flags, struct proxy_l *prox
 		tm_has_request_disponsition_no_cancel(p_msg)==0 )
 			t->flags|=T_MULTI_200OK_FLAG;
 
-		/* update the transaction only if in REQUEST route; for other types
-		   of routes we do not want to inherit the local changes */
-		if (route_type==REQUEST_ROUTE)
-			update_cloned_msg_from_msg( t->uas.request, p_msg);
-
 		if (route_type==FAILURE_ROUTE) {
 			/* If called from failure route we need reset the branch counter to
 			 * ignore the previous set of branches (already terminated) */
@@ -1347,6 +1342,12 @@ static int w_t_relay( struct sip_msg  *p_msg , void *flags, struct proxy_l *prox
 			 * created, better lock here to avoid any overlapping with 
 			 * branch injection from other processes */
 			LOCK_REPLIES(t);
+
+			/* update the transaction only if in REQUEST route; for other types
+			   of routes we do not want to inherit the local changes */
+			if (route_type==REQUEST_ROUTE)
+				update_cloned_msg_from_msg( t->uas.request, p_msg);
+
 			ret = t_forward_nonack( t, p_msg, p, 1/*reset*/,1/*locked*/);
 			UNLOCK_REPLIES(t);
 		}


### PR DESCRIPTION
**Summary**
Aims to fix double free crash happening when a branch gets injected into a transaction which has not relayed yet.

**Details**
1. process Y creates the transaction and calls t_wait_for_new_branches() ( either directly or via lookup() )
2. procesX tries to inject a new branch and makes a clone of t.uas.request https://github.com/OpenSIPS/opensips/blob/master/modules/tm/t_fwd.c#L1064
3. proces Y calls t_relay() and updates t.uas.request https://github.com/OpenSIPS/opensips/blob/master/modules/tm/tm.c#L1339, frees old add_rm ( along other old fields ) https://github.com/OpenSIPS/opensips/blob/master/modules/tm/sip_msg.c#L1286
4. procesX tries to free it's fake req, https://github.com/OpenSIPS/opensips/blob/master/modules/tm/t_msgbuilder.h#L403 ,finds a different pointer than the one in t.uas.request, ending in a double free

**Solution**
When doing t_relay(), update the UAS request under lock, to avoid these race conditions

**Compatibility**
Should be backwards compatible
