### PR TITLE
Fix SIPREC crash issue when sync data to cluster

### DIFF
--- a/modules/siprec/siprec_sess.c
+++ b/modules/siprec/siprec_sess.c
@@ -756,7 +756,8 @@ void src_event_trigger(enum b2b_entity_type et, str *key,
 		str *logic_key, void *param, enum b2b_event_type event_type,
 		bin_packet_t *store, int backend)
 {
-	struct src_ctx *ctx = (struct src_ctx *)param;
+	struct src_sess *ss = (struct src_sess *)param;
+	struct src_ctx *ctx = ss->ctx;
 
 	switch (event_type) {
 		case B2B_EVENT_CREATE:


### PR DESCRIPTION
Summary

Using SIPREC module,  OpenSIPS encounters with segmentation fault  when prepare to sync siprec session list information to cluster

Details

On the callback function `src_event_trigger`, the wrong convert of  the param, it should be `src_sess `pointer, not `src_ctx` pointer

Solution

Correct the logic 

Compatibility

It seems that this change will not break other scenarios. 