### PR TITLE
Fix libdl linking typo to eliminate build warnings

### DIFF
--- a/modules/cachedb_mongodb/Makefile
+++ b/modules/cachedb_mongodb/Makefile
@@ -21,11 +21,11 @@ include ../../Makefile.openssl
 
 	DEFS += -I$(SYSBASE)/include/libmongoc-1.0 -I$(SYSBASE)/include/libbson-1.0
 	LIBS += -L$(LOCALBASE)/lib -lrt -lmongoc-1.0 -lbson-1.0
-	LIBS += -dl -Bsymbolic
+	LIBS += -ldl -Bsymbolic
 else
 	DEFS += $(shell $(MONGOC_BUILDER) --cflags)
 	LIBS += $(shell $(MONGOC_BUILDER) --libs)
-	LIBS += -dl -Bsymbolic
+	LIBS += -ldl -Bsymbolic
 endif
 
 include ../../Makefile.modules

--- a/modules/db_http/Makefile
+++ b/modules/db_http/Makefile
@@ -26,6 +26,6 @@ else
 	LIBS +=-L$(LOCALBASE)/lib -lcurl
 endif 
 
-LIBS += -dl -Bsymbolic
+LIBS += -ldl -Bsymbolic
 
 include ../../Makefile.modules

--- a/modules/db_mysql/Makefile
+++ b/modules/db_mysql/Makefile
@@ -19,7 +19,7 @@ ifeq ($(HAS_MYSQLCFG),YES)
 	# use autodetection
 	DEFS += $(shell mysql_config --include)
 	LIBS += $(shell mysql_config --libs)
-	LIBS += -dl -Bsymbolic
+	LIBS += -ldl -Bsymbolic
 
 else
 
@@ -35,7 +35,7 @@ else
 		-L$(LOCALBASE)/mysql/lib \
 		-L$(SYSBASE)/lib64/mysql \
 		-lm -lmysqlclient -lz
-	LIBS += -dl -Bsymbolic
+	LIBS += -ldl -Bsymbolic
 
 endif
 

--- a/modules/rest_client/Makefile
+++ b/modules/rest_client/Makefile
@@ -9,6 +9,6 @@ include ../../Makefile.defs
 auto_gen=
 NAME=rest_client.so
 LIBS+=-lcurl
-LIBS += -dl -Bsymbolic
+LIBS += -ldl -Bsymbolic
 
 include ../../Makefile.modules


### PR DESCRIPTION
**Summary**
Fix libdl linking typo to eliminate build warnings

**Details**
During compilation, the following annoying warnings appear during linking:

```
gcc -shared -fPIC -DPIC -Wl,-z,relro -Wl,--as-needed  -Wl,-z,pack-relative-relocs -Wl,-z,now -specs=/usr/lib/rpm/redhat/redhat-hardened-ld -specs=/usr/lib/rpm/redhat/redhat-hardened-ld-errors -specs=/usr/lib/rpm/redhat/redhat-annobin-cc1  -Wl,--build-id=sha1 -specs=/usr/lib/rpm/redhat/redhat-package-notes   -Wl,-O2 -Wl,-E   db_http.o http_dbase.o ssl_tweaks.o   -ldl -lresolv -pthread -lcurl -dl -Bsymbolic  -o db_http.so
lto1: warning: unrecognized gcc debugging option: l
lto1: warning: unrecognized gcc debugging option: l
```

They seems harmless but really noisy so after a little research I've found that they were caused by the following lines in a several Makefiles:

```
LIBS += -dl -Bsymbolic
```

These were adeed in a few commits, such as 149e69e3f67 and a3e87277f27. Apparently the idea was to link against libdl e.g. `LIBS += -ldl`.

**Solution**
Although in most cases libdl is linked by default and there is no strict requirement to specifically mention it (that's probably why nobody saw it) it's better to link it explicitly to make the original intention more clear.

**Compatibility**
Seems harmless.

**Closing issues**
N/a. Removing warnings.

cc @razvancrainea @rvlad-patrascu 