### PR TITLE
Fix curl type warnings: use long instead of int

### DIFF
--- a/modules/db_http/http_dbase.c
+++ b/modules/db_http/http_dbase.c
@@ -811,7 +811,7 @@ int do_http_op (  const db_con_t* h, const db_key_t* k, const db_op_t* op,
 
 	LM_DBG("Sent:%s \n",q.s);
 
-	w_curl_easy_setopt(conn->handle, CURLOPT_HTTPGET, 1);
+	w_curl_easy_setopt(conn->handle, CURLOPT_HTTPGET, 1L);
 	w_curl_easy_setopt(conn->handle, CURLOPT_URL, q.s);
 
 
@@ -826,7 +826,7 @@ int do_http_op (  const db_con_t* h, const db_key_t* k, const db_op_t* op,
 	}
 
 
-	w_curl_easy_setopt(conn->handle, CURLOPT_FAILONERROR,1);
+	w_curl_easy_setopt(conn->handle, CURLOPT_FAILONERROR,1L);
 	ret = curl_easy_perform(conn->handle);
 
 
@@ -1058,8 +1058,8 @@ db_con_t* db_http_init(const str* url)
 		w_curl_easy_setopt(curl->handle,CURLOPT_HTTPHEADER,curl->headers);
 	}
 
-	w_curl_easy_setopt(curl->handle,CURLOPT_SSL_VERIFYPEER,0);
-	w_curl_easy_setopt(curl->handle,CURLOPT_SSL_VERIFYHOST,0);
+	w_curl_easy_setopt(curl->handle,CURLOPT_SSL_VERIFYPEER,0L);
+	w_curl_easy_setopt(curl->handle,CURLOPT_SSL_VERIFYHOST,0L);
 
 	w_curl_easy_setopt(curl->handle,CURLOPT_USERPWD,user_pass);
 	w_curl_easy_setopt(curl->handle,CURLOPT_HTTPAUTH,CURLAUTH_ANY);
@@ -1067,7 +1067,7 @@ db_con_t* db_http_init(const str* url)
 	w_curl_easy_setopt(curl->handle,CURLOPT_ERRORBUFFER,error_buffer);
 #if LIBCURL_VERSION_NUM >= 0x071002
 	LM_DBG("timeout set to %d", db_http_timeout);
-	w_curl_easy_setopt(curl->handle,CURLOPT_TIMEOUT_MS,db_http_timeout);
+	w_curl_easy_setopt(curl->handle,CURLOPT_TIMEOUT_MS,(long)db_http_timeout);
 #endif
 
 	ret = snprintf(path, DB_HTTP_BUFF_SIZE, "http");

--- a/modules/rest_client/rest_methods.c
+++ b/modules/rest_client/rest_methods.c
@@ -405,7 +405,7 @@ static int init_transfer(CURL *handle, char *url, unsigned long timeout_s)
 
 	w_curl_easy_setopt(handle, CURLOPT_URL, url);
 	if (curl_http_version != CURL_HTTP_VERSION_NONE)
-		w_curl_easy_setopt(handle, CURLOPT_HTTP_VERSION, curl_http_version);
+		w_curl_easy_setopt(handle, CURLOPT_HTTP_VERSION, (long)curl_http_version);
 
 	if (tls_dom) {
 		w_curl_easy_setopt(handle, CURLOPT_SSLCERT, tls_dom->cert.s);
@@ -419,9 +419,9 @@ static int init_transfer(CURL *handle, char *url, unsigned long timeout_s)
 	w_curl_easy_setopt(handle, CURLOPT_TIMEOUT,
 			timeout_s && timeout_s < curl_timeout ? timeout_s : curl_timeout);
 
-	w_curl_easy_setopt(handle, CURLOPT_VERBOSE, 1);
+	w_curl_easy_setopt(handle, CURLOPT_VERBOSE, 1L);
 	w_curl_easy_setopt(handle, CURLOPT_STDERR, stdout);
-	w_curl_easy_setopt(handle, CURLOPT_FAILONERROR, 0);
+	w_curl_easy_setopt(handle, CURLOPT_FAILONERROR, 0L);
 
 	if (ssl_capath)
 		w_curl_easy_setopt(handle, CURLOPT_CAPATH, ssl_capath);
@@ -477,7 +477,7 @@ static inline int set_upload_opts(CURL *handle, str *ctype, str *body)
 	 *	   strings (e.g. $du), thus curl's strlen() may overflow or crash
 	 */
 #if (LIBCURL_VERSION_NUM >= 0x071101)
-	w_curl_easy_setopt(handle, CURLOPT_POSTFIELDSIZE, body->len);
+	w_curl_easy_setopt(handle, CURLOPT_POSTFIELDSIZE, (long)body->len);
 	w_curl_easy_setopt(handle, CURLOPT_COPYPOSTFIELDS, body->s);
 #else
 	w_curl_easy_setopt(handle, CURLOPT_POSTFIELDS, body->s);
@@ -490,7 +490,7 @@ cleanup:
 
 #define set_post_opts(handle, ctype, body) \
 	do { \
-		w_curl_easy_setopt(handle, CURLOPT_POST, 1); \
+		w_curl_easy_setopt(handle, CURLOPT_POST, 1L); \
 		if (set_upload_opts(handle, ctype, body) != 0) { \
 			LM_ERR("failed to init POST to %s\n", url); \
 			goto cleanup; \
@@ -820,8 +820,8 @@ int start_async_http_req(struct sip_msg *msg, enum rest_client_method method,
 	CURLcode rc;
 	CURLMcode mrc;
 	fd_set rset, wset, eset;
-	int max_fd, fd, http_rc, ret = RCL_INTERNAL_ERR;
-	long busy_wait, timeout, connect_timeout;
+	int max_fd, fd, ret = RCL_INTERNAL_ERR;
+	long http_rc, busy_wait, timeout, connect_timeout;
 	long retry_time;
 	OSS_CURLM *multi_list;
 	CURLM *multi_handle;

--- a/modules/xcap_client/xcap_functions.c
+++ b/modules/xcap_client/xcap_functions.c
@@ -558,9 +558,9 @@ char* send_http_get(char* path, unsigned int xcap_port, char* match_etag,
 
 	curl_easy_setopt(curl_handle, CURLOPT_URL, path);
 
-	curl_easy_setopt(curl_handle, CURLOPT_PORT, xcap_port);
+	curl_easy_setopt(curl_handle, CURLOPT_PORT, (long)xcap_port);
 
-	curl_easy_setopt(curl_handle, CURLOPT_VERBOSE, 1);
+	curl_easy_setopt(curl_handle, CURLOPT_VERBOSE, 1L);
 
 	curl_easy_setopt(curl_handle,  CURLOPT_STDERR, stdout);
 
@@ -581,7 +581,7 @@ char* send_http_get(char* path, unsigned int xcap_port, char* match_etag,
 	}
 
 	/* non-2xx => error */
-	curl_easy_setopt(curl_handle, CURLOPT_FAILONERROR, 1);
+	curl_easy_setopt(curl_handle, CURLOPT_FAILONERROR, 1L);
 
 	ret_code= curl_easy_perform(curl_handle );
 


### PR DESCRIPTION
**Summary**
Fix curl type warnings: use long instead of int

**Details**
Multiple warnings appear during compilation of modules using libcurl:

```
gcc -fPIC -DPIC -O2 -flto=auto -ffat-lto-objects -fexceptions -g -grecord-gcc-switches -pipe -Wall -Wno-complain-wrong-lang -Werror=format-security -Wp,-U_FORTIFY_SOURCE,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -fstack-protector-strong -specs=/usr/lib/rpm/redhat/redhat-annobin-cc1 -m64 -march=x86-64 -mtune=generic -fasynchronous-unwind-tables -fstack-clash-protection -fcf-protection -mtls-dialect=gnu2 -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -DMOD_NAME='rest_client' -DPKG_MALLOC  -DSHM_MMAP  -DUSE_MCAST  -DDISABLE_NAGLE  -DSTATISTICS  -DHAVE_RESOLV_RES  -DF_MALLOC  -DQ_MALLOC  -DHP_MALLOC  -DDBG_MALLOC  -DF_PARALLEL_MALLOC  -DHAVE_STDATOMIC -DHAVE_GENERICS  -DNAME='"opensips"' -DVERSION='"3.6.2"' -DARCH='"x86_64"' -DOS='"linux"' -DCOMPILER='"gcc 15"' -D__CPU_x86_64 -D__OS_linux -D__SMP_yes -DCFG_DIR='"/etc/opensips/"'  -DVERSIONTYPE='"git"' -DTHISREVISION='"994bcd690"' -DFAST_LOCK -DADAPTIVE_WAIT -DADAPTIVE_WAIT_LOOPS=1024 -DHAVE_GETHOSTBYNAME2 -DHAVE_UNION_SEMUN -DHAVE_MSG_NOSIGNAL -DHAVE_MSGHDR_MSG_CONTROL -DHAVE_ALLOCA_H -DHAVE_TIMEGM -DHAVE_EPOLL -DHAVE_SIGIO_RT -DHAVE_SELECT -c rest_methods.c -o rest_methods.o
rest_methods.c: In function ‘init_transfer’:
rest_methods.c:408:17: warning: call to ‘Wcurl_easy_setopt_err_long’ declared with attribute warning: curl_easy_setopt expects a long argument [-Wattribute-warning]
  408 |                 w_curl_easy_setopt(handle, CURLOPT_HTTP_VERSION, curl_http_version);
      |                 ^
rest_methods.c:422:9: warning: call to ‘Wcurl_easy_setopt_err_long’ declared with attribute warning: curl_easy_setopt expects a long argument [-Wattribute-warning]
  422 |         w_curl_easy_setopt(handle, CURLOPT_VERBOSE, 1);
      |         ^
rest_methods.c:424:9: warning: call to ‘Wcurl_easy_setopt_err_long’ declared with attribute warning: curl_easy_setopt expects a long argument [-Wattribute-warning]
  424 |         w_curl_easy_setopt(handle, CURLOPT_FAILONERROR, 0);
      |         ^
rest_methods.c: In function ‘set_upload_opts’:
rest_methods.c:480:9: warning: call to ‘Wcurl_easy_setopt_err_long’ declared with attribute warning: curl_easy_setopt expects a long argument [-Wattribute-warning]
  480 |         w_curl_easy_setopt(handle, CURLOPT_POSTFIELDSIZE, body->len);
      |         ^
rest_methods.c: In function ‘rest_sync_transfer’:
rest_methods.c:714:17: warning: call to ‘Wcurl_easy_setopt_err_long’ declared with attribute warning: curl_easy_setopt expects a long argument [-Wattribute-warning]
  714 |                 set_post_opts(sync_handle, ctype, body);
      |                 ^
rest_methods.c: In function ‘start_async_http_req’:
rest_methods.c:847:17: warning: call to ‘Wcurl_easy_setopt_err_long’ declared with attribute warning: curl_easy_setopt expects a long argument [-Wattribute-warning]
  847 |                 set_post_opts(handle, req_ctype, req_body);
      |                 ^
rest_methods.c:918:25: warning: call to ‘Wcurl_easy_getinfo_err_long’ declared with attribute warning: curl_easy_getinfo expects a pointer to long [-Wattribute-warning]
  918 |                         curl_easy_getinfo(handle, CURLINFO_RESPONSE_CODE, &http_rc);
      |                         ^
```

**Solution**
Let's ensure we pass a literals and variables with a proper type.

**Compatibility**
Fixes Curl APi usage on 64-bit arches where long and int types have disserent size.

**Closing issues**
N/a.
