### PR TITLE
Reduce verbosity of libcurl and send errors to stderr

### DIFF
--- a/modules/rest_client/rest_methods.c
+++ b/modules/rest_client/rest_methods.c
@@ -419,8 +419,7 @@ static int init_transfer(CURL *handle, char *url, unsigned long timeout_s)
 	w_curl_easy_setopt(handle, CURLOPT_TIMEOUT,
 			timeout_s && timeout_s < curl_timeout ? timeout_s : curl_timeout);
 
-	w_curl_easy_setopt(handle, CURLOPT_VERBOSE, 1L);
-	w_curl_easy_setopt(handle, CURLOPT_STDERR, stdout);
+	w_curl_easy_setopt(handle, CURLOPT_VERBOSE, 0L);
 	w_curl_easy_setopt(handle, CURLOPT_FAILONERROR, 0L);
 
 	if (ssl_capath)


### PR DESCRIPTION
**Summary**
Reduce rest_client logging verbosity and send errors to stderr

**Details**
When running OpenSIPS in a container and logging to stdout, libcurl is way too verbose and produces alot of noise that pollutes the logs

**Solution**
Reduce verbosity and send errors to stderr

**Compatibility**
Backwards compatible
