### PR TITLE
Fixes to PUA and related Usrloc-changes

### DIFF
--- a/db/schema/location.xml
+++ b/db/schema/location.xml
@@ -9,7 +9,7 @@
 
 <table id="location" xmlns:db="http://docbook.org/ns/docbook">
     <name>location</name>
-    <version>1013</version>
+    <version>1014</version>
     <type db="mysql">&MYSQL_TABLE_TYPE;</type>
     <description>
         <db:para>Persistent user location information for the usrloc module. More information can be found at: &OPENSIPS_MOD_DOC;usrloc.html
@@ -176,5 +176,14 @@
         <null/>
         <default><null/></default>
         <description>Optional information specific to each registration</description>
+    </column>
+
+    <column>
+        <name>params</name>
+        <type>text</type>
+        <size>512</size>
+        <default><null/></default>
+        <null/>
+        <description>Parameters of the Contact header</description>
     </column>
 </table>

--- a/lib/reg/ci.c
+++ b/lib/reg/ci.c
@@ -110,6 +110,14 @@ ucontact_info_t *pack_ci(struct sip_msg* _m, contact_t* _c, unsigned int _e,
 			ci.received = path_received;
 		}
 
+		if (parse_headers(_m, HDR_CONTACT_F, 0) != -1) {
+			ci.params = get_first_contact(_m)->params;
+		} else {
+			if(_c && _c->params) {
+				ci.params = _c->params;
+			}
+		}		
+
 		if (ownership_tag)
 			ci.shtag = *ownership_tag;
 

--- a/lib/str_buffer.c
+++ b/lib/str_buffer.c
@@ -1,0 +1,302 @@
+/*
+ * str_buffer.c - A str_buffer for building strings without knowing the size.
+ *
+ * Author: Larry Laffer (larrylaffer130@gmail.com)
+ * Copyright (C) 2025 Larry Laffer
+ *
+ * This file is part of opensips, a free SIP server.
+ *
+ * opensips is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version
+ *
+ * opensips is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301  USA
+ */
+
+#include "str_buffer.h"
+
+#include "../mem/mem.h"
+#include "../dprint.h"
+
+#include <stdarg.h>
+
+/* generic logging helper for allocation errors in private system memory */
+#ifdef SYS_MALLOC
+#define PKG_MEM_ERROR LM_ERR("could not allocate private memory from sys pool\n")
+#define PKG_MEM_CRITICAL LM_CRIT("could not allocate private memory from sys pool\n")
+
+#ifdef __SUNPRO_C
+#define PKG_MEM_ERROR_FMT(...) LM_ERR("could not allocate private memory from sys pool" __VA_ARGS__)
+#define PKG_MEM_CRITICAL_FMT(...) LM_CRIT("could not allocate private memory from sys pool" __VA_ARGS__)
+#else
+#define PKG_MEM_ERROR_FMT(fmt, args...) LM_ERR("could not allocate private memory from sys pool - " fmt , ## args)
+#define PKG_MEM_CRITICAL_FMT(fmt, args...) LM_CRIT("could not allocate private memory from sys pool - " fmt , ## args)
+#endif
+
+/* generic logging helper for allocation errors in private memory pool */
+#else
+
+#define PKG_MEM_ERROR LM_ERR("could not allocate private memory from pkg pool\n")
+#define PKG_MEM_CRITICAL LM_CRIT("could not allocate private memory from pkg pool\n")
+
+#ifdef __SUNPRO_C
+#define PKG_MEM_ERROR_FMT(...) LM_ERR("could not allocate private memory from pkg pool" __VA_ARGS__)
+#define PKG_MEM_CRITICAL_FMT(...) LM_CRIT("could not allocate private memory from pkg pool" __VA_ARGS__)
+#else
+#define PKG_MEM_ERROR_FMT(fmt, args...) LM_ERR("could not allocate private memory from pkg pool - " fmt , ## args)
+#define PKG_MEM_CRITICAL_FMT(fmt, args...) LM_CRIT("could not allocate private memory from pkg pool - " fmt , ## args)
+#endif
+
+#endif /* SYS_MALLOC */
+
+/**
+ * @brief Resize str_buffer storage if current usage and len will not fit in it.
+ *
+ * @param buf str_buffer to resize
+ * @param len len that needs to fit in str_buffer
+ * @return 1 on success else 0
+ */
+static inline int resizeIfRequired(str_buffer *buf, int len)
+{
+	if(buf->storage.len + len >= (1 << buf->scaling) * BUFFER_SCALE_PERCENT) {
+		char *res = NULL;
+
+		while(buf->storage.len + len
+				>= (1 << buf->scaling) * BUFFER_SCALE_PERCENT) {
+			++buf->scaling;
+		}
+
+		res = pkg_realloc(buf->storage.s, 1 << buf->scaling);
+		if(!res) {
+			buf->error = 1;
+			PKG_MEM_ERROR;
+			return 0;
+		}
+
+		buf->storage.s = res;
+	}
+
+	return 1;
+}
+
+/**
+ * @brief Calculate the strlen after the replacement in format string.
+ *
+ * @param fmt  format string
+ * @param args argument list
+ * @return length of string after the replacement plus 1 because of \0
+ */
+static inline int lengthAfterReplaced(char *fmt, va_list args)
+{
+	int len = 0;
+	va_list tmpArgs;
+
+	va_copy(tmpArgs, args);
+	len = vsnprintf(NULL, 0, fmt, tmpArgs) + 1;
+	va_end(tmpArgs);
+
+	return len;
+}
+
+/**
+ * @brief Append a given format with replaced values to the str_buffer.
+ *
+ * @param buf  str_buffer where to append
+ * @param src  char* format to append
+ * @param len  length of the char*
+ * @param args replacement for the format
+ * @return 1 on success else 0
+ */
+static inline int str_buffer_append_varg(
+		str_buffer *buf, char *src, int len, va_list args)
+{
+	va_list tmpArgs;
+	char *tmp = NULL;
+	int replacedLen = 0;
+
+	if(!buf) {
+		LM_BUG("Wrong usage passing NULL as the buffer\n");
+		return 0;
+	}
+	if(!src || len == 0) {
+		return 1;
+	}
+
+	// temp one bigger than original and zero filled, to make sure its zero terminated
+	tmp = pkg_malloc(sizeof(char) * len + 1);
+	if(!tmp) {
+		buf->error = 1;
+		PKG_MEM_ERROR;
+		return 0;
+	}
+	memset(tmp, 0, sizeof(char) * len + 1);
+	memcpy(tmp, src, len);
+
+	replacedLen = lengthAfterReplaced(tmp, args);
+	if(!resizeIfRequired(buf, replacedLen)) {
+		pkg_free(tmp);
+		return 0;
+	}
+
+	va_copy(tmpArgs, args);
+	len = vsnprintf(
+			buf->storage.s + buf->storage.len, 1 << buf->scaling, tmp, tmpArgs);
+	buf->storage.len += len;
+	va_end(tmpArgs);
+
+	pkg_free(tmp);
+
+	return 1;
+}
+
+str_buffer *new_str_buffer(void)
+{
+	str_buffer *buf = NULL;
+	buf = pkg_malloc(sizeof(str_buffer));
+	if(!buf) {
+		PKG_MEM_ERROR;
+		return NULL;
+	}
+
+	buf->storage.s = pkg_malloc(1 << BUFFER_START_BLOCK_SIZE * sizeof(char));
+	if(!buf->storage.s) {
+		PKG_MEM_ERROR;
+		pkg_free(buf);
+		return NULL;
+	}
+	memset(buf->storage.s, 0, 1 << BUFFER_START_BLOCK_SIZE * sizeof(char));
+
+	buf->storage.len = 0;
+	buf->scaling = BUFFER_START_BLOCK_SIZE;
+	buf->error = 0;
+
+	return buf;
+}
+
+void free_str_buffer(str_buffer *buf)
+{
+	if(!buf) {
+		LM_BUG("Wrong usage passing NULL as the buffer\n");
+		return;
+	}
+
+	if(buf->storage.s) {
+		pkg_free(buf->storage.s);
+	}
+
+	pkg_free(buf);
+}
+
+int str_buffer_has_error(str_buffer *buf)
+{
+	if(!buf) {
+		LM_BUG("Wrong usage passing NULL as the buffer\n");
+		return 0;
+	}
+
+	return buf->error;
+}
+
+int str_buffer_append_str(str_buffer *buf, str *src)
+{
+	if(!src) {
+		return 1;
+	}
+
+	return str_buffer_append_char_ptr(buf, src->s, src->len);
+}
+
+int str_buffer_append_char_ptr(str_buffer *buf, char *src, int len)
+{
+	if(!buf) {
+		LM_BUG("Wrong usage passing NULL as the buffer\n");
+		return 0;
+	}
+	if(!src || len == 0) {
+		return 1;
+	}
+	if(!resizeIfRequired(buf, len)) {
+		return 0;
+	}
+
+	memcpy(buf->storage.s + buf->storage.len, src, len);
+	buf->storage.len += len;
+
+	return 1;
+}
+
+int str_buffer_append_str_fmt(str_buffer *buf, str *src, ...)
+{
+	int res = 0;
+	va_list args;
+
+	if(!src) {
+		return 1;
+	}
+
+	va_start(args, src);
+	res = str_buffer_append_varg(buf, src->s, src->len, args);
+	va_end(args);
+
+	return res;
+}
+
+int str_buffer_append_char_ptr_fmt(str_buffer *buf, char *src, int len, ...)
+{
+	int res = 0;
+	va_list args;
+
+	va_start(args, len);
+	res = str_buffer_append_varg(buf, src, len, args);
+	va_end(args);
+
+	return res;
+}
+
+int str_buffer_append_int(str_buffer *buf, int val)
+{
+	return str_buffer_append_char_ptr_fmt(buf, "%d", 2, val);
+}
+
+int str_buffer_to_str(str_buffer *buf, str *dest)
+{
+	if(!dest) {
+		LM_BUG("Wrong usage passing NULL as the destination\n");
+		return 0;
+	}
+
+	return str_buffer_to_char_ptr(buf, &dest->s, &dest->len);
+}
+
+int str_buffer_to_char_ptr(str_buffer *buf, char **dest, int *len)
+{
+	if(!buf) {
+		LM_BUG("Wrong usage passing NULL as the buffer\n");
+		return 0;
+	}
+	if(!dest) {
+		LM_BUG("Wrong usage passing NULL as the destination\n");
+		return 0;
+	}
+
+	*dest = pkg_malloc(sizeof(char) * buf->storage.len + 1);
+	if(!*dest) {
+		PKG_MEM_ERROR;
+		return 0;
+	}
+	memset(*dest, 0, sizeof(char) * buf->storage.len + 1);
+	memcpy(*dest, buf->storage.s, buf->storage.len);
+	if(len) {
+		*len = buf->storage.len;
+	}
+
+	return 1;
+}

--- a/lib/str_buffer.h
+++ b/lib/str_buffer.h
@@ -1,0 +1,130 @@
+/*
+ * str_buffer.h - A str_buffer for building strings without knowing the size.
+ *
+ * Author: Larry Laffer (larrylaffer130@gmail.com)
+ * Copyright (C) 2025 Larry Laffer
+ *
+ * This file is part of opensips, a free SIP server.
+ *
+ * opensips is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version
+ *
+ * opensips is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301  USA
+ */
+
+
+#ifndef STR_BUFFER_H_
+#define STR_BUFFER_H_
+
+#include "../str.h"
+
+/** start storage chunk size, exponent for the power of two */
+#define BUFFER_START_BLOCK_SIZE 10
+/** resize threshold */
+#define BUFFER_SCALE_PERCENT 0.9
+
+/**
+ * @brief Structure storing the str_buffer data.
+ *
+ */
+typedef struct _str_buffer
+{
+	str storage;
+	int scaling;
+	int error;
+} str_buffer;
+
+/**
+ * @brief Create a new str_buffer.
+ *
+ * @return NULL or new str_buffer
+ */
+str_buffer *new_str_buffer(void);
+/**
+ * @brief Destroy a given str_buffer.
+ *
+ * @param buf str_buffer to destroy
+ */
+void free_str_buffer(str_buffer *buf);
+
+/**
+ * @brief Test whether there were issues while filling the str_buffer.
+ *
+ * @param buf str_buffer to test
+ * @return 1 if issues exists else 0
+ */
+int str_buffer_has_error(str_buffer *buf);
+
+/**
+ * @brief Append a given str to the str_buffer.
+ *
+ * @param buf str_buffer where to append
+ * @param src str to append
+ * @return 1 on success else 0
+ */
+int str_buffer_append_str(str_buffer *buf, str *src);
+/**
+ * @brief Append a given char* with len to the str_buffer.
+ *
+ * @param buf str_buffer where to append
+ * @param src char* to append
+ * @param len length of the char*
+ * @return 1 on success else 0
+ */
+int str_buffer_append_char_ptr(str_buffer *buf, char *src, int len);
+/**
+ * @brief Append a give str format with replaced values to the str_buffer.
+ *
+ * @param buf     str_buffer where to append
+ * @param src     str format to append
+ * @param VARARGS replacement for the format
+ * @return 1 on success else 0
+ */
+int str_buffer_append_str_fmt(str_buffer *buf, str *src, ...);
+/**
+ * @brief Append a given char* format with replaced values to the str_buffer.
+ *
+ * @param buf     str_buffer where to append
+ * @param src     char* format to append
+ * @param len     length of the char*
+ * @param VARARGS replacement for the format
+ * @return 1 on success else 0
+ */
+int str_buffer_append_char_ptr_fmt(str_buffer *buf, char *src, int len, ...);
+/**
+ * @brief Append a give int to the str_buffer.
+ *
+ * @param buf str_buffer where to append
+ * @param val int to append
+ * @return 1 on success else 0
+ */
+int str_buffer_append_int(str_buffer *buf, int val);
+
+/**
+ * @brief Save str_buffer content as str.
+ *
+ * @param buf  str_buffer to save
+ * @param dest str where to save str_buffer content
+ * @return 1 on success else 0
+ */
+int str_buffer_to_str(str_buffer *buf, str *dest);
+/**
+ * @brief Save str_buffer content as char*.
+ *
+ * @param buf  str_buffer to save
+ * @param dest char* where to save str_buffer content
+ * @param len  if not null len will be filled with the char pointer length
+ * @return 1 on success else 0
+ */
+int str_buffer_to_char_ptr(str_buffer *buf, char **dest, int *len);
+
+#endif

--- a/modules/pua_reginfo/notify.c
+++ b/modules/pua_reginfo/notify.c
@@ -234,11 +234,8 @@ int process_body(str notify_body, udomain_t *domain)
 	str contact_uri = {0, 0};
 	str contact_params = {0, 0};
 	str param = {0, 0};
-	str received = {0, 0};
-	str path = {0, 0};
-	str user_agent = {0, 0};
-	int state, event, expires, result, final_result = RESULT_ERROR;
-	char *expires_char, *cseq_char;
+	int state = STATE_UNKNOWN, event, expires, result, final_result = RESULT_ERROR;
+	char *expires_char = NULL, *cseq_char = NULL,*state_attr = NULL, *event_attr = NULL, *param_name = NULL;
 	int cseq = 0;
 	int len;
 	urecord_t *ul_record = NULL;
@@ -265,8 +262,12 @@ int process_body(str notify_body, udomain_t *domain)
 		/* Only process registration sub-items */
 		if(xmlStrcasecmp(registrations->name, BAD_CAST "registration") != 0)
 			goto next_registration;
-		state = reginfo_parse_state(
-				xmlGetAttrContentByName(registrations, "state"));
+		state_attr = xmlGetAttrContentByName(registrations, "state");
+		if(state_attr) {
+			state = reginfo_parse_state(state_attr);
+			xmlFree(state_attr);
+			state_attr = NULL;
+		}
 		if(state == STATE_UNKNOWN) {
 			LM_ERR("No state for this contact!\n");
 			goto next_registration;
@@ -288,10 +289,10 @@ int process_body(str notify_body, udomain_t *domain)
 
 		if(reginfo_use_domain) {
 			aor_key.s = uri;
+			aor_key.len = strlen(aor_key.s);
 		} else {
-			aor_key.s = parsed_aor.user.s;
+			aor_key = parsed_aor.user;
 		}
-		aor_key.len = strlen(aor_key.s);
 		/* Now let's lock that domain for this AOR: */
 		ul.lock_udomain(domain, &aor_key);
 		/* and retrieve the user-record for this user: */
@@ -346,31 +347,15 @@ int process_body(str notify_body, udomain_t *domain)
 					callid.s = xmlGetAttrContentByName(contacts, "id");
 				callid.len = strlen(callid.s);
 				LM_DBG("Got Call-ID \"%.*s\"\n", callid.len, callid.s);
-				received.s = xmlGetAttrContentByName(contacts, "received");
-				if(received.s == NULL) {
-					LM_DBG("No received for this contact!\n");
-					received.len = 0;
-				} else {
-					received.len = strlen(received.s);
-				}
 
-				path.s = xmlGetAttrContentByName(contacts, "path");
-				if(path.s == NULL) {
-					LM_DBG("No path for this contact!\n");
-					path.len = 0;
-				} else {
-					path.len = strlen(path.s);
+				event_attr = xmlGetAttrContentByName(contacts, "event");
+				if(event_attr == NULL) {
+					LM_ERR("No event for this contact!\n");
+					goto next_contact;
 				}
-
-				user_agent.s = xmlGetAttrContentByName(contacts, "user_agent");
-				if(user_agent.s == NULL) {
-					LM_DBG("No user_agent for this contact!\n");
-					user_agent.len = 0;
-				} else {
-					user_agent.len = strlen(user_agent.s);
-				}
-				event = reginfo_parse_event(
-						xmlGetAttrContentByName(contacts, "event"));
+				event = reginfo_parse_event(event_attr);
+				xmlFree(event_attr);
+				event_attr = NULL;
 				if(event == EVENT_UNKNOWN) {
 					LM_ERR("No event for this contact!\n");
 					goto next_contact;
@@ -381,6 +366,8 @@ int process_body(str notify_body, udomain_t *domain)
 					goto next_contact;
 				}
 				expires = atoi(expires_char);
+				xmlFree(expires_char);
+				expires_char = NULL;				
 				if(expires < 0) {
 					LM_ERR("No valid expires for this contact!\n");
 					goto next_contact;
@@ -397,6 +384,8 @@ int process_body(str notify_body, udomain_t *domain)
 						LM_WARN("No valid cseq for this contact!\n");
 					}
 				}
+				xmlFree(cseq_char);
+				cseq_char = NULL;
 
 				// <unknown-param name="+g.oma.sip-im"></unknown-param>
 				// <unknown-param name="language">en,fr</unknown-param>
@@ -408,12 +397,18 @@ int process_body(str notify_body, udomain_t *domain)
 					if(xmlStrcasecmp(params->name, BAD_CAST "unknown-param")
 							!= 0)
 						goto next_param;
-					len += 1 /* ; */
-						   + strlen(xmlGetAttrContentByName(params, "name"));
+					param_name = xmlGetAttrContentByName(params, "name");
+					len += 1 /* ; */ + strlen(param_name);
 					param.s = (char *)xmlNodeGetContent(params);
 					param.len = strlen(param.s);
 					if(param.len > 0)
 						len += 1 /* = */ + param.len;
+					xmlFree(param_name);
+					param_name = NULL;
+					xmlFree(param.s);
+					param.s = NULL;
+					param.len = 0;
+
 				next_param:
 					params = params->next;
 				}
@@ -430,10 +425,11 @@ int process_body(str notify_body, udomain_t *domain)
 						if(xmlStrcasecmp(params->name, BAD_CAST "unknown-param")
 								!= 0)
 							goto next_param2;
+
+						param_name = xmlGetAttrContentByName(params, "name");
 						contact_params.len += snprintf(
 								contact_params.s + contact_params.len,
-								len - contact_params.len, ";%s",
-								xmlGetAttrContentByName(params, "name"));
+								len - contact_params.len, ";%s", param_name);
 						param.s = (char *)xmlNodeGetContent(params);
 						param.len = strlen(param.s);
 						if(param.len > 0)
@@ -444,6 +440,12 @@ int process_body(str notify_body, udomain_t *domain)
 
 						LM_DBG("Contact params are: %.*s\n", contact_params.len,
 								contact_params.s);
+
+						xmlFree(param_name);
+						param_name = NULL;
+						xmlFree(param.s);
+						param.s = NULL;
+						param.len = 0;
 
 					next_param2:
 						params = params->next;
@@ -489,10 +491,20 @@ int process_body(str notify_body, udomain_t *domain)
 					/* Process the result */
 					if(final_result != RESULT_CONTACTS_FOUND)
 						final_result = result;
+
+					xmlFree(contact_uri.s);
+					contact_uri.s = NULL;
+					contact_uri.len = 0;						
 				next_uri:
+				
 					uris = uris->next;
 				}
 			next_contact:
+				if(callid.s) {
+					xmlFree(callid.s);
+					callid.s = NULL;
+					callid.len = 0;
+				}			
 				contacts = contacts->next;
 			}
 		}
@@ -502,7 +514,16 @@ int process_body(str notify_body, udomain_t *domain)
 		/* Unlock the domain for this AOR: */
 		if(aor_key.len > 0)
 			ul.unlock_udomain(domain, &aor_key);
-
+		if(callid.s) {
+			xmlFree(callid.s);
+			callid.s = NULL;
+			callid.len = 0;
+		}
+		if(aor.s) {
+			xmlFree(aor.s);
+			aor.s = NULL;
+			aor.len = 0;
+		}
 		registrations = registrations->next;
 	}
 error:

--- a/modules/pua_reginfo/usrloc_cb.c
+++ b/modules/pua_reginfo/usrloc_cb.c
@@ -21,6 +21,7 @@
  */
 #include "usrloc_cb.h"
 #include "pua_reginfo.h"
+#include "../../lib/str_buffer.h"
 #include <libxml/parser.h>
 #include "../pua/pua.h"
 #include "../presence/bind_presence.h"
@@ -50,6 +51,20 @@ Call-ID: 9ad9f89f-164d-bb86-1072-52e7e9eb5025.
 .</registration>
 </reginfo> */
 
+/** Formats ::str string for use in printf-like functions.
+ * This is a macro that prepares a ::str string for use in functions which 
+ * use printf-like formatting strings. This macro is necessary  because 
+ * ::str strings do not have to be zero-terminated and thus it is necessary 
+ * to provide printf-like functions with the number of characters in the 
+ * string manually. Here is an example how to use the macro: 
+ * \code printf("%.*s\n", STR_FMT(var));\endcode Note well that the correct 
+ * sequence in the formatting string is %.*, see the man page of printf for 
+ * more details.
+ */
+#define STR_FMT(_pstr_)	\
+  ((_pstr_ != (str *)0) ? (_pstr_)->len : 0), \
+  ((_pstr_ != (str *)0) ? (_pstr_)->s : "")
+
 static int _pua_reginfo_self_op = 0;
 
 static pres_ev_t *reginfo_event = NULL;
@@ -59,89 +74,217 @@ void pua_reginfo_update_self_op(int v)
 	_pua_reginfo_self_op = v;
 }
 
-str r_active = str_init("active");
-str r_terminated = str_init("terminated");
-str r_registered = str_init("registered");
-str r_refreshed = str_init("refreshed");
-str r_expired = str_init("expired");
-str r_unregistered = str_init("unregistered");
 #define VERSION_HOLDER "00000000000"
 
 str reginfo_key_etag = str_init("reginfo_etag");
 
-str *build_reginfo_full(urecord_t *record, ucontact_t *contact, str aor[], unsigned int aor_count, int type, int * count)
+
+static str xml_start = str_init("<?xml version=\"1.0\"?>\n");
+
+static str r_full = str_init("full");
+static str r_reginfo_s = str_init(
+		"<reginfo xmlns=\"urn:ietf:params:xml:ns:reginfo\" version=\"%s\" "
+		"state=\"%.*s\">\n"); // before 74 but calculated 76
+static str r_reginfo_e = str_init("</reginfo>\n");
+
+static str r_active = str_init("active");
+static str r_terminated = str_init("terminated");
+static str registration_s = str_init(
+		"\t<registration aor=\"%.*s\" id=\"%p\" state=\"%.*s\">\n");
+static str registration_e = str_init("\t</registration>\n");
+
+//richard: we only use reg unreg refrsh and expire
+static str r_registered = str_init("registered");
+static str r_refreshed = str_init("refreshed");
+static str r_expired = str_init("expired");
+static str r_unregistered = str_init("unregistered");
+static str contact_s =
+		str_init("\t\t<contact id=\"%p\" state=\"%.*s\" event=\"%.*s\" "
+						"expires=\"%d\" callid=\"%.*s\">\n");
+
+static str contact_s_q =
+		str_init("\t\t<contact id=\"%p\" state=\"%.*s\" "
+						"event=\"%.*s\" expires=\"%d\" q=\"%.3f\" callid=\"%.*s\">\n");
+static str contact_s_params_with_body = str_init(
+		"\t\t<unknown-param name=\"%.*s\">\"%.*s\"</unknown-param>\n");
+/**NOTIFY XML needs < to be replaced by &lt; and > to be replaced by &gt;*/
+/*For params that need to be fixed we pass in str removing first and last character and replace them with &lt; and &gt;**/
+static str contact_s_params_with_body_fix = str_init(
+		"\t\t<unknown-param name=\"%.*s\">\"&lt;%.*s&gt;\"</unknown-param>\n");
+static str contact_s_params_no_body = str_init(
+		"\t\t<unknown-param name=\"%.*s\"></unknown-param>\n"); // 1, but 47
+static str contact_e = str_init("\t\t</contact>\n");		// 13, but 14
+
+static str uri_s = str_init("\t\t\t<uri>");
+static str uri_e = str_init("</uri>\n");
+
+/*We currently only support certain unknown params to be sent in NOTIFY bodies
+ This prevents having compatability issues with UEs including non-standard params in contact header
+ Supported params:
+ */
+static str param_q = str_init("q");
+static str param_video = str_init("video");
+static str param_expires = str_init("expires");
+static str param_sip_instance = str_init("+sip.instance");
+static str param_3gpp_smsip = str_init("+g.3gpp.smsip");
+static str param_3gpp_icsi_ref = str_init("+g.3gpp.icsi-ref");
+
+static int inline supported_param(str *param_name)
 {
-	xmlDocPtr doc = NULL;
-	xmlNodePtr root_node = NULL;
-	xmlNodePtr registration_node = NULL;
-	xmlNodePtr contact_node = NULL;
-	xmlNodePtr uri_node = NULL;
-	str *body = NULL;
+
+	if(strncasecmp(param_name->s, param_q.s, param_name->len) == 0) {
+		return 0;
+	} else if(strncasecmp(param_name->s, param_video.s, param_name->len) == 0) {
+		return 0;
+	} else if(strncasecmp(param_name->s, param_expires.s, param_name->len)
+			  == 0) {
+		return 0;
+	} else if(strncasecmp(param_name->s, param_sip_instance.s, param_name->len)
+			  == 0) {
+		return 0;
+	} else if(strncasecmp(param_name->s, param_3gpp_smsip.s, param_name->len)
+			  == 0) {
+		return 0;
+	} else if(strncasecmp(param_name->s, param_3gpp_icsi_ref.s, param_name->len)
+			  == 0) {
+		return 0;
+	} else {
+		return -1;
+	}
+}
+
+static void process_xml_for_contact(str_buffer *buffer, ucontact_t *ptr, int expires, str state, str event)
+{
+	param_t *param;	
+	if(ptr->q != -1) {
+		float q = (float)ptr->q / 1000;
+
+		str_buffer_append_str_fmt(buffer, &contact_s_q, ptr,
+				STR_FMT(&state), STR_FMT(&event), expires, q, STR_FMT(&ptr->callid));
+	} else {
+		// XXX: before was it contact_s_q but no q so changed to contact_s
+		str_buffer_append_str_fmt(buffer, &contact_s, ptr,
+				STR_FMT(&state), STR_FMT(&event), expires, STR_FMT(&ptr->callid));
+	}
+
+	LM_DBG("Appending contact address: <%.*s>\n", STR_FMT(&ptr->c));
+
+	str_buffer_append_str(buffer, &uri_s);
+	str_buffer_append_str(buffer, &ptr->c);
+	str_buffer_append_str(buffer, &uri_e);
+
+	param = ptr->params;
+	while(param) {
+		if(supported_param(&param->name) != 0) {
+			param = param->next;
+			continue;
+		}
+
+		if(param->body.len > 0) {
+			LM_DBG("This contact has params name: [%.*s] body [%.*s]\n",
+				param->name.len, param->name.s, param->body.len, param->body.s);
+
+			if(param->body.s[0] == '<'
+					&& param->body.s[param->body.len - 1] == '>') {
+				str tmp = STR_NULL;
+				LM_DBG("This param body starts with '<' and ends with '>' we "
+					   "will clean these for the NOTIFY XML with &lt; and "
+					   "&gt;\n");
+
+				tmp.len = param->body.len - 2;
+				tmp.s = param->body.s + 1;
+
+				str_buffer_append_str_fmt(buffer, &contact_s_params_with_body_fix,
+					param->name.len, param->name.s, tmp.len, tmp.s);
+			} else {
+				str_buffer_append_str_fmt(buffer, &contact_s_params_with_body,
+						param->name.len, param->name.s, 
+						param->body.len, param->body.s);
+			}
+		} else {
+			LM_DBG("This contact has params name: [%.*s] \n",
+					STR_FMT(&param->name));
+
+			str_buffer_append_str_fmt(
+					buffer, &contact_s_params_no_body, STR_FMT(&param->name));
+		}
+
+		param = param->next;
+	}
+
+	str_buffer_append_str(buffer, &contact_e);
+}
+
+str build_reginfo_full(urecord_t *record, ucontact_t *contact, str aor[], unsigned int aor_count, int type, int * count)
+{
+	str_buffer *buffer = NULL;
+	str x = STR_NULL;
 	str state = STR_NULL;
 	str event = STR_NULL;
 	ucontact_t *ptr;
-	char buf[512];
-	int reg_active = 0;
 	time_t cur_time = time(0);
 	int expires = 0;
 	int i = 0;
 
-	/* create the XML-Body */
-	doc = xmlNewDoc(BAD_CAST "1.0");
-	if(doc == 0) {
-		LM_ERR("Unable to create XML-Doc\n");
-		return NULL;
+	buffer = new_str_buffer();
+	if(!buffer) {
+		LM_ERR("Error allocating str_buffer\n");
+		return x;
 	}
+	str_buffer_append_str(buffer, &xml_start);
+	str_buffer_append_str_fmt(
+			buffer, &r_reginfo_s, VERSION_HOLDER, STR_FMT(&r_full));
 
-	root_node = xmlNewNode(NULL, BAD_CAST "reginfo");
-	if(root_node == 0) {
-		LM_ERR("Unable to create reginfo-XML-Element\n");
-		xmlFreeDoc(doc);
-		return NULL;
+	ptr = record->contacts;
+	LM_DBG("Records %p\n", ptr);
+	while(ptr) {
+		if(ptr == contact) {
+			switch(type) {
+					//richard we only use registered and refreshed and expired and unregistered
+				case UL_CONTACT_INSERT:
+				case UL_CONTACT_UPDATE:
+					state = r_active;
+					break;
+				case UL_CONTACT_EXPIRE:
+				case UL_CONTACT_DELETE:
+					state = r_terminated;
+					break;
+				default:
+					state = r_active;
+			}
+		} else {
+			if (VALID_CONTACT(ptr, cur_time)) {
+				state = r_active;
+			} else {
+				state = r_terminated;
+			}
+		}
+		ptr = ptr->next;
 	}
-	/* This is our Root-Element: */
-	xmlDocSetRootElement(doc, root_node);
-
-	xmlNewProp(root_node, BAD_CAST "xmlns",
-			BAD_CAST "urn:ietf:params:xml:ns:reginfo");
-
-	/* we set the version to 0 but it should be set to the correct value in the pua module */
-	xmlNewProp(root_node, BAD_CAST "version", BAD_CAST VERSION_HOLDER);
-	xmlNewProp(root_node, BAD_CAST "state", BAD_CAST "full");
 
 	for (i = 0; i < aor_count; i++) {
 		/* Registration Node */
-		registration_node =
-				xmlNewChild(root_node, NULL, BAD_CAST "registration", NULL);
-		if(registration_node == NULL) {
-			LM_ERR("while adding child\n");
-			goto error;
-		}
-		reg_active = 0;
-
-		/* Add the properties to this Node for AOR and ID: */
-		xmlNewProp(registration_node, BAD_CAST "aor", BAD_CAST aor[i].s);
-		snprintf(buf, sizeof(buf), "%p.%i", record, i);
-		xmlNewProp(registration_node, BAD_CAST "id", BAD_CAST buf);
+		LM_DBG("Registration Node for AOR %.*s [%.*s]\n", aor[i].len, aor[i].s, STR_FMT(&state));
+		str_buffer_append_str_fmt(buffer, &registration_s,
+				STR_FMT(&aor[i]), record, STR_FMT(&state));
 
 		ptr = record->contacts;
 		LM_DBG("Records %p\n", ptr);
 		*count = 0;
 		while(ptr) {
 			expires = (int)(ptr->expires - cur_time);
-			LM_DBG("Contact %.*s (Expires %i, now %i, in %i)\n", ptr->c.len, ptr->c.s, (int)ptr->expires, (int)cur_time, expires);
+			LM_DBG("  Contact %.*s (Expires %i, now %i, in %i)\n", ptr->c.len, ptr->c.s, (int)ptr->expires, (int)cur_time, expires);
+			*count = *count + 1;
 			if(ptr == contact) {
 				switch(type) {
 						//richard we only use registered and refreshed and expired and unregistered
 					case UL_CONTACT_INSERT:
 						state = r_active;
 						event = r_registered;
-						reg_active = 1;
 						break;
 					case UL_CONTACT_UPDATE:
 						state = r_active;
 						event = r_refreshed;
-						reg_active = 1;
 						break;
 					case UL_CONTACT_EXPIRE:
 						state = r_terminated;
@@ -156,133 +299,45 @@ str *build_reginfo_full(urecord_t *record, ucontact_t *contact, str aor[], unsig
 					default:
 						state = r_active;
 						event = r_registered;
-						reg_active = 1;
 				}
 			} else {
 				if (VALID_CONTACT(ptr, cur_time)) {
 					state = r_active;
 					event = r_registered;
-					reg_active = 1;
 				} else {
 					state = r_terminated;
 					event = r_expired;
 					expires = 0;
 				}
 			}
-			*count = *count + 1;
-			LM_DBG("Contact %.*s\n", ptr->c.len, ptr->c.s);
-			/* Contact-Node */
-			contact_node = xmlNewChild(
-					registration_node, NULL, BAD_CAST "contact", NULL);
-			if(contact_node == NULL) {
-				LM_ERR("while adding child\n");
-				goto error;
-			}
-			memset(buf, 0, sizeof(buf));
-			snprintf(buf, sizeof(buf), "%p", ptr);
-			xmlNewProp(contact_node, BAD_CAST "id", BAD_CAST buf);
-			memset(buf, 0, sizeof(buf));
-			snprintf(buf, sizeof(buf), "%.*s", state.len, state.s);
-			xmlNewProp(contact_node, BAD_CAST "state", BAD_CAST buf);
-			memset(buf, 0, sizeof(buf));
-			snprintf(buf, sizeof(buf), "%.*s", event.len, event.s);
-			xmlNewProp(
-					contact_node, BAD_CAST "event", BAD_CAST buf);
-			memset(buf, 0, sizeof(buf));
-			snprintf(
-					buf, sizeof(buf), "%i", (int)expires);
-			xmlNewProp(contact_node, BAD_CAST "expires", BAD_CAST buf);
-			if(ptr->q != Q_UNSPECIFIED) {
-				float q = (float)ptr->q / 1000;
-				memset(buf, 0, sizeof(buf));
-				snprintf(buf, sizeof(buf), "%.3f", q);
-				xmlNewProp(contact_node, BAD_CAST "q", BAD_CAST buf);
-			}
-			/* CallID Attribute */
-			memset(buf, 0, sizeof(buf));
-			snprintf(buf, sizeof(buf), "%.*s", ptr->callid.len, ptr->callid.s);
-			xmlNewProp(contact_node, BAD_CAST "callid", BAD_CAST buf);
 
-			/* CSeq Attribute */
-			memset(buf, 0, sizeof(buf));
-			snprintf(buf, sizeof(buf), "%d", ptr->cseq);
-			xmlNewProp(contact_node, BAD_CAST "cseq", BAD_CAST buf);
-
-			if (ptr->received.len) {
-				/* received Attribute */
-				memset(buf, 0, sizeof(buf));
-				snprintf(buf, sizeof(buf), "%.*s", ptr->received.len,
-						ptr->received.s);
-				xmlNewProp(contact_node, BAD_CAST "received", BAD_CAST buf);
-			}
-
-			if (ptr->path.len) {
-				/* path Attribute */
-				memset(buf, 0, sizeof(buf));
-				snprintf(buf, sizeof(buf), "%.*s", ptr->path.len, ptr->path.s);
-				xmlNewProp(contact_node, BAD_CAST "path", BAD_CAST buf);
-			}
-
-			if (ptr->user_agent.len) {
-				/* user_agent Attribute */
-				memset(buf, 0, sizeof(buf));
-				snprintf(buf, sizeof(buf), "%.*s", ptr->user_agent.len,
-						ptr->user_agent.s);
-				xmlNewProp(contact_node, BAD_CAST "user_agent", BAD_CAST buf);
-			}
-
-			/* URI-Node */
-			memset(buf, 0, sizeof(buf));
-			snprintf(buf, sizeof(buf), "%.*s", ptr->c.len, ptr->c.s);
-			uri_node = xmlNewChild(
-					contact_node, NULL, BAD_CAST "uri", BAD_CAST buf);
-			if(uri_node == NULL) {
-				LM_ERR("while adding child\n");
-				goto error;
-			}
+			process_xml_for_contact(buffer, ptr, expires, state, event);
 			ptr = ptr->next;
 		}
 
-		/* add registration state (at least one active contact): */
-		if(reg_active == 0)
-			xmlNewProp(registration_node, BAD_CAST "state", BAD_CAST "terminated");
-		else
-			xmlNewProp(registration_node, BAD_CAST "state", BAD_CAST "active");
+		str_buffer_append_str(buffer, &registration_e);
 	}
 
-	/* create the body */
-	body = (str *)pkg_malloc(sizeof(str));
-	if(body == NULL) {
-		LM_ERR("while allocating memory\n");
-		return NULL;
+	str_buffer_append_str(buffer, &r_reginfo_e);
+
+	if(str_buffer_has_error(buffer)) {
+		LM_ERR("str_buffer had memory allocating errors while building\n");
+	} else if(!str_buffer_to_str(buffer, &x)) {
+		LM_ERR("no more pkg memory\n");
 	}
-	memset(body, 0, sizeof(str));
 
-	/* Write the XML into the body */
-	xmlDocDumpFormatMemory(
-			doc, (unsigned char **)(void *)&body->s, &body->len, 1);
+	free_str_buffer(buffer);
 
-	/*free the document */
-	xmlFreeDoc(doc);
-	xmlCleanupParser();
+	LM_DBG("Returned full reg-info: [%.*s]\n", STR_FMT(&x));
 
-	return body;
-error:
-	if(body) {
-		if(body->s)
-			xmlFree(body->s);
-		pkg_free(body);
-	}
-	if(doc)
-		xmlFreeDoc(doc);
-	return NULL;
+	return x;
 }
 
 void reginfo_usrloc_cb(void *binding, ul_cb_type type, ul_cb_extra *_) {
 	ucontact_t *contact = (ucontact_t*)binding;
 	urecord_t *record = NULL;
 	event_t ev;
-	str *body = NULL;
+	str body = {NULL, 0};
 	publ_info_t publ;
 	presentity_t presentity;
 	str content_type;
@@ -303,9 +358,9 @@ void reginfo_usrloc_cb(void *binding, ul_cb_type type, ul_cb_extra *_) {
 	str s, str_dup;
 
 	/* Get the URecord for the contact */
-	LM_DBG("Searching urecord for contact-AOR %.*s (Contact %.*s)\n",
+	LM_ERR("Searching urecord for contact-AOR %.*s (Contact %.*s), type %i\n",
 		contact->aor->len, contact->aor->s,
-		contact->c.len, contact->c.s);
+		contact->c.len, contact->c.s, (int)type);
 	ul.get_urecord(ul_domain, contact->aor, &record);
 	if (record == NULL) {
 		LM_DBG("Unable to get urecord for contact-AOR %.*s (Contact %.*s)\n",
@@ -393,12 +448,12 @@ void reginfo_usrloc_cb(void *binding, ul_cb_type type, ul_cb_extra *_) {
 	
 	/* Build the XML-Body: */
 	body = build_reginfo_full(record, contact, aorlist, aor_count, type, &count);
-
-	if(body == NULL || body->s == NULL) {
+	if(body.s == NULL) {
 		LM_ERR("Error on creating XML-Body for publish\n");
 		goto error;
 	}
-	LM_DBG("XML-Body (%i entries):\n%.*s\n", count, body->len, body->s);
+
+	LM_DBG("XML-Body (%i entries):\n%.*s\n", count, body.len, body.s);
 
 	if (pres.update_presentity != NULL) {
 		if (reginfo_event == NULL) {
@@ -444,7 +499,12 @@ void reginfo_usrloc_cb(void *binding, ul_cb_type type, ul_cb_extra *_) {
 		  presentity.new_etag.len, presentity.new_etag.s,
 		  presentity.old_etag.len, presentity.old_etag.s);
 		
-		presentity.body = *body;
+		presentity.body = body;
+
+		memset(&new_value, 0, sizeof(int_str_t));
+		new_value.is_str = 1;
+		new_value.s = presentity.new_etag;
+		ul.put_urecord_key(record, &reginfo_key_etag, &new_value);
 
 		/* query the database and update or insert */
 		if(pres.update_presentity(&presentity) <0)
@@ -456,11 +516,6 @@ void reginfo_usrloc_cb(void *binding, ul_cb_type type, ul_cb_extra *_) {
 		LM_DBG("etag_new = %i, new_etag %.*s, old_etag %.*s\n", presentity.etag_new,
 		  presentity.new_etag.len, presentity.new_etag.s,
 		  presentity.old_etag.len, presentity.old_etag.s);
-
-		memset(&new_value, 0, sizeof(int_str_t));
-		new_value.is_str = 1;
-		new_value.s = presentity.new_etag;
-		ul.put_urecord_key(record, &reginfo_key_etag, &new_value);
 	}
 
 	if (publish_reginfo && pua.send_publish != NULL) {
@@ -471,7 +526,7 @@ void reginfo_usrloc_cb(void *binding, ul_cb_type type, ul_cb_extra *_) {
 		memset(&publ, 0, sizeof(publ_info_t));
 
 		publ.pres_uri = &uri;
-		publ.body = body;
+		publ.body = &body;
 		id_buf_len = snprintf(id_buf, sizeof(id_buf), "REGINFO_PUBLISH.%.*s@%.*s",
 				record->aor.len, record->aor.s, record->domain->len, record->domain->s);
 		publ.id.s = id_buf;
@@ -496,11 +551,8 @@ void reginfo_usrloc_cb(void *binding, ul_cb_type type, ul_cb_extra *_) {
 error:
 	for (i = 0; i < aor_count; i++)
 		pkg_free(aorlist[i].s);
-	if(body) {
-		if(body->s)
-			xmlFree(body->s);
-		pkg_free(body);
-	}
+	if(body.s)
+		pkg_free(body.s);
 
 	return;
 }

--- a/modules/usrloc/doc/usrloc_admin.xml
+++ b/modules/usrloc/doc/usrloc_admin.xml
@@ -640,6 +640,26 @@ modparam("usrloc", "attr_column", "attributes")
 		</example>
 	</section>
 
+	<section id="param_attr_column" xreflabel="params_column">
+		<title><varname>params_column</varname> (string)</title>
+		<para>
+		Name of column containing the parameters of the contact header.
+		</para>
+		<para>
+		<emphasis>
+			Default value is <quote>params</quote>.
+		</emphasis>
+		</para>
+		<example>
+		<title>Set <varname>params_column</varname> parameter</title>
+		<programlisting format="linespecific">
+...
+modparam("usrloc", "params_column", "parameters")
+...
+</programlisting>
+		</example>
+	</section>
+
 	<section id="param_use_domain" xreflabel="use_domain">
 		<title><varname>use_domain</varname> (integer)</title>
 		<para>

--- a/modules/usrloc/ucontact.h
+++ b/modules/usrloc/ucontact.h
@@ -126,6 +126,7 @@ typedef struct ucontact {
 	time_t last_modified;   /*!< When the record was last modified */
 	unsigned int methods;   /*!< Supported methods */
 	str attr;               /*!< Additional registration info  */
+	param_t *params;        /*!< Params header details> */
 	struct proxy_l next_hop;/*!< SIP-wise determined next hop */
 	unsigned short label;   /*!< label to find the contact in contact list>*/
 	int sipping_latency;    /*!< useconds; not restart-persistent >*/
@@ -167,6 +168,7 @@ typedef struct ucontact_info {
 	time_t last_modified;
 	str *packed_kv_storage;
 	str *attr;
+	param_t *params;        /*!< Params header details> */
 	str shtag;
 	str cdb_key;
 	int refresh_time;

--- a/modules/usrloc/ul_cluster.h
+++ b/modules/usrloc/ul_cluster.h
@@ -42,7 +42,8 @@
 #define UL_BIN_V3      3 // added "cmatch" (default: CT_MATCH_CONTACT_CALLID)
 #define UL_BIN_V4      4 // changed 'ct.cflags' from int bitmask to string repr
 #define UL_BIN_V5      5 // added 'r.kv_storage' to AoR INSERT packets
-#define UL_BIN_VERSION UL_BIN_V5
+#define UL_BIN_V6      6 // added 'r.params' to AoR INSERT packets
+#define UL_BIN_VERSION UL_BIN_V6
 
 extern int location_cluster;
 extern struct clusterer_binds clusterer_api;

--- a/modules/usrloc/ul_mod.c
+++ b/modules/usrloc/ul_mod.c
@@ -261,6 +261,7 @@ static const param_export_t params[] = {
 	{"latency_event_min_us",   INT_PARAM, &latency_event_min_us  },
 	{"latency_event_min_us_delta",   INT_PARAM, &latency_event_min_us_delta  },
 	{"attr_column",        STR_PARAM, &attr_col.s        },
+	{"params_column",      STR_PARAM, &params_col.s      },	
 	{"matching_mode",      INT_PARAM, &matching_mode     },
 	{"cseq_delay",         INT_PARAM, &cseq_delay        },
 	{"hash_size",          INT_PARAM, &ul_hash_size      },

--- a/modules/usrloc/ul_mod.c
+++ b/modules/usrloc/ul_mod.c
@@ -83,6 +83,7 @@
 #define SIP_INSTANCE_COL   "sip_instance"
 #define KV_STORE_COL   "kv_store"
 #define ATTR_COL       "attr"
+#define PARAMS_COL       "params"
 
 static int mod_init(void);        /*!< Module initialization */
 static void destroy(void);        /*!< Module destroy */
@@ -133,6 +134,7 @@ str kv_store_col    = str_init(KV_STORE_COL);		/*!< Name of column containing ge
 str attr_col        = str_init(ATTR_COL);		/*!< Name of column containing additional info */
 str sip_instance_col = str_init(SIP_INSTANCE_COL);
 str contactid_col   = str_init(CONTACTID_COL);
+str params_col      = str_init(PARAMS_COL);
 
 str db_url          = STR_NULL;					/*!< Database URL */
 str cdb_url         = STR_NULL;					/*!< Cache Database URL */
@@ -254,6 +256,7 @@ static const param_export_t params[] = {
 	{"methods_column",     STR_PARAM, &methods_col.s     },
 	{"sip_instance_column",STR_PARAM, &sip_instance_col.s},
 	{"kv_store_column",    STR_PARAM, &kv_store_col.s    },
+	{"params_column",      STR_PARAM, &params_col.s      },	
 	{"mi_dump_kv_store",   INT_PARAM, &mi_dump_kv_store  },
 	{"latency_event_min_us",   INT_PARAM, &latency_event_min_us  },
 	{"latency_event_min_us_delta",   INT_PARAM, &latency_event_min_us_delta  },
@@ -263,6 +266,7 @@ static const param_export_t params[] = {
 	{"hash_size",          INT_PARAM, &ul_hash_size      },
 	{"nat_bflag",          STR_PARAM, &nat_bflag_str     },
 	{"contact_refresh_timer",  INT_PARAM, &ct_refresh_timer },
+
 
 	/* data replication through clusterer using TCP binary packets */
 	{ "location_cluster",	INT_PARAM, &location_cluster   },

--- a/modules/usrloc/ul_mod.h
+++ b/modules/usrloc/ul_mod.h
@@ -97,9 +97,9 @@ static inline int tags_in_use(void)
  */
 
 
-#define UL_TABLE_VERSION 1013
+#define UL_TABLE_VERSION 1014
 
-#define UL_COLS 19
+#define UL_COLS 20
 extern str contactid_col;
 extern str user_col;
 extern str domain_col;
@@ -119,6 +119,7 @@ extern str kv_store_col;
 extern str attr_col;
 extern str last_mod_col;
 extern str sip_instance_col;
+extern str params_col;
 
 extern str db_url;
 extern enum usrloc_modes db_mode;


### PR DESCRIPTION
**Summary**
This PR fixes some crashes identified in the pua_usrloc module. In order for this module to provide the relevant information, Usrloc needs to store additional information (Parameters from Contact), which is now incorporated as well.

**Details**
Since the body may become large, the PR introduces a variable String-Buffer to facilitate larger results. Since the result should include the params of the Contact-Header, the according Params are retrieved (and stored) from usrloc.

**Solution**
I did not fully test the clustering and DB-operations of data yet.

**Compatibility**
This PR changes the schema of the location DB (added location column), so it is not backward compatible.

