### PR TITLE
Fix: siprec segfault when copy delete

### DIFF
--- a/modules/siprec/siprec.c
+++ b/modules/siprec/siprec.c
@@ -199,14 +199,6 @@ static void mod_destroy(void)
 {
 }
 
-static void tm_src_unref_session(void *p)
-{
-	struct src_sess *ss = (struct src_sess *)p;
-	srec_dlg.dlg_unref(ss->ctx->dlg, 1); /* release the dialog */
-	srec_hlog(ss, SREC_UNREF, "start recording unref");
-	SIPREC_UNREF(ss);
-}
-
 /*
  * function that simply prints the parameters passed
  */
@@ -318,7 +310,7 @@ static int siprec_start_rec(struct sip_msg *msg, str *srs, str *instance)
 	SIPREC_REF_UNSAFE(ss);
 	srec_hlog(ss, SREC_REF, "starting recording");
 	if (srec_tm.register_tmcb(msg, 0, TMCB_RESPONSE_OUT, tm_start_recording,
-			ss, tm_src_unref_session) <= 0) {
+			ss, NULL) <= 0) {
 		LM_ERR("cannot register tm callbacks\n");
 		srec_hlog(ss, SREC_UNREF, "error starting recording");
 		SIPREC_UNREF_UNSAFE(ss);

--- a/modules/siprec/siprec_logic.c
+++ b/modules/siprec/siprec_logic.c
@@ -748,6 +748,13 @@ void tm_start_recording(struct cell *t, int type, struct tmcb_params *ps)
 	SIPREC_UNLOCK(ss->ctx);
 }
 
+static void src_unref_session(struct src_sess *ss)
+{
+	srec_dlg.dlg_unref(ss->dlg, 1); /* release the dialog */
+	srec_hlog(ss, SREC_UNREF, "start recording unref");
+	SIPREC_UNREF(ss);
+}
+
 void srec_logic_destroy(struct src_sess *sess, int keep_sdp)
 {
 	if (!sess->b2b_key.s)
@@ -756,6 +763,10 @@ void srec_logic_destroy(struct src_sess *sess, int keep_sdp)
 	if (!keep_sdp && sess->initial_sdp.s) {
 		shm_free(sess->initial_sdp.s);
 		sess->initial_sdp.s = NULL;
+	}
+
+	if (!keep_sdp) {
+		src_unref_session(sess);
 	}
 
 	srec_b2b.entity_delete(B2B_CLIENT, &sess->b2b_key, sess->dlginfo, 1, 1);


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!
In order to consider and evaluate your PR, it is mandatory to provide detailed information about (1) what is the issue the PR addresses, (2) how the PR is solving the issue (logic and coding), (3) what are (if any) limitations of the proposed PR and (4) if there are any known side-effects/ backward compatibility issues/SIP interoperability issues.
Note that if the PR is missing information, it might take longer to be merged, as extra resources have to be allocated by the maintainers to reverse engineer the changes, understand them, understand the motivation, etc. That is why it is important to provide as much information as possible.
-->

**Summary**
<!-- Summary of the PR - what the PR is aiming to solve -->
To fix issue https://github.com/OpenSIPS/opensips/issues/3602.
In short, the siprec unreference the dialog recorded too early. After releasing the memory of the rtp_relay_ctx in dialog, check of the dialog (by pointer) is not valid. Do failover and end the recording(copy delete) both access the dialog (access call id, rtp relay context, etc). So, I try to unreference the dialog when the recording dialog ends.

**Details**
<!--
Details about the content of the PR - is it a bug fix, a new feature or perhaps a hack? Explain the **motivation** for making this change.
What existing problem does the pull request solve? Is this a particular problem (i.e. only some particular scenarios are affected, only some UACs, etc) or a generic one?
Do not assume others understand what you're trying to do and provide as much information as you may have.
-->
The code following will unreference the dialog when the transaction end,
https://github.com/OpenSIPS/opensips/blob/b17f160696a5cb6c31f8d08de98b5fd9ccf579d4/modules/siprec/siprec.c#L320-L321
And if the recorded dialog end before the srs respond (before siprec get the b2b notify), the `srec_b2b_notify`'s processing of the dialog will be uncertain. So, the segment fault is likely to raise here (when invoke rtp_relay `copy_delete` or rebuild the invite body).

To simplify the code, I invoke the `src_unref_session` in the `srec_logic_destroy` function and use the `keep_sdp` flag. If this is inappropriate, please let me know.

**Solution**
<!-- Explain how your PR fixes the problem. Are there any remaining concerns that might need to be addressed? -->
Make siprec unref the dialog when the recording end.

**Compatibility**
<!-- Does your change break other scenarios, or do they need to be migrated in order to work similarly? -->
The fix works well with 3.4.11.

**Closing issues**
<!-- Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). -->
