### PR TITLE
Fix: cachedb_redis initialization fails checking for JSON support in …

### DIFF
--- a/modules/cachedb_redis/cachedb_redis_dbase.c
+++ b/modules/cachedb_redis/cachedb_redis_dbase.c
@@ -257,7 +257,7 @@ int redis_connect(redis_con *con)
 		freeReplyObject(rpl);
 	}
 
-	rpl = redisCommand(ctx, "JSON.SET opensipsTestJSON . null");
+	rpl = redisCommand(ctx, "JSON.DEBUG help");
 	if (rpl == NULL || rpl->type == REDIS_REPLY_ERROR) {
 		LM_INFO("no JSON support detected on Redis server %s:%d\n",
 		        con->host, con->port);


### PR DESCRIPTION

**Summary**
When using Redis Clustering, it is possible for the redis_connect() initialization function of cachedb_redis to fail when checking for JSON support when the cluster does indeed support JSON.

**Details**
Currently in `redis_connect()` the command `JSON.SET` is used to test JSON compatibility on a redis server by dropping in a test json document. Being that `JSON.SET` is a keyed command, it is possible that the server will respond back with a MOVED reply (considered an error) because the key does not belong to that node in the cluster. [](https://redis.io/docs/latest/operate/oss_and_stack/reference/cluster-spec/#:~:text=Redirection%20and%20resharding-,MOVED%20Redirection,-A%20Redis%20client)
Since this initialization routine does not use the `redis_run_command()` wrapper function but rather the `redisCommand()` function directly from HiRedis, there is no retry happening to move to the next server in the cluster. 

This fix changes the `redis_connect()` method to instead use the non-keyed test of `JSON.DEBUG help` which will produce a succesfull reply if JSON support is installed and enabled on a server/cluster regardless of which node the command is sent to.

[](https://redis.io/docs/latest/commands/json.debug-help/)

**Solution**
Replace the use of `JSON.SET` with `JSON.DEBUG help` which will not yield a potential `MOVED` response from Redis. 

**Compatibility**
This does not seem to affect other scenarios

**Closing issues**
n/a
