### PR TITLE
Add support for MySQL UNIX Socket connections

### DIFF
--- a/db/db_id.h
+++ b/db/db_id.h
@@ -43,6 +43,7 @@ struct db_id {
 	char* username;      /**< Username, case sensitive */
 	char* password;      /**< Password, case sensitive */
 	char* host;          /**< Host or IP, case insensitive */
+	char* unix_socket;   /**< Unix socket location */
 	unsigned short port; /**< Port number */
 	char* database;      /**< Database, case sensitive */
 	char *parameters;	 /**< Parameters, case sensitive */

--- a/db/doc/db-api.txt
+++ b/db/doc/db-api.txt
@@ -338,6 +338,7 @@ prefix). This function MUST be called __FIRST__ !
 The function takes two parameters, the first parameter must contain a database 
 connection URL or a database module name. The db_url is of the form 
 "mysql://username:password@host:port/database" or
+"mysql://username:password@unix(/named/socket/location)/database or
 "mysql" (database module name).
 In the case of a database connection URL, this function looks only at the first
 token (the database protocol). In the example above that would be "mysql":
@@ -368,7 +369,8 @@ function is called.
 
 The function takes one parameter, the parameter must contain database 
 connection URL. The URL is of the form 
-mysql://username:password@host:port/database where:
+mysql://username:password@host:port/database or
+mysql://username:password@unix(/named/socket/location)/database where:
 
 username: Username to use when logging into database (optional).
 password: password if it was set (optional)
@@ -376,6 +378,9 @@ host:     Hosname or IP address of the host where database server lives
           (mandatory)
 port:     Port number of the server if the port differs from default value 
           (optional)
+unix:    Indicates that a named socket location within parens follows.
+         If this is specified, the host and port are not allowed. The
+         host is internally set to "localhost".
 database: If the database server supports multiple databases, you must specify 
           name of the database (optional).
 

--- a/modules/db_mysql/my_con.c
+++ b/modules/db_mysql/my_con.c
@@ -171,6 +171,9 @@ int db_mysql_connect(struct my_con* ptr)
 	if (ptr->id->port) {
 		LM_DBG("opening connection: mysql://xxxx:xxxx@%s:%d/%s\n",
 			ZSW(ptr->id->host), ptr->id->port, ZSW(ptr->id->database));
+	} else if (ptr->id->unix_socket) {
+		LM_DBG("opening connection: mysql://xxxx:xxxx@unix(%s)/%s\n",
+			ZSW(ptr->id->unix_socket), ZSW(ptr->id->database));
 	} else {
 		LM_DBG("opening connection: mysql://xxxx:xxxx@%s/%s\n",
 			ZSW(ptr->id->host), ZSW(ptr->id->database));
@@ -178,7 +181,7 @@ int db_mysql_connect(struct my_con* ptr)
 
 	if (!mysql_real_connect(ptr->con, ptr->id->host,
 			ptr->id->username, ptr->id->password,
-			ptr->id->database, ptr->id->port, 0,
+			ptr->id->database, ptr->id->port, ptr->id->unix_socket,
 #if (MYSQL_VERSION_ID >= 40100)
 			CLIENT_MULTI_STATEMENTS|CLIENT_REMEMBER_OPTIONS
 #else


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!
In order to consider and evaluate your PR, it is mandatory to provide detailed information about (1) what is the issue the PR addresses, (2) how the PR is solving the issue (logic and coding), (3) what are (if any) limitations of the proposed PR and (4) if there are any known side-effects/ backward compatibility issues/SIP interoperability issues.
Note that if the PR is missing information, it might take longer to be merged, as extra resources have to be allocated by the maintainers to reverse engineer the changes, understand them, understand the motivation, etc. That is why it is important to provide as much information as possible.
-->

**Summary**
<!-- Summary of the PR - what the PR is aiming to solve -->
This PR adds support for MySQL UNIX Socket connections.

**Details**
<!--
Details about the content of the PR - is it a bug fix, a new feature or perhaps a hack? Explain the **motivation** for making this change.
What existing problem does the pull request solve? Is this a particular problem (i.e. only some particular scenarios are affected, only some UACs, etc) or a generic one?
Do not assume others understand what you're trying to do and provide as much information as you may have.
-->
OpenSIPS traditionally communicates with MySQL using the network stack. Often times OpenSIPS runs within a Docker container. When MySQL also runs within a Docker container on the same server a performance improvement can be achieved by removing the network stack communication and replacing it with UNIX sockets.

**Solution**
<!-- Explain how your PR fixes the problem. Are there any remaining concerns that might need to be addressed? -->
MySQL supports UNIX socket communication and its C API exposes the mysql_real_connect() function contains a "unix_socket" parameter. Prior to this PR, the "unix_socket" parameter is hard-coded to NULL indicating that is is not used.

This PR enhances the db_url parsing logic to add the ability to specify a UNIX Socket named path. When a UNIX Socket is specified, the "host" and "port" parameters are no longer parsed by the db_url parsing logic. Note that when a UNIX Socket is specified, the MySQL documentation indicates that the "host" must be set to NULL or "localhost". This PR sets the "host" to "localhost" when a UNIX Socket is specified.

The db_url parsing will recognize the following db_url modparam as shown in this example:

modparam("usrloc", "db_url", "mysql://opensips:opensipsrw@unix(/var/run/mysqld/mysqld.sock)/opensips)

The UNIX Socket is defined in the same place that previously would have been the "host:port". The rest of the db_url syntax remains unchanged.

To use a MySQL UNIX Socket in a Docker containerized environment, the following example settings can be made:

Update the MySQL my.cnf file to use a UNIX Socket:

[mysqld]
socket=/var/run/mysqld/mysqld.sock

Update docker-compose.yml to share the UNIX Socket between the MySQL and OpenSIPS services:

volumes:
  shared-sockets:
    driver: local

services:
  mysql:
    volumes:
      - shared-sockets:/var/run/mysqld

  opensips:
    volumes:
      - shared-sockets:/var/run/mysqld

Define the UNIX Socket in opensips.cfg:

modparam("usrloc", "db_url", "mysql://opensips:opensipsrw@unix(/var/run/mysqld/mysqld.sock)/opensips)

**Compatibility**
<!-- Does your change break other scenarios, or do they need to be migrated in order to work similarly? -->
This is a new feature so there are no backward compatibility issues.

The db_url parsing has been enhanced to support the UNIX Socket specification. If not specified, the existing db_url parsing logic will be used and remains unchanged.

**Closing issues**
<!-- Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). -->
