### PR TITLE
sipmsgops: fix warning: ‘*’ may be used uninitialized [-Wmaybe-uninit…

### DIFF
--- a/modules/sipmsgops/sipmsgops.c
+++ b/modules/sipmsgops/sipmsgops.c
@@ -1016,8 +1016,8 @@ static int add_body_part_f(struct sip_msg *msg, str *body, str *mime,
 static int get_updated_body_part_f(struct sip_msg *msg, int *type, pv_spec_t* res)
 {
 	static str out = {NULL, 0};
-	struct body_part *p, *it;
-	unsigned int out_offs, orig_offs, parts;
+	struct body_part *p = NULL, *it;
+	unsigned int out_offs, orig_offs, parts = 0;
 	pv_value_t val;
 
 


### PR DESCRIPTION
Fix the following warning for `gcc version 13.3.0`:
```
sipmsgops.c: In function ‘get_updated_body_part_f’:
sipmsgops.c:1093:28: warning: ‘p’ may be used uninitialized [-Wmaybe-uninitialized]
 1093 |                         if (it!=p) {
      |                            ^
sipmsgops.c:1019:27: note: ‘p’ was declared here
 1019 |         struct body_part *p, *it;
      |                           ^
sipmsgops.c:1100:47: warning: ‘parts’ may be used uninitialized [-Wmaybe-uninitialized]
 1100 |                 msg->body->updated_part_count = parts;
      |                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~
sipmsgops.c:1020:43: note: ‘parts’ was declared here
 1020 |         unsigned int out_offs, orig_offs, parts;
      |                                           ^~~~~

```