### PR TITLE
add support for resource limit error messages from rtpengine

### DIFF
--- a/modules/rtpengine/rtpengine.c
+++ b/modules/rtpengine/rtpengine.c
@@ -824,6 +824,9 @@ struct module_exports exports = {
 static char *rtpe_default_failover_errors[] = {
 	"Parallel session limit reached",
 	"Ran out of ports",
+	"CPU usage limit exceeded",
+	"Load limit exceeded",
+	"Bandwidth limit exceeded",
 };
 
 static void rtpe_stats_free(struct rtpe_stats *stats)


### PR DESCRIPTION
The rtpengine module handles the "Parallel session limit reached" error message when the maxsession setting has been reached. This can happen if the server is being drained, or is overloaded.

There are other errors which can also occur if the server is under load. This change recognises the error messages corresponding to these load limits and handles them in the same way as the session limit.


supports LOAD_LIMIT_CPU, LOAD_LIMIT_LOAD, LOAD_LIMIT_BW from rtpengine:
```const char magic_load_limit_strings[__LOAD_LIMIT_MAX][64] = {
        [LOAD_LIMIT_MAX_SESSIONS] = "Parallel session limit reached",
        [LOAD_LIMIT_CPU] = "CPU usage limit exceeded",
        [LOAD_LIMIT_LOAD] = "Load limit exceeded",
        [LOAD_LIMIT_BW] = "Bandwidth limit exceeded",
};```