### PR TITLE
Fix CI issues (#3501 fallout)

### DIFF
--- a/.github/workflows/.rtp.io.yml
+++ b/.github/workflows/.rtp.io.yml
@@ -204,6 +204,8 @@ jobs:
     needs: [build_rtp_io_dock, set_env]
     runs-on: ubuntu-latest
     if: ${{ github.event_name != 'pull_request' }}
+    permissions:
+      packages: read
     strategy:
       fail-fast: false
       matrix:
@@ -219,6 +221,13 @@ jobs:
       uses: docker/setup-qemu-action@v3
       with:
         platforms: ${{ env.TARGETPLATFORM }}
+
+    - name: Login to GitHub Container Registry
+      uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: ${{ github.repository_owner }}
+        password: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Test ${{ env.TARGETPLATFORM }}
       run: |

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -16,7 +16,7 @@ jobs:
   # This workflow contains a single job called "build"
   build_and_test:
     # The type of runner that the job will run on
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-${{ matrix.os }}
     continue-on-error: true
     env:
       COMPILER: ${{ matrix.compiler }}

--- a/modules/b2b_entities/dlg.c
+++ b/modules/b2b_entities/dlg.c
@@ -2776,6 +2776,7 @@ int b2b_send_req(b2b_dlg_t* dlg, enum b2b_entity_type etype,
 }
 
 static struct sip_msg dummy_msg;
+static struct hdr_field callid_hdr, from_hdr, to_hdr;
 
 static int build_extra_headers_from_msg(str buf, str *extra_hdr,
 													str *new_hdrs, str *body)
@@ -2890,7 +2891,6 @@ void b2b_tm_cback(struct cell *t, b2b_table htable, struct tmcb_params *ps)
 	struct hdr_field cseq;
 	enum b2b_entity_type etype=(htable==server_htable?B2B_SERVER:B2B_CLIENT);
 	int dlg_based_search = 0;
-	struct hdr_field callid_hdr, from_hdr, to_hdr;
 	struct to_body to_hdr_parsed, from_hdr_parsed;
 	int dlg_state = 0, prev_state = B2B_UNDEFINED;
 	struct uac_credential* crd;

--- a/modules/cpl_c/cpl_switches.h
+++ b/modules/cpl_c/cpl_switches.h
@@ -190,7 +190,7 @@ static inline char *run_address_switch( struct cpl_interpreter *intr )
 							goto script_error;
 					}
 					LM_DBG("extracted val. is <%.*s>\n",
-						(msg_val==0)?0:msg_val->len, (msg_val==0)?0:msg_val->s);
+						(msg_val==0)?0:msg_val->len, (msg_val==0)?"":msg_val->s);
 				}
 				/* does the value from script match the one from message? */
 				switch (attr_name) {

--- a/modules/sqlops/sqlops_impl.c
+++ b/modules/sqlops/sqlops_impl.c
@@ -843,7 +843,7 @@ err1:
 int ops_sql_api_select(struct db_url *url, struct sip_msg* msg, str *cols,
 		str *table, str *filter, str * order, pvname_list_t* dest, int one_col)
 {
-	cJSON *Jcols, *Jfilter;
+	cJSON *Jcols = NULL, *Jfilter;
 	int ret;
 
 	ret = _parse_json_col_and_filter( cols, filter, &Jcols, &Jfilter);
@@ -868,7 +868,7 @@ int ops_sql_api_select(struct db_url *url, struct sip_msg* msg, str *cols,
 int ops_sql_api_update(struct db_url *url, struct sip_msg* msg, str *cols,
 		str *table, str *filter)
 {
-	cJSON *Jcols, *Jfilter;
+	cJSON *Jcols = NULL, *Jfilter;
 	int ret;
 
 	ret = _parse_json_col_and_filter( cols, filter, &Jcols, &Jfilter);
@@ -892,7 +892,7 @@ int ops_sql_api_update(struct db_url *url, struct sip_msg* msg, str *cols,
 int ops_sql_api_insert(struct db_url *url, struct sip_msg* msg, str *table,
 		str *cols)
 {
-	cJSON *Jcols, *Jfilter;
+	cJSON *Jcols = NULL, *Jfilter;
 	int ret;
 
 	ret = _parse_json_col_and_filter( cols, NULL, &Jcols, &Jfilter);
@@ -916,7 +916,7 @@ int ops_sql_api_insert(struct db_url *url, struct sip_msg* msg, str *table,
 int ops_sql_api_delete(struct db_url *url, struct sip_msg* msg,
 		str *table, str *filter)
 {
-	cJSON *Jcols, *Jfilter;
+	cJSON *Jcols = NULL, *Jfilter;
 	int ret;
 
 	ret = _parse_json_col_and_filter( NULL, filter, &Jcols, &Jfilter);
@@ -940,7 +940,7 @@ int ops_sql_api_delete(struct db_url *url, struct sip_msg* msg,
 int ops_sql_api_replace(struct db_url *url, struct sip_msg* msg, str *table,
 		str *cols)
 {
-	cJSON *Jcols, *Jfilter;
+	cJSON *Jcols = NULL, *Jfilter;
 	int ret;
 
 	ret = _parse_json_col_and_filter( cols, NULL, &Jcols, &Jfilter);

--- a/scripts/build/build_libtap.sh
+++ b/scripts/build/build_libtap.sh
@@ -2,8 +2,7 @@
 
 set -e
 
-. $(dirname $0)/dockerize.sub
-
 . $(dirname $0)/build.conf.sub
+. $(dirname $0)/dockerize.sub
 
 make -C "${1}" CFLAGS="-O1 -fPIE -fPIC" libtap.a

--- a/scripts/build/build_test_harness.sh
+++ b/scripts/build/build_test_harness.sh
@@ -2,6 +2,7 @@
 
 set -e
 
+. $(dirname $0)/build.conf.sub
 . $(dirname $0)/dockerize.sub
 
 make Makefile.conf

--- a/scripts/build/do_build.sh
+++ b/scripts/build/do_build.sh
@@ -2,9 +2,8 @@
 
 set -e
 
-. $(dirname $0)/dockerize.sub
-
 . $(dirname $0)/build.conf.sub
+. $(dirname $0)/dockerize.sub
 
 EXCLUDE_MODULES="db_oracle osp sngtc cachedb_cassandra cachedb_couchbase \
   cachedb_mongodb auth_jwt event_kafka aaa_diameter launch_darkly http2d \

--- a/scripts/build/dockerize.sub
+++ b/scripts/build/dockerize.sub
@@ -1,4 +1,8 @@
 if [ -e /tmp/docker_opensips.cid ]
 then
-  exec docker exec -w `pwd` --env COMPILER --env BUILD_OS --env MAKE_TGT `cat /tmp/docker_opensips.cid` sh -x "${0}" "${@}"
+  if [ "${DOCKR_PLATFORM}" = "arm64/v8" ]
+  then
+    DOCKR_ARGS="-e QEMU_CPU=cortex-a53"
+  fi
+  exec docker exec -w `pwd` --env COMPILER --env BUILD_OS --env MAKE_TGT ${DOCKR_ARGS} `cat /tmp/docker_opensips.cid` sh -x "${0}" "${@}"
 fi

--- a/scripts/build/get-arch-buildargs.rtp.io
+++ b/scripts/build/get-arch-buildargs.rtp.io
@@ -44,6 +44,12 @@ platformopts() {
       ;;
     esac
     ;;
+  ubuntu*)
+    case "${TARGETPLATFORM}" in
+    linux/arm64/v8)
+      out="${out} QEMU_CPU=cortex-a53"
+      ;;
+    esac
   esac
   echo "${out}"
   echo "${@}"

--- a/scripts/build/install_depends.sh
+++ b/scripts/build/install_depends.sh
@@ -2,11 +2,9 @@
 
 set -e
 
-. $(dirname $0)/dockerize.sub
-
 PKGS=$(cat "$(dirname $0)/apt_requirements.txt")
-
 . $(dirname $0)/build.conf.sub
+. $(dirname $0)/dockerize.sub
 
 _PKGS=""
 for pkg in ${PKGS}

--- a/scripts/build/print_ccache_stats.sh
+++ b/scripts/build/print_ccache_stats.sh
@@ -2,8 +2,7 @@
 
 set -e
 
-. $(dirname $0)/dockerize.sub
-
 . $(dirname $0)/build.conf.sub
+. $(dirname $0)/dockerize.sub
 
 ccache --show-stats

--- a/scripts/build/zero_ccache_stats.sh
+++ b/scripts/build/zero_ccache_stats.sh
@@ -2,9 +2,8 @@
 
 set -e
 
-. $(dirname $0)/dockerize.sub
-
 . $(dirname $0)/build.conf.sub
+. $(dirname $0)/dockerize.sub
 
 ccache --max-size=100M
 ccache --cleanup

--- a/transformations.c
+++ b/transformations.c
@@ -1715,7 +1715,7 @@ int tr_eval_sdp(struct sip_msg *msg, tr_param_t *tp,int subtype,
 		case TR_SDP_STREAM_DEL:
 			/* determine the media type we are talking about
 			 * either by index or by name */
-			media.s = NULL;
+			media = STR_NULL;
 			entryNo = 0;
 			switch (tp->type) {
 				case TR_PARAM_NUMBER:


### PR DESCRIPTION
**Summary**

Fix CI issues caused by the merge of #3501.

**Details**

There were some CI issues related to addition of ubuntu 24.04 and the fact that GHCR images are not shared publicly by the OpenSIPS project. 

**Solution**

Typo is fixed, some gcc-1[34] errors are fixes. I also think addressed some issue with undue slowness of the arm64 clang build on ubuntu specifically. Somehow it takes 10x time compared to other emulated architectures, suspected use of some advanced instructions that are not very well emulated. The virtual "CPU" has been "downgraded" to the lowest possible arm64 variant, which seems to bring arm64/ubuntu build times back in line.
