### PR TITLE
GH Actions cleanups and improvements

### DIFF
--- a/.github/workflows/.notify.yml
+++ b/.github/workflows/.notify.yml
@@ -1,0 +1,31 @@
+name: notify
+
+on:
+  workflow_call:
+    inputs:
+      job_name:
+        required: true
+        type: string
+      job_result:
+        required: true
+        type: string
+
+jobs:
+  notify_slack:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Notify slack fail
+        if: ${{ inputs.job_result == 'failure' && github.repository == 'OpenSIPS/opensips' }}
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+        uses: voxmedia/github-action-slack-notify-build@v1
+        with:
+          channel: devel
+          status: FAILED
+          color: danger
+
+      - name: Post Fail
+        if: ${{ inputs.job_result == 'failure' }}
+        run: |
+          echo "💥 \"${{ inputs.job_name }}\" failed – marking workflow 💩" >&2
+          exit 1

--- a/.github/workflows/.rtp.io.yml
+++ b/.github/workflows/.rtp.io.yml
@@ -41,7 +41,7 @@ jobs:
     - name: Set dynamic environment
       id: set-env
       run: |
-        BUILD_OS="`echo ${{ inputs.rtpp-tag }} | sed 's|-.*|| ; s|_|-|g'`"
+        BUILD_OS="`echo ${{ inputs.rtpp-tag }} | sed 's|-.*|| ; s|_|:|g'`"
         PLATFORMS="`docker manifest inspect ${{ env.BASE_IMAGE }} | \
           jq -r '.manifests[] | "\(.platform.os)/\(.platform.architecture)\(if .platform.variant != null then "/\(.platform.variant)" else "" end)"' | \
           sort -u | grep -v unknown | BUILD_OS="${BUILD_OS}" ./scripts/build/get-arch-buildargs.rtp.io fltplatforms | paste -sd ','`"
@@ -169,7 +169,8 @@ jobs:
       id: set-env
       run: |
         OUTPUT_TAG="myimage:`echo ${{ matrix.platform }} | sed 's|/|-|g'`"
-        OUTPUT_IMAGE_N="image-${BUILD_OS}-`echo ${{ matrix.platform }} | sed 's|/|-|g'`"
+        _BUILD_OS="`echo ${BUILD_OS} | sed 's|:|-|g'`"
+        OUTPUT_IMAGE_N="image-${_BUILD_OS}-`echo ${{ matrix.platform }} | sed 's|/|-|g'`"
         OUTPUT_IMAGE="./${OUTPUT_IMAGE_N}.tar"
         CACHE_SPEC="type=gha,scope=${OUTPUT_IMAGE_N}-buildcache"
         echo OUTPUT_TAG="${OUTPUT_TAG}" >> $GITHUB_ENV
@@ -255,7 +256,8 @@ jobs:
       id: set-env
       run: |
         OUTPUT_TAG="myimage:`echo ${{ matrix.platform }} | sed 's|/|-|g'`"
-        OUTPUT_IMAGE_N="image-${BUILD_OS}-`echo ${{ matrix.platform }} | sed 's|/|-|g'`"
+        _BUILD_OS="`echo ${BUILD_OS} | sed 's|:|-|g'`"
+        OUTPUT_IMAGE_N="image-${_BUILD_OS}-`echo ${{ matrix.platform }} | sed 's|/|-|g'`"
         OUTPUT_IMAGE="./${OUTPUT_IMAGE_N}.tar"
         echo OUTPUT_TAG="${OUTPUT_TAG}" >> $GITHUB_ENV
         echo OUTPUT_IMAGE="${OUTPUT_IMAGE}" >> $GITHUB_ENV

--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -23,3 +23,11 @@ jobs:
       with:
         name: artifacts
         path: ./out/artifacts
+
+  all_done:
+    needs: Fuzzing
+    uses: ./.github/workflows/.notify.yml
+    with:
+      job_name: "CIFuzz"
+      job_result: ${{ needs.Fuzzing.result }}
+    if: ${{ always() }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,6 @@ jobs:
   build:
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
-    continue-on-error: true
     container:
       image: ubuntu:${{ matrix.os }}
     env:
@@ -79,16 +78,10 @@ jobs:
       - name: Build
         run: sh -x scripts/build/do_build.sh
 
-  notify:
-    runs-on: ubuntu-latest
+  all_done:
     needs: build
-    steps:
-      - name: Notify slack fail
-        if: failure() && github.repository == 'OpenSIPS/opensips'
-        env:
-          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
-        uses: voxmedia/github-action-slack-notify-build@v1
-        with:
-          channel: devel
-          status: FAILED
-          color: danger
+    uses: ./.github/workflows/.notify.yml
+    with:
+      job_name: "Main CI"
+      job_result: ${{ needs.build.result }}
+    if: ${{ always() }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,14 +22,22 @@ jobs:
       image: ubuntu:${{ matrix.os }}
     env:
       COMPILER: ${{ matrix.compiler }}
-      BUILD_OS: ubuntu-${{ matrix.os }}
+      BUILD_OS: ubuntu:${{ matrix.os }}
 
     strategy:
       fail-fast: false
       matrix:
-        os: [22.04, 24.04]
+        os: [20.04, 22.04, 24.04]
         compiler: ['gcc', 'clang']
         include:
+          - os: 20.04
+            compiler: 'gcc-9'
+          - os: 20.04
+            compiler: 'gcc-10'
+          - os: 20.04
+            compiler: 'clang-9'
+          - os: 20.04
+            compiler: 'clang-10'
           - os: 22.04
             compiler: 'gcc-11'
           - os: 22.04
@@ -53,7 +61,6 @@ jobs:
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
-      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - name: Install git
         run: |
           apt-get update

--- a/.github/workflows/multiarch.yml
+++ b/.github/workflows/multiarch.yml
@@ -16,20 +16,28 @@ jobs:
   # This workflow contains a single job called "build"
   build_multiarch:
     # The type of runner that the job will run on
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     continue-on-error: true
+    container:
+      image: ubuntu:${{ matrix.os }}
+      options: >-
+        -v sources:/__w/${{ github.event.repository.name }}/${{ github.event.repository.name }}
     env:
       COMPILER: ${{ matrix.compiler }}
-      BUILD_OS: ${{ matrix.os }}
-
+      BUILD_OS: ubuntu:${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         compiler: ['gcc-i386-cross', 'clang-i386-cross', 'gcc-mips64-cross', 'gcc-arm32-cross', 'gcc-arm64-cross',  'gcc-arm32-qemu-cross', 'gcc-arm64-qemu-cross', 'clang-arm32-qemu-cross', 'clang-arm64-qemu-cross']
-        os: [ubuntu-22.04]
+        os: [22.04]
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
+      - name: Install git
+        run: |
+          apt-get update
+          apt-get install -y git lsb-release gnupg2 wget
+
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/multiarch.yml
+++ b/.github/workflows/multiarch.yml
@@ -17,7 +17,6 @@ jobs:
   build_multiarch:
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
-    continue-on-error: true
     container:
       image: ubuntu:${{ matrix.os }}
       options: >-
@@ -71,16 +70,10 @@ jobs:
         if: endsWith(matrix.compiler, '-qemu-cross')
         run: scripts/build/print_ccache_stats.sh
 
-  notify:
-    runs-on: ubuntu-latest
+  all_done:
     needs: build_multiarch
-    steps:
-      - name: Notify slack fail
-        if: failure() && github.repository == 'OpenSIPS/opensips'
-        env:
-          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
-        uses: voxmedia/github-action-slack-notify-build@v1
-        with:
-          channel: devel
-          status: FAILED
-          color: danger
+    uses: ./.github/workflows/.notify.yml
+    with:
+      job_name: "Multi-Architecture Build"
+      job_result: ${{ needs.build_multiarch.result }}
+    if: ${{ always() }}

--- a/.github/workflows/rtp.io.yml
+++ b/.github/workflows/rtp.io.yml
@@ -130,3 +130,11 @@ jobs:
       fail-fast: false
       matrix:
         rtpp-tag: [debian_12-slim, ubuntu_latest]
+
+  all_done:
+    needs: build_test_rtp_io_dock
+    uses: ./.github/workflows/.notify.yml
+    with:
+      job_name: "rtp.io"
+      job_result: ${{ needs.build_test_rtp_io_dock.result }}
+    if: ${{ always() }}

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -17,7 +17,6 @@ jobs:
   build_and_test:
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
-    continue-on-error: true
     container:
       image: ubuntu:${{ matrix.os }}
       options: >-
@@ -120,17 +119,10 @@ jobs:
           path: |
             unit_tests.log
 
-  notify:
-    runs-on: ubuntu-latest
+  all_done:
     needs: build_and_test
-    steps:
-      - name: Notify slack fail
-        if: failure() && github.repository == 'OpenSIPS/opensips'
-        env:
-          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
-        uses: voxmedia/github-action-slack-notify-build@v1
-        with:
-          channel: devel
-          status: FAILED
-          color: danger
-
+    uses: ./.github/workflows/.notify.yml
+    with:
+      job_name: "Unit Tests"
+      job_result: ${{ needs.build_and_test.result }}
+    if: ${{ always() }}

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -16,11 +16,15 @@ jobs:
   # This workflow contains a single job called "build"
   build_and_test:
     # The type of runner that the job will run on
-    runs-on: ubuntu-${{ matrix.os }}
+    runs-on: ubuntu-latest
     continue-on-error: true
+    container:
+      image: ubuntu:${{ matrix.os }}
+      options: >-
+        -v sources:/__w/${{ github.event.repository.name }}/${{ github.event.repository.name }}
     env:
       COMPILER: ${{ matrix.compiler }}
-      BUILD_OS: ubuntu-${{ matrix.os }}
+      BUILD_OS: ubuntu:${{ matrix.os }}
 
     strategy:
       fail-fast: false
@@ -28,6 +32,18 @@ jobs:
         os: [22.04]
         compiler: ['gcc', 'clang', 'gcc-11', 'gcc-12', 'clang-11', 'clang-12', 'clang-13', 'clang-14', 'clang-15', 'gcc-arm64-qemu-cross', 'gcc-arm32-qemu-cross', 'clang-arm64-qemu-cross', 'clang-arm32-qemu-cross']
         include:
+          - os: 20.04
+            compiler: 'gcc'
+          - os: 20.04
+            compiler: 'clang'
+          - os: 20.04
+            compiler: 'gcc-9'
+          - os: 20.04
+            compiler: 'gcc-10'
+          - os: 20.04
+            compiler: 'clang-9'
+          - os: 20.04
+            compiler: 'clang-10'
           - os: 24.04
             compiler: 'gcc'
           - os: 24.04
@@ -47,6 +63,11 @@ jobs:
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
+      - name: Install git
+        run: |
+          apt-get update
+          apt-get install -y git lsb-release gnupg2 wget
+
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v4
         with:

--- a/docker/Dockerfile.rtp.io
+++ b/docker/Dockerfile.rtp.io
@@ -14,7 +14,7 @@ WORKDIR /src
 ARG LLVM_VER=18
 ARG LLVM_VER_OLD=16
 ARG TARGETPLATFORM
-ARG BUILD_OS=ubuntu-latest
+ARG BUILD_OS=ubuntu:latest
 RUN --mount=type=bind,source=scripts/build,target=scripts/build \
  --mount=type=cache,target=/var/cache/apt,sharing=locked \
  env `./scripts/build/get-arch-buildargs.rtp.io platformopts` \

--- a/scripts/build/build.conf.sub
+++ b/scripts/build/build.conf.sub
@@ -1,8 +1,3 @@
-enable_ubuntu_toolchain_test() {
-	${SUDO} env DEBIAN_FRONTEND=noninteractive apt-get install -y software-properties-common
-	${SUDO} add-apt-repository -y ppa:ubuntu-toolchain-r/test
-}
-
 setup_qemu() {
 	ARCH1="${1}"
 	ARCH2="${2}"
@@ -41,17 +36,15 @@ gcc-i386-cross)
 	export CC="gcc"
 	CC_EXTRA_OPTS="-Werror -m32"
 	MAKE_TGT="opensips"
-	DOCKR_BASE="ubuntu:18.04"
 	DOCKR_PLATFORM="x86_64"
-	export BUILD_OS="ubuntu-18.04"
+	export BUILD_OS="ubuntu:18.04"
 	PRE_INSTALL_CMD="${SUDO} dpkg --add-architecture i386"
 	PKGS="`exclude_pkgs 2.3.7` gcc g++ libc6-dev:i386 libstdc++6:i386 lib32gcc-7-dev"
 	;;
 gcc-mips64-cross)
 	MAKE_TGT="opensips"
-	DOCKR_BASE="ubuntu:18.04"
 	DOCKR_PLATFORM="x86_64"
-	export BUILD_OS="ubuntu-18.04"
+	export BUILD_OS="ubuntu:18.04"
 	export CC="mips64-linux-gnuabi64-gcc"
 	export AR="mips64-linux-gnuabi64-ar"
 	export RANLIB="mips64-linux-gnuabi64-ranlib"
@@ -64,8 +57,7 @@ gcc-arm32-cross)
 	export AR="arm-linux-gnueabihf-ar"
 	export RANLIB="arm-linux-gnueabihf-ranlib"
 	POST_INSTALL_CMD="setup_qemu arm gnueabihf"
-	export BUILD_OS="ubuntu-18.04"
-	DOCKR_BASE="ubuntu:18.04"
+	export BUILD_OS="ubuntu:18.04"
 	DOCKR_PLATFORM="x86_64"
 	PKGS="`exclude_pkgs 2.3.7` gcc-arm-linux-gnueabihf libc-dev-armhf-cross qemu-user-static"
 	;;
@@ -75,15 +67,13 @@ gcc-arm64-cross)
 	export AR="aarch64-linux-gnu-ar"
 	export RANLIB="aarch64-linux-gnu-ranlib"
 	POST_INSTALL_CMD="setup_qemu aarch64 gnu"
-	export BUILD_OS="ubuntu-18.04"
-	DOCKR_BASE="ubuntu:18.04"
+	export BUILD_OS="ubuntu:18.04"
 	DOCKR_PLATFORM="x86_64"
 	PKGS="`exclude_pkgs 2.3.7` gcc-aarch64-linux-gnu libc-dev-arm64-cross qemu-user-static"
 	;;
 gcc-arm32-qemu-cross)
 	export CC="/usr/lib/ccache/gcc"
 	export CCACHE_DIR="`pwd`/ccache"
-	DOCKR_BASE="ubuntu"
 	DOCKR_PLATFORM="arm/v7"
 	PKGS="`exclude_pkgs 2.3.7` gcc g++ ccache"
 	EXCLUDE_MODULES_ADD="db_unixodbc"
@@ -91,7 +81,6 @@ gcc-arm32-qemu-cross)
 clang-arm32-qemu-cross)
 	export CC="/usr/lib/ccache/clang"
 	export CCACHE_DIR="`pwd`/ccache"
-	DOCKR_BASE="ubuntu"
 	DOCKR_PLATFORM="arm/v7"
 	PKGS="`exclude_pkgs 2.3.7` clang llvm-dev ccache"
 	EXCLUDE_MODULES_ADD="db_unixodbc"
@@ -99,7 +88,6 @@ clang-arm32-qemu-cross)
 gcc-arm64-qemu-cross)
 	export CC="/usr/lib/ccache/gcc"
 	export CCACHE_DIR="`pwd`/ccache"
-	DOCKR_BASE="ubuntu"
 	DOCKR_PLATFORM="arm64/v8"
 	PKGS="`exclude_pkgs 2.3.7` gcc g++ ccache"
 	EXCLUDE_MODULES_ADD="db_unixodbc"
@@ -107,7 +95,6 @@ gcc-arm64-qemu-cross)
 clang-arm64-qemu-cross)
 	export CC="/usr/lib/ccache/clang"
 	export CCACHE_DIR="`pwd`/ccache"
-	DOCKR_BASE="ubuntu"
 	DOCKR_PLATFORM="arm64/v8"
 	PKGS="`exclude_pkgs 2.3.7` clang llvm-dev ccache"
 	EXCLUDE_MODULES_ADD="db_unixodbc"
@@ -123,9 +110,8 @@ clang-i386-cross)
 	export CC="clang"
 	CC_EXTRA_OPTS="-Werror -m32"
 	MAKE_TGT="opensips"
-	DOCKR_BASE="ubuntu:18.04"
 	DOCKR_PLATFORM="x86_64"
-	export BUILD_OS="ubuntu-18.04"
+	export BUILD_OS="ubuntu:18.04"
 	PRE_INSTALL_CMD="${SUDO} dpkg --add-architecture i386"
 	PKGS="`exclude_pkgs 2.3.7` clang llvm-dev libc6-dev:i386 libstdc++6:i386 lib32gcc-7-dev"
 	;;
@@ -133,8 +119,8 @@ gcc-*)
 	export CC="${COMPILER}"
 	export AR="gcc-ar-${COMPILER_VER}"
 	export RANLIB="gcc-ranlib-${COMPILER_VER}"
+	export CPP_CMD="cpp-${COMPILER_VER}"
 	export GCOV_CMD="gcov-${COMPILER_VER}"
-	PRE_INSTALL_CMD="enable_ubuntu_toolchain_test"
 	PKGS="${PKGS} gcc-${COMPILER_VER} g++-${COMPILER_VER}"
 	;;
 clang-*)

--- a/scripts/build/build_test_harness.sh
+++ b/scripts/build/build_test_harness.sh
@@ -9,7 +9,7 @@ make Makefile.conf
 sed -i.bak '/-DCC_O0/d' Makefile.conf
 echo 'DEFS+= -I$(shell pwd)/'"${1}" >> Makefile.conf
 echo 'LIBS+= -L$(TOP_SRCDIR)/'"${1}" >> Makefile.conf
-if [ "${BUILD_OS}" = "ubuntu-22.04" ]
+if [ "${BUILD_OS}" = "ubuntu:22.04" ]
 then
   case "${COMPILER}" in
   *-qemu-cross)

--- a/scripts/build/dockerize.sub
+++ b/scripts/build/dockerize.sub
@@ -4,5 +4,6 @@ then
   then
     DOCKR_ARGS="-e QEMU_CPU=cortex-a53"
   fi
-  exec docker exec -w `pwd` --env COMPILER --env BUILD_OS --env MAKE_TGT ${DOCKR_ARGS} `cat /tmp/docker_opensips.cid` sh -x "${0}" "${@}"
+  CID="`cat /tmp/docker_opensips.cid`"
+  exec docker exec -w `pwd` --env COMPILER --env BUILD_OS --env MAKE_TGT ${DOCKR_ARGS} "${CID}" sh -x "${0}" "${@}"
 fi

--- a/scripts/build/get-arch-buildargs.rtp.io
+++ b/scripts/build/get-arch-buildargs.rtp.io
@@ -4,7 +4,7 @@ set -e
 
 isbrokenplatform() {
   case "${BUILD_OS}" in
-  debian*)
+  debian:*)
     case "${TARGETPLATFORM}" in
     linux/386 | linux/arm/v7 | linux/mips64le | linux/ppc64le | linux/s390x)
       exit 1
@@ -24,7 +24,7 @@ isbrokenplatform() {
 
 fltplatforms() {
    case "${BUILD_OS}" in
-   debian*)
+   debian:*)
      FILT="grep -v -e ^linux/arm/v5\$" # broken 64-bit stdatomics
      ;;
    *)
@@ -37,7 +37,7 @@ fltplatforms() {
 platformopts() {
   out="COMPILER=clang-${LLVM_VER} LINKER=lld-${LLVM_VER}"
   case "${BUILD_OS}" in
-  debian*)
+  debian:*)
     case "${TARGETPLATFORM}" in
     linux/ppc64le | linux/arm/v7 | linux/mips64le | linux/arm/v5)
       out="COMPILER=clang-${LLVM_VER_OLD} LINKER=lld-${LLVM_VER_OLD}"

--- a/scripts/build/install_depends.sh
+++ b/scripts/build/install_depends.sh
@@ -9,11 +9,11 @@ PKGS=$(cat "$(dirname $0)/apt_requirements.txt")
 _PKGS=""
 for pkg in ${PKGS}
 do
-  if [ "${BUILD_OS}" != ubuntu-20.04 -a "${BUILD_OS}" != ubuntu-18.04 -a "${pkg}" = python-dev ]
+  if [ "${BUILD_OS}" != "ubuntu:20.04" -a "${BUILD_OS}" != "ubuntu:18.04" -a "${pkg}" = python-dev ]
   then
     pkg="python-dev-is-python3"
   fi
-  if [ "${BUILD_OS%-*}" = "debian" -a "${pkg}" = libmysqlclient-dev ]
+  if [ "${BUILD_OS%:*}" = "debian" -a "${pkg}" = libmysqlclient-dev ]
   then
     pkg="libmariadb-dev"
   fi

--- a/scripts/build/start_container.sh
+++ b/scripts/build/start_container.sh
@@ -4,12 +4,18 @@ set -e
 
 . $(dirname $0)/build.conf.sub
 
-if [ -z "${DOCKR_PLATFORM}" -o -z "${DOCKR_BASE}" ]
+if [ -z "${DOCKR_PLATFORM}" -o -z "${BUILD_OS}" ]
 then
-  echo "DOCKR_BASE / DOCKR_PLATFORM is not set" >&2
+  echo "BUILD_OS / DOCKR_PLATFORM is not set" >&2
   exit 1
 fi
 
-sudo apt-get update
-sudo apt-get install -y qemu-user-static
-docker run --cidfile /tmp/docker_opensips.cid -d --restart=always --platform linux/${DOCKR_PLATFORM} -v `pwd`:`pwd` ${DOCKR_BASE} sleep infinity
+if ! docker -v 2>/dev/null
+then
+  ${SUDO} apt-get update
+  ${SUDO} apt-get install -y docker.io
+fi
+docker run --rm --privileged tonistiigi/binfmt:latest -install all
+docker run --cidfile /tmp/docker_opensips.cid -d --restart=always \
+ --platform linux/${DOCKR_PLATFORM} -v sources:`pwd` "${BUILD_OS}" \
+ tail -f /dev/null


### PR DESCRIPTION
**Summary**

GH Actions cleanups and improvements

**Details**

There is a problem with the `continue-on-error: true` usage, which causes the failure of the build/test job to be masked out by the notification job. 

Another issue is that we rely on the GH-provided images, which first are "dirty" in a sense that they have random set of packages pre-installed (as well as point to the Microsoft-own packages repo) and need a separate step of "cleansing". Also, GH apply a quite aggressive depreciation policy, while opensips historically tries to keep compatibility with older systems if possible.

**Solution**

Instead of the `continue-on-error`, the `if: ${{ always() }}` should be used in the notification. Also, the notification job itself should fail after delivering notification, causing the pipeline to be marked as failed.

Also, for unification the notification job can be moved to a separate file and loaded into all pipelines.

Current version, note that several builds failed, still the job is green.

![ScreenShot1477](https://github.com/user-attachments/assets/1b264243-2ade-475e-a80e-a0e577578e99)

This is how the failure looks after the change. Notification still runs but the pipeline marked as failed:

![ScreenShot1475](https://github.com/user-attachments/assets/ecd61842-a6cf-4c24-8767-88ca90d822d2)

The second change is to use GH-provided ubuntu-latest to "bootstrap" a pipeline, running build in a separate container based on official ubuntu images. This allows us to add back ubuntu 20.10 that is being "deprecated" by the GH.

**Compatibility**

None. Once merged into a master I also plan to merge into 3.5 and 3.4, which are currently semi-broken due to the depreciation of the 20.04 runners on GH.



