### PR TITLE
Fix const-correctness warnings with libxml2 error handling

### DIFF
--- a/modules/presence/presentity.c
+++ b/modules/presence/presentity.c
@@ -231,7 +231,7 @@ int dialog_fix_remote_target(str *body, str *fixed_body)
 	xmlNodePtr remote_node;
 	xmlNodePtr identity_node;
 	xmlNodePtr node;
-	xmlErrorPtr	xml_error;
+	const xmlError* xml_error;
 	unsigned char* attr;
 
 	if (!fixed_body)

--- a/modules/presence_xml/notify_body.c
+++ b/modules/presence_xml/notify_body.c
@@ -82,7 +82,7 @@ int dialog_offline_body(str* body, str** offline_body)
 {
 	xmlDocPtr doc= NULL;
 	xmlNodePtr node;
-	xmlErrorPtr xml_error;
+	const xmlError* xml_error;
 	str* new_body = NULL;
 	char *err_msg;
 	int rc = OFFB_STATUS_ERROR;
@@ -143,7 +143,7 @@ int presence_offline_body(str* body, str** offline_body)
 	xmlDocPtr new_doc= NULL;
 	xmlNodePtr node, tuple_node= NULL, status_node;
 	xmlNodePtr root_node, add_node, pres_node;
-	xmlErrorPtr	xml_error;
+	const xmlError* xml_error;
 	str* new_body;
 	char *err_msg;
 	int rc = OFFB_STATUS_ERROR;

--- a/modules/pua_bla/notify.c
+++ b/modules/pua_bla/notify.c
@@ -40,7 +40,7 @@ static int bla_body_is_valid(str *bla_body)
 {
 	xmlDocPtr	doc = NULL;
 	xmlNodePtr	node = NULL;
-	xmlErrorPtr	xml_err = NULL;
+	const xmlError* xml_err = NULL;
 	int		valid = 0;
 
 	doc = xmlParseMemory(bla_body->s, bla_body->len);


### PR DESCRIPTION
**Summary**
Fix const-correctness warnings with libxml2 error handling

**Details**
Multiple warnings appear during compilation of modules using libxml2:

```
Compiling presentity.c
gcc -fPIC -DPIC -O2 -flto=auto -ffat-lto-objects -fexceptions -g -grecord-gcc-switches -pipe -Wall -Wno-complain-wrong-lang -Werror=format-security -Wp,-U_FORTIFY_SOURCE,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -fstack-protector-strong -specs=/usr/lib/rpm/redhat/redhat-annobin-cc1 -m64 -march=x86-64 -mtune=generic -fasynchronous-unwind-tables -fstack-clash-protection -fcf-protection -mtls-dialect=gnu2 -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -DMOD_NAME='presence' -DPKG_MALLOC  -DSHM_MMAP  -DUSE_MCAST  -DDISABLE_NAGLE  -DSTATISTICS  -DHAVE_RESOLV_RES  -DF_MALLOC  -DQ_MALLOC  -DHP_MALLOC  -DDBG_MALLOC  -DF_PARALLEL_MALLOC  -DHAVE_STDATOMIC -DHAVE_GENERICS  -DNAME='"opensips"' -DVERSION='"3.6.0"' -DARCH='"x86_64"' -DOS='"linux"' -DCOMPILER='"gcc 15"' -D__CPU_x86_64 -D__OS_linux -D__SMP_yes -DCFG_DIR='"/etc/opensips/"'  -DVERSIONTYPE='"git"' -DTHISREVISION='"07da80880"' -DFAST_LOCK -DADAPTIVE_WAIT -DADAPTIVE_WAIT_LOOPS=1024 -DHAVE_GETHOSTBYNAME2 -DHAVE_UNION_SEMUN -DHAVE_MSG_NOSIGNAL -DHAVE_MSGHDR_MSG_CONTROL -DHAVE_ALLOCA_H -DHAVE_TIMEGM -DHAVE_EPOLL -DHAVE_SIGIO_RT -DHAVE_SELECT -I/usr/include/libxml2 -I/usr/include/libxml2 -c presentity.c -o presentity.o
presentity.c: In function ‘dialog_fix_remote_target’:
presentity.c:246:27: warning: assignment discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
  246 |                 xml_error = xmlGetLastError();
      |                           ^
...
Compiling notify_body.c
gcc -fPIC -DPIC -O2 -flto=auto -ffat-lto-objects -fexceptions -g -grecord-gcc-switches -pipe -Wall -Wno-complain-wrong-lang -Werror=format-security -Wp,-U_FORTIFY_SOURCE,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -fstack-protector-strong -specs=/usr/lib/rpm/redhat/redhat-annobin-cc1 -m64 -march=x86-64 -mtune=generic -fasynchronous-unwind-tables -fstack-clash-protection -fcf-protection -mtls-dialect=gnu2 -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -DMOD_NAME='presence_xml' -DPKG_MALLOC  -DSHM_MMAP  -DUSE_MCAST  -DDISABLE_NAGLE  -DSTATISTICS  -DHAVE_RESOLV_RES  -DF_MALLOC  -DQ_MALLOC  -DHP_MALLOC  -DDBG_MALLOC  -DF_PARALLEL_MALLOC  -DHAVE_STDATOMIC -DHAVE_GENERICS  -DNAME='"opensips"' -DVERSION='"3.6.0"' -DARCH='"x86_64"' -DOS='"linux"' -DCOMPILER='"gcc 15"' -D__CPU_x86_64 -D__OS_linux -D__SMP_yes -DCFG_DIR='"/etc/opensips/"'  -DVERSIONTYPE='"git"' -DTHISREVISION='"07da80880"' -DFAST_LOCK -DADAPTIVE_WAIT -DADAPTIVE_WAIT_LOOPS=1024 -DHAVE_GETHOSTBYNAME2 -DHAVE_UNION_SEMUN -DHAVE_MSG_NOSIGNAL -DHAVE_MSGHDR_MSG_CONTROL -DHAVE_ALLOCA_H -DHAVE_TIMEGM -DHAVE_EPOLL -DHAVE_SIGIO_RT -DHAVE_SELECT -I/usr/include/libxml2 -c notify_body.c -o notify_body.o
notify_body.c: In function ‘dialog_offline_body’:
notify_body.c:48:13: warning: assignment discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
   48 |         (e) = xmlGetLastError(); (msg) = (e) ? (e)->message : "unknown error"
      |             ^
notify_body.c:100:17: note: in expansion of macro ‘GET_LAST_XML_ERROR’
  100 |                 GET_LAST_XML_ERROR(xml_error, err_msg);
      |                 ^~~~~~~~~~~~~~~~~~
notify_body.c: In function ‘presence_offline_body’:
notify_body.c:48:13: warning: assignment discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
   48 |         (e) = xmlGetLastError(); (msg) = (e) ? (e)->message : "unknown error"
      |             ^
notify_body.c:154:17: note: in expansion of macro ‘GET_LAST_XML_ERROR’
  154 |                 GET_LAST_XML_ERROR(xml_error, err_msg);
      |                 ^~~~~~~~~~~~~~~~~~
notify_body.c:48:13: warning: assignment discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
   48 |         (e) = xmlGetLastError(); (msg) = (e) ? (e)->message : "unknown error"
      |             ^
notify_body.c:189:17: note: in expansion of macro ‘GET_LAST_XML_ERROR’
  189 |                 GET_LAST_XML_ERROR(xml_error, err_msg);
      |                 ^~~~~~~~~~~~~~~~~~
notify_body.c:48:13: warning: assignment discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
   48 |         (e) = xmlGetLastError(); (msg) = (e) ? (e)->message : "unknown error"
      |             ^
notify_body.c:197:17: note: in expansion of macro ‘GET_LAST_XML_ERROR’
  197 |                 GET_LAST_XML_ERROR(xml_error, err_msg);
      |                 ^~~~~~~~~~~~~~~~~~
notify_body.c:48:13: warning: assignment discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
   48 |         (e) = xmlGetLastError(); (msg) = (e) ? (e)->message : "unknown error"
      |             ^
notify_body.c:206:17: note: in expansion of macro ‘GET_LAST_XML_ERROR’
  206 |                 GET_LAST_XML_ERROR(xml_error, err_msg);
      |                 ^~~~~~~~~~~~~~~~~~
notify_body.c:48:13: warning: assignment discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
   48 |         (e) = xmlGetLastError(); (msg) = (e) ? (e)->message : "unknown error"
      |             ^
notify_body.c:216:17: note: in expansion of macro ‘GET_LAST_XML_ERROR’
  216 |                 GET_LAST_XML_ERROR(xml_error, err_msg);
      |                 ^~~~~~~~~~~~~~~~~~
...
Compiling notify.c
gcc -fPIC -DPIC -O2 -flto=auto -ffat-lto-objects -fexceptions -g -grecord-gcc-switches -pipe -Wall -Wno-complain-wrong-lang -Werror=format-security -Wp,-U_FORTIFY_SOURCE,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -fstack-protector-strong -specs=/usr/lib/rpm/redhat/redhat-annobin-cc1 -m64 -march=x86-64 -mtune=generic -fasynchronous-unwind-tables -fstack-clash-protection -fcf-protection -mtls-dialect=gnu2 -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -DMOD_NAME='pua_bla' -DPKG_MALLOC  -DSHM_MMAP  -DUSE_MCAST  -DDISABLE_NAGLE  -DSTATISTICS  -DHAVE_RESOLV_RES  -DF_MALLOC  -DQ_MALLOC  -DHP_MALLOC  -DDBG_MALLOC  -DF_PARALLEL_MALLOC  -DHAVE_STDATOMIC -DHAVE_GENERICS  -DNAME='"opensips"' -DVERSION='"3.6.0"' -DARCH='"x86_64"' -DOS='"linux"' -DCOMPILER='"gcc 15"' -D__CPU_x86_64 -D__OS_linux -D__SMP_yes -DCFG_DIR='"/etc/opensips/"'  -DVERSIONTYPE='"git"' -DTHISREVISION='"07da80880"' -DFAST_LOCK -DADAPTIVE_WAIT -DADAPTIVE_WAIT_LOOPS=1024 -DHAVE_GETHOSTBYNAME2 -DHAVE_UNION_SEMUN -DHAVE_MSG_NOSIGNAL -DHAVE_MSGHDR_MSG_CONTROL -DHAVE_ALLOCA_H -DHAVE_TIMEGM -DHAVE_EPOLL -DHAVE_SIGIO_RT -DHAVE_SELECT -I/usr/include/libxml2 -c notify.c -o notify.o
notify.c: In function ‘bla_body_is_valid’:
notify.c:49:25: warning: assignment discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
   49 |                 xml_err = xmlGetLastError();
      |                         ^
```

Libxml2's xmlGetLastError() returns 'const xmlError*' to indicate that the error structure is owned by the library and should not be modified. The code was assigning this to non-const pointers, discarding the const qualifier.

**Compatibility**
Better conforms to Libxml2 API.

**Closing issues**
N/a.