### PR TITLE
Add min_ttl parameter to dns_cache

### DIFF
--- a/modules/dns_cache/README
+++ b/modules/dns_cache/README
@@ -14,7 +14,6 @@ dns_cache Module
 
               1.3.1. cachedb_url (string)
               1.3.2. blacklist_timeout (int)
-              1.3.3. min_ttl (int)
 
         1.4. Exported Functions
 
@@ -81,17 +80,6 @@ modparam("dns_cache", "cachedb_url","memcached://192.168.2.130:8888/")
    Example 1.2. Set blacklist_timeout parameter
 ...
 modparam("dns_cache", "blacklist_timeout",7200) # 2 hours
-...
-
-1.3.3. min_ttl (int)
-
-   The minimum number of seconds that a DNS record will be kept in
-   cache. If the TTL receivd in the DNS answer is lower than this
-   value, the record will be cached for min_ttl seconds.
-
-   Example 1.3. Set min_ttl parameter
-...
-modparam("min_ttl", "min_ttl",300) # 5 minutes
 ...
 
 1.4. Exported Functions

--- a/modules/dns_cache/README
+++ b/modules/dns_cache/README
@@ -14,6 +14,7 @@ dns_cache Module
 
               1.3.1. cachedb_url (string)
               1.3.2. blacklist_timeout (int)
+              1.3.3. min_ttl (int)
 
         1.4. Exported Functions
 
@@ -80,6 +81,17 @@ modparam("dns_cache", "cachedb_url","memcached://192.168.2.130:8888/")
    Example 1.2. Set blacklist_timeout parameter
 ...
 modparam("dns_cache", "blacklist_timeout",7200) # 2 hours
+...
+
+1.3.3. min_ttl (int)
+
+   The minimum number of seconds that a DNS record will be kept in
+   cache. If the TTL receivd in the DNS answer is lower than this
+   value, the record will be cached for min_ttl seconds.
+
+   Example 1.3. Set min_ttl parameter
+...
+modparam("min_ttl", "min_ttl",300) # 5 minutes
 ...
 
 1.4. Exported Functions

--- a/modules/dns_cache/dns_cache.c
+++ b/modules/dns_cache/dns_cache.c
@@ -58,7 +58,7 @@ static int min_ttl=0; /* seconds */
 static const param_export_t params[]={
 	{ "cachedb_url",                 STR_PARAM, &cachedb_url.s},
 	{ "blacklist_timeout",           INT_PARAM, &blacklist_timeout},
-  { "min_ttl",                     INT_PARAM, &min_ttl},
+	{ "min_ttl",                     INT_PARAM, &min_ttl},
 	{0,0,0}
 };
 
@@ -841,8 +841,8 @@ int put_dnscache_value(char *name,int r_type,void *record,int rdata_len,
 	/* avoid caching records with TTL=0 */
 	if (!failure && ttl==0) {
 		/* RFC1035 states : "Zero TTL values are interpreted to mean that
-		   the RR can only be used for the transaction in progress, and
-		   should not be cached." */
+			 the RR can only be used for the transaction in progress, and
+			 should not be cached." */
 		return 1;
 	}
 
@@ -880,10 +880,9 @@ int put_dnscache_value(char *name,int r_type,void *record,int rdata_len,
 
 		key_ttl = ttl;
 
-    if (min_ttl > 0 && key_ttl < min_ttl) {
-      LM_DBG("increasing ttl from %d to %d",key_ttl,min_ttl);
-      key_ttl = min_ttl;
-    }
+		if (min_ttl > 0 && key_ttl < min_ttl) {
+			key_ttl = min_ttl;
+		}
 	}
 
 	LM_INFO("putting key [%.*s] with value [%.*s] ttl = %d\n",

--- a/modules/dns_cache/dns_cache.c
+++ b/modules/dns_cache/dns_cache.c
@@ -841,8 +841,8 @@ int put_dnscache_value(char *name,int r_type,void *record,int rdata_len,
 	/* avoid caching records with TTL=0 */
 	if (!failure && ttl==0) {
 		/* RFC1035 states : "Zero TTL values are interpreted to mean that
-			 the RR can only be used for the transaction in progress, and
-			 should not be cached." */
+		   the RR can only be used for the transaction in progress, and
+		   should not be cached." */
 		return 1;
 	}
 

--- a/modules/dns_cache/dns_cache.c
+++ b/modules/dns_cache/dns_cache.c
@@ -53,10 +53,12 @@ static cachedb_con *cdbc = 0;
 
 static int blacklist_timeout=3600; /* seconds */
 static str cachedb_url = {0,0};
+static int min_ttl=0; /* seconds */
 
 static const param_export_t params[]={
 	{ "cachedb_url",                 STR_PARAM, &cachedb_url.s},
 	{ "blacklist_timeout",           INT_PARAM, &blacklist_timeout},
+  { "min_ttl",                     INT_PARAM, &min_ttl},
 	{0,0,0}
 };
 
@@ -877,6 +879,11 @@ int put_dnscache_value(char *name,int r_type,void *record,int rdata_len,
 		}
 
 		key_ttl = ttl;
+
+    if (min_ttl > 0 && key_ttl < min_ttl) {
+      LM_DBG("increasing ttl from %d to %d",key_ttl,min_ttl);
+      key_ttl = min_ttl;
+    }
 	}
 
 	LM_INFO("putting key [%.*s] with value [%.*s] ttl = %d\n",

--- a/modules/dns_cache/doc/dns_cache_admin.xml
+++ b/modules/dns_cache/doc/dns_cache_admin.xml
@@ -83,7 +83,7 @@ modparam("dns_cache", "blacklist_timeout",7200) # 2 hours
 		<title>Set <varname>min_ttl</varname> parameter</title>
 		<programlisting format="linespecific">
 ...
-modparam("min_ttl", "min_ttl",300) # 5 minutes
+modparam("dns_cache", "min_ttl",300) # 5 minutes
 ...
 		</programlisting>
 		</example>

--- a/modules/dns_cache/doc/dns_cache_admin.xml
+++ b/modules/dns_cache/doc/dns_cache_admin.xml
@@ -78,6 +78,11 @@ modparam("dns_cache", "blacklist_timeout",7200) # 2 hours
 			cache. If the TTL received in the DNS answer is lower than this
 			value, the record will be cached for min_ttl seconds.
 		</para>
+    <para>
+		<emphasis>
+			Default value is <emphasis role='bold'>0</emphasis> seconds (no minimum TTL is enforced).
+		</emphasis>
+		</para>
 		
 		<example>
 		<title>Set <varname>min_ttl</varname> parameter</title>

--- a/modules/dns_cache/doc/dns_cache_admin.xml
+++ b/modules/dns_cache/doc/dns_cache_admin.xml
@@ -78,7 +78,7 @@ modparam("dns_cache", "blacklist_timeout",7200) # 2 hours
 			cache. If the TTL received in the DNS answer is lower than this
 			value, the record will be cached for min_ttl seconds.
 		</para>
-    <para>
+		<para>
 		<emphasis>
 			Default value is <emphasis role='bold'>0</emphasis> seconds (no minimum TTL is enforced).
 		</emphasis>

--- a/modules/dns_cache/doc/dns_cache_admin.xml
+++ b/modules/dns_cache/doc/dns_cache_admin.xml
@@ -70,6 +70,25 @@ modparam("dns_cache", "blacklist_timeout",7200) # 2 hours
 		</example>
 		
 		</section>
+
+		<section id="param_min_ttl" xreflabel="min_ttl">
+		<title><varname>min_ttl</varname> (int)</title>
+		<para>
+			The minimum number of seconds that a DNS record will be kept in
+			cache. If the TTL received in the DNS answer is lower than this
+			value, the record will be cached for min_ttl seconds.
+		</para>
+		
+		<example>
+		<title>Set <varname>min_ttl</varname> parameter</title>
+		<programlisting format="linespecific">
+...
+modparam("min_ttl", "min_ttl",300) # 5 minutes
+...
+		</programlisting>
+		</example>
+		
+		</section>
 	</section>
 	
 


### PR DESCRIPTION
**Summary**
This PR introduces a `min_ttl` parameter to the `dns_cache` module, allowing a minimum TTL to be enforced for cached DNS records.

**Details**
DNS records with very short TTLs can cause excessive re-queries to DNS servers, leading to increased load on DNS infrastructure, unnecessary latency, and degraded performance due to the blocking nature of DNS lookups. To mitigate these issues, it is beneficial to enforce a minimum TTL for cached records.

**Solution**
This PR enables applications using `dns_cache` to define a `min_ttl` parameter, specifying the minimum number of seconds a DNS record should be cached. If a DNS response provides a TTL lower than `min_ttl`, the record will instead be cached for `min_ttl` seconds.
