### PR TITLE
Fix duplicate mi_enable_rtp_proxy function name

### DIFF
--- a/modules/rtpengine/rtpengine.c
+++ b/modules/rtpengine/rtpengine.c
@@ -372,7 +372,7 @@ static int pv_get_rtpstat_f(struct sip_msg *, pv_param_t *, pv_value_t *);
 static int pv_get_rtpquery_f(struct sip_msg *, pv_param_t *, pv_value_t *);
 
 /*mi commands*/
-static mi_response_t *mi_enable_rtp_proxy(const mi_params_t *params,
+static mi_response_t *mi_enable_rtpengine(const mi_params_t *params,
 								struct mi_handler *async_hdl);
 static mi_response_t *mi_show_rtpengines(const mi_params_t *params,
 								struct mi_handler *async_hdl);
@@ -757,8 +757,8 @@ static const param_export_t params[] = {
 
 static const mi_export_t mi_cmds[] = {
 	{ MI_ENABLE_RTP_ENGINE, 0, 0, 0, {
-		{mi_enable_rtp_proxy, {"url", "enable", 0}},
-		{mi_enable_rtp_proxy, {"url", "enable", "setid", 0}},
+		{mi_enable_rtpengine, {"url", "enable", 0}},
+		{mi_enable_rtpengine, {"url", "enable", "setid", 0}},
 		{EMPTY_MI_RECIPE}}
 	},
 	{ MI_SHOW_RTP_ENGINES, 0, 0, 0, {
@@ -1167,7 +1167,7 @@ static int rtpengine_add_rtpengine_set( char * rtp_proxies, int set_id)
 	for(;*rtp_proxies && isspace(*rtp_proxies);rtp_proxies++);
 
 	if(!(*rtp_proxies)){
-		LM_ERR("script error -empty rtp_proxy list\n");
+		LM_ERR("script error -empty rtpengine list\n");
 		return -1;;
 	}
 
@@ -1252,7 +1252,7 @@ static int fixup_free_set_id(void **param)
 	return 0;
 }
 
-static mi_response_t *mi_enable_rtp_proxy(const mi_params_t *params,
+static mi_response_t *mi_enable_rtpengine(const mi_params_t *params,
 								struct mi_handler *async_hdl)
 {
 	str rtpe_url;


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!
In order to consider and evaluate your PR, it is mandatory to provide detailed information about (1) what is the issue the PR addresses, (2) how the PR is solving the issue (logic and coding), (3) what are (if any) limitations of the proposed PR and (4) if there are any known side-effects/ backward compatibility issues/SIP interoperability issues.
Note that if the PR is missing information, it might take longer to be merged, as extra resources have to be allocated by the maintainers to reverse engineer the changes, understand them, understand the motivation, etc. That is why it is important to provide as much information as possible.
-->

**Summary**
<!-- Summary of the PR - what the PR is aiming to solve -->
This PR updates the mi_enable_rtp_proxy function in rtpengine.c

**Details**
<!--
Details about the content of the PR - is it a bug fix, a new feature or perhaps a hack? Explain the **motivation** for making this change.
What existing problem does the pull request solve? Is this a particular problem (i.e. only some particular scenarios are affected, only some UACs, etc) or a generic one?
Do not assume others understand what you're trying to do and provide as much information as you may have.
-->
The function named mi_enable_rtp_proxy() is located in the following two locations:

1. modules/rtpengine/rtpengine.c:
2. modules/rtpproxy/rtpproxy.c

**Solution**
<!-- Explain how your PR fixes the problem. Are there any remaining concerns that might need to be addressed? -->
The solution is to rename mi_enable_rtp_proxy() to mi_enable_rtpengine(). This will remove the duplicate function name and reduce confusion between the RPTProxy and RTPEngine modules.

**Compatibility**
<!-- Does your change break other scenarios, or do they need to be migrated in order to work similarly? -->
This change does not change any logic so should not have any compatibility concerns.

**Closing issues**
<!-- Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). -->
