### PR TITLE
Both true and false are now reserved words in a modern ANSI C

### DIFF
--- a/modules/statistics/statistics.c
+++ b/modules/statistics/statistics.c
@@ -98,8 +98,8 @@ union stat_series_slot {
 		unsigned int nr;
 	} avg;
 	struct {
-		unsigned long true;
-		unsigned long false;
+		unsigned long t;
+		unsigned long f;
 	} perc;
 	long acc;
 };
@@ -919,8 +919,8 @@ inline static void reset_stat_series_slot(struct stat_series *ss, union stat_ser
 			ss->cache.acc -= slot->acc;
 			break;
 		case STAT_ALG_PERC:
-			ss->cache.perc.true -= slot->perc.true;
-			ss->cache.perc.false -= slot->perc.false;
+			ss->cache.perc.t -= slot->perc.t;
+			ss->cache.perc.f -= slot->perc.f;
 			break;
 		default:
 			LM_ERR("unknown profile algorithm %d\n", ss->profile->algorithm);
@@ -984,9 +984,9 @@ static unsigned long get_stat_series(struct stat_series *ss)
 			ret = ss->cache.acc;
 			break;
 		case STAT_ALG_PERC:
-			total = ss->cache.perc.true + ss->cache.perc.false;
+			total = ss->cache.perc.t + ss->cache.perc.f;
 			if (total != 0)
-				ret = ss->cache.perc.true * ss->profile->factor / total;
+				ret = ss->cache.perc.t * ss->profile->factor / total;
 			break;
 		default:
 			LM_ERR("unknown profile algorithm %d\n", ss->profile->algorithm);
@@ -1072,11 +1072,11 @@ static int update_stat_series(struct stat_series *ss, int value)
 			break;
 		case STAT_ALG_PERC:
 			if (value > 0) {
-				s->perc.true += value;
-				ss->cache.perc.true += value;
+				s->perc.t += value;
+				ss->cache.perc.t += value;
 			} else {
-				s->perc.false -= value;
-				ss->cache.perc.false -= value;
+				s->perc.f -= value;
+				ss->cache.perc.f -= value;
 			}
 			break;
 		default:


### PR DESCRIPTION
**Summary**
Both true and false are now reserved words in a modern ANSI C. This prevents the following compile error:

```
Compiling statistics.c
gcc -fPIC -DPIC -O2 -flto=auto -ffat-lto-objects -fexceptions -g -grecord-gcc-switches -pipe -Wall -Wno-complain-wrong-lang -Werror=format-security -Wp,-U_FORTIFY_SOURCE,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -fstack-protector-strong -specs=/usr/lib/rpm/redhat/redhat-annobin-cc1 -m64 -march=x86-64 -mtune=generic -fasynchronous-unwind-tables -fstack-clash-protection -fcf-protection -mtls-dialect=gnu2 -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fgnu89-inline -DMOD_NAME='statistics' -DPKG_MALLOC  -DSHM_MMAP  -DUSE_MCAST  -DDISABLE_NAGLE  -DSTATISTICS  -DHAVE_RESOLV_RES  -DF_MALLOC  -DQ_MALLOC  -DHP_MALLOC  -DDBG_MALLOC  -DHAVE_STDATOMIC -DHAVE_GENERICS  -DNAME='"opensips"' -DVERSION='"3.5.4"' -DARCH='"x86_64"' -DOS='"linux"' -DCOMPILER='"gcc 15"' -D__CPU_x86_64 -D__OS_linux -D__SMP_yes -DCFG_DIR='"/etc/opensips/"'  -DVERSIONTYPE='"git"' -DTHISREVISION='"5ebf81d1d"' -DFAST_LOCK -DADAPTIVE_WAIT -DADAPTIVE_WAIT_LOOPS=1024 -DHAVE_GETHOSTBYNAME2 -DHAVE_UNION_SEMUN -DHAVE_MSG_NOSIGNAL -DHAVE_MSGHDR_MSG_CONTROL -DHAVE_ALLOCA_H -DHAVE_TIMEGM -DHAVE_EPOLL -DHAVE_SIGIO_RT -DHAVE_SELECT -c stats_funcs.c -o stats_funcs.o
gcc -fPIC -DPIC -O2 -flto=auto -ffat-lto-objects -fexceptions -g -grecord-gcc-switches -pipe -Wall -Wno-complain-wrong-lang -Werror=format-security -Wp,-U_FORTIFY_SOURCE,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -fstack-protector-strong -specs=/usr/lib/rpm/redhat/redhat-annobin-cc1 -m64 -march=x86-64 -mtune=generic -fasynchronous-unwind-tables -fstack-clash-protection -fcf-protection -mtls-dialect=gnu2 -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fgnu89-inline -DMOD_NAME='statistics' -DPKG_MALLOC  -DSHM_MMAP  -DUSE_MCAST  -DDISABLE_NAGLE  -DSTATISTICS  -DHAVE_RESOLV_RES  -DF_MALLOC  -DQ_MALLOC  -DHP_MALLOC  -DDBG_MALLOC  -DHAVE_STDATOMIC -DHAVE_GENERICS  -DNAME='"opensips"' -DVERSION='"3.5.4"' -DARCH='"x86_64"' -DOS='"linux"' -DCOMPILER='"gcc 15"' -D__CPU_x86_64 -D__OS_linux -D__SMP_yes -DCFG_DIR='"/etc/opensips/"'  -DVERSIONTYPE='"git"' -DTHISREVISION='"5ebf81d1d"' -DFAST_LOCK -DADAPTIVE_WAIT -DADAPTIVE_WAIT_LOOPS=1024 -DHAVE_GETHOSTBYNAME2 -DHAVE_UNION_SEMUN -DHAVE_MSG_NOSIGNAL -DHAVE_MSGHDR_MSG_CONTROL -DHAVE_ALLOCA_H -DHAVE_TIMEGM -DHAVE_EPOLL -DHAVE_SIGIO_RT -DHAVE_SELECT -c statistics.c -o statistics.o
statistics.c:101:31: error: expected identifier or ‘(’ before ‘true’
  101 |                 unsigned long true;
      |                               ^~~~
statistics.c:102:31: error: expected identifier or ‘(’ before ‘false’
  102 |                 unsigned long false;
      |                               ^~~~~
statistics.c:103:9: warning: no semicolon at end of struct or union
  103 |         } perc;
      |         ^
statistics.c: In function ‘reset_stat_series_slot’:
statistics.c:922:40: error: expected identifier before ‘true’
  922 |                         ss->cache.perc.true -= slot->perc.true;
      |                                        ^~~~
statistics.c:923:40: error: expected identifier before ‘false’
  923 |                         ss->cache.perc.false -= slot->perc.false;
      |                                        ^~~~~
statistics.c: In function ‘get_stat_series’:
statistics.c:987:48: error: expected identifier before ‘true’
  987 |                         total = ss->cache.perc.true + ss->cache.perc.false;
      |                                                ^~~~
statistics.c:989:54: error: expected identifier before ‘true’
  989 |                                 ret = ss->cache.perc.true * ss->profile->factor / total;
      |                                                      ^~~~
statistics.c: In function ‘update_stat_series’:
statistics.c:1075:41: error: expected identifier before ‘true’
 1075 |                                 s->perc.true += value;
      |                                         ^~~~
statistics.c:1076:48: error: expected identifier before ‘true’
 1076 |                                 ss->cache.perc.true += value;
      |                                                ^~~~
statistics.c:1078:41: error: expected identifier before ‘false’
 1078 |                                 s->perc.false -= value;
      |                                         ^~~~~
statistics.c:1079:48: error: expected identifier before ‘false’
 1079 |                                 ss->cache.perc.false -= value;
      |                                                ^~~~~
make[1]: Leaving directory '/builddir/build/BUILD/opensips-3.5.4-build/opensips-3.5.4/modules/statistics'
make[1]: *** [../../Makefile.rules:27: statistics.o] Error 1
make: *** [Makefile:198: modules] Error 2
```