### PR TITLE
Fix: wrong transaction reset after success reply

### DIFF
--- a/modules/b2b_entities/dlg.c
+++ b/modules/b2b_entities/dlg.c
@@ -1847,6 +1847,8 @@ int _b2b_send_reply(b2b_dlg_t* dlg, b2b_rpl_data_t* rpl_data)
 			LM_DBG("Reset transaction- send final reply [%p], uas_tran=0\n", dlg);
 			if(sip_method == METHOD_UPDATE)
 				dlg->update_tran = NULL;
+			else if (sip_method == METHOD_PRACK)
+				dlg->prack_tran = NULL;
 			else
 				dlg->uas_tran = NULL;
 		}


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!
In order to consider and evaluate your PR, it is mandatory to provide detailed information about (1) what is the issue the PR addresses, (2) how the PR is solving the issue (logic and coding), (3) what are (if any) limitations of the proposed PR and (4) if there are any known side-effects/ backward compatibility issues/SIP interoperability issues.
Note that if the PR is missing information, it might take longer to be merged, as extra resources have to be allocated by the maintainers to reverse engineer the changes, understand them, understand the motivation, etc. That is why it is important to provide as much information as possible.
-->

**Summary**
Resetting the correct transaction based on the SIP method. On the reception of 200 OK for the PRACK sets the uas transaction instead of prack transaction. This behaviour is particularly seen when we enable the passthru_prack in the 
b2b_entities module.

**Details**
The behaviour is particularly seen when we enable the passthru_prack in the b2b_entities module. When we receive the success reply for the PRACK, wrong transaction gets reset (dlg->uas_trans).

**Solution**
Add the missing check for sip_method PRACK and reset the correct transaction.

**Compatibility**
Does not break anything

**Closing issues**
<!-- Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). -->
None
