### PR TITLE
Add support for bigints in JSON ( store as string )

### DIFF
--- a/modules/json/json.c
+++ b/modules/json/json.c
@@ -457,10 +457,16 @@ int pv_get_json_ext(struct sip_msg* msg,  pv_param_t* pvp, pv_value_t* val, int 
 
 	if( json_object_is_type(obj, json_type_int) )
 	{
-		val->rs.s = sint2str(json_object_get_int(obj), &val->rs.len);
-		val->ri = json_object_get_int(obj);;
-		val->flags |= PV_VAL_INT|PV_TYPE_INT|PV_VAL_STR;
-
+		int_value = json_object_get_int64(obj);
+		val->rs.s = sint2str(int_value, &val->rs.len);
+		if (int_value<=INT_MAX && int_value>=INT_MIN) {
+			/* safe to store it as an INT in the pvar */
+			val->ri = int_value;;
+			val->flags |= PV_VAL_INT|PV_TYPE_INT|PV_VAL_STR;
+		} else {
+			/* we would overflow/underflow, store as string only */
+			val->flags |= PV_VAL_STR;
+		}
 	}
 	else if( json_object_is_type(obj, json_type_string))
 	{

--- a/modules/json/json.c
+++ b/modules/json/json.c
@@ -415,6 +415,7 @@ int pv_get_json_ext(struct sip_msg* msg,  pv_param_t* pvp, pv_value_t* val, int 
 	json_t * obj;
 	json_name * id = (json_name *) pvp->pvn.u.dname;
 	UNUSED(id);
+	int64_t int_value;
 
 	if( expand_tag_list( msg, ((json_name *)pvp->pvn.u.dname)->tags ) < 0)
 	{
@@ -461,7 +462,7 @@ int pv_get_json_ext(struct sip_msg* msg,  pv_param_t* pvp, pv_value_t* val, int 
 		val->rs.s = sint2str(int_value, &val->rs.len);
 		if (int_value<=INT_MAX && int_value>=INT_MIN) {
 			/* safe to store it as an INT in the pvar */
-			val->ri = int_value;;
+			val->ri = int_value;
 			val->flags |= PV_VAL_INT|PV_TYPE_INT|PV_VAL_STR;
 		} else {
 			/* we would overflow/underflow, store as string only */


### PR DESCRIPTION
**Summary**
Add support for bigints in JSON

**Details**
In certain scenarios ( like #3533 ), we are processing JSONs which have bigints in them, so we need to properly parse those and export sub-fields in the opensips scripts.

**Solution**
Expose bigints in JSON as string to the opensips script.

**Compatibility**
Backwards compatible
