### PR TITLE
Fix FTBFS with recent GCC

### DIFF
--- a/db/db.h
+++ b/db/db.h
@@ -46,6 +46,7 @@
 #include "db_cap.h"
 #include "db_row.h"
 #include "db_ps.h"
+#include "db_pool.h"
 #include "../globals.h"
 
 extern stat_var *sql_total_queries;
@@ -407,7 +408,7 @@ int db_bind_mod(const str* mod, db_func_t* dbf);
  * \return returns a pointer to the db_con_t representing the connection if it was
    successful, otherwise 0 is returned.
  */
-db_con_t* db_do_init(const str* url, void* (*new_connection)());
+db_con_t* db_do_init(const str* url, void* (*new_connection)(const struct db_id *));
 
 
 /**
@@ -418,7 +419,7 @@ db_con_t* db_do_init(const str* url, void* (*new_connection)());
  * \param _h database connection handle
  * \param (*free_connection) Pointer to the db specifc free_connection method
  */
-void db_do_close(db_con_t* _h, void (*free_connection)());
+void db_do_close(db_con_t* _h, void (*free_connection)(struct pool_con*));
 
 
 /**

--- a/modules/db_unixodbc/db_con.c
+++ b/modules/db_unixodbc/db_con.c
@@ -190,12 +190,13 @@ err2:
 /*
  * Close the connection and release memory
  */
-void db_unixodbc_free_connection(struct my_con* con)
+void db_unixodbc_free_connection(struct pool_con* con)
 {
-	if (!con) return;
-	SQLFreeHandle(SQL_HANDLE_ENV, con->env);
-	SQLDisconnect(con->dbc);
-	SQLFreeHandle(SQL_HANDLE_DBC, con->dbc);
+	struct my_con* mcon = (struct my_con*)con;
+	if (!mcon) return;
+	SQLFreeHandle(SQL_HANDLE_ENV, mcon->env);
+	SQLDisconnect(mcon->dbc);
+	SQLFreeHandle(SQL_HANDLE_DBC, mcon->dbc);
 	pkg_free(con);
 }
 

--- a/modules/db_unixodbc/db_con.h
+++ b/modules/db_unixodbc/db_con.h
@@ -86,7 +86,7 @@ struct my_con* db_unixodbc_new_connection(struct db_id* id);
 /*
  * Close the connection and release memory
  */
-void db_unixodbc_free_connection(struct my_con* con);
+void db_unixodbc_free_connection(struct pool_con* con);
 
 char *db_unixodbc_build_conn_str(const struct db_id* id, char *buf);
 


### PR DESCRIPTION
**Summary**
This PR fixes building with a very modern GCC which does even better type checking.

**Details**
GCC 15 treats declarations like `int foo();` differently. In C23 (a default for GCC 15), it's equivalent to `int foo(void);` whereas, in earlier versions of C, such a declaration plays fast and loose with the type system — essentially meaning, "we don't know how many parameters this function takes or their types; let's hope your code is correct!".

I've updated code accordingly and fixed other type incompatibility.

**Compatibility**
Builds file with both modern GCC 15 and older version.

