### PR TITLE
New TOS (per socket) options

### DIFF
--- a/cfg.lex
+++ b/cfg.lex
@@ -321,6 +321,7 @@ TICK		\'
 SLASH		"/"
 AS			{EAT_ABLE}("as"|"AS"){EAT_ABLE}
 USE_WORKERS	{EAT_ABLE}("use_workers"|"USE_WORKERS"){EAT_ABLE}
+SOCK_TOS	{EAT_ABLE}("tos"|"TOS"){EAT_ABLE}
 USE_AUTO_SCALING_PROFILE {EAT_ABLE}("use_auto_scaling_profile"|"USE_AUTO_SCALING_PROFILE"){EAT_ABLE}
 SCALE_UP_TO		{EAT_ABLE}("scale"|"SCALE"){EAT_ABLE}+("up"|"UP"){EAT_ABLE}+("to"|"TO"){EAT_ABLE}
 SCALE_DOWN_TO	{EAT_ABLE}("scale"|"SCALE"){EAT_ABLE}+("down"|"DOWN"){EAT_ABLE}+("to"|"TO"){EAT_ABLE}
@@ -601,6 +602,7 @@ SPACE		[ ]
 <INITIAL>{COMMA}		{ count(); return COMMA; }
 <INITIAL>{SEMICOLON}	{ count(); return SEMICOLON; }
 <INITIAL>{USE_WORKERS}  { count(); return USE_WORKERS; }
+<INITIAL>{SOCK_TOS}	{ count(); return SOCK_TOS; }
 <INITIAL>{USE_AUTO_SCALING_PROFILE}  { count(); return USE_AUTO_SCALING_PROFILE; }
 <INITIAL>{COLON}	{ count(); return COLON; }
 <INITIAL>{RPAREN}	{ count(); return RPAREN; }

--- a/cfg.y
+++ b/cfg.y
@@ -180,6 +180,7 @@ extern char *finame;
 struct listen_param {
 	enum si_flags flags;
 	int workers;
+	int tos;
 	struct socket_id *socket;
 	char *tag;
 	char *auto_scaling_profile;
@@ -458,6 +459,7 @@ extern int cfg_parse_only_routes;
 %token SLASH
 %token AS
 %token USE_WORKERS
+%token SOCK_TOS
 %token USE_AUTO_SCALING_PROFILE
 %token MAX
 %token MIN
@@ -732,6 +734,9 @@ socket_def_param: ANYCAST { IFOR();
 					}
 				| USE_WORKERS NUMBER { IFOR();
 					p_tmp.workers=$2;
+					}
+				| SOCK_TOS NUMBER { IFOR();
+					p_tmp.tos=$2;
 					}
 				| AS listen_id_def { IFOR();
 					p_tmp.socket = $2;
@@ -2746,6 +2751,7 @@ static void fill_socket_id(struct listen_param *param, struct socket_id *s)
 	while (s) {
 		s->flags |= param->flags;
 		s->workers = param->workers;
+		s->tos = param->tos;
 		s->auto_scaling_profile = param->auto_scaling_profile;
 		s->tag = param->tag;
 		if (param->socket) {

--- a/cfg.y
+++ b/cfg.y
@@ -1540,7 +1540,7 @@ assign_stm: LOGLEVEL EQUAL snumber { IFOR();
 		  }
 		| MCAST_TTL EQUAL error { yyerror("number expected as tos"); }
 		| TOS EQUAL NUMBER { IFOR(); tos = $3;
-							if (tos<=0)
+							if (tos<0)
 								yyerror("invalid tos value");
 		 }
 		| TOS EQUAL ID { IFOR();

--- a/ip_addr.h
+++ b/ip_addr.h
@@ -122,6 +122,7 @@ struct socket_id {
 	int proto;
 	int port;
 	int workers;
+	int tos;
 	enum si_flags flags;
 	struct socket_id* next;
 };

--- a/modules/cgrates/cgrates_engine.c
+++ b/modules/cgrates/cgrates_engine.c
@@ -271,7 +271,7 @@ static int cgrc_conn(struct cgr_conn *c)
 
 	tcp_con_get_profile(&c->engine->su, src_su, PROTO_TCP, &prof);
 
-	s = tcp_sync_connect_fd(src_su, &c->engine->su, PROTO_TCP, &prof, 0);
+	s = tcp_sync_connect_fd(src_su, &c->engine->su, PROTO_TCP, &prof, 0, 0);
 	if (s < 0) {
 		LM_ERR("cannot connect to %.*s:%d\n", c->engine->host.len,
 				c->engine->host.s, c->engine->port);

--- a/modules/janus/ws_common.h
+++ b/modules/janus/ws_common.h
@@ -718,7 +718,7 @@ static int janus_ws_sync_connect(janus_connection *sock)
 
 	tcp_con_get_profile(to_su, src_su, PROTO_TCP, &sock->profile);
 
-	s = tcp_sync_connect_fd(src_su, to_su, PROTO_TCP, &sock->profile,0);
+	s = tcp_sync_connect_fd(src_su, to_su, PROTO_TCP, &sock->profile,0,0);
 	if (s < 0) {
 		LM_ERR("cannot TCP connect to %.*s:%d\n",
 		sock->parsed_url.host.len,sock->parsed_url.host.s,

--- a/modules/proto_ws/ws_common.h
+++ b/modules/proto_ws/ws_common.h
@@ -649,7 +649,7 @@ static struct tcp_connection* ws_sync_connect(const struct socket_info* send_soc
 		goto error;
 	}
 
-	if (tcp_init_sock_opt(s, prof, send_sock->flags)<0){
+	if (tcp_init_sock_opt(s, prof, send_sock->flags, send_sock->tos)<0){
 		LM_ERR("tcp_init_sock_opt failed\n");
 		goto error;
 	}

--- a/net/net_tcp.c
+++ b/net/net_tcp.c
@@ -248,9 +248,11 @@ int tcp_init_sock_opt(int s, const struct tcp_conn_profile *prof, enum si_flags 
 #endif
 	/* tos*/
 	optval = tos;
-	if (setsockopt(s, IPPROTO_IP, IP_TOS, (void*)&optval,sizeof(optval)) ==-1){
-		LM_WARN("setsockopt tos: %s\n",	strerror(errno));
-		/* continue since this is not critical */
+	if (optval > 0) {
+		if (setsockopt(s, IPPROTO_IP, IP_TOS, (void*)&optval,sizeof(optval)) ==-1){
+			LM_WARN("setsockopt tos: %s\n",	strerror(errno));
+			/* continue since this is not critical */
+		}
 	}
 
 	if (probe_max_sock_buff(s,1,MAX_SEND_BUFFER_SIZE,BUFFER_INCREMENT)) {
@@ -376,10 +378,12 @@ int tcp_init_listener(struct socket_info *si)
 #endif
 	/* tos */
 	optval = tos;
-	if (setsockopt(si->socket, IPPROTO_IP, IP_TOS, (void*)&optval,
-	sizeof(optval)) ==-1){
-		LM_WARN("setsockopt tos: %s\n", strerror(errno));
-		/* continue since this is not critical */
+	if (optval > 0) {
+		if (setsockopt(si->socket, IPPROTO_IP, IP_TOS, (void*)&optval,
+		sizeof(optval)) ==-1){
+			LM_WARN("setsockopt tos: %s\n", strerror(errno));
+			/* continue since this is not critical */
+		}
 	}
 
 	if (probe_max_sock_buff(si->socket,1,MAX_SEND_BUFFER_SIZE,

--- a/net/net_tcp.h
+++ b/net/net_tcp.h
@@ -79,7 +79,7 @@ mi_response_t *mi_tcp_list_conns(const mi_params_t *params,
 int tcp_init_listener(struct socket_info *si);
 
 /* helper function to set all TCP related options to a socket */
-int tcp_init_sock_opt(int s, const struct tcp_conn_profile *prof, enum si_flags socketflags);
+int tcp_init_sock_opt(int s, const struct tcp_conn_profile *prof, enum si_flags socketflags, int sock_tos);
 
 /********************** TCP conn management functions ************************/
 

--- a/net/net_udp.c
+++ b/net/net_udp.c
@@ -198,7 +198,7 @@ int udp_init_listener(struct socket_info *si, int status_flags)
 	}
 
 	/* tos */
-	optval=tos;
+	optval = (si->tos > 0) ? si->tos : tos;
 	if (optval > 0) {
 		if (addr->s.sa_family==AF_INET6){
 			if (setsockopt(si->socket,  IPPROTO_IPV6, IPV6_TCLASS, (void*)&optval, sizeof(optval)) ==-1){

--- a/net/net_udp.c
+++ b/net/net_udp.c
@@ -199,15 +199,17 @@ int udp_init_listener(struct socket_info *si, int status_flags)
 
 	/* tos */
 	optval=tos;
-	if (addr->s.sa_family==AF_INET6){
-		if (setsockopt(si->socket,  IPPROTO_IPV6, IPV6_TCLASS, (void*)&optval, sizeof(optval)) ==-1){
-			LM_WARN("setsockopt tos for IPV6: %s\n", strerror(errno));
-			/* continue since this is not critical */
-		}
-	} else {
-		if (setsockopt(si->socket, IPPROTO_IP, IP_TOS, (void*)&optval, sizeof(optval)) ==-1){
-			LM_WARN("setsockopt tos: %s\n", strerror(errno));
-			/* continue since this is not critical */
+	if (optval > 0) {
+		if (addr->s.sa_family==AF_INET6){
+			if (setsockopt(si->socket,  IPPROTO_IPV6, IPV6_TCLASS, (void*)&optval, sizeof(optval)) ==-1){
+				LM_WARN("setsockopt tos for IPV6: %s\n", strerror(errno));
+				/* continue since this is not critical */
+			}
+		} else {
+			if (setsockopt(si->socket, IPPROTO_IP, IP_TOS, (void*)&optval, sizeof(optval)) ==-1){
+				LM_WARN("setsockopt tos: %s\n", strerror(errno));
+				/* continue since this is not critical */
+			}
 		}
 	}
 #if defined (__linux__) && defined(UDP_ERRORS)

--- a/net/tcp_common.c
+++ b/net/tcp_common.c
@@ -146,7 +146,7 @@ int tcp_connect_blocking(int fd, const struct sockaddr *servaddr,
 }
 
 int tcp_sync_connect_fd(const union sockaddr_union* src, const union sockaddr_union* dst,
-                 enum sip_protos proto, const struct tcp_conn_profile *prof, enum si_flags flags)
+                 enum sip_protos proto, const struct tcp_conn_profile *prof, enum si_flags flags, int sock_tos)
 {
 	int s;
 	union sockaddr_union my_name;
@@ -158,7 +158,7 @@ int tcp_sync_connect_fd(const union sockaddr_union* src, const union sockaddr_un
 		goto error;
 	}
 
-	if (tcp_init_sock_opt(s, prof, flags)<0){
+	if (tcp_init_sock_opt(s, prof, flags, sock_tos)<0){
 		LM_ERR("tcp_init_sock_opt failed\n");
 		goto error;
 	}
@@ -193,7 +193,7 @@ struct tcp_connection* tcp_sync_connect(const struct socket_info* send_sock,
 	struct tcp_connection* con;
 	int s;
 
-	s = tcp_sync_connect_fd(&send_sock->su, server, send_sock->proto, prof, send_sock->flags);
+	s = tcp_sync_connect_fd(&send_sock->su, server, send_sock->proto, prof, send_sock->flags, send_sock->tos);
 	if (s < 0)
 		return NULL;
 
@@ -237,7 +237,7 @@ int tcp_async_connect(const struct socket_info* send_sock,
 		return -1;
 	}
 
-	if (tcp_init_sock_opt(fd, prof, send_sock->flags)<0){
+	if (tcp_init_sock_opt(fd, prof, send_sock->flags, send_sock->tos)<0){
 		LM_ERR("tcp_init_sock_opt failed\n");
 		goto error;
 	}

--- a/net/tcp_common.h
+++ b/net/tcp_common.h
@@ -31,7 +31,7 @@ int tcp_connect_blocking_timeout(int fd, const struct sockaddr *servaddr,
 
 
 int tcp_sync_connect_fd(const union sockaddr_union* src, const union sockaddr_union* dst,
-                 enum sip_protos proto, const struct tcp_conn_profile *prof, enum si_flags flags);
+                 enum sip_protos proto, const struct tcp_conn_profile *prof, enum si_flags flags, int sock_tos);
 
 struct tcp_connection* tcp_sync_connect(const struct socket_info* send_sock,
                const union sockaddr_union* server, struct tcp_conn_profile *prof,

--- a/socket_info.c
+++ b/socket_info.c
@@ -176,6 +176,7 @@ struct socket_info_full* new_sock_info( struct socket_id *sid)
 	} else {
 		if (sid->workers)
 			si->workers = sid->workers;
+		si->tos = sid->tos;
 		if (sid->auto_scaling_profile) {
 			si->s_profile = get_scaling_profile(sid->auto_scaling_profile);
 			if (si->s_profile==NULL) {
@@ -440,6 +441,7 @@ static int expand_interface(const struct socket_info *si, struct socket_info_ful
 	sid.port = si->port_no;
 	sid.proto = si->proto;
 	sid.workers = si->workers;
+	sid.tos = si->tos;
 	sid.auto_scaling_profile = si->s_profile?si->s_profile->name:NULL;
 	sid.adv_port = si->adv_port;
 	sid.adv_name = si->adv_name_str.s; /* it is NULL terminated */

--- a/socket_info.h
+++ b/socket_info.h
@@ -61,6 +61,7 @@ struct socket_info {
 	struct ip_addr adv_address; /* Advertised address in ip_addr form (for find_si) */
 	unsigned short adv_port;    /* optimization for grep_sock_info() */
 	unsigned short workers;
+	unsigned short tos;
 	struct scaling_profile *s_profile;
 	void *extra_data;
 	enum sip_protos internal_proto;


### PR DESCRIPTION
**Summary**  
This PR introduces two key changes:  
1. Allows setting the global TOS (Type of Service) parameter to `0` to disable the `IP_TOS` socket option.  
2. Adds a per-socket parameter `tos`, allowing TOS to be set on a per-socket basis. If this parameter is set, it overrides the global value.  

**Details**  
Previously, the global `TOS` parameter could not be set to `0`, meaning that disabling the `IP_TOS` socket option was not straightforward. This PR introduces the ability to explicitly set `TOS=0`, ensuring that no `IP_TOS` is applied.  

Additionally, this PR introduces a new per-socket `tos` parameter, which enables granular control over TOS settings on an individual socket level. If a socket-specific value is provided, it takes precedence over the global setting, allowing for more flexible traffic prioritization configurations.  

**Solution**  
- Modified the global TOS handling logic to allow `0` as a valid value.  
- Introduced a per-socket `tos` parameter in the socket configuration.  
- Ensured that when the per-socket `tos` value is set, it overrides the global TOS setting.  
- Maintained backward compatibility by preserving previous behaviors unless explicitly overridden.  

**Compatibility**  
- This change maintains backward compatibility as existing configurations remain unchanged unless explicitly modified.  
- The ability to set `TOS=0` does not affect existing deployments but provides more flexibility.  
- The per-socket `tos` parameter is an additional feature that does not interfere with existing configurations.  
