### PR TITLE
Fix: rtp_relay memory leak

### DIFF
--- a/modules/rtp_relay/rtp_relay_ctx.c
+++ b/modules/rtp_relay/rtp_relay_ctx.c
@@ -1879,6 +1879,13 @@ static void rtp_relay_ctx_initial_cb(struct cell* t, int type, struct tmcb_param
 					rtp_relay_ctx_leg_reply(ctx, p->rpl, t, sess, RTP_RELAY_CALLEE);
 					break;
 				case 1:
+					struct dlg_cell *dlg;
+					dlg = rtp_relay_dlg.get_dlg();
+					if (!dlg) {
+						LM_ERR("could not find dialog!\n");
+					} else{
+						RTP_RELAY_PUT_DLG_CTX(dlg, ctx);
+					}
 					lock_start_write(rtp_relay_contexts_lock);
 					if (list_is_valid(&ctx->list))
 						list_del(&ctx->list);


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!
In order to consider and evaluate your PR, it is mandatory to provide detailed information about (1) what is the issue the PR addresses, (2) how the PR is solving the issue (logic and coding), (3) what are (if any) limitations of the proposed PR and (4) if there are any known side-effects/ backward compatibility issues/SIP interoperability issues.
Note that if the PR is missing information, it might take longer to be merged, as extra resources have to be allocated by the maintainers to reverse engineer the changes, understand them, understand the motivation, etc. That is why it is important to provide as much information as possible.
-->

**Summary**
<!-- Summary of the PR - what the PR is aiming to solve -->

To fix rtp_relay memory leak metioned in https://github.com/OpenSIPS/opensips/issues/3539.

**Details**
<!--
Details about the content of the PR - is it a bug fix, a new feature or perhaps a hack? Explain the **motivation** for making this change.
What existing problem does the pull request solve? Is this a particular problem (i.e. only some particular scenarios are affected, only some UACs, etc) or a generic one?
Do not assume others understand what you're trying to do and provide as much information as you may have.
-->

The rtp_relay_ctx is not released when the opensips receive uas response with status >= 300. In which case the delete request to rtpengine/rtpproxy is sent and session is freed. But the rtp_relay_ctx pointer is not put into dialog. So when dialog destory, it will not release the corresponding rtp_relay_ctx.

**Solution**
<!-- Explain how your PR fixes the problem. Are there any remaining concerns that might need to be addressed? -->

Retrive the dialog and put the ctx pointer in. So that when destroy dialog, the rtp_relay_ctx will be released.

**Compatibility**
<!-- Does your change break other scenarios, or do they need to be migrated in order to work similarly? -->
The change don't break other scenarios. It work well on opensips 3.4.11 .
