### PR TITLE
Libcouchbase3 for merge

### DIFF
--- a/modules/cachedb_couchbase/cachedb_couchbase_dbase.c
+++ b/modules/cachedb_couchbase/cachedb_couchbase_dbase.c
@@ -385,7 +385,7 @@ int couchbase_set(cachedb_con *connection,str *attr,
 
 	commands[0] = &cmd;
 	memset(&cmd, 0, sizeof(cmd));
-	cmd.v.v0.operation = LCB_SET;
+	cmd.v.v0.operation = LCB_STORE_UPSERT;
 	cmd.v.v0.key = attr->s;
 	cmd.v.v0.nkey = attr->len;
 	cmd.v.v0.bytes = val->s;

--- a/modules/cachedb_couchbase/cachedb_couchbase_dbase.c
+++ b/modules/cachedb_couchbase/cachedb_couchbase_dbase.c
@@ -40,7 +40,7 @@ volatile str get_res = {0,0};
 volatile int arithmetic_res = 0;
 volatile lcb_error_t op_error  = LCB_SUCCESS;
 
-static void couchbase_get_cb(lcb_t instance,
+static void couchbase_get_cb(lcb_INSTANCE* instance,
 		const void *cookie, lcb_error_t error,
 		const lcb_get_resp_t *item)
 {
@@ -64,7 +64,7 @@ static void couchbase_get_cb(lcb_t instance,
 	get_res.len = item->v.v0.nbytes;
 }
 
-static void couchbase_store_cb(lcb_t instance, const void *cookie,
+static void couchbase_store_cb(lcb_INSTANCE* instance, const void *cookie,
 							lcb_storage_t operation,
 							lcb_error_t err,
 							const lcb_store_resp_t *item)
@@ -77,7 +77,7 @@ static void couchbase_store_cb(lcb_t instance, const void *cookie,
 	}
 }
 
-static void couchbase_remove_cb(lcb_t instance,
+static void couchbase_remove_cb(lcb_INSTANCE* instance,
 							const void *cookie,
 							lcb_error_t err,
 							const lcb_remove_resp_t *item)
@@ -91,7 +91,7 @@ static void couchbase_remove_cb(lcb_t instance,
 	}
 }
 
-static void couchbase_arithmetic_cb(lcb_t instance,
+static void couchbase_arithmetic_cb(lcb_INSTANCE* instance,
 								const void *cookie,
 								lcb_error_t error,
 								const lcb_arithmetic_resp_t *item)
@@ -106,7 +106,7 @@ static void couchbase_arithmetic_cb(lcb_t instance,
 	arithmetic_res = item->v.v0.value;
 }
 
-lcb_error_t cb_connect(lcb_t instance) {
+lcb_error_t cb_connect(lcb_INSTANCE* instance) {
 	lcb_error_t rc;
 
 	rc = lcb_connect(instance);
@@ -126,7 +126,7 @@ lcb_error_t cb_connect(lcb_t instance) {
 	return rc;
 }
 
-lcb_error_t cb_get(lcb_t instance, const void *command_cookie, lcb_size_t num, const lcb_get_cmd_t *const *commands) {
+lcb_error_t cb_get(lcb_INSTANCE* instance, const void *command_cookie, lcb_size_t num, const lcb_get_cmd_t *const *commands) {
 	lcb_error_t rc;
 
 	rc = lcb_get(instance, command_cookie, num, commands);
@@ -144,7 +144,7 @@ lcb_error_t cb_get(lcb_t instance, const void *command_cookie, lcb_size_t num, c
 	return op_error;
 }
 
-lcb_error_t cb_store(lcb_t instance, const void *command_cookie, lcb_size_t num, const lcb_store_cmd_t *const *commands) {
+lcb_error_t cb_store(lcb_INSTANCE* instance, const void *command_cookie, lcb_size_t num, const lcb_store_cmd_t *const *commands) {
 	lcb_error_t rc;
 
 	rc = lcb_store(instance, command_cookie, num, commands);
@@ -162,7 +162,7 @@ lcb_error_t cb_store(lcb_t instance, const void *command_cookie, lcb_size_t num,
 	return op_error;
 }
 
-lcb_error_t cb_arithmetic(lcb_t instance, const void *command_cookie, lcb_size_t num, const lcb_arithmetic_cmd_t *const *commands) {
+lcb_error_t cb_arithmetic(lcb_INSTANCE* instance, const void *command_cookie, lcb_size_t num, const lcb_arithmetic_cmd_t *const *commands) {
 	lcb_error_t rc;
 
 	rc = lcb_arithmetic(instance, command_cookie, num, commands);
@@ -180,7 +180,7 @@ lcb_error_t cb_arithmetic(lcb_t instance, const void *command_cookie, lcb_size_t
 	return op_error;
 }
 
-lcb_error_t cb_remove(lcb_t instance, const void *command_cookie, lcb_size_t num, const lcb_remove_cmd_t *const *commands) {
+lcb_error_t cb_remove(lcb_INSTANCE* instance, const void *command_cookie, lcb_size_t num, const lcb_remove_cmd_t *const *commands) {
 	lcb_error_t rc;
 
 	rc = lcb_remove(instance, command_cookie, num, commands);
@@ -241,7 +241,7 @@ couchbase_con* couchbase_connect(struct cachedb_id* id, int is_reconnect)
 	couchbase_con *con;
 	struct lcb_create_st options;
 	lcb_uint32_t tmo = 0;
-	lcb_t instance;
+	lcb_INSTANCE* instance;
 	lcb_error_t rc;
 
 	if (id == NULL) {
@@ -377,7 +377,7 @@ int couchbase_conditional_reconnect(cachedb_con *con, lcb_error_t err) {
 int couchbase_set(cachedb_con *connection,str *attr,
 		str *val,int expires)
 {
-	lcb_t instance;
+	lcb_INSTANCE* instance;
 	lcb_error_t oprc;
 	lcb_store_cmd_t cmd;
 	const lcb_store_cmd_t *commands[1];
@@ -429,7 +429,7 @@ int couchbase_set(cachedb_con *connection,str *attr,
 
 int couchbase_remove(cachedb_con *connection,str *attr)
 {
-	lcb_t instance;
+	lcb_INSTANCE* instance;
 	lcb_error_t oprc;
 	lcb_remove_cmd_t cmd;
 	const lcb_remove_cmd_t *commands[1];
@@ -488,7 +488,7 @@ int couchbase_remove(cachedb_con *connection,str *attr)
 
 int couchbase_get(cachedb_con *connection,str *attr,str *val)
 {
-	lcb_t instance;
+	lcb_INSTANCE* instance;
 	lcb_error_t oprc;
 	lcb_get_cmd_t cmd;
 	const lcb_get_cmd_t *commands[1];
@@ -557,7 +557,7 @@ int couchbase_get(cachedb_con *connection,str *attr,str *val)
 
 int couchbase_add(cachedb_con *connection,str *attr,int val,int expires,int *new_val)
 {
-	lcb_t instance;
+	lcb_INSTANCE* instance;
 	lcb_error_t oprc;
 	lcb_arithmetic_cmd_t cmd;
 	const lcb_arithmetic_cmd_t *commands[1];
@@ -630,7 +630,7 @@ int couchbase_sub(cachedb_con *connection,str *attr,int val,int expires,int *new
 
 int couchbase_get_counter(cachedb_con *connection,str *attr,int *val)
 {
-	lcb_t instance;
+	lcb_INSTANCE* instance;
 	lcb_error_t oprc;
 	lcb_get_cmd_t cmd;
 	const lcb_get_cmd_t *commands[1];

--- a/modules/cachedb_couchbase/cachedb_couchbase_dbase.c
+++ b/modules/cachedb_couchbase/cachedb_couchbase_dbase.c
@@ -271,13 +271,10 @@ couchbase_con* couchbase_connect(struct cachedb_id* id, int is_reconnect)
 		return 0;
 	}
 
-	(void)lcb_set_get_callback(instance,
-			couchbase_get_cb);
-	(void)lcb_set_store_callback(instance,
-			couchbase_store_cb);
-	(void)lcb_set_remove_callback(instance,
-			couchbase_remove_cb);
-	(void)lcb_set_arithmetic_callback(instance,couchbase_arithmetic_cb);
+	(void)lcb_install_callback(instance, LCB_CALLBACK_GET, (lcb_RESPCALLBACK)couchbase_get_cb);
+	(void)lcb_install_callback(instance, LCB_CALLBACK_STORE, (lcb_RESPCALLBACK)couchbase_store_cb);
+	(void)lcb_install_callback(instance, LCB_CALLBACK_REMOVE, (lcb_RESPCALLBACK)couchbase_remove_cb);
+	(void)lcb_install_callback(instance, LCB_CALLBACK_COUNTER, (lcb_RESPCALLBACK)couchbase_arithmetic_cb);
 
 	//Set Timeout
 	tmo = (lcb_uint32_t)couch_timeout_usec;

--- a/modules/cachedb_couchbase/cachedb_couchbase_dbase.c
+++ b/modules/cachedb_couchbase/cachedb_couchbase_dbase.c
@@ -286,7 +286,7 @@ couchbase_con* couchbase_connect(struct cachedb_id* id, int is_reconnect)
 		/*Check connection*/
 		if (rc != LCB_SUCCESS) {
 			/*Consider these connect failurs as fatal*/
-			if(rc == LCB_AUTH_ERROR || rc == LCB_INVALID_HOST_FORMAT || rc == LCB_INVALID_CHAR) {
+			if(rc == LCB_ERR_AUTHENTICATION_FAILURE || rc == LCB_ERR_INVALID_HOST_FORMAT || rc == LCB_ERR_INVALID_CHAR) {
 				LM_ERR("Fatal connection error to Couchbase. Host: %s Bucket: %s Error: %s",
 					id->host, id->database, lcb_strerror_short(rc));
 				lcb_destroy(instance);
@@ -340,11 +340,10 @@ int couchbase_conditional_reconnect(cachedb_con *con, lcb_STATUS err) {
 
 	switch (err) {
 		/* Error codes to attempt reconnects on */
-		case LCB_EINTERNAL:
-		case LCB_CLIENT_ETMPFAIL:
-		case LCB_EBADHANDLE:
-		case LCB_NETWORK_ERROR:
-                case LCB_ETIMEDOUT:
+		case LCB_ERR_SDK_INTERNAL:
+		case LCB_ERR_NO_CONFIGURATION:
+		case LCB_ERR_NETWORK:
+		case LCB_ERR_TIMEOUT:
 		break;
 		default:
 			/*nothing to do*/

--- a/modules/cachedb_couchbase/cachedb_couchbase_dbase.c
+++ b/modules/cachedb_couchbase/cachedb_couchbase_dbase.c
@@ -47,7 +47,7 @@ static void couchbase_get_cb(lcb_INSTANCE* instance,
 	op_error = error;
 
 	if (error != LCB_SUCCESS) {
-		if (error != LCB_KEY_ENOENT) {
+		if (error != LCB_ERR_DOCUMENT_NOT_FOUND) {
 			LM_ERR("Failure to get %.*s - %s\n",(int)item->v.v0.nkey,(char*)item->v.v0.key,lcb_strerror(instance, error));
 		}
 
@@ -85,7 +85,7 @@ static void couchbase_remove_cb(lcb_INSTANCE* instance,
 	op_error = err;
 
 	if (err != LCB_SUCCESS) {
-		if (err != LCB_KEY_ENOENT) {
+		if (err != LCB_ERR_DOCUMENT_NOT_FOUND) {
 			LM_ERR("Failure to remove %.*s - %s\n",(int)item->v.v0.nkey,(char*)item->v.v0.key,lcb_strerror(instance, err));
 		}
 	}
@@ -444,7 +444,7 @@ int couchbase_remove(cachedb_con *connection,str *attr)
 	oprc = cb_remove(instance, NULL, 1, commands);
 
 	if (oprc != LCB_SUCCESS) {
-		if (oprc == LCB_KEY_ENOENT) {
+		if (oprc == LCB_ERR_DOCUMENT_NOT_FOUND) {
 			_stop_expire_timer(start,couch_exec_threshold,
 				"cachedb_couchbase remove",attr->s,attr->len,0,
 				cdb_slow_queries, cdb_total_queries);
@@ -463,7 +463,7 @@ int couchbase_remove(cachedb_con *connection,str *attr)
 		oprc = cb_remove(instance, NULL, 1, commands);
 
 		if (oprc != LCB_SUCCESS) {
-			if (oprc == LCB_KEY_ENOENT) {
+			if (oprc == LCB_ERR_DOCUMENT_NOT_FOUND) {
 				LM_ERR("Remove command successfully retried\n");
 				_stop_expire_timer(start,couch_exec_threshold,
 					"cachedb_couchbase remove",attr->s,attr->len,0,
@@ -505,7 +505,7 @@ int couchbase_get(cachedb_con *connection,str *attr,str *val)
 
 	if (oprc != LCB_SUCCESS) {
 		/* Key not present, record does not exist */
-		if (oprc == LCB_KEY_ENOENT) {
+		if (oprc == LCB_ERR_DOCUMENT_NOT_FOUND) {
 			_stop_expire_timer(start,couch_exec_threshold,
 				"cachedb_couchbase get",attr->s,attr->len,0,
 				cdb_slow_queries, cdb_total_queries);
@@ -524,7 +524,7 @@ int couchbase_get(cachedb_con *connection,str *attr,str *val)
 		instance = COUCHBASE_CON(connection);
 		oprc = cb_get(instance, NULL, 1, commands);
 		if (oprc != LCB_SUCCESS) {
-			if (oprc == LCB_KEY_ENOENT) {
+			if (oprc == LCB_ERR_DOCUMENT_NOT_FOUND) {
 				LM_ERR("Get command successfully retried\n");
 				_stop_expire_timer(start,couch_exec_threshold,
 					"cachedb_couchbase get",attr->s,attr->len,0,
@@ -577,7 +577,7 @@ int couchbase_add(cachedb_con *connection,str *attr,int val,int expires,int *new
 	oprc = cb_arithmetic(instance, NULL, 1, commands);
 
 	if (oprc != LCB_SUCCESS) {
-		if (oprc == LCB_KEY_ENOENT) {
+		if (oprc == LCB_ERR_DOCUMENT_NOT_FOUND) {
 			return -1;
 			_stop_expire_timer(start,couch_exec_threshold,
 				"cachedb_couchbase add",attr->s,attr->len,0,
@@ -598,7 +598,7 @@ int couchbase_add(cachedb_con *connection,str *attr,int val,int expires,int *new
 		oprc = cb_arithmetic(instance, NULL, 1, commands);
 
 		if (oprc != LCB_SUCCESS) {
-			if (oprc == LCB_KEY_ENOENT) {
+			if (oprc == LCB_ERR_DOCUMENT_NOT_FOUND) {
 				LM_ERR("Arithmetic command successfully retried\n");
 				_stop_expire_timer(start,couch_exec_threshold,
 					"cachedb_couchbase add",attr->s,attr->len,0,
@@ -647,7 +647,7 @@ int couchbase_get_counter(cachedb_con *connection,str *attr,int *val)
 
 	if (oprc != LCB_SUCCESS) {
 		/* Key not present, record does not exist */
-		if (oprc == LCB_KEY_ENOENT) {
+		if (oprc == LCB_ERR_DOCUMENT_NOT_FOUND) {
 			_stop_expire_timer(start,couch_exec_threshold,
 				"cachedb_couchbase get counter",attr->s,attr->len,0,
 				cdb_slow_queries, cdb_total_queries);
@@ -666,7 +666,7 @@ int couchbase_get_counter(cachedb_con *connection,str *attr,int *val)
 		instance = COUCHBASE_CON(connection);
 		oprc = cb_get(instance, NULL, 1, commands);
 		if (oprc != LCB_SUCCESS) {
-			if (oprc == LCB_KEY_ENOENT) {
+			if (oprc == LCB_ERR_DOCUMENT_NOT_FOUND) {
 				LM_ERR("Get counter command successfully retried\n");
 				_stop_expire_timer(start,couch_exec_threshold,
 					"cachedb_couchbase get counter",attr->s,attr->len,0,

--- a/modules/cachedb_couchbase/cachedb_couchbase_dbase.c
+++ b/modules/cachedb_couchbase/cachedb_couchbase_dbase.c
@@ -38,10 +38,10 @@ extern int couch_exec_threshold;
 
 volatile str get_res = {0,0};
 volatile int arithmetic_res = 0;
-volatile lcb_error_t op_error  = LCB_SUCCESS;
+volatile lcb_STATUS op_error  = LCB_SUCCESS;
 
 static void couchbase_get_cb(lcb_INSTANCE* instance,
-		const void *cookie, lcb_error_t error,
+		const void *cookie, lcb_STATUS error,
 		const lcb_get_resp_t *item)
 {
 	op_error = error;
@@ -66,7 +66,7 @@ static void couchbase_get_cb(lcb_INSTANCE* instance,
 
 static void couchbase_store_cb(lcb_INSTANCE* instance, const void *cookie,
 							lcb_storage_t operation,
-							lcb_error_t err,
+							lcb_STATUS err,
 							const lcb_store_resp_t *item)
 {
 
@@ -79,7 +79,7 @@ static void couchbase_store_cb(lcb_INSTANCE* instance, const void *cookie,
 
 static void couchbase_remove_cb(lcb_INSTANCE* instance,
 							const void *cookie,
-							lcb_error_t err,
+							lcb_STATUS err,
 							const lcb_remove_resp_t *item)
 {
 	op_error = err;
@@ -93,7 +93,7 @@ static void couchbase_remove_cb(lcb_INSTANCE* instance,
 
 static void couchbase_arithmetic_cb(lcb_INSTANCE* instance,
 								const void *cookie,
-								lcb_error_t error,
+								lcb_STATUS error,
 								const lcb_arithmetic_resp_t *item)
 {
 	op_error = error;
@@ -106,8 +106,8 @@ static void couchbase_arithmetic_cb(lcb_INSTANCE* instance,
 	arithmetic_res = item->v.v0.value;
 }
 
-lcb_error_t cb_connect(lcb_INSTANCE* instance) {
-	lcb_error_t rc;
+lcb_STATUS cb_connect(lcb_INSTANCE* instance) {
+	lcb_STATUS rc;
 
 	rc = lcb_connect(instance);
 
@@ -126,8 +126,8 @@ lcb_error_t cb_connect(lcb_INSTANCE* instance) {
 	return rc;
 }
 
-lcb_error_t cb_get(lcb_INSTANCE* instance, const void *command_cookie, lcb_size_t num, const lcb_get_cmd_t *const *commands) {
-	lcb_error_t rc;
+lcb_STATUS cb_get(lcb_INSTANCE* instance, const void *command_cookie, lcb_size_t num, const lcb_get_cmd_t *const *commands) {
+	lcb_STATUS rc;
 
 	rc = lcb_get(instance, command_cookie, num, commands);
 
@@ -144,8 +144,8 @@ lcb_error_t cb_get(lcb_INSTANCE* instance, const void *command_cookie, lcb_size_
 	return op_error;
 }
 
-lcb_error_t cb_store(lcb_INSTANCE* instance, const void *command_cookie, lcb_size_t num, const lcb_store_cmd_t *const *commands) {
-	lcb_error_t rc;
+lcb_STATUS cb_store(lcb_INSTANCE* instance, const void *command_cookie, lcb_size_t num, const lcb_store_cmd_t *const *commands) {
+	lcb_STATUS rc;
 
 	rc = lcb_store(instance, command_cookie, num, commands);
 
@@ -162,8 +162,8 @@ lcb_error_t cb_store(lcb_INSTANCE* instance, const void *command_cookie, lcb_siz
 	return op_error;
 }
 
-lcb_error_t cb_arithmetic(lcb_INSTANCE* instance, const void *command_cookie, lcb_size_t num, const lcb_arithmetic_cmd_t *const *commands) {
-	lcb_error_t rc;
+lcb_STATUS cb_arithmetic(lcb_INSTANCE* instance, const void *command_cookie, lcb_size_t num, const lcb_arithmetic_cmd_t *const *commands) {
+	lcb_STATUS rc;
 
 	rc = lcb_arithmetic(instance, command_cookie, num, commands);
 
@@ -180,8 +180,8 @@ lcb_error_t cb_arithmetic(lcb_INSTANCE* instance, const void *command_cookie, lc
 	return op_error;
 }
 
-lcb_error_t cb_remove(lcb_INSTANCE* instance, const void *command_cookie, lcb_size_t num, const lcb_remove_cmd_t *const *commands) {
-	lcb_error_t rc;
+lcb_STATUS cb_remove(lcb_INSTANCE* instance, const void *command_cookie, lcb_size_t num, const lcb_remove_cmd_t *const *commands) {
+	lcb_STATUS rc;
 
 	rc = lcb_remove(instance, command_cookie, num, commands);
 
@@ -242,7 +242,7 @@ couchbase_con* couchbase_connect(struct cachedb_id* id, int is_reconnect)
 	struct lcb_create_st options;
 	lcb_uint32_t tmo = 0;
 	lcb_INSTANCE* instance;
-	lcb_error_t rc;
+	lcb_STATUS rc;
 
 	if (id == NULL) {
 		LM_ERR("null cachedb_id\n");
@@ -335,7 +335,7 @@ void couchbase_destroy(cachedb_con *con)
 }
 
 /*Conditionally reconnect based on the error code*/
-int couchbase_conditional_reconnect(cachedb_con *con, lcb_error_t err) {
+int couchbase_conditional_reconnect(cachedb_con *con, lcb_STATUS err) {
 	cachedb_pool_con *tmp;
 	void *newcon;
 
@@ -378,7 +378,7 @@ int couchbase_set(cachedb_con *connection,str *attr,
 		str *val,int expires)
 {
 	lcb_INSTANCE* instance;
-	lcb_error_t oprc;
+	lcb_STATUS oprc;
 	lcb_store_cmd_t cmd;
 	const lcb_store_cmd_t *commands[1];
 	struct timeval start;
@@ -430,7 +430,7 @@ int couchbase_set(cachedb_con *connection,str *attr,
 int couchbase_remove(cachedb_con *connection,str *attr)
 {
 	lcb_INSTANCE* instance;
-	lcb_error_t oprc;
+	lcb_STATUS oprc;
 	lcb_remove_cmd_t cmd;
 	const lcb_remove_cmd_t *commands[1];
 	struct timeval start;
@@ -489,7 +489,7 @@ int couchbase_remove(cachedb_con *connection,str *attr)
 int couchbase_get(cachedb_con *connection,str *attr,str *val)
 {
 	lcb_INSTANCE* instance;
-	lcb_error_t oprc;
+	lcb_STATUS oprc;
 	lcb_get_cmd_t cmd;
 	const lcb_get_cmd_t *commands[1];
 	struct timeval start;
@@ -558,7 +558,7 @@ int couchbase_get(cachedb_con *connection,str *attr,str *val)
 int couchbase_add(cachedb_con *connection,str *attr,int val,int expires,int *new_val)
 {
 	lcb_INSTANCE* instance;
-	lcb_error_t oprc;
+	lcb_STATUS oprc;
 	lcb_arithmetic_cmd_t cmd;
 	const lcb_arithmetic_cmd_t *commands[1];
 	struct timeval start;
@@ -631,7 +631,7 @@ int couchbase_sub(cachedb_con *connection,str *attr,int val,int expires,int *new
 int couchbase_get_counter(cachedb_con *connection,str *attr,int *val)
 {
 	lcb_INSTANCE* instance;
-	lcb_error_t oprc;
+	lcb_STATUS oprc;
 	lcb_get_cmd_t cmd;
 	const lcb_get_cmd_t *commands[1];
 	struct timeval start;

--- a/modules/cachedb_couchbase/cachedb_couchbase_dbase.c
+++ b/modules/cachedb_couchbase/cachedb_couchbase_dbase.c
@@ -115,7 +115,7 @@ lcb_STATUS cb_connect(lcb_INSTANCE* instance) {
 		return rc;
 	}
 
-	rc = lcb_wait(instance);
+	rc = lcb_wait(instance, LCB_WAIT_DEFAULT);
 
 	if (rc != LCB_SUCCESS) {
 		return rc;
@@ -135,7 +135,7 @@ lcb_STATUS cb_get(lcb_INSTANCE* instance, const void *command_cookie, lcb_size_t
 		return rc;
 	}
 
-	rc = lcb_wait(instance);
+	rc = lcb_wait(instance, LCB_WAIT_DEFAULT);
 
 	if (rc != LCB_SUCCESS) {
 		return rc;
@@ -153,7 +153,7 @@ lcb_STATUS cb_store(lcb_INSTANCE* instance, const void *command_cookie, lcb_size
 		return rc;
 	}
 
-	rc = lcb_wait(instance);
+	rc = lcb_wait(instance, LCB_WAIT_DEFAULT);
 
 	if (rc != LCB_SUCCESS) {
 		return rc;
@@ -171,7 +171,7 @@ lcb_STATUS cb_arithmetic(lcb_INSTANCE* instance, const void *command_cookie, lcb
 		return rc;
 	}
 
-	rc = lcb_wait(instance);
+	rc = lcb_wait(instance, LCB_WAIT_DEFAULT);
 
 	if (rc != LCB_SUCCESS) {
 		return rc;
@@ -189,7 +189,7 @@ lcb_STATUS cb_remove(lcb_INSTANCE* instance, const void *command_cookie, lcb_siz
 		return rc;
 	}
 
-	rc = lcb_wait(instance);
+	rc = lcb_wait(instance, LCB_WAIT_DEFAULT);
 
 	if (rc != LCB_SUCCESS) {
 		return rc;

--- a/modules/cachedb_couchbase/cachedb_couchbase_dbase.h
+++ b/modules/cachedb_couchbase/cachedb_couchbase_dbase.h
@@ -35,7 +35,7 @@ typedef struct {
 	unsigned int ref;
 	struct cachedb_pool_con_t *next;
 
-	lcb_t couchcon;
+	lcb_INSTANCE* couchcon;
 } couchbase_con;
 
 #define COUCHBASE_CON(cdb_con) (((couchbase_con*)((cdb_con)->data))->couchcon)


### PR DESCRIPTION
**Summary**
Make module `cachedb_couchbase` compatible with @couchbase's libcouchbase ver. 3.

**Details**
libcouchbase ver. 3 broke API and already 5 years old. Let's make this module compatible with this library. See also PR #2913 and #2389.

**Compatibility**
Module will require libcouchbase >= 3.0.0.

**Closing issues**
N/a.