### PR TITLE
Fix pointer type on 32-bin ix86 machines

### DIFF
--- a/modules/aaa_diameter/aaa_diameter.c
+++ b/modules/aaa_diameter/aaa_diameter.c
@@ -362,7 +362,7 @@ static int dm_send_answer(struct sip_msg *msg, str *avp_json, int *is_error)
 	pv_value_t res;
 	str sessid;
 	int appid, cmdcode, rc;
-	unsigned long fd_req;
+	uint64_t fd_req;
 
 	if (route_type != EVENT_ROUTE) {
 		LM_ERR("can only run 'dm_send_answer()' inside an EVENT_ROUTE\n");


### PR DESCRIPTION
**Summary**
Fix pointer types on i686 machines.

**Details**
Unfortunately `uint64_t` is `long long` on i686 machines. Let's just use uint64_t everywhere.

**Solution**
This patch fixes the following compile-time error on i686 machine:

```
aaa_diameter.c: In function ‘dm_send_answer’:
aaa_diameter.c:420:60: error: passing argument 4 of ‘reverse_hex2int64’ from incompatible pointer type [-Wincompatible-pointer-types]
  420 |                 reverse_hex2int64(res.rs.s, res.rs.len, 1, &fd_req);
      |                                                            ^~~~~~~
      |                                                            |
      |                                                            long unsigned int *
In file included from aaa_diameter.c:26:
../../ut.h:399:78: note: expected ‘uint64_t *’ {aka ‘long long unsigned int *’} but argument is of type ‘long unsigned int *’
  399 | inline static int reverse_hex2int64( char *c, int len, int unsafe, uint64_t *r)
      |                                                                    ~~~~~~~~~~^
make[1]: *** [../../Makefile.rules:28: aaa_diameter.o] Error 1
make[1]: *** Waiting for unfinished jobs....
```

**Compatibility**
I am not aware of any incompatibilities.

**Closing issues**
n/a

<!--
Thanks for submitting a pull request!
In order to consider and evaluate your PR, it is mandatory to provide detailed information about (1) what is the issue the PR addresses, (2) how the PR is solving the issue (logic and coding), (3) what are (if any) limitations of the proposed PR and (4) if there are any known side-effects/ backward compatibility issues/SIP interoperability issues.
Note that if the PR is missing information, it might take longer to be merged, as extra resources have to be allocated by the maintainers to reverse engineer the changes, understand them, understand the motivation, etc. That is why it is important to provide as much information as possible.
-->

