### PR TITLE
Pass the directional flag to rtpengine if required

### DIFF
--- a/modules/rtpengine/rtpengine.c
+++ b/modules/rtpengine/rtpengine.c
@@ -2239,6 +2239,12 @@ static int parse_flags(struct ng_flags_parse *ng_flags, struct sip_msg *msg,
 					continue;
 				} else if (str_eq(&key, "directional")) {
 					ng_flags->directional = 1;
+					bitem = bencode_str(bencode_item_buffer(ng_flags->flags), &key);
+					if (!bitem) {
+						err = "no more memory for list value";
+						goto error;
+					}
+					BCHECK(bencode_list_add(ng_flags->flags, bitem));
 					continue;
 				}
 				break;


### PR DESCRIPTION
I don't think this is covered in an issue but it was raised on the mailing list for OpenSIPS and rtpengine, I also had the same issue.

RTPEngine requires the `directional` flag to be sent if there are to be directional operations, comment from Richard Fuchs on the mailing list of rtpengine on 20th Jan 2025

"This is a side effect of a somewhat recent (?) change in how flags are
parsed. Just giving a `from-tag` now is not enough to trigger
directional operation, because depending on the control module, the
from-tag may always be present. So the flag `directional` must now be
given in addition to that."

This patch ensures the flag is sent if specified in rtpengine_offer/manage/answer