### PR TITLE
domain: accept BIGINT type for accept_subdomain column

### DIFF
--- a/modules/domain/domain.c
+++ b/modules/domain/domain.c
@@ -332,6 +332,8 @@ int reload_domain_table ( void )
 			accept_subdomain = 0;
 		} else if (VAL_TYPE(val + 2) == DB_INT) {
 			accept_subdomain = VAL_INT(val + 2);
+		} else if (VAL_TYPE(val + 2) == DB_BIGINT) {
+			accept_subdomain = VAL_BIGINT(val + 2);
 		} else {
 			LM_ERR("Database problem on accept_subdomain column\n");
 			domain_dbf.free_result(db_handle, res);


### PR DESCRIPTION
**Summary**
accept BIGINT type for accept_subdomain column

**Details**
If using a `VIEW `(instead of a regular `TABLE`) and populating the `accept_subdomain `column with a default value, in MySQL we have the option to convert to `UNSIGNED `and this will create a `BIGINT`.

Something like:
```
CREATE VIEW domain (
    id,
    domain,
    attrs,
    accept_subdomain,
    last_modified
) AS SELECT
    ...
   CAST(0 AS UNSIGNED),
   ...
FROM my_table;
```
Allowing `accept_subdomain `to be parsed as a BIGINT solves the issue.