### PR TITLE
Make GCC happy by addressing its warnings about possibly uninitialized variables

### DIFF
--- a/modules/aaa_diameter/app_opensips/avps.c
+++ b/modules/aaa_diameter/app_opensips/avps.c
@@ -561,7 +561,7 @@ int parse_attr_def(char *line, FILE *fp)
 	unsigned int vendor_id = -1;
 	size_t buflen = strlen(line);
 	int i, len = buflen, attr_len = strlen("ATTRIBUTE"), name_len, avp_code;
-	char *name, *nt_name, *newp, *p = line, *end = p + len;
+	char *name, *nt_name = NULL, *newp, *p = line, *end = p + len;
 	enum dict_avp_basetype avp_type;
 	enum dict_avp_enc_type enc_type = AVP_ENC_TYPE_NONE;
 

--- a/modules/clusterer/sharing_tags.c
+++ b/modules/clusterer/sharing_tags.c
@@ -682,7 +682,7 @@ int shtag_activate(str *tag_name, int cluster_id, char *reason, int reason_len)
 {
 	struct sharing_tag *tag;
 	int lock_old_flag;
-	int ret, old_state;
+	int ret, old_state = SHTAG_STATE_BACKUP;
 	struct n_send_info *ni;
 	node_info_t *node;
 	cluster_info_t *cl;

--- a/modules/event_kafka/kafka_producer.c
+++ b/modules/event_kafka/kafka_producer.c
@@ -379,7 +379,7 @@ void kafka_report_status(int sender, void *param)
 {
 	struct kafka_report_param *p =
 		(struct kafka_report_param *)param;
-	script_job_data_t *job_data;
+	script_job_data_t *job_data = NULL;
 
 	if (p->job->type == KAFKA_JOB_EVI) {
 		evi_job_data_t *job_data = (evi_job_data_t *)p->job->data;

--- a/modules/http2d/http2d.c
+++ b/modules/http2d/http2d.c
@@ -135,7 +135,7 @@ static int h2_send_response(struct sip_msg *msg, int *code,
 		str *headers_json, str *body)
 {
 #define H_STATUS ":status"
-	cJSON *hdrs, *it;
+	cJSON *hdrs = NULL, *it;
 	struct h2_response *r;
 	int nh = 1;
 


### PR DESCRIPTION
**Summary**
Modern GCC checks for possible use or free of uninitialized variables (`-Wmaybe-uninitialized`). Some of these warnings are real issues some are just misunderstanding of what's really going on (thus cosmetic mostly).

**Solution**
I've addressed several GCC' complains about possible uninitialized variables thus reducing noise.

**Compatibility**
Should be compatible with all compiler's version.

**Closing issues**
n/a.
