### PR TITLE
Ensure proper memory deallocation in case of parsing errors

### DIFF
--- a/parser/msg_parser.c
+++ b/parser/msg_parser.c
@@ -872,7 +872,7 @@ int parse_msg(char* buf, unsigned int len, struct sip_msg* msg)
 	}
 	msg->unparsed=tmp;
 	/*find first Via: */
-	if (parse_headers(msg, flags, 0)==-1) goto error;
+	if (parse_headers(msg, flags, 0)==-1) goto parse_error;
 
 #ifdef EXTRA_DEBUG
 	/* dump parsed data */
@@ -923,6 +923,11 @@ int parse_msg(char* buf, unsigned int len, struct sip_msg* msg)
 #endif
 
 	return 0;
+
+parse_error:
+	/* Free the SIP message if it has already been created to prevent memory leaks */
+	free_sip_msg(msg);
+	memset(msg, 0, sizeof(*msg));
 
 error:
 	/* more debugging, msg->orig is/should be null terminated*/


### PR DESCRIPTION
**Summary**
This PR addresses a memory leak issue in OpenSIPS that occurs when message parsing fails under certain conditions. Currently, in some failure scenarios within parse_msg(), allocated memory is not properly freed, leading to potential leaks. This patch ensures proper memory deallocation in case of parsing errors.

**Details**
The parse_msg() function is responsible for processing incoming SIP messages. However, its behavior regarding memory management on failure is inconsistent across different parts of the OpenSIPS codebase—sometimes the SIP message structure is freed, while in other cases, it is not handled explicitly.

This can result in memory being allocated but never released when parsing errors occur, leading to a slow memory leak. Over time, under high traffic conditions, this could contribute to increased memory usage and degraded system performance.

**Solution**
This PR ensures that parse_msg() consistently frees allocated memory when a parsing failure occurs. Specifically, it:
	•	Adds explicit memory deallocation inside parse_msg() in case of failure.
	•	Prevents potential memory leaks caused by incomplete or erroneous message parsing.

While this fix does not change OpenSIPS’ parsing logic, it improves robustness by ensuring memory is properly handled in failure cases.

**Compatibility**
This patch does not introduce any functional changes to OpenSIPS’ behavior beyond improved memory management. It only ensures that resources are properly freed in failure scenarios. However, some minor adjustments might be needed in other parts of the codebase to align with the improved cleanup logic and avoid redundant free() calls.

**Closing issues**
closes #3589 partially
