### PR TITLE
event_flatstore improvement: new header parameter

### DIFF
--- a/modules/event_flatstore/doc/event_flatstore_admin.xml
+++ b/modules/event_flatstore/doc/event_flatstore_admin.xml
@@ -264,6 +264,25 @@ modparam("event_flatstore", "suffix", "$time(%Y)")
 </programlisting>
 		</example>
 	</section>
+	<section id="param_header" xreflabel="header">
+	<title><varname>header</varname> (string)</title>
+	<para>
+		If set, the string is written as the very first line of
+		every new log file created by the module.
+		Useful for column names.
+	</para>
+	<para>
+	<emphasis>Default value is <quote>""</quote> (disabled)</emphasis>.
+	</para>
+	<example>
+	<title>Set <varname>header</varname> parameter</title>
+	<programlisting  format="linespecific">
+...
+modparam("event_flatstore", "header", "event,time,param1,param2")
+...
+	</programlisting>
+	</example>
+	</section>
 	</section>
 	<section id="exported_functions" xreflabel="exported_functions">
 	<title>Exported Functions</title>

--- a/modules/event_flatstore/event_flatstore.h
+++ b/modules/event_flatstore/event_flatstore.h
@@ -49,6 +49,7 @@ struct flat_file {
 	unsigned int counter_open;
 	unsigned int rotate_version;
 	unsigned int flat_socket_ref;
+	int header_written;
 	struct flat_file *next;
 	struct flat_file *prev;
 };


### PR DESCRIPTION
## **Summary**

This PR adds **per-file headers** to the **event_flatstore** module.  
With the new `header` parameter, you can write an arbitrary string (e.g. CSV column names) as **the very first line of every newly created or rotated log file** — making it easier to work with parsers and analysis tools.

## **Details**

* **Current behavior**  
When a flatstore log file is rotated, the new file starts immediately with data lines — no header is added.

* **Problem**  
Many downstream tools expect a header row (e.g. in CSV files). Manually injecting headers after rotation is error-prone and inconvenient. Letting the module write the header automatically ensures consistency.

## **Solution**

* **New parameter**

| Parameter | Type   | Default          | Notes                                                                 |
|-----------|--------|------------------|-----------------------------------------------------------------------|
| `header`  | string | _(empty string)_ | Written as the **first line** of every new file. No trailing newline required. UTF-8 supported. |

When the module opens a new file (initial, rotated, or reopened), it will prepend this string as a line if `header` is set.

## **Compatibility**

* Fully backwards-compatible — if `header` is not configured, behavior remains unchanged.