### PR TITLE
Fix buffer overflow in dnscache (#3669)

### DIFF
--- a/modules/dns_cache/dns_cache.c
+++ b/modules/dns_cache/dns_cache.c
@@ -223,7 +223,7 @@ static char* serialize_he_rdata(struct hostent *he,int *buf_len,int do_encoding)
 
 	/* copy aliases, if any */
 	if (he->h_aliases)
-		for (i=0;he->h_aliases[i];i++) {
+		for (i=0;i<alias_no;i++) {
 			len=strlen(he->h_aliases[i])+1;
 			/* copy alias length */
 			memcpy(p,&len,sizeof(int));
@@ -239,7 +239,7 @@ static char* serialize_he_rdata(struct hostent *he,int *buf_len,int do_encoding)
 
 	/* copy addresses */
 	if (he->h_addr_list)
-		for (i=0;he->h_addr_list[i];i++) {
+		for (i=0;i<addr_no;i++) {
 			/* copy addreses. length will be known from the addrtype field */
 			len=he->h_length;
 			memcpy(p,he->h_addr_list[i],len);


### PR DESCRIPTION
**Summary**
Fix buffer overflow in dnscache (#3669)

@pb-dstny wrote this fix for our internal use.

**Details**
`addr_no` and `alias_no` are calculated based on whichever is smaller out of the actual number of addresses/aliases, and `MAXADDRS-1`/`MAXALIASES-1`.

But then the code inserted all of the actual number of addresses/aliases anyway, which makes for a potential buffer overflow, and corrupted deserialisation later.

**Solution**
This PR fixes the problem by using the calculated values of `addr_no` and `alias_no`.

**Compatibility**
<!-- Does your change break other scenarios, or do they need to be migrated in order to work similarly? -->

**Closing issues**
`closes #3669`
