### PR TITLE
rtp.io: hook the OpenSIPS notification socket automatically

### DIFF
--- a/.github/workflows/.rtp.io.yml
+++ b/.github/workflows/.rtp.io.yml
@@ -230,10 +230,17 @@ jobs:
         username: ${{ github.repository_owner }}
         password: ${{ secrets.GITHUB_TOKEN }}
 
+    - name: Set dynamic environment
+      run: |
+        if [ "${TARGETPLATFORM}" != "linux/amd64" ]
+        then
+          echo "TEST_SET_MIGHTFAIL=early_cancel_lost100,early_cancel" >> $GITHUB_ENV
+        fi
+
     - name: Test ${{ env.TARGETPLATFORM }}
       run: |
         docker pull ${BUILD_IMAGE}
-        docker run --platform ${TARGETPLATFORM} --name test --cap-add=SYS_PTRACE \
+        docker run --platform ${TARGETPLATFORM} --env TEST_SET_MIGHTFAIL --name test --cap-add=SYS_PTRACE \
          --privileged --sysctl net.ipv6.conf.all.disable_ipv6=0 ${BUILD_IMAGE}
       timeout-minutes: 2
 
@@ -259,6 +266,10 @@ jobs:
         _BUILD_OS="`echo ${BUILD_OS} | sed 's|:|-|g'`"
         OUTPUT_IMAGE_N="image-${_BUILD_OS}-`echo ${{ matrix.platform }} | sed 's|/|-|g'`"
         OUTPUT_IMAGE="./${OUTPUT_IMAGE_N}.tar"
+        if [ "${TARGETPLATFORM}" != "linux/amd64" ]
+        then
+          echo TEST_SET_MIGHTFAIL="early_cancel_lost100,early_cancel"" >> $GITHUB_ENV
+        fi
         echo OUTPUT_TAG="${OUTPUT_TAG}" >> $GITHUB_ENV
         echo OUTPUT_IMAGE="${OUTPUT_IMAGE}" >> $GITHUB_ENV
         echo OUTPUT_IMAGE_N="${OUTPUT_IMAGE_N}" >> $GITHUB_ENV
@@ -280,6 +291,6 @@ jobs:
 
     - name: Test ${{ env.TARGETPLATFORM }}
       run: |
-        docker run --platform ${TARGETPLATFORM} --name test --cap-add=SYS_PTRACE \
+        docker run --platform ${TARGETPLATFORM} --env TEST_SET_MIGHTFAIL --name test --cap-add=SYS_PTRACE \
          --privileged --sysctl net.ipv6.conf.all.disable_ipv6=0 ${OUTPUT_TAG}
       timeout-minutes: 2

--- a/docker/Dockerfile.rtp.io
+++ b/docker/Dockerfile.rtp.io
@@ -30,8 +30,10 @@ RUN --mount=type=bind,source=dist/voiptests/requirements.txt,target=requirements
 COPY --exclude=.git --exclude=.github --exclude=docker --exclude=dist \
  . .
 
-ARG KEEP_MODULES="dialog sipmsgops sl tm rr maxfwd rtp.io rtpproxy textops"
-ARG SKIP_MODULES="usrloc event_routing clusterer rtp_relay"
+ARG KEEP_MODULES="dialog sipmsgops sl tm rr maxfwd rtp.io rtpproxy textops \
+ signaling mi_fifo usrloc registrar acc rtp_relay siprec b2b_entities \
+ uac_auth presence pua alias_db b2b_logic"
+ARG SKIP_MODULES="event_routing clusterer"
 RUN mkdir tmp && cd modules && mv ${KEEP_MODULES} ${SKIP_MODULES} ../tmp && \
  rm -rf * && cd ../tmp && mv ${KEEP_MODULES} ${SKIP_MODULES} ../modules && \
  cd .. && rmdir tmp

--- a/docker/Dockerfile.rtp.io
+++ b/docker/Dockerfile.rtp.io
@@ -57,4 +57,5 @@ ENV RTPPC_TYPE=rtp.io
 ENV RTPPROXY_DIST=../../dist/rtpproxy
 ENV MM_INIT_DELAY=2
 WORKDIR dist/voiptests
+ARG TEST_SET_MIGHTFAIL
 ENTRYPOINT [ "sh", "-x", "./test_run.sh" ]

--- a/docker/Dockerfile.rtp.io
+++ b/docker/Dockerfile.rtp.io
@@ -55,5 +55,6 @@ ENV MM_ROOT=../..
 ENV RTPP_BRANCH=DOCKER
 ENV RTPPC_TYPE=rtp.io
 ENV RTPPROXY_DIST=../../dist/rtpproxy
+ENV MM_INIT_DELAY=2
 WORKDIR dist/voiptests
 ENTRYPOINT [ "sh", "-x", "./test_run.sh" ]

--- a/modules/rtp.io/rtp_io.c
+++ b/modules/rtp.io/rtp_io.c
@@ -231,7 +231,7 @@ child_init(int rank)
         return -1;
     }
     int is_nproc = is_nproc_f(NPROC_CHECK);
-    LM_DBG("rtp.io: child_init(%d), notifier: %d\n", rank, is_nproc);
+    LM_INFO("rtp.io: child_init(%d), notifier: %d\n", rank, is_nproc);
     if (rank > rpi_descp->socks->n) {
         LM_ERR("BUG: rank is higher than the number of sockets!\n");
         return -1;

--- a/modules/rtp.io/rtp_io.c
+++ b/modules/rtp.io/rtp_io.c
@@ -29,6 +29,8 @@
 #include "../../dprint.h"
 #include "../../timer.h"
 
+#include "../rtpproxy/rtpproxy.h"
+#include "../rtpproxy/notification_process.h"
 #include "rtp_io.h"
 #include "rtp_io_util.h"
 #include "rtp_io_params.h"
@@ -40,7 +42,7 @@ static void mod_destroy(void);
 
 static const dep_export_t deps = {
     { /* OpenSIPS module dependencies */
-        { MOD_TYPE_DEFAULT, "rtpproxy", DEP_SILENT|DEP_REVERSE },
+        { MOD_TYPE_DEFAULT, "rtpproxy", (DEP_SILENT|DEP_REVERSE) & (~DEP_REVERSE_CINIT) },
         { MOD_TYPE_NULL, NULL, 0 },
     },
 	{ /* modparam dependencies */
@@ -49,12 +51,14 @@ static const dep_export_t deps = {
 };
 
 static int rtp_io_getchildsock(int);
+static int rtp_io_getrnsock(struct rtpp_notify_cfg *);
 
 /*
  * Exported functions
  */
 static const cmd_export_t cmds[] = {
     {"rtp_io_getchildsock", (cmd_function)rtp_io_getchildsock, {0}, 0},
+    {"rtp_io_getrnsock", (cmd_function)rtp_io_getrnsock, {0}, 0},
     {0}
 };
 
@@ -162,17 +166,29 @@ static int mod_init(void)
         ENV_ADD(argv_stat[i], e1);
     }
 
+    struct rtpp_n_sock *n_sock = &rpi_descp->n_sock;
+    int *fdp = n_sock->_fds;
+    if (socketpair(AF_UNIX, SOCK_STREAM, 0, fdp) < 0)
+        goto e1;
+    snprintf(n_sock->_name, sizeof(n_sock->_name), "fd:%d", n_sock->fds.rtpp);
+    n_sock->name.s = n_sock->_name;
+    n_sock->name.len = strlen(n_sock->_name);
+    ENV_ADD("-n", e2);
+    ENV_ADD("%s", e2, n_sock->name.s);
     for (int i = 0; i < nsocks; i++) {
         int *fdp = &rpi_descp->socks->holder[i * 2];
         if (socketpair(AF_UNIX, SOCK_STREAM, 0, fdp) < 0)
-            goto e1;
-        ENV_ADD("-s", e1);
-        ENV_ADD("fd:%d", e1, fdp[0]);
+            goto e2;
+        ENV_ADD("-s", e2);
+        ENV_ADD("fd:%d", e2, fdp[0]);
     }
 
     rpi_descp->socks->n = nsocks;
 
     return 0;
+e2:
+    close(n_sock->_fds[0]);
+    close(n_sock->_fds[1]);
 e1:
     free(rpi_descp->socks);
 e0:
@@ -198,6 +214,7 @@ void mod_destroy(void)
     }
     rtp_io_close_serv_socks();
     rtp_io_close_cnlt_socks();
+    rtp_io_close_cnlt_nsock();
     free(rpi_descp->socks);
 }
 
@@ -206,8 +223,22 @@ void mod_destroy(void)
 static int
 child_init(int rank)
 {
+    rtpproxy_is_nproc_t is_nproc_f;
+
+    is_nproc_f = (rtpproxy_is_nproc_t)find_export("rtpproxy_is_nproc", 0);
+    if (is_nproc_f == NULL) {
+        LM_ERR("rtpproxy_is_nproc() not found in the rtpproxy module\n");
+        return -1;
+    }
+    int is_nproc = is_nproc_f(NPROC_CHECK);
+    LM_DBG("rtp.io: child_init(%d), notifier: %d\n", rank, is_nproc);
     if (rank > rpi_descp->socks->n) {
         LM_ERR("BUG: rank is higher than the number of sockets!\n");
+        return -1;
+    }
+
+    if (!is_nproc && rtp_io_close_cnlt_nsock() != 0) {
+        LM_ERR("rtp_io_close_cnlt_nsock() failed\n");
         return -1;
     }
 
@@ -240,3 +271,12 @@ static int rtp_io_getchildsock(int rank)
     int *fdp = &rpi_descp->socks->holder[(rank - 1) * 2];
     return (fdp[1]);
 }
+
+static int rtp_io_getrnsock(struct rtpp_notify_cfg *rn_cfg)
+{
+
+    rn_cfg->name = rpi_descp->n_sock.name;
+    rn_cfg->sock.rn_umode = CM_RTPIO;
+    rn_cfg->sock.fd = rpi_descp->n_sock.fds.osips;
+    return (0);
+};

--- a/modules/rtp.io/rtp_io.h
+++ b/modules/rtp.io/rtp_io.h
@@ -25,10 +25,23 @@ struct rtp_io_socks {
     int holder[];
 };
 
+struct rtpp_n_sock {
+    char _name[32];
+    str name;
+    union {
+        struct {
+            int rtpp;
+            int osips;
+        } fds;
+        int _fds[2];
+    };
+};
+
 struct rtp_io_desc {
     struct rtpp_cfg *rtpp_cfsp;
     struct rtpp_env_hd env;
     struct rtp_io_socks *socks;
+    struct rtpp_n_sock n_sock;
 };
 
 extern struct rtp_io_desc *rpi_descp;

--- a/modules/rtp.io/rtp_io_api.h
+++ b/modules/rtp.io/rtp_io_api.h
@@ -1,3 +1,6 @@
 #pragma once
 
+struct rtpp_notify_cfg;
+
 typedef int (*rtp_io_getchildsock_t)(int);
+typedef int (*rtp_io_getrnsock_t)(struct rtpp_notify_cfg *);

--- a/modules/rtp.io/rtp_io_host.c
+++ b/modules/rtp.io/rtp_io_host.c
@@ -72,6 +72,8 @@ void rtpproxy_host_process(int rank)
         goto e1;
     if (rtp_io_close_cnlt_socks() != 0)
         goto e1;
+    if (rtp_io_close_cnlt_nsock() != 0)
+        goto e1;
 
     OPT_RESTORE();
     rpi_descp->rtpp_cfsp = rtpp_main(argc, argv);
@@ -100,6 +102,9 @@ ipc_shutdown_rtpp_host(int sender, void *param)
     for (int i = 0; i < (rpi_descp->socks->n * 2); i++) {
         if (rpi_descp->socks->holder[i] != -1)
             close(rpi_descp->socks->holder[i]);
+    }
+    if (rpi_descp->n_sock.fds.rtpp != -1) {
+        close(rpi_descp->n_sock.fds.rtpp);
     }
     free(rpi_descp->socks);
 }

--- a/modules/rtp.io/rtp_io_util.c
+++ b/modules/rtp.io/rtp_io_util.c
@@ -85,11 +85,27 @@ int rtp_io_close_serv_socks(void)
 
     for (int i = 0; i < (rpi_descp->socks->n * 2); i+=2) {
         if (rpi_descp->socks->holder[i] != -1) {
-            close(rpi_descp->socks->holder[i]);
+            if (close(rpi_descp->socks->holder[i]) != 0)
+                return -1;
             rpi_descp->socks->holder[i] = -1;
         }
     }
+    if (rpi_descp->n_sock.fds.rtpp != -1) {
+        if (close(rpi_descp->n_sock.fds.rtpp) != 0)
+            return -1;
+        rpi_descp->n_sock.fds.rtpp = -1;
+    }
     return (0);
+}
+
+int rtp_io_close_cnlt_nsock(void)
+{
+    if (rpi_descp->n_sock.fds.osips != -1) {
+	if (close(rpi_descp->n_sock.fds.osips) != 0)
+            return -1;
+	rpi_descp->n_sock.fds.osips = -1;
+    }
+    return 0;
 }
 
 int rtp_io_close_cnlt_socks(void)
@@ -97,7 +113,8 @@ int rtp_io_close_cnlt_socks(void)
 
     for (int i = 0; i < (rpi_descp->socks->n * 2); i+=2) {
         if (rpi_descp->socks->holder[i+1] != -1) {
-            close(rpi_descp->socks->holder[i+1]);
+            if (close(rpi_descp->socks->holder[i+1]) != 0)
+                return -1;
             rpi_descp->socks->holder[i+1] = -1;
         }
     }

--- a/modules/rtp.io/rtp_io_util.h
+++ b/modules/rtp.io/rtp_io_util.h
@@ -11,3 +11,4 @@ const char *const * rtp_io_env_gen_argv(struct rtpp_env_hd *, int *);
 
 int rtp_io_close_serv_socks(void);
 int rtp_io_close_cnlt_socks(void);
+int rtp_io_close_cnlt_nsock(void);

--- a/modules/rtpproxy/notification_process.c
+++ b/modules/rtpproxy/notification_process.c
@@ -420,7 +420,7 @@ void notification_listener_process(int rank)
 		socket_fd = rn_sock->fd;
 		len = -1;
 		saddr = NULL;
-		LM_DBG("using rtp.io notification socket %d\n", socket_fd);
+		LM_INFO("using rtp.io notification socket %d\n", socket_fd);
 		break;
 	default:
 		abort();

--- a/modules/rtpproxy/notification_process.h
+++ b/modules/rtpproxy/notification_process.h
@@ -1,0 +1,7 @@
+#pragma once
+
+enum inp_op {NPROC_CHECK = 0, NPROC_SET};
+
+int rtpproxy_is_nproc(enum inp_op);
+
+typedef int (*rtpproxy_is_nproc_t)(enum inp_op);

--- a/modules/rtpproxy/rtpproxy.h
+++ b/modules/rtpproxy/rtpproxy.h
@@ -57,6 +57,16 @@ struct rtpp_node {
 	struct rtpp_node	*rn_next;
 };
 
+struct rtpp_sock {
+	int fd;
+	enum comm_modes rn_umode;
+};
+
+struct rtpp_notify_cfg {
+	str name;
+	struct rtpp_sock sock;
+};
+
 #define CM_STREAM(ndp) ((ndp)->rn_umode == CM_TCP || (ndp)->rn_umode == CM_TCP6 || \
     (ndp)->rn_umode == CM_CUNIX || (ndp)->rn_umode == CM_RTPIO)
 
@@ -150,8 +160,7 @@ struct rtpp_dtmf_event {
 int rtpproxy_raise_dtmf_event(struct rtpp_dtmf_event *dtmf);
 
 extern rw_lock_t *nh_lock;
-extern str rtpp_notify_socket;
-extern int rtpp_notify_socket_un;
+extern struct rtpp_notify_cfg rtpp_notify_cfg;
 extern struct dlg_binds dlg_api;
 extern int detect_rtp_idle;
 extern int rtpproxy_tout;

--- a/modules/rtpproxy/rtpproxy.h
+++ b/modules/rtpproxy/rtpproxy.h
@@ -30,6 +30,7 @@
 #include "../../pvar.h"
 #include "../dialog/dlg_load.h"
 #include "../../rw_locking.h"
+#include "../rtp.io/rtp_io_api.h"
 
 struct rtpproxy_vcmd;
 
@@ -168,6 +169,7 @@ extern struct rtpp_set_head ** rtpp_set_list;
 int init_rtpp_notify();
 void update_rtpp_notify();
 void notification_listener_process(int rank);
+int fill_rtp_io_rnsock(void);
 
 /* Functions from nathelper */
 struct rtpp_set *get_rtpp_set(nh_set_param_t *);


### PR DESCRIPTION
**Summary**

rtp.io: hook the OpenSIPS notification socket automatically.

**Details**

In the current version of the rtp.io, the notification socket still needs to be configured manually in both rtp.io and rtpproxy modules. 

**Solution**

This patch is expected to fix that by allocating extra socketpair and passing that to the librtpproxy and rtpproxy module.

**Compatibility**

Existing configuration should work as is.