### PR TITLE
dispatcher: fix persistent_state

### DIFF
--- a/modules/dispatcher/dispatcher.c
+++ b/modules/dispatcher/dispatcher.c
@@ -782,13 +782,13 @@ static int partition_init(ds_db_head_t *db_head, ds_partition_t *partition)
 	}
 
 	partition->persistent_state = ds_persistent_state;
-	if (str_strcmp(&db_head->persistent_state, const_str("0")) ||
-			str_strcmp(&db_head->persistent_state, const_str("no")) ||
-			str_strcmp(&db_head->persistent_state, const_str("off")))
+    if (str_strcmp(&db_head->persistent_state, const_str("0")) == 0 ||
+        str_strcmp(&db_head->persistent_state, const_str("no")) == 0 ||
+        str_strcmp(&db_head->persistent_state, const_str("off")) == 0)
 		partition->persistent_state = 0;
-	else if (str_strcmp(&db_head->persistent_state, const_str("1")) ||
-			str_strcmp(&db_head->persistent_state, const_str("yes")) ||
-			str_strcmp(&db_head->persistent_state, const_str("on")))
+    else if (str_strcmp(&db_head->persistent_state, const_str("1")) == 0 ||
+        str_strcmp(&db_head->persistent_state, const_str("yes")) == 0 ||
+        str_strcmp(&db_head->persistent_state, const_str("on")) == 0)
 		partition->persistent_state = 1;
 
 	if (partition->persistent_state)


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!
In order to consider and evaluate your PR, it is mandatory to provide detailed information about (1) what is the issue the PR addresses, (2) how the PR is solving the issue (logic and coding), (3) what are (if any) limitations of the proposed PR and (4) if there are any known side-effects/ backward compatibility issues/SIP interoperability issues.
Note that if the PR is missing information, it might take longer to be merged, as extra resources have to be allocated by the maintainers to reverse engineer the changes, understand them, understand the motivation, etc. That is why it is important to provide as much information as possible.
-->

**Summary**
<!-- Summary of the PR - what the PR is aiming to solve -->
This PR fixes the issue [3567](https://github.com/OpenSIPS/opensips/issues/3567) in dispatcher module, currently setting persistent_state to enabled is not working and destinations state is not stored in database when opensips service is restarted, or based on timer callback.
**Details**
<!--
Details about the content of the PR - is it a bug fix, a new feature or perhaps a hack? Explain the **motivation** for making this change.
What existing problem does the pull request solve? Is this a particular problem (i.e. only some particular scenarios are affected, only some UACs, etc) or a generic one?
Do not assume others understand what you're trying to do and provide as much information as you may have.
-->
This PR fixes dispatcher persistence problem by changing the way value of persistent_state is checked.

**Solution**
<!-- Explain how your PR fixes the problem. Are there any remaining concerns that might need to be addressed? -->
Instead of using str_strcmp function output directly, it's return value must be checked with 0 which this pull request tries to do.
**Compatibility**
<!-- Does your change break other scenarios, or do they need to be migrated in order to work similarly? -->
This PR will not break other scenarios.
**Closing issues**
<!-- Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). -->
closes #3567
