### PR TITLE
registrar: increase MAX_FORCED_BINDING_LEN in save function

### DIFF
--- a/modules/registrar/save.c
+++ b/modules/registrar/save.c
@@ -721,7 +721,7 @@ return_minus_one:
 	return -1;
 }
 
-#define MAX_FORCED_BINDING_LEN 256
+#define MAX_FORCED_BINDING_LEN 512
 int save(struct sip_msg* _m, void* _d, void* _f, str* _s, str* _owtag)
 {
 	struct sip_msg* msg = _m;
@@ -843,7 +843,7 @@ int save(struct sip_msg* _m, void* _d, void* _f, str* _s, str* _owtag)
 								forced_binding.s);
 							break;
 						} else {
-							LM_ERR("forced binding to BIG:"
+							LM_ERR("forced binding too BIG:"
 								" %d > MAX_FORCED_BINDING_LEN\n",
 								forced_binding.len);
 							goto done;


### PR DESCRIPTION
**Summary**

Sometimes the SIP Contact header field URI can be larger than 256 chars. For example, 'pn-provider', 'pn-prid' and 'pn-param' MUST be in the URI if SIP UA requests push notifications and they can be quite long.