### PR TITLE
Ignore extra headers in MSRP

### DIFF
--- a/modules/proto_msrp/msrp_parser.c
+++ b/modules/proto_msrp/msrp_parser.c
@@ -184,12 +184,13 @@ int parse_msrp_msg( char* buf, int len, struct msrp_msg *msg)
 			case HDR_EXPIRES_T:
 				link_hdr( expires, hf);
 				break;
-			case HDR_OTHER_T:
-				break;
 			case HDR_ERROR_T:
-			default:
 				LM_INFO("bad header field\n");
 				goto err_free_hf;
+			case HDR_OTHER_T:
+			default:
+				/* There can be other headers in the MSRP but we don't need to use them, so ignoring it */
+				break;
 		}
 
 		/* add the header to the list*/


### PR DESCRIPTION
**Summary**
This PR fixes an issue if MSRP messages container other/non-required headers. 

**Details**
If an MSRP message contains a header such as Content-Disposition, which is a recognized header, the message will get rejected with "ERROR:core:handle_mi_request: Invalid parameters". This is a valid header in an MSRP message as described in RFC 4975, section 9. 

**Solution**
This fix moves the "default" switch case to be grouped with HDR_OTHER_T instead of HDR_ERROR_T and allows for the continued processing of the message.

**Compatibility**
This should not cause any issues with existing code unless it was relying on a message with other headers being rejected.

**Closing issues**
