### PR TITLE
uac_registrant: add socket to the reg_list output

### DIFF
--- a/modules/uac_registrant/registrant.c
+++ b/modules/uac_registrant/registrant.c
@@ -1148,6 +1148,14 @@ int run_mi_reg_list(void *e_data, void *data, void *r_data)
 			rec->td.loc_uri.s, rec->td.loc_uri.len) < 0)
 			goto error;
 
+	if (rec->td.send_sock)
+	{
+		p = socket2str(rec->td.send_sock, NULL, &len, 0);
+		if (p)
+			if (add_mi_string(record_item, MI_SSTR("socket"), p, len) < 0)
+				goto error;
+	}
+
 	if (rec->td.obp.s && rec->td.obp.len)
 		if (add_mi_string(record_item, MI_SSTR("proxy"),
 			rec->td.obp.s, rec->td.obp.len) < 0)


### PR DESCRIPTION
Summary
This PR enhances the output of the `reg_list` MI command in the `uac_registrant` module by including the `socket` used for registration, if configured.

Details
Currently, the `reg_list` command does not show which forced socket (if any) is being used by a specific UAC registration. This information is useful in deployments where multiple sockets are configured, especially when different registrations use different local addresses or interfaces.
Exposing this data helps operators and integrators to debug and verify the actual registration path and socket binding.

Solution
The patch modifies the logic of the `reg_list` MI command to include the configured socket (if present) in its output.
No changes are made to the registration behavior itself — this is a non-intrusive improvement to the management interface only.
The output format is extended to include a new `socket` field, maintaining backward compatibility by not removing or renaming any existing fields.

Compatibility
The change is backward compatible. It only adds an additional field to the MI output of `reg_list`, which should not affect existing scripts or tools unless they strictly parse the output structure. Even then, such tools would likely ignore unknown fields rather than fail.

Closing issues
N/A