### PR TITLE
fix: when deciding if we need to propagate a reply, skip branches scheduled for cancellation but with no replies yet

### DIFF
--- a/modules/tm/t_reply.c
+++ b/modules/tm/t_reply.c
@@ -833,6 +833,11 @@ static inline int t_pick_branch( struct cell *t, int *res_code, int *do_cancel)
 			continue;
 		/* skip 'empty branches' */
 		if (!t->uac[b].request.buffer.s) continue;
+
+		/* skip branches with no replies yet, but which were marked to
+		 * be cancelled via t_cancel_branch */
+		if (t->uac[b].flags & T_UAC_TO_CANCEL_FLAG) continue;
+
 		/* there is still an unfinished UAC transaction; wait now! */
 		if ( t->uac[b].last_received<200 ) {
 			if (t->uac[b].br_flags & minor_branch_flag) {


### PR DESCRIPTION
**Summary**
Current bug is : 

- we have branch1 sent to a destination which is dead/down/not replying
- we have branch2 replying with a code that the script decides should terminate the transaction ( ie. if ($rs == 486) t_cancel_branch("o")

The bug is that the 486 does not get propagated on the spot - it gets saved internally and relayed only when fr_timeout elapses.

**Details**
Ignore branches scheduled for CANCELation via t_cancel_branch, which don't have any replies on them yet.

**Solution**
Ignore branches scheduled for CANCELation via t_cancel_branch, which don't have any replies on them yet.

**Compatibility**
Should be backwards compatible - I hope.

