### PR TITLE
Add support to send a command to an RTPEngine specified by the sock_var

### DIFF
--- a/modules/rtpengine/README
+++ b/modules/rtpengine/README
@@ -442,6 +442,15 @@ modparam("rtpengine", "ping_enabled", yes)
 
 1.5. Exported Functions
 
+    Many rtpengine_* functions accept a "sock_var" parameter that
+    will be populated with the socket of the RTPEngine chosen for
+    the particular operation. The format of the data stored in
+    "sock_var" is: "proto:ip:port".  If the "sock_var" has
+    been specified and it is non-NULL then it will be used to
+    determine the specific RTPEngine to use.  Note that the socket
+    specified by "sock_var" must be a member of the current RTPEngine
+    Set context.
+
 1.5.1.  rtpengine_use_set(setid)
 
    Sets the ID of the RTP proxy set to be used for the next

--- a/modules/rtpengine/doc/rtpengine_admin.xml
+++ b/modules/rtpengine/doc/rtpengine_admin.xml
@@ -78,6 +78,16 @@
 		You can use the <xref linkend="param_extra_failover_error"/> parameter
 		to extend the above list.
 	</para>
+	<para>
+		Many rtpengine_* functions accept a "sock_var" parameter that
+		will be populated with the socket of the RTPEngine chosen for
+		the particular operation. The format of the data stored in
+		"sock_var" is: "proto:ip:port".  If the "sock_var" has
+		been specified and it is non-NULL then it will be used to
+		determine the specific RTPEngine to use.  Note that the socket
+		specified by "sock_var" must be a member of the current RTPEngine
+		Set context.
+	</para>
 	</section>
 
 	<section id="dependencies" xreflabel="Dependencies">

--- a/modules/rtpengine/rtpengine.c
+++ b/modules/rtpengine/rtpengine.c
@@ -2836,27 +2836,22 @@ static bencode_item_t *rtpe_function_call(bencode_buffer_t *bencbuf, struct sip_
 	if (rtpe_function_call_prepare(bencbuf, msg, op, &ng_flags, flags_str, body_in, extra_dict,&err) < 0)
 		goto error;
 
-	/*
-	 * If the Set is not specified as a parameter into this routine
-	 * try to determine. Using the specified setid_avp module parameter,
-	 * or from the default default_rtpe_set().
-	 */
+	/*** set can be passed into this routine. If it is NULL, then attempt to determine it. ***/
 	if (!set) {
-		set_rtpengine_set_from_avp(msg);
 		if ((set=rtpe_ctx_set_get())==NULL)
 			set = *default_rtpe_set;
+	}
+
+	/*** If the spvar "sock_var" has been specified, parse it into a (socket_val) STR variable ***/
+	if (spvar) {
+		memset(&socket_val, 0, sizeof(pv_value_t));
+		pv_get_spec_value(msg, spvar, &socket_val);
 	}
 
 	failed_node = NULL;
 
 	RTPE_START_READ();
 	do {
-		/* If the spvar "sock_var" has been specified, parse it into a (socket_val) STR variable */
-		if (spvar) {
-			memset(&socket_val, 0, sizeof(pv_value_t));
-			pv_get_spec_value(msg, spvar, &socket_val);
-		}
-
 		/*
 		 * Many rtpengine_* commands allow a "sock_var" to be specified by the script writer.
 		 * The "sock_var" will be populated by the rtpengine_* command with the RTPEngine that

--- a/modules/rtpengine/rtpengine.c
+++ b/modules/rtpengine/rtpengine.c
@@ -2867,7 +2867,7 @@ static bencode_item_t *rtpe_function_call(bencode_buffer_t *bencbuf, struct sip_
 		 * toward a specific RTPEngine instance.
 		 */
 		if (spvar && (socket_val.rs.len > 0)) {
-			LM_DBG("Sending command [%d] to RTPEngine socket: [%.*s] set id: [%d]\n", op, (int)(socket_val.rs.len), (char *)(socket_val.rs.s, set->id_set));
+			LM_DBG("Sending command [%d] to RTPEngine socket: [%.*s] set id: [%d]\n", op, (int)(socket_val.rs.len), (char *)(socket_val.rs.s), set->id_set);
 			node = lookup_rtpe_node(set, &socket_val.rs);
 			if (node == NULL) {
 				RTPE_STOP_READ();

--- a/modules/rtpengine/rtpengine.c
+++ b/modules/rtpengine/rtpengine.c
@@ -2863,11 +2863,10 @@ static bencode_item_t *rtpe_function_call(bencode_buffer_t *bencbuf, struct sip_
 		 * toward a specific RTPEngine instance.
 		 */
 		if (spvar && (socket_val.rs.len > 0)) {
-			LM_DBG("Attempting to send command [%d] to RTPEngine socket: [%d] [%.*s] set id: [%d]\n", op, socket_val.rs.len, socket_val.rs.s, set->id_set);
 			node = get_rtpe_node(&socket_val.rs, set);
 
 			if (node == NULL) {
-				LM_ERR("WARNING --- node is NULL when socket: [%.*s] set [%d] has been specified\n", socket_val.rs.len, socket_val.rs.s, set->id_set);
+				LM_ERR("WARNING --- node is NULL when socket is specified\n");
 				RTPE_STOP_READ();
 				goto error;
 			}
@@ -2940,7 +2939,7 @@ static bencode_item_t *rtpe_function_call(bencode_buffer_t *bencbuf, struct sip_
 		val.flags = PV_VAL_STR;
 		val.rs = node->rn_url;
 		if(pv_set_value(msg, spvar, (int)EQ_T, &val)<0)
-		    LM_ERR("Storing rtpengine socket pvar failed [%.*s]\n", val.rs.len, val.rs.s);
+		    LM_ERR("Storing rtpengine socket pvar failed\n");
 	}
 
 	return resp;

--- a/modules/rtpengine/rtpengine.c
+++ b/modules/rtpengine/rtpengine.c
@@ -2837,9 +2837,8 @@ static bencode_item_t *rtpe_function_call(bencode_buffer_t *bencbuf, struct sip_
 		goto error;
 
 	/*
-	 * If the Set is not specified as a parameter into this routine:
-	 *
-	 * Otherwise, eet the RTPEngine setid from the specified AVP,
+	 * If the Set is not specified as a parameter into this routine
+	 * try to determine. Using the specified setid_avp module parameter,
 	 * or from the default default_rtpe_set().
 	 */
 	if (!set) {


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!
In order to consider and evaluate your PR, it is mandatory to provide detailed information about (1) what is the issue the PR addresses, (2) how the PR is solving the issue (logic and coding), (3) what are (if any) limitations of the proposed PR and (4) if there are any known side-effects/ backward compatibility issues/SIP interoperability issues.
Note that if the PR is missing information, it might take longer to be merged, as extra resources have to be allocated by the maintainers to reverse engineer the changes, understand them, understand the motivation, etc. That is why it is important to provide as much information as possible.
-->

**Summary**
<!-- Summary of the PR - what the PR is aiming to solve -->

Many rtpengine_* functions accept a parameter that will be populated with the socket of the RTPEngine chosen for the particular operation.  For example, the rtpengine_offer() function accepts a "sock_var" parameter. The "sock_var" variable is populated correctly. The ability to use the "sock_var" in subsequent rtpengine_* function calls has not been available.  This PR adds the ability to have the "sock_var" used to determine the specific RTPEngine that the operation is to be directed towards.

**Details**
<!--
Details about the content of the PR - is it a bug fix, a new feature or perhaps a hack? Explain the **motivation** for making this change.
What existing problem does the pull request solve? Is this a particular problem (i.e. only some particular scenarios are affected, only some UACs, etc) or a generic one?
Do not assume others understand what you're trying to do and provide as much information as you may have.
-->

When using a pool of RTPEngines (and/or a pool of OpenSIPS servers) and enabling services such as early media along with bridging multiple call legs it is possible that an OpenSIPS server may not be able to use the call-id to locate which RTPEngine the legs of a call are on. Most of the time, the call-id lookups that rtpengine.c use work well. In some advanced scenarios, the lookup will send the RTPEngine command to an incorrect RTPEngine sever.

This PR provides an ability for the script writer to store the chosen RTPEngine in the "sock_var" variable for an rtpengine_play_media() command and then use the "sock_var" in the rtpengine_stop_media() command.

The format of the data stored in "sock_var" is: proto:ip:port so it is possible for the script writer to create and use a "sock_var" without having it first stored by one of the rtpengine_* functions. Clearly, the script writer needs to have some mechanism to select the correct RTPEngine server.

**Solution**
<!-- Explain how your PR fixes the problem. Are there any remaining concerns that might need to be addressed? -->

The rtpengine.c module is designed in a modular way with subroutines for each rtpengine_* call. All of these subroutines eventually call rtpe_function_call() where the specific RTPEngine node is determined. This PR adds additional logic to rtpe_function_call() to support using the "sock_var" if it has been specified and is non-empty.

In addition, an important improvement has been made to the rtpe_test() subroutine. During the development of this PR a memory corruption / leak was identified. Two different binary encoding (bencode) routines where called, one for requests and the other for replies. Each of these routines allocates space on the bencode_buffer. The problem is that each of these routines stored the resulting allocated memory address in the same variable.  Creation of a second variable so that requests and replies are stored separately resolved this issue.

**Compatibility**
<!-- Does your change break other scenarios, or do they need to be migrated in order to work similarly? -->

There is no change to any logic when storing the chosen RTPEngine in a specified "sock_var".

If a script specifies a "sock_var" and that variable is non-NULL, then it will be used to determine the RTPEngine server to direct the command to.

If the script writer wants to specify a "sock_var" parameter, but does not want it to be used then the "sock_var" variable should not be populated. In this case, it will be populated when one of the rtpengine_* functions has chosen an RTPEngine server.

**Closing issues**
<!-- Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). -->
