### PR TITLE
event_rabbitmq: proper initialization for rabbitmq connection

### DIFF
--- a/modules/event_rabbitmq/event_rabbitmq.c
+++ b/modules/event_rabbitmq/event_rabbitmq.c
@@ -397,7 +397,7 @@ static evi_reply_sock* rmq_parse(str socket)
 			case '@':
 				st = ST_HOST;
 				if (dupl_string(&tmp, begin, socket.s + i)) goto err;
-				memcpy(param->conn.uri.user, tmp.s, tmp.len);
+				param->conn.uri.user = tmp.s;
 				param->conn.uri.user[tmp.len] = '\0';
 				begin = socket.s + i + 1;
 				param->conn.flags |= RMQ_PARAM_USER;
@@ -422,12 +422,12 @@ static evi_reply_sock* rmq_parse(str socket)
 			switch(socket.s[i]) {
 			case '@':
 				st = ST_HOST;
-				memcpy(param->conn.uri.user, prev_token.s, prev_token.len);
+				param->conn.uri.user = prev_token.s;
 				param->conn.flags |= RMQ_PARAM_USER;
 				prev_token.s = 0;
 				if (dupl_string(&tmp, begin, socket.s + i) < 0)
 					goto err;
-				memcpy(param->conn.uri.password, tmp.s, tmp.len);
+				param->conn.uri.password = tmp.s;
 				param->conn.flags |= RMQ_PARAM_PASS;
 				begin = socket.s + i + 1;
 				break;


### PR DESCRIPTION
**Summary**
Fix crash on module initialization during the connection setup.

**Details**
The uri structure in the connection params has pointers to char and we need to update the value of the pointer instead of copying the whole string to the uninitialized address 0x0.

**Solution**
Instead of making a memory copy, we need to just update the pointer.

