### PR TITLE
Minor fixes to db_sqlite module

### DIFF
--- a/modules/db_sqlite/db_sqlite.c
+++ b/modules/db_sqlite/db_sqlite.c
@@ -33,9 +33,6 @@
 #define ALLOC_LIMIT 10
 #define LDEXT_LIST_DELIM ';'
 
-unsigned int db_sqlite_timeout_interval = 2;   /* Default is 6 seconds */
-unsigned int db_sliqte_exec_query_threshold = 0;   /* Warning in case DB query
-											takes too long disabled by default*/
 int db_sqlite_alloc_limit=ALLOC_LIMIT;
 
 

--- a/modules/db_sqlite/db_sqlite.c
+++ b/modules/db_sqlite/db_sqlite.c
@@ -46,7 +46,7 @@ static int db_sqlite_add_extension(modparam_t type, void *val);
 struct db_sqlite_extension_list *extension_list=0;
 
 /*
- * MySQL database module interface
+ * SQLite database module interface
  */
 static const cmd_export_t cmds[] = {
 	{"db_bind_api", (cmd_function)db_sqlite_bind_api, {{0,0,0}},0},

--- a/modules/db_sqlite/dbase.c
+++ b/modules/db_sqlite/dbase.c
@@ -34,7 +34,7 @@
 #include "../../db/db_ut.h"
 #include "../../db/db_insertq.h"
 #include "../../db/db_res.h"
-#include "my_con.h"
+#include "sqlite_con.h"
 #include "val.h"
 #include "res.h"
 #include "row.h"

--- a/modules/db_sqlite/res.c
+++ b/modules/db_sqlite/res.c
@@ -34,7 +34,7 @@
 #include "../../db/db_insertq.h"
 #include "../../db/db_res.h"
 #include "../../ut.h"
-#include "my_con.h"
+#include "sqlite_con.h"
 #include "row.h"
 
 

--- a/modules/db_sqlite/row.c
+++ b/modules/db_sqlite/row.c
@@ -29,7 +29,7 @@
 #include "../../db/db_ut.h"
 #include "../../db/db_val.h"
 #include "../../db/db_row.h"
-#include "my_con.h"
+#include "sqlite_con.h"
 #include "val.h"
 #include "row.h"
 

--- a/modules/db_sqlite/sqlite_con.c
+++ b/modules/db_sqlite/sqlite_con.c
@@ -34,7 +34,7 @@
 #include "../../db/db_insertq.h"
 #include "../../db/db_id.h"
 #include "../../mem/mem.h"
-#include "my_con.h"
+#include "sqlite_con.h"
 #include "db_sqlite.h"
 
 extern struct db_sqlite_extension_list *extension_list;
@@ -43,7 +43,7 @@ extern struct db_sqlite_extension_list *extension_list;
 #define URL_BUFSIZ 1024
 char url_buf[URL_BUFSIZ];
 
-int db_sqlite_connect(struct my_con* ptr)
+int db_sqlite_connect(struct sqlite_con* ptr)
 {
 	sqlite3* con;
 	char* errmsg;
@@ -110,23 +110,23 @@ out_free:
  * Create a new connection structure,
  * open the sqlite connection and set reference count to 1
  */
-struct my_con* db_sqlite_new_connection(const struct db_id* id)
+struct sqlite_con* db_sqlite_new_connection(const struct db_id* id)
 {
 
-	struct my_con* ptr;
+	struct sqlite_con* ptr;
 
 	if (!id) {
 		LM_ERR("invalid parameter value\n");
 		return 0;
 	}
 
-	ptr = (struct my_con*)pkg_malloc(sizeof(struct my_con));
+	ptr = (struct sqlite_con*)pkg_malloc(sizeof(struct sqlite_con));
 	if (!ptr) {
 		LM_ERR("no private memory left\n");
 		return 0;
 	}
 
-	memset(ptr, 0, sizeof(struct my_con));
+	memset(ptr, 0, sizeof(struct sqlite_con));
 	ptr->ref = 1;
 
 	ptr->id = (struct db_id*)id;
@@ -149,8 +149,8 @@ void db_sqlite_free_connection(struct pool_con* con)
 {
 	if (!con) return;
 
-	struct my_con * _c;
-	_c = (struct my_con*) con;
+	struct sqlite_con * _c;
+	_c = (struct sqlite_con*) con;
 
 	if (_c->id) free_db_id(_c->id);
 	if (_c->con) {

--- a/modules/db_sqlite/sqlite_con.c
+++ b/modules/db_sqlite/sqlite_con.c
@@ -60,7 +60,7 @@ int db_sqlite_connect(struct sqlite_con* ptr)
 	url_buf[ptr->id->url.len - (sizeof(SQLITE_ID)-1)] = '\0';
 
 	if (sqlite3_open(url_buf, &con) != SQLITE_OK) {
-		LM_ERR("Can't open database: %s\n", sqlite3_errmsg((sqlite3*)ptr->con));
+		LM_ERR("Can't open database: %s\n", sqlite3_errmsg(con));
 		return -1;
 	}
 
@@ -90,8 +90,6 @@ int db_sqlite_connect(struct sqlite_con* ptr)
 			return -1;
 		}
 	}
-
-
 
 	ptr->con = con;
 

--- a/modules/db_sqlite/sqlite_con.c
+++ b/modules/db_sqlite/sqlite_con.c
@@ -80,6 +80,7 @@ int db_sqlite_connect(struct sqlite_con* ptr)
 						"Errmsg [%s]!\n",
 						iter->ldpath, iter->entry_point,
 						errmsg);
+				sqlite3_free(errmsg);
 				goto out_free;
 			}
 			LM_DBG("Extension [%s] loaded!\n", iter->ldpath);

--- a/modules/db_sqlite/sqlite_con.h
+++ b/modules/db_sqlite/sqlite_con.h
@@ -22,14 +22,14 @@
  * -------
  *  2015-02-18  initial version (Ionut Ionita)
 */
-#ifndef MY_SQLITE_CON_H
-#define MY_SQLITE_CON_H
+#ifndef SQLITE_CON_H
+#define SQLITE_CON_H
 #define PREP_STMT_VAL_LEN	1024
 
 #include <sqlite3.h>
 
 
-struct my_con {
+struct sqlite_con {
 	struct db_id* id;        /**< Connection identifier */
 	unsigned int ref;        /**< Reference count */
 	struct pool_con *async_pool; /**< Subpool of identical database handles */
@@ -43,38 +43,38 @@ struct my_con {
 	sqlite3* con;              /* Connection representation */
 	sqlite3_stmt* curr_ps;
 	int			curr_ps_rows;
-	unsigned int init;       /* If the mysql conn was initialized */
+	unsigned int init;       /* If the sqlite conn was initialized */
 
 	struct prep_stmt *ps_list; /* list of prepared statements */
 };
 
-struct my_stmt_ctx {
+struct sqlite_stmt_ctx {
 	sqlite3_stmt *stmt;
 	str query;
 	int query_rows;
 
-	struct my_stmt_ctx *next;
+	struct sqlite_stmt_ctx *next;
 };
 
 struct prep_stmt {
-	struct my_stmt_ctx *stmt_list;
-	struct my_stmt_ctx *ctx;
+	struct sqlite_stmt_ctx *stmt_list;
+	struct sqlite_stmt_ctx *ctx;
 };
 
 
-#define CON_CONNECTION(db_con) (((struct my_con*)((db_con)->tail))->con)
-#define CON_ROW(db_con)        (((struct my_con*)((db_con)->tail))->row)
-#define CON_SQLITE_PS(db_con)  (((struct my_con*)((db_con)->tail))->curr_ps)
-#define CON_RAW_QUERY(db_con)  (((struct my_con*)((db_con)->tail))->raw_query)
-#define CON_PS_ROWS(db_con)  (((struct my_con*)((db_con)->tail))->curr_ps_rows)
-#define CON_DISCON(db_con)     (((struct my_con*)((db_con)->tail))->disconnected)
+#define CON_CONNECTION(db_con) (((struct sqlite_con*)((db_con)->tail))->con)
+#define CON_ROW(db_con)        (((struct sqlite_con*)((db_con)->tail))->row)
+#define CON_SQLITE_PS(db_con)  (((struct sqlite_con*)((db_con)->tail))->curr_ps)
+#define CON_RAW_QUERY(db_con)  (((struct sqlite_con*)((db_con)->tail))->raw_query)
+#define CON_PS_ROWS(db_con)  (((struct sqlite_con*)((db_con)->tail))->curr_ps_rows)
+#define CON_DISCON(db_con)     (((struct sqlite_con*)((db_con)->tail))->disconnected)
 
 
 
 
 
-int db_sqlite_connect(struct my_con* ptr);
-struct my_con* db_sqlite_new_connection(const struct db_id* id);
+int db_sqlite_connect(struct sqlite_con* ptr);
+struct sqlite_con* db_sqlite_new_connection(const struct db_id* id);
 void db_sqlite_free_connection(struct pool_con* con);
 
-#endif /* MY_SQLITE_CON_H */
+#endif /* SQLITE_CON_H */

--- a/modules/db_sqlite/val.c
+++ b/modules/db_sqlite/val.c
@@ -27,7 +27,7 @@
 #include "../../db/db_ut.h"
 #include "../../db/db_query.h"
 #include "val.h"
-#include "my_con.h"
+#include "sqlite_con.h"
 
 #include <string.h>
 #include <stdio.h>


### PR DESCRIPTION
**Summary**
Fixed several minor issues:
- Rename prefixes and names from old copy/paste
- Fix uninitialized memory access
- Remove unused variables
- Free memory for errmsg variables

**Solution**
Please review the commits

**Compatibility**
PR does not change the behavior.
