### PR TITLE
Added menuconfig options to disable event_sqs and rtp.io module builds

### DIFF
--- a/Makefile.conf.template
+++ b/Makefile.conf.template
@@ -22,6 +22,7 @@
 #dialplan= Implements generic string translations based on matching and replacement rules | PCRE development library, typically libpcre-dev
 #emergency= Provides emergency call treatment for OpenSIPS | CURL dev library - typically libcurl4-openssl-dev
 #event_rabbitmq= Provides the implementation of a RabbitMQ client for the Event Interface | RabbitMQ development library, librabbitmq-dev
+#event_sqs= Provides the implementation of a Amazon SQS client for the Event Interface | AWS SDK C++, aws-sdk-cpp
 #event_kafka= Provides the implementation of an Apache Kafka producer for the Event Interface | Kafka development library, librdkafka-dev
 #h350= Enables access to SIP account data stored in an LDAP [RFC4510] directory containing H.350 commObjects | OpenLDAP library & development files, typically libldap and libldap-dev
 #regex= Offers matching operations against regular expressions using the powerful PCRE library. | Development library for PCRE, typically libpcre-dev
@@ -59,6 +60,7 @@
 #python= Easily implement your own OpenSIPS extensions in Python | Shared Python runtime library, libpython
 #rest_client= Simple HTTP client | CURL library - libcurl
 #rls= Resource List Server implementation following the specification in RFC 4662 and RFC 4826 | parsing/building XML library, typically libxml-dev
+#rtp.io= Implements internal RTP proxy based on library of RTPProxy >=3.1 | librtpproxy
 #sngtc= Voice Transcoding using the D-series Sangoma transcoding cards | libsngtc_node
 #siprec= SIP Call Recording to an external/passive recorder | uuid-dev
 #snmpstats= Provides an SNMP management interface to OpenSIPS | NetSNMP v5.3


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!
In order to consider and evaluate your PR, it is mandatory to provide detailed information about (1) what is the issue the PR addresses, (2) how the PR is solving the issue (logic and coding), (3) what are (if any) limitations of the proposed PR and (4) if there are any known side-effects/ backward compatibility issues/SIP interoperability issues.
Note that if the PR is missing information, it might take longer to be merged, as extra resources have to be allocated by the maintainers to reverse engineer the changes, understand them, understand the motivation, etc. That is why it is important to provide as much information as possible.
-->

**Summary**
<!-- Summary of the PR - what the PR is aiming to solve -->
This fix add options to disable event_sqs and rtp.io module builds

**Details**
<!--
Details about the content of the PR - is it a bug fix, a new feature or perhaps a hack? Explain the **motivation** for making this change.
What existing problem does the pull request solve? Is this a particular problem (i.e. only some particular scenarios are affected, only some UACs, etc) or a generic one?
Do not assume others understand what you're trying to do and provide as much information as you may have.
-->
Without this fix event_sqs and rtp.io modules will attempt to build at OpenSIPS compile time. If you haven't prepared the operating system for this, the OpenSIPS build from source will be failed

**Solution**
<!-- Explain how your PR fixes the problem. Are there any remaining concerns that might need to be addressed? -->

**Compatibility**
<!-- Does your change break other scenarios, or do they need to be migrated in order to work similarly? -->
For OpenSIPS >= 3.6

**Closing issues**
<!-- Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). -->
