### PR TITLE
db_sqlite: new parameters and minor improvements

### DIFF
--- a/modules/db_sqlite/db_sqlite.c
+++ b/modules/db_sqlite/db_sqlite.c
@@ -33,9 +33,6 @@
 #define ALLOC_LIMIT 10
 #define LDEXT_LIST_DELIM ';'
 
-unsigned int db_sqlite_timeout_interval = 2;   /* Default is 6 seconds */
-unsigned int db_sliqte_exec_query_threshold = 0;   /* Warning in case DB query
-											takes too long disabled by default*/
 int db_sqlite_alloc_limit=ALLOC_LIMIT;
 
 

--- a/modules/db_sqlite/db_sqlite.c
+++ b/modules/db_sqlite/db_sqlite.c
@@ -34,13 +34,14 @@
 #define LDEXT_LIST_DELIM ';'
 
 int db_sqlite_alloc_limit=ALLOC_LIMIT;
-
-
+int db_sqlite_busy_timeout = 0;
 
 static int sqlite_mod_init(void);
 static void sqlite_mod_destroy(void);
 static int db_sqlite_add_extension(modparam_t type, void *val);
 struct db_sqlite_extension_list *extension_list=0;
+static int db_sqlite_exec_pragma(modparam_t type, void *val);
+struct db_sqlite_pragma_list *pragma_list=0;
 
 /*
  * SQLite database module interface
@@ -55,8 +56,11 @@ static const cmd_export_t cmds[] = {
  */
 static const param_export_t params[] = {
 	{"alloc_limit", INT_PARAM, &db_sqlite_alloc_limit},
+	{"busy_timeout", INT_PARAM, &db_sqlite_busy_timeout},
 	{"load_extension", STR_PARAM|USE_FUNC_PARAM,
 								(void *)db_sqlite_add_extension},
+	{"exec_pragma", STR_PARAM|USE_FUNC_PARAM,
+								(void *)db_sqlite_exec_pragma},
 	{0, 0, 0}
 };
 
@@ -92,10 +96,17 @@ static int sqlite_mod_init(void)
 static void sqlite_mod_destroy(void)
 {
 	struct db_sqlite_extension_list *foo=NULL;
+	struct db_sqlite_pragma_list *p_iter=NULL;
+	
 	while (extension_list) {
 		foo=extension_list;
 		extension_list=extension_list->next;
 		pkg_free(foo);
+	}
+	while (pragma_list) {
+		p_iter=pragma_list;
+		pragma_list=pragma_list->next;
+		pkg_free(p_iter);
 	}
 }
 
@@ -148,6 +159,24 @@ static int db_sqlite_add_extension(modparam_t type, void *val)
 	/* Reduce the overhead of introducing in the end */
 	node->next=extension_list;
 	extension_list=node;
+
+	return 0;
+out:
+	LM_ERR("no more pkg mem\n");
+	return -1;
+}
+
+static int db_sqlite_exec_pragma(modparam_t type, void *val)
+{
+	struct db_sqlite_pragma_list *node;
+
+	node=pkg_malloc(sizeof(struct db_sqlite_pragma_list));
+	if (!node)
+		goto out;
+
+	node->pragma=(char *)val;
+	node->next=pragma_list;
+	pragma_list=node;
 
 	return 0;
 out:

--- a/modules/db_sqlite/db_sqlite.c
+++ b/modules/db_sqlite/db_sqlite.c
@@ -32,9 +32,10 @@
 #include <sqlite3.h>
 #define ALLOC_LIMIT 10
 #define LDEXT_LIST_DELIM ';'
+#define BUSY_TIMEOUT 500
 
 int db_sqlite_alloc_limit=ALLOC_LIMIT;
-int db_sqlite_busy_timeout = 0;
+int db_sqlite_busy_timeout=BUSY_TIMEOUT;
 
 static int sqlite_mod_init(void);
 static void sqlite_mod_destroy(void);

--- a/modules/db_sqlite/db_sqlite.c
+++ b/modules/db_sqlite/db_sqlite.c
@@ -46,7 +46,7 @@ static int db_sqlite_add_extension(modparam_t type, void *val);
 struct db_sqlite_extension_list *extension_list=0;
 
 /*
- * MySQL database module interface
+ * SQLite database module interface
  */
 static const cmd_export_t cmds[] = {
 	{"db_bind_api", (cmd_function)db_sqlite_bind_api, {{0,0,0}},0},

--- a/modules/db_sqlite/db_sqlite.h
+++ b/modules/db_sqlite/db_sqlite.h
@@ -32,6 +32,12 @@ struct db_sqlite_extension_list {
 	struct db_sqlite_extension_list *next;
 };
 
+struct db_sqlite_pragma_list {
+	char *pragma;
+
+	struct db_sqlite_pragma_list *next;
+};
+
 int db_sqlite_bind_api(const str* mod, db_func_t *dbb);
 
 #endif

--- a/modules/db_sqlite/dbase.c
+++ b/modules/db_sqlite/dbase.c
@@ -117,10 +117,7 @@ db_sqlite_get_query_rows(const db_con_t* _h, const str* query, const db_val_t* _
 	int ret;
 	sqlite3_stmt* stmt;
 
-again:
 	ret=sqlite3_prepare_v2(CON_CONNECTION(_h), query->s, query->len, &stmt, NULL);
-	if (ret == SQLITE_BUSY)
-		goto again;
 
 	if (ret != SQLITE_OK) {
 		LM_ERR("failed to prepare query\n");
@@ -134,11 +131,7 @@ again:
 	}
 #endif
 
-again2:
 	ret=sqlite3_step(stmt);
-	if (ret == SQLITE_BUSY)
-		goto again2;
-
 	if (ret != SQLITE_ROW) {
 		sqlite3_finalize(stmt);
 		LM_ERR("failed to fetch query size\n");
@@ -180,12 +173,9 @@ int db_sqlite_query(const db_con_t* _h, const db_key_t* _k, const db_op_t* _op,
 	}
 
 
-again:
 	ret=sqlite3_prepare_v2(CON_CONNECTION(_h),
 				query_holder.s, query_holder.len, &CON_SQLITE_PS(_h), NULL);
 
-	if (ret==SQLITE_BUSY)
-		goto again;
 	if (ret!=SQLITE_OK)
 		LM_ERR("failed to prepare: (%s)\n", sqlite3_errmsg(CON_CONNECTION(_h)));
 
@@ -383,11 +373,8 @@ int db_sqlite_raw_query(const db_con_t* _h, const str* _s, db_res_t** _r)
 		return -1;
 	}
 
-again:
 	ret=sqlite3_prepare_v2(CON_CONNECTION(_h),
 				_s->s, _s->len, &CON_SQLITE_PS(_h), NULL);
-	if (ret==SQLITE_BUSY)
-		goto again;
 	if (ret!=SQLITE_OK)
 		LM_ERR("failed to prepare: (%s)\n",
 				sqlite3_errmsg(CON_CONNECTION(_h)));
@@ -432,11 +419,8 @@ int db_sqlite_insert(const db_con_t* _h, const db_key_t* _k, const db_val_t* _v,
 		return ret;
 	}
 
-again:
 	ret=sqlite3_prepare_v2(CON_CONNECTION(_h),
 			query_holder.s, query_holder.len, &stmt, NULL);
-	if (ret==SQLITE_BUSY)
-		goto again;
 	if (ret!=SQLITE_OK)
 		LM_ERR("failed to prepare: (%s)\n",
 				sqlite3_errmsg(CON_CONNECTION(_h)));
@@ -448,10 +432,7 @@ again:
 	}
 #endif
 
-again2:
 	ret = sqlite3_step(stmt);
-	if (ret==SQLITE_BUSY)
-		goto again2;
 
 	if (ret != SQLITE_DONE) {
 		LM_ERR("insert query failed %s\n", sqlite3_errmsg(CON_CONNECTION(_h)));
@@ -492,11 +473,8 @@ int db_sqlite_delete(const db_con_t* _h, const db_key_t* _k, const db_op_t* _o,
 	}
 
 
-again:
 	ret=sqlite3_prepare_v2(CON_CONNECTION(_h),
 			query_holder.s, query_holder.len, &stmt, NULL);
-	if (ret==SQLITE_BUSY)
-		goto again;
 	if (ret!=SQLITE_OK)
 		LM_ERR("failed to prepare: (%s)\n",
 				sqlite3_errmsg(CON_CONNECTION(_h)));
@@ -508,10 +486,7 @@ again:
 	}
 #endif
 
-again2:
 	ret = sqlite3_step(stmt);
-	if (ret==SQLITE_BUSY)
-		goto again2;
 
 	if (ret != SQLITE_DONE) {
 		LM_ERR("insert query failed %s\n", sqlite3_errmsg(CON_CONNECTION(_h)));
@@ -554,11 +529,8 @@ int db_sqlite_update(const db_con_t* _h, const db_key_t* _k, const db_op_t* _o,
 		return ret;
 	}
 
-again:
 	ret=sqlite3_prepare_v2(CON_CONNECTION(_h),
 			query_holder.s, query_holder.len, &stmt, NULL);
-	if (ret==SQLITE_BUSY)
-		goto again;
 	if (ret!=SQLITE_OK)
 		LM_ERR("failed to prepare: (%s)\n",
 				sqlite3_errmsg(CON_CONNECTION(_h)));
@@ -571,10 +543,7 @@ again:
 	}
 #endif
 
-again2:
 	ret = sqlite3_step(stmt);
-	if (ret==SQLITE_BUSY)
-		goto again2;
 
 	if (ret != SQLITE_DONE) {
 		LM_ERR("insert query failed %s\n", sqlite3_errmsg(CON_CONNECTION(_h)));
@@ -611,11 +580,8 @@ int db_sqlite_replace(const db_con_t* _h, const db_key_t* _k, const db_val_t* _v
 		return ret;
 	}
 
-again:
 	ret=sqlite3_prepare_v2(CON_CONNECTION(_h),
 			query_holder.s, query_holder.len, &stmt, NULL);
-	if (ret==SQLITE_BUSY)
-		goto again;
 	if (ret!=SQLITE_OK)
 		LM_ERR("failed to prepare: (%s)\n",
 				sqlite3_errmsg(CON_CONNECTION(_h)));
@@ -627,10 +593,7 @@ again:
 	}
 #endif
 
-again2:
 	ret = sqlite3_step(stmt);
-	if (ret==SQLITE_BUSY)
-		goto again2;
 
 	if (ret != SQLITE_DONE) {
 		LM_ERR("insert query failed %s\n", sqlite3_errmsg(CON_CONNECTION(_h)));
@@ -704,11 +667,8 @@ int db_last_inserted_id(const db_con_t* _h)
 	sql_str.s = sql_buf;
 	sql_str.len = off;
 
-again:
 	ret=sqlite3_prepare_v2(CON_CONNECTION(_h),
 			sql_str.s, sql_str.len, &stmt, NULL);
-	if (ret==SQLITE_BUSY)
-		goto again;
 	if (ret!=SQLITE_OK)
 		LM_ERR("failed to prepare: (%s)\n",
 				sqlite3_errmsg(CON_CONNECTION(_h)));
@@ -720,10 +680,7 @@ again:
 	}
 #endif
 
-again2:
 	ret = sqlite3_step(stmt);
-	if (ret==SQLITE_BUSY)
-		goto again2;
 
 	if (ret != SQLITE_DONE) {
 		LM_ERR("insert query failed %s\n", sqlite3_errmsg(CON_CONNECTION(_h)));

--- a/modules/db_sqlite/dbase.c
+++ b/modules/db_sqlite/dbase.c
@@ -34,7 +34,7 @@
 #include "../../db/db_ut.h"
 #include "../../db/db_insertq.h"
 #include "../../db/db_res.h"
-#include "my_con.h"
+#include "sqlite_con.h"
 #include "val.h"
 #include "res.h"
 #include "row.h"

--- a/modules/db_sqlite/doc/db_sqlite_admin.xml
+++ b/modules/db_sqlite/doc/db_sqlite_admin.xml
@@ -116,7 +116,7 @@ modparam("db_sqlite", "load_extension", "/usr/lib/sqlite3/pcre.so;sqlite3_extens
 		</para>
 		<para>
 		<emphasis>
-			Default value is 0.
+			Default value is 500.
 		</emphasis>
 		</para>
 		<example>

--- a/modules/db_sqlite/doc/db_sqlite_admin.xml
+++ b/modules/db_sqlite/doc/db_sqlite_admin.xml
@@ -94,7 +94,7 @@ modparam("db_sqlite", "alloc_limit", 25)
 		</emphasis>
 		</para>
 		<example>
-		<title>Set <varname>db_sqlite_alloc_limit</varname> parameter</title>
+		<title>Set <varname>load_extension</varname> parameter</title>
 		<programlisting format="linespecific">
 ...
 modparam("db_sqlite", "load_extension", "/usr/lib/sqlite3/pcre.so")
@@ -103,7 +103,57 @@ modparam("db_sqlite", "load_extension", "/usr/lib/sqlite3/pcre.so;sqlite3_extens
 </programlisting>
 		</example>
 	</section>
-
+	<section id="param_busy_timeout" xreflabel="busy_timeout">
+		<title><varname>busy_timeout</varname> (integer)</title>
+		<para>
+		This parameter sets the default busy_handler for the SQLite library, that sleeps for 
+		a specified amount of time when a table is locked. The handler will sleep multiple 
+		times until at least the specified "busy_timeout" duration (in milliseconds) has been 
+		reached. Setting this parameter to a value less than or equal to zero turns off all 
+		busy handlers. (read more in the  
+		<ulink url="https://www.sqlite.org/capi3ref.html#sqlite3_busy_timeout">SQLite 
+		official documentation</ulink>)
+		</para>
+		<para>
+		<emphasis>
+			Default value is 0.
+		</emphasis>
+		</para>
+		<example>
+		<title>Set <varname>busy_timeout</varname> parameter</title>
+		<programlisting format="linespecific">
+...
+modparam("db_sqlite", "busy_timeout", 5000)
+...
+</programlisting>
+		</example>
+	</section>
+	<section id="param_exec_pragma" xreflabel="exec_pragma">
+		<title><varname>exec_pragma</varname> (string)</title>
+		<para>
+		This parameter allows configuring an SQLite database with "PRAGMA" statements, (read 
+		more in the <ulink url="https://sqlite.org/pragma.html">SQLite official documentation</ulink>)
+		To use this functionality you must specify the exec_pragma parameter value as
+		"pragma-name=pragma-value". Multiple parameters with the same name can be specified, 
+		and they will be executed one by one on every database connection. If a parameter has an 
+		incorrect name or syntax, it will be ignored by SQLite without any error messages.
+		</para>
+		<para>
+		<emphasis>
+			By default, no PRAGMA statements are executed.
+		</emphasis>
+		</para>
+		<example>
+		<title>Set <varname>exec_pragma</varname> parameter</title>
+		<programlisting format="linespecific">
+...
+modparam("db_sqlite", "exec_pragma", "journal_mode=wal")
+modparam("db_sqlite", "exec_pragma", "synchronous=normal")
+modparam("db_sqlite", "exec_pragma", "cache_size=-2000")
+...
+</programlisting>
+		</example>
+	</section>
 	</section>
 	<section id="exported_functions" xreflabel="exported_functions">
 	<title>Exported Functions</title>

--- a/modules/db_sqlite/res.c
+++ b/modules/db_sqlite/res.c
@@ -34,7 +34,7 @@
 #include "../../db/db_insertq.h"
 #include "../../db/db_res.h"
 #include "../../ut.h"
-#include "my_con.h"
+#include "sqlite_con.h"
 #include "row.h"
 
 

--- a/modules/db_sqlite/res.c
+++ b/modules/db_sqlite/res.c
@@ -374,8 +374,6 @@ static inline int db_sqlite_convert_rows(const db_con_t* _h, db_res_t* _r)
 
 	while (ret != SQLITE_DONE) {
 		ret = sqlite3_step(CON_SQLITE_PS(_h));
-		if (ret == SQLITE_BUSY)
-			continue;
 
 		if (ret == SQLITE_DONE) {
 			RES_ROW_N(_r) = RES_LAST_ROW(_r) = RES_NUM_ROWS(_r) = row;

--- a/modules/db_sqlite/row.c
+++ b/modules/db_sqlite/row.c
@@ -29,7 +29,7 @@
 #include "../../db/db_ut.h"
 #include "../../db/db_val.h"
 #include "../../db/db_row.h"
-#include "my_con.h"
+#include "sqlite_con.h"
 #include "val.h"
 #include "row.h"
 

--- a/modules/db_sqlite/sqlite_con.c
+++ b/modules/db_sqlite/sqlite_con.c
@@ -34,7 +34,7 @@
 #include "../../db/db_insertq.h"
 #include "../../db/db_id.h"
 #include "../../mem/mem.h"
-#include "my_con.h"
+#include "sqlite_con.h"
 #include "db_sqlite.h"
 
 extern struct db_sqlite_extension_list *extension_list;
@@ -43,7 +43,7 @@ extern struct db_sqlite_extension_list *extension_list;
 #define URL_BUFSIZ 1024
 char url_buf[URL_BUFSIZ];
 
-int db_sqlite_connect(struct my_con* ptr)
+int db_sqlite_connect(struct sqlite_con* ptr)
 {
 	sqlite3* con;
 	char* errmsg;
@@ -110,23 +110,23 @@ out_free:
  * Create a new connection structure,
  * open the sqlite connection and set reference count to 1
  */
-struct my_con* db_sqlite_new_connection(const struct db_id* id)
+struct sqlite_con* db_sqlite_new_connection(const struct db_id* id)
 {
 
-	struct my_con* ptr;
+	struct sqlite_con* ptr;
 
 	if (!id) {
 		LM_ERR("invalid parameter value\n");
 		return 0;
 	}
 
-	ptr = (struct my_con*)pkg_malloc(sizeof(struct my_con));
+	ptr = (struct sqlite_con*)pkg_malloc(sizeof(struct sqlite_con));
 	if (!ptr) {
 		LM_ERR("no private memory left\n");
 		return 0;
 	}
 
-	memset(ptr, 0, sizeof(struct my_con));
+	memset(ptr, 0, sizeof(struct sqlite_con));
 	ptr->ref = 1;
 
 	ptr->id = (struct db_id*)id;
@@ -149,8 +149,8 @@ void db_sqlite_free_connection(struct pool_con* con)
 {
 	if (!con) return;
 
-	struct my_con * _c;
-	_c = (struct my_con*) con;
+	struct sqlite_con * _c;
+	_c = (struct sqlite_con*) con;
 
 	if (_c->id) free_db_id(_c->id);
 	if (_c->con) {

--- a/modules/db_sqlite/sqlite_con.c
+++ b/modules/db_sqlite/sqlite_con.c
@@ -60,7 +60,7 @@ int db_sqlite_connect(struct sqlite_con* ptr)
 	url_buf[ptr->id->url.len - (sizeof(SQLITE_ID)-1)] = '\0';
 
 	if (sqlite3_open(url_buf, &con) != SQLITE_OK) {
-		LM_ERR("Can't open database: %s\n", sqlite3_errmsg((sqlite3*)ptr->con));
+		LM_ERR("Can't open database: %s\n", sqlite3_errmsg(con));
 		return -1;
 	}
 
@@ -90,8 +90,6 @@ int db_sqlite_connect(struct sqlite_con* ptr)
 			return -1;
 		}
 	}
-
-
 
 	ptr->con = con;
 

--- a/modules/db_sqlite/sqlite_con.c
+++ b/modules/db_sqlite/sqlite_con.c
@@ -66,8 +66,8 @@ int db_sqlite_connect(struct sqlite_con* ptr)
 
 	/* trying to load extensions */
 	if (extension_list) {
-		if (sqlite3_enable_load_extension(con, 1)) {
-			LM_ERR("failed to enable extension loading\n");
+		if (sqlite3_db_config(con, SQLITE_DBCONFIG_ENABLE_LOAD_EXTENSION, 1, NULL) != SQLITE_OK) {
+			LM_ERR("failed to enable extension loading: %s\n", sqlite3_errmsg(con));
 			return -1;
 		}
 
@@ -86,8 +86,8 @@ int db_sqlite_connect(struct sqlite_con* ptr)
 			LM_DBG("Extension [%s] loaded!\n", iter->ldpath);
 		}
 
-		if (sqlite3_enable_load_extension(con, 0)) {
-			LM_ERR("failed to enable extension loading\n");
+		if (sqlite3_db_config(con, SQLITE_DBCONFIG_ENABLE_LOAD_EXTENSION, 0, NULL) != SQLITE_OK) {
+			LM_ERR("failed to disable extension loading: %s\n", sqlite3_errmsg(con));
 			return -1;
 		}
 	}

--- a/modules/db_sqlite/sqlite_con.c
+++ b/modules/db_sqlite/sqlite_con.c
@@ -80,6 +80,7 @@ int db_sqlite_connect(struct sqlite_con* ptr)
 						"Errmsg [%s]!\n",
 						iter->ldpath, iter->entry_point,
 						errmsg);
+				sqlite3_free(errmsg);
 				goto out_free;
 			}
 			LM_DBG("Extension [%s] loaded!\n", iter->ldpath);

--- a/modules/db_sqlite/sqlite_con.h
+++ b/modules/db_sqlite/sqlite_con.h
@@ -22,14 +22,14 @@
  * -------
  *  2015-02-18  initial version (Ionut Ionita)
 */
-#ifndef MY_SQLITE_CON_H
-#define MY_SQLITE_CON_H
+#ifndef SQLITE_CON_H
+#define SQLITE_CON_H
 #define PREP_STMT_VAL_LEN	1024
 
 #include <sqlite3.h>
 
 
-struct my_con {
+struct sqlite_con {
 	struct db_id* id;        /**< Connection identifier */
 	unsigned int ref;        /**< Reference count */
 	struct pool_con *async_pool; /**< Subpool of identical database handles */
@@ -43,38 +43,38 @@ struct my_con {
 	sqlite3* con;              /* Connection representation */
 	sqlite3_stmt* curr_ps;
 	int			curr_ps_rows;
-	unsigned int init;       /* If the mysql conn was initialized */
+	unsigned int init;       /* If the sqlite conn was initialized */
 
 	struct prep_stmt *ps_list; /* list of prepared statements */
 };
 
-struct my_stmt_ctx {
+struct sqlite_stmt_ctx {
 	sqlite3_stmt *stmt;
 	str query;
 	int query_rows;
 
-	struct my_stmt_ctx *next;
+	struct sqlite_stmt_ctx *next;
 };
 
 struct prep_stmt {
-	struct my_stmt_ctx *stmt_list;
-	struct my_stmt_ctx *ctx;
+	struct sqlite_stmt_ctx *stmt_list;
+	struct sqlite_stmt_ctx *ctx;
 };
 
 
-#define CON_CONNECTION(db_con) (((struct my_con*)((db_con)->tail))->con)
-#define CON_ROW(db_con)        (((struct my_con*)((db_con)->tail))->row)
-#define CON_SQLITE_PS(db_con)  (((struct my_con*)((db_con)->tail))->curr_ps)
-#define CON_RAW_QUERY(db_con)  (((struct my_con*)((db_con)->tail))->raw_query)
-#define CON_PS_ROWS(db_con)  (((struct my_con*)((db_con)->tail))->curr_ps_rows)
-#define CON_DISCON(db_con)     (((struct my_con*)((db_con)->tail))->disconnected)
+#define CON_CONNECTION(db_con) (((struct sqlite_con*)((db_con)->tail))->con)
+#define CON_ROW(db_con)        (((struct sqlite_con*)((db_con)->tail))->row)
+#define CON_SQLITE_PS(db_con)  (((struct sqlite_con*)((db_con)->tail))->curr_ps)
+#define CON_RAW_QUERY(db_con)  (((struct sqlite_con*)((db_con)->tail))->raw_query)
+#define CON_PS_ROWS(db_con)  (((struct sqlite_con*)((db_con)->tail))->curr_ps_rows)
+#define CON_DISCON(db_con)     (((struct sqlite_con*)((db_con)->tail))->disconnected)
 
 
 
 
 
-int db_sqlite_connect(struct my_con* ptr);
-struct my_con* db_sqlite_new_connection(const struct db_id* id);
+int db_sqlite_connect(struct sqlite_con* ptr);
+struct sqlite_con* db_sqlite_new_connection(const struct db_id* id);
 void db_sqlite_free_connection(struct pool_con* con);
 
-#endif /* MY_SQLITE_CON_H */
+#endif /* SQLITE_CON_H */

--- a/modules/db_sqlite/val.c
+++ b/modules/db_sqlite/val.c
@@ -27,7 +27,7 @@
 #include "../../db/db_ut.h"
 #include "../../db/db_query.h"
 #include "val.h"
-#include "my_con.h"
+#include "sqlite_con.h"
 
 #include <string.h>
 #include <stdio.h>


### PR DESCRIPTION
**Summary**
- Fix uninitialized memory access
- Remove unused variables
- Free memory for errmsg variables
- Add new parameters to the module to configure the behavior of the database
- Rename prefixes and names from old copy/paste
- Use recommended by SQLite documentation way of processing locked state

**Details**
The PR was started as new feature, but fixed some issues during implementation.

**Solution**
Please review commits

**Compatibility**
The original behavior has been changed. If the database is locked, the process attempting to access it will no longer enter an infinite loop. Instead, it will return an error after the default timeout of 500 ms (this value can be modified as module parameter).
