### PR TITLE
fix tls_mgm release domain issue

### DIFF
--- a/modules/tls_mgm/tls_domain.c
+++ b/modules/tls_mgm/tls_domain.c
@@ -97,11 +97,14 @@ void map_remove_tls_dom(struct tls_domain *dom)
 
 		val = iterator_val(&it_tmp);
 		doms_array = (struct dom_filt_array *)*val;
-		for (i = 0; i < doms_array->size; i++)
+		for (i = 0; i < doms_array->size;)
 			if (doms_array->arr[i].dom_link == dom) {
 				for (j = i + 1; j < doms_array->size; j++)
 					doms_array->arr[j-1] = doms_array->arr[j];
 				doms_array->size--;
+			}
+			else {
+				i++;
 			}
 		if (doms_array->size == 0) {
 			map_free_node(doms_array);


### PR DESCRIPTION
**Summary**
This PR fixes the issue where the contents in `client_dom_matching` or `server_dom_matching` are not fully released after executing the `tls_reload` command.

**Details**
Assuming the content of `tls_mgm` config file which used by `tls_mgm` module as follows, where `127.0.0.1` and `127.0.0.2` are associated with `dom1` via `match_sip_domain`.

```
id(int,auto) domain(string) match_ip_address(string,null) match_sip_domain(string,null) type(int) method(string,null) verify_cert(int,null) require_cert(int,null) certificate(blob,null) private_key(blob,null) crl_check_all(int,null) crl_dir(string,null) ca_list(blob,null) ca_dir(string,null) cipher_list(string,null) dh_params(blob,null) ec_curve(string,null) 

1:dom1::127.0.0.1,127.0.0.2:1::1:1:/tmp/cert.pem:/tmp/key.pem:0::::::
2:dom2::127.0.0.3:1::1:1:/tmp/cert.pem:/tmp/key.pem:0::::::
```

After the `tls_mgm` module has been loaded, the `dom_filt_array` in `client_dom_matching` is stored in the following format like:
```
doms_array->size = 3

doms_array->arr[0].dom_link ->dom1

doms_array->arr[1].dom_link ->dom1

doms_array->arr[2].dom_link ->dom2
```

When performing the `tls_reload` operation, it is necessary to call `tls_free_db_domains` to release the old domain data, including the data in `client_dom_matching`.

`
reload_data
   -> tls_free_db_domains
        -> map_remove_tls_dom
`
However, during the loop iteration in `map_remove_tls_dom`, the removal is incomplete. In the example mentioned above, the data associated with `127.0.0.2` would not be deleted. This can lead to an even worse situation — executing `tls_reload` again may cause OpenSIPS to crash.

**Solution**
Adjust iteration logic in `map_remove_tls_dom` to make sure the data can be release completely

**Compatibility**
This is a change-specific and isolated in tls_mgm module - it's 100% retro-compatible with the other versions.

**Closing issues**

