### PR TITLE
Stop leaving sockets in CLOSE_WAIT on failed TLS connections

### DIFF
--- a/modules/proto_tls/proto_tls.c
+++ b/modules/proto_tls/proto_tls.c
@@ -622,6 +622,9 @@ send_it:
 	return rlen;
 con_release:
 	sh_log(c->hist, TCP_SEND2MAIN, "send 1, (%d)", c->refcnt);
+	/* close the fd if this process is not meant to own it */
+	if (c->proc_id != process_no)
+		close(fd);
 	tcp_conn_release(c, (rlen < 0)?0:1);
 	return rlen;
 }


### PR DESCRIPTION
**Summary**

Prevent outbound TLS sockets from being left in `CLOSE_WAIT` after failed handshakes.

**Details**

When an outbound TLS connection fails during the handshake (e.g. due to missing certificates), a file descriptor sticks around without being closed, and ends up stuck in `CLOSE_WAIT`.

Although `tcp_conn_release()` is called, it does not actually close the file descriptor. In other paths this is handled explicitly with `close(fd)` if the connection's `proc_id` differs from the current process. This fix follows the same pattern.

Testing confirmed that TLS sockets now close promptly on failure and that working TLS connections continue to function correctly.

**Solution**

Add a conditional `close(fd)` in `proto_tls_send()` after calling `tcp_conn_release()`, using the pattern already present elsewhere: only close if `c->proc_id != process_no`.

**Compatibility**

I don't think this change breaks any other scenarios.
