### PR TITLE
json: add a new pseudo-variable - json_compact_noescape

### DIFF
--- a/modules/json/doc/json_admin.xml
+++ b/modules/json/doc/json_admin.xml
@@ -405,7 +405,7 @@ $json(object/array) := $json(array) ;
 		<title><varname>$json_pretty(id)</varname></title>
 		<para>
 			The <varname>json_pretty</varname> variable has the
-			same purpose as the <varname>json</varname> variable,
+			same purpose as the <xref linkend="pv_json"/> variable,
 			but prints the JSON object in a pretty format, adding
 			spaces and tabs to make the output more readable.
 		</para>
@@ -414,10 +414,35 @@ $json(object/array) := $json(array) ;
 		<title><varname>$json_compact(id)</varname></title>
 		<para>
 			The <varname>json_compact</varname> variable has the
-			same purpose as the <varname>json</varname> variable,
+			same purpose as the <xref linkend="pv_json"/> variable,
 			but prints the JSON object in a more compact form,
 			without formatting spaces.
 		</para>
+	</section>
+	<section id="pv_json_compact_noescape" xreflabel="$json_compact_noescape">
+		<title><varname>$json_compact_noescape(id)</varname></title>
+		<para>
+			The <varname>json_compact_noescape</varname> variable has the
+			same purpose as the <xref linkend="pv_json_compact"/> variable,
+			printing the JSON object in the compact form, but without
+			escaping the slashes.
+		</para>
+			<example>
+			<title>Difference between json_compact and json_compact_noescape</title>
+			<programlisting format="linespecific">
+...
+$json(obj) := "{}";
+$json(obj/path) = "/path/to/some/file";
+xlog("The json is: $json_compact(obj)\n");
+# will print:
+# The json is: {"path":"\/path\/to\/some\/file"}
+
+xlog("The json no escape is: $json_compact_noescape(obj)\n");
+# will print:
+# The json no escape is: {"path":"/path/to/some/file"}
+...
+			</programlisting>
+			</example>
 	</section>
 	</section>
 

--- a/modules/json/json.c
+++ b/modules/json/json.c
@@ -108,6 +108,7 @@ static int fixup_json_bind(void**);
 static int pv_set_json (struct sip_msg*,  pv_param_t*, int , pv_value_t* );
 static int pv_get_json (struct sip_msg*,  pv_param_t*, pv_value_t* );
 static int pv_get_json_compact(struct sip_msg*,  pv_param_t*, pv_value_t* );
+static int pv_get_json_compact_noescape(struct sip_msg*,  pv_param_t*, pv_value_t* );
 static int pv_get_json_pretty(struct sip_msg*,  pv_param_t*, pv_value_t* );
 static int pv_get_json_ext(struct sip_msg*,  pv_param_t*, pv_value_t* , int flags);
 static int json_bind(struct sip_msg* , pv_spec_t* , pv_spec_t* );
@@ -147,6 +148,8 @@ static const pv_export_t mod_items[] = {
 	{ str_const_init("json_compact"), PVT_JSON, pv_get_json_compact,
 		pv_set_json, pv_parse_json_name, 0, 0, 0},
 	{ str_const_init("json_pretty"), PVT_JSON, pv_get_json_pretty,
+		pv_set_json, pv_parse_json_name, 0, 0, 0},
+	{ str_const_init("json_compact_noescape"), PVT_JSON, pv_get_json_compact_noescape,
 		pv_set_json, pv_parse_json_name, 0, 0, 0},
 	{ {0, 0}, 0, 0, 0, 0, 0, 0, 0 }
 };
@@ -367,6 +370,11 @@ int pv_get_json(struct sip_msg* msg,  pv_param_t* pvp, pv_value_t* val)
 int pv_get_json_compact(struct sip_msg* msg,  pv_param_t* pvp, pv_value_t* val)
 {
 	return pv_get_json_ext(msg, pvp, val, JSON_C_TO_STRING_PLAIN);
+}
+
+int pv_get_json_compact_noescape(struct sip_msg* msg,  pv_param_t* pvp, pv_value_t* val)
+{
+	return pv_get_json_ext(msg, pvp, val, JSON_C_TO_STRING_PLAIN | JSON_C_TO_STRING_NOSLASHESCAPE);
 }
 
 int pv_get_json_pretty(struct sip_msg* msg,  pv_param_t* pvp, pv_value_t* val)


### PR DESCRIPTION
Added this pv to support printing in compact form, but without escaping slashes, addressing issue #3684.
