### PR TITLE
Fix various function or variable type mismatch

### DIFF
--- a/modules/auth_jwt/authorize.h
+++ b/modules/auth_jwt/authorize.h
@@ -28,8 +28,9 @@
 int auth_db_init(const str* db_url);
 void auth_db_close();
 
-int jwt_db_authorize(struct sip_msg* _msg, str* jwt_token, pv_spec_t* auth_user);
-int jwt_script_authorize(struct sip_msg* _msg, str* jwt_token, str* key, 
+int jwt_db_authorize(struct sip_msg* _msg, str* jwt_token, pv_spec_t*
+		decoded_jwt, pv_spec_t* auth_user);
+int jwt_script_authorize(struct sip_msg* _msg, str* jwt_token, str* key,
 		pv_spec_t* decoded_jwt);
 
 #endif /* JWTAUTHORIZE_H */

--- a/modules/domain/domain.h
+++ b/modules/domain/domain.h
@@ -32,13 +32,13 @@
 /*
  * Check if host in From uri is local
  */
-int is_from_local(struct sip_msg* _msg, char* _s1, char* _s2);
+int is_from_local(struct sip_msg* _msg, pv_spec_t* _s1);
 
 
 /*
  * Check if host in Request URI is local
  */
-int is_uri_host_local(struct sip_msg* _msg, char* _s1, char* _s2);
+int is_uri_host_local(struct sip_msg* _msg, pv_spec_t* _s1);
 
 
 /*

--- a/modules/event_routing/ebr_data.c
+++ b/modules/event_routing/ebr_data.c
@@ -50,7 +50,7 @@ typedef struct _ebr_ipc_job {
 } ebr_ipc_job;
 
 /* IPC type registered with the IPC layer */
-extern int ebr_ipc_type;
+extern ipc_handler_type ebr_ipc_type;
 
 /* TM API */
 extern struct tm_binds ebr_tmb;


### PR DESCRIPTION
**Summary**
Fix a few definition/declaration type mismatches

**Details**
This PR fixes various GCC warnings about type mismatch.

**Solution**
Ensured that function/variable declaration and their definition are consistent.

**Compatibility**
This improves compatibility with various ANSI C compilers I believe.

**Closing issues**
n/a.
