### PR TITLE
Support HTTP fragmentation

### DIFF
--- a/modules/httpd/doc/httpd_admin.xml
+++ b/modules/httpd/doc/httpd_admin.xml
@@ -193,6 +193,25 @@ modparam("httpd", "post_buf_size", 4096)
 </programlisting>
 		</example>
 	</section>
+
+	<section id="param_receive_buf_size" xreflabel="receive_buf_size">
+		<title><varname>receive_buf_size</varname> (integer)</title>
+		<para>
+		It specifies the maximum length (in bytes) of the received HTTP requests.  
+		For receiving large POST request, the default value might require to be increased.
+		</para>
+		<para>
+		<emphasis> The default value is 1024.</emphasis>
+		</para>
+		<example>
+		<title>Set <varname>receive_buf_size</varname> parameter</title>
+		<programlisting format="linespecific">
+...
+modparam("httpd", "receive_buf_size", 4096)
+...
+</programlisting>
+		</example>
+	</section>
 	<section id="param_tls_cert_file" xreflabel="tls_cert_file">
 		<title><varname>tls_cert_file</varname> (string)</title>
 		<para>

--- a/modules/httpd/httpd.c
+++ b/modules/httpd/httpd.c
@@ -64,8 +64,11 @@ str tls_cert_file = {NULL, 0};
 str tls_key_file = {NULL, 0};
 str tls_ciphers = {"SECURE256:+SECURE192:-VERS-ALL:+VERS-TLS1.2", 45};
 int post_buf_size = DEFAULT_POST_BUF_SIZE;
+int receive_buf_size = DEFAULT_POST_BUF_SIZE;
 struct httpd_cb *httpd_cb_list = NULL;
 
+char *httpd_receive_buff = NULL;
+int httpd_receive_buff_pos=0;
 
 static const proc_export_t mi_procs[] = {
 	{"HTTPD",  0,  0, httpd_proc, 1,
@@ -81,6 +84,7 @@ static const param_export_t params[] = {
 	{"buf_size",      INT_PARAM, &buffer.len},
 	{"conn_timeout",  INT_PARAM, &hd_conn_timeout_s},
 	{"post_buf_size", INT_PARAM, &post_buf_size},
+	{"receive_buf_size", INT_PARAM, &receive_buf_size},
 	{"tls_cert_file", STR_PARAM, &tls_cert_file.s},
 	{"tls_key_file", STR_PARAM,  &tls_key_file.s},
 	{"tls_ciphers", STR_PARAM, &tls_ciphers.s},
@@ -184,6 +188,12 @@ static int mod_init(void)
 	if (buffer.len == 0)
 		buffer.len = (pkg_mem_size/4);
 	LM_DBG("buf_size=[%d]\n", buffer.len);
+
+	httpd_receive_buff = pkg_malloc(receive_buf_size);
+	if (httpd_receive_buff == NULL) {
+		LM_ERR("No more pkg\n");
+		return -1;
+	}
 
 	return 0;
 }


### PR DESCRIPTION
**Summary**
Sometimes, HTTP POST traffic can become fragmented, and the HTTP module does not support it.

**Details**
Enforce fragmentation at the interface layer somehow, and notice how fragmentation breaks httpd mod.

**Solution**
Accumulate HTTP incoming buffer until complete, and only then pass it to the processing layer.

**Compatibility**
Backwards compatible
