### PR TITLE
core: split DEP_REVERSE_INIT into _MINIT and _CINIT parts

### DIFF
--- a/sr_module.c
+++ b/sr_module.c
@@ -675,7 +675,7 @@ static int init_mod_child( struct sr_module* m, int rank, char *type,
 	if (!skip_others && init_mod_child(m->next, rank, type, 0) != 0)
 		return -1;
 
-	for (dep = m->sr_deps_init; dep; dep = dep->next)
+	for (dep = m->sr_deps_cinit; dep; dep = dep->next)
 		if (!dep->mod->init_child_done)
 			if (init_mod_child(dep->mod, rank, type, 1) != 0)
 				return -1;

--- a/sr_module.h
+++ b/sr_module.h
@@ -145,6 +145,9 @@ struct sr_module{
 	/* modules which must be initialized before this module */
 	struct sr_module_dep *sr_deps_init;
 
+	/* modules which childs must be initialized before this module */
+	struct sr_module_dep *sr_deps_cinit;
+
 	/* modules which must be destroyed before this module */
 	struct sr_module_dep *sr_deps_destroy;
 

--- a/sr_module_deps.c
+++ b/sr_module_deps.c
@@ -229,6 +229,50 @@ int add_module_dependencies(struct sr_module *mod)
 	return 0;
 }
 
+static struct sr_module_dep *make_dep(struct sr_module_dep *md,
+    unsigned int dep_type, unsigned int df, struct sr_module *mod_a,
+    struct sr_module *mod_b)
+{
+	struct sr_module_dep **dip_a, **dip_b;
+
+	switch (df) {
+	case DEP_REVERSE_MINIT:
+		dip_a = &mod_a->sr_deps_init;
+		dip_b = &mod_b->sr_deps_init;
+		break;
+	case DEP_REVERSE_CINIT:
+		dip_a = &mod_a->sr_deps_cinit;
+		dip_b = &mod_b->sr_deps_cinit;
+		break;
+	case DEP_REVERSE_DESTROY:
+		dip_a = &mod_a->sr_deps_destroy;
+		dip_b = &mod_b->sr_deps_destroy;
+		break;
+	default:
+		LM_ERR("BUG, unhandled dep_type: %d\n", df);
+		abort();
+	}
+
+	if (md == NULL) {
+		md = pkg_malloc(sizeof *md);
+		if (!md) {
+			LM_ERR("no more pkg\n");
+			return NULL;
+		}
+		memset(md, 0, sizeof *md);
+	}
+
+	if (dep_type & df) {
+		md->mod = mod_a;
+		md->next = *dip_b;
+		*dip_b = md;
+	} else {
+		md->mod = mod_b;
+		md->next = *dip_a;
+		*dip_a = md;
+	}
+	return md;
+}
 
 int solve_module_dependencies(struct sr_module *modules)
 {
@@ -251,111 +295,53 @@ int solve_module_dependencies(struct sr_module *modules)
 
 		this = md->mod;
 		dep_type = md->type;
+		int byname = (md->dep.s != NULL) ? 1 : 0;
+		mod_type = md->mod_type;
 
 		/*
 		 * for generic dependencies (e.g. dialog depends on MOD_TYPE_SQLDB),
 		 * first load all modules of given type
+		 *
+		 * re-purpose this @md structure by linking it into a module's
+		 * list of dependencies (will be used at init time)
+		 *
+		 * md->mod used to point to (highlighted with []):
+		 *		[sr_module A] ---> "mod_name"
+		 *
+		 * now, the dependency is solved. md->mod will point to:
+		 *		sr_module A  ---> [sr_module B]
 		 */
-		if (!md->dep.s) {
-			/*
-			 * re-purpose this @md structure by linking it into a module's
-			 * list of dependencies (will be used at init time)
-			 *
-			 * md->mod used to point to (highlighted with []):
-			 *		[sr_module A] ---> "mod_name"
-			 *
-			 * now, the dependency is solved. md->mod will point to:
-			 *		sr_module A  ---> [sr_module B]
-			 */
-			mod_type = md->mod_type;
 
-			for (dep_solved = 0, mod = modules; mod; mod = mod->next) {
-				if (mod != this && mod->exports->type == mod_type) {
-					if (!md) {
-						md = pkg_malloc(sizeof *md);
-						if (!md) {
-							LM_ERR("no more pkg\n");
-							return -1;
-						}
-						memset(md, 0, sizeof *md);
-					}
-
-					if (dep_type & DEP_REVERSE_INIT) {
-						md->mod = this;
-						md->next = mod->sr_deps_init;
-						mod->sr_deps_init = md;
-					} else {
-						md->mod = mod;
-						md->next = this->sr_deps_init;
-						this->sr_deps_init = md;
-					}
-
-					md = pkg_malloc(sizeof *md);
-					if (!md) {
-						LM_ERR("no more pkg\n");
-						return -1;
-					}
-					memset(md, 0, sizeof *md);
-
-					if (dep_type & DEP_REVERSE_DESTROY) {
-						md->mod = mod;
-						md->next = this->sr_deps_destroy;
-						this->sr_deps_destroy = md;
-					} else {
-						md->mod = this;
-						md->next = mod->sr_deps_destroy;
-						mod->sr_deps_destroy = md;
-					}
-
-					md = NULL;
-					dep_solved++;
-				}
-			}
-		} else {
-			for (dep_solved = 0, mod = modules; mod; mod = mod->next) {
+		for (dep_solved = 0, mod = modules; mod; mod = mod->next) {
+			if (!byname) {
+				if (mod == this || mod->exports->type != mod_type)
+					continue;
+			} else {
 				if (strcmp(mod->exports->name, md->dep.s) != 0)
 					continue;
-
-				/* quick sanity check */
-				if (mod->exports->type != md->mod_type)
+				if (mod->exports->type != mod_type)
 					LM_BUG("[%.*s %d] -> [%s %d]\n", md->dep.len, md->dep.s,
-							md->mod_type, mod->exports->name,
-							mod->exports->type);
-
-				/* same re-purposing technique as above */
-				if (dep_type & DEP_REVERSE_INIT) {
-					md->next = mod->sr_deps_init;
-					mod->sr_deps_init = md;
-				} else {
-					md->mod = mod;
-					md->next = this->sr_deps_init;
-					this->sr_deps_init = md;
-				}
-
-				md = pkg_malloc(sizeof *md);
-				if (!md) {
-					LM_ERR("no more pkg\n");
-					return -1;
-				}
-				memset(md, 0, sizeof *md);
-
-				if (dep_type & DEP_REVERSE_DESTROY) {
-					md->mod = mod;
-					md->next = this->sr_deps_destroy;
-					this->sr_deps_destroy = md;
-				} else {
-					md->mod = this;
-					md->next = mod->sr_deps_destroy;
-					mod->sr_deps_destroy = md;
-				}
-
-				dep_solved++;
-				break;
+						mod_type, mod->exports->name,
+						mod->exports->type);
 			}
+			md = make_dep(md, dep_type, DEP_REVERSE_MINIT, this, mod);
+			if (!md)
+				return -1;
+			md = make_dep(NULL, dep_type, DEP_REVERSE_DESTROY, mod, this);
+			if (!md)
+				return -1;
+			md = make_dep(NULL, dep_type, DEP_REVERSE_CINIT, this, mod);
+			if (!md)
+				return -1;
+
+			dep_solved++;
+			if (byname)
+				break;
+			md = NULL;
 		}
 
 		/* reverse-init dependencies are always solved! */
-		if (dep_solved || dep_type & DEP_REVERSE_INIT)
+		if (dep_solved || dep_type & DEP_REVERSE_MINIT)
 			continue;
 
 		/* treat unmet dependencies using the intended behaviour */

--- a/sr_module_deps.h
+++ b/sr_module_deps.h
@@ -74,10 +74,12 @@ enum module_type {
 #define DEP_WARN	(1 << 1) /* re-order init & destroy; warn if dep n/f */
 #define DEP_ABORT	(1 << 2) /* re-order init & destroy; exit if dep n/f */
 /* in some cases, the dependency direction will be reversed */
-#define DEP_REVERSE_INIT    (1 << 3) /* if A->B, A inits before B */
+#define DEP_REVERSE_MINIT   (1 << 3) /* if A->B, A.mod_init() before B.mod_init() */
 #define DEP_REVERSE_DESTROY (1 << 4) /* if A->B, B destroys before A */
+#define DEP_REVERSE_CINIT   (1 << 5) /* if A->B, A.child_init() before B.child_init() */
 
-#define DEP_REVERSE (DEP_REVERSE_INIT|DEP_REVERSE_DESTROY)
+#define DEP_REVERSE_INIT (DEP_REVERSE_MINIT|DEP_REVERSE_CINIT)
+#define DEP_REVERSE      (DEP_REVERSE_INIT|DEP_REVERSE_DESTROY)
 
 typedef struct module_dependency {
 	enum module_type mod_type;


### PR DESCRIPTION
**Summary**

Add `DEP_REVERSE_CINIT` and `DEP_REVERSE_MINIT` dependency flags allowing to reverse `mod_init()` and `child_init()` call order for module A and module B independently.

Make DEP_REVERSE_INIT be (DEP_REVERSE_CINIT|DEP_REVERSE_MINIT).

**Details**

This is needed when for whatever architectural reason certain pair of modules (i.e. `rtp.io` and `rtpproxy`) want to use different order for `mod_init()` and `child_init()`. In case of the `rtp.io` vs `rtpproxy`, we want `mod_init()` for the `rtp.io` first so that it can allocate sockets and initialize `rtpproxy` client config. Yet, we want `child_init()` for the `rtpproxy` module to be called first, so that we can set flag when we are in the notification process.

**Solution**

`DEP_REVERSE_INIT` became `DEP_REVERSE_MINIT`, added `DEP_REVERSE_CINIT` and define compound `DEP_REVERSE_INIT` be `(DEP_REVERSE_CINIT|DEP_REVERSE_MINIT)`.

**Compatibility**

Should not be any.