### PR TITLE
fix: Disable TLS tickets for 1.2 and 1.3 in order to support reconnects after OpenSIPS restart

### DIFF
--- a/modules/tls_wolfssl/wolfssl_conn_ops.c
+++ b/modules/tls_wolfssl/wolfssl_conn_ops.c
@@ -201,6 +201,14 @@ int _wolfssl_tls_conn_init(struct tcp_connection* c,
 		return -1;
 	}
 
+	/* we are no managing TLS 1.2 or 1.3 tickets server side
+	 * so in case a client will want to reconnect after an OpenSIPS
+	 * restart, it will provide a pre-shared ticket and this re-connection
+	 * will just fail, so take the lazy way out and disable tickets 
+	 * https://datatracker.ietf.org/doc/html/rfc8446#section-2.2 */
+	wolfSSL_NoTicketTLSv12(_WOLFSSL_READ_SSL(c->extra_data));
+	wolfSSL_no_ticket_TLSv13(_WOLFSSL_READ_SSL(c->extra_data));
+
 	/* put pointers to the tcp_connection and tls_domain structs
 	 * in the WOLFSSL struct as extra data */
 	if (!wolfSSL_set_ex_data(_WOLFSSL_READ_SSL(c->extra_data),


### PR DESCRIPTION
**Summary**
Fix clients opening new SSL connections ( TLS, WSS, etc ) after an OpenSIPS restart

**Details**
We are not managing TLS 1.2 or 1.3 tickets server side
so in case a client will want to reconnect after an OpenSIPS
restart, it will provide a pre-shared ticket and this re-connection
 will just fail, so take the lazy way out and disable tickets 
https://datatracker.ietf.org/doc/html/rfc8446#section-2.2


**Solution**
Disable tickets support for TLS 1.2 and 1.3

**Compatibility**
Backwards compatible
