### PR TITLE
[event_stream]Don't run error handling when there was no error

### DIFF
--- a/modules/event_stream/stream_send.c
+++ b/modules/event_stream/stream_send.c
@@ -432,6 +432,8 @@ static void handle_new_stream(stream_send_t *stream)
 		}
 	}
 
+	return;
+
 error:
 	if (stream->async_ctx.status_cb)
 		stream_dispatch_status_cb(&stream->async_ctx, EVI_STATUS_FAIL);


### PR DESCRIPTION
**Summary**
When testing event_stream under event_virtual, event_virtual was always reporting that the event could not be raised. Double-frees were also observed.

**Details**
handle_new_stream() in event_stream was erroneously always running its error handler on event submission, causing all events to report as failure. This also caused double-frees, as the event_virtual error handling would free the submitted event params while it was running.

This only seems to happen under event_virtual, or other places where it is running async. Direct, synchronous, usage of event_stream was unaffected.

**Solution**
Return before running the error handling if there wasn't an error.

**Compatibility**
Should not cause any compatibility issues.
