### PR TITLE
b2b_logic: fix column indexes for the update of b2b legs

### DIFF
--- a/modules/b2b_logic/b2bl_db.c
+++ b/modules/b2b_logic/b2bl_db.c
@@ -256,11 +256,13 @@ void b2b_logic_dump(int no_lock)
 
 			if(tuple->bridge_entities[2])
 			{
-				qvals[15].val.int_val = tuple->bridge_entities[2]->type;
-				qvals[16].val.str_val = tuple->bridge_entities[2]->scenario_id;
-				qvals[17].val.str_val = tuple->bridge_entities[2]->to_uri;
-				qvals[18].val.str_val = tuple->bridge_entities[2]->from_uri;
-				qvals[19].val.str_val = tuple->bridge_entities[2]->key;
+				qvals[16].val.int_val = tuple->bridge_entities[2]->type;
+				qvals[17].val.str_val = tuple->bridge_entities[2]->scenario_id;
+				qvals[18].val.str_val = tuple->bridge_entities[2]->to_uri;
+				qvals[19].val.str_val = tuple->bridge_entities[2]->from_uri;
+				qvals[20].val.str_val = tuple->bridge_entities[2]->key;
+
+				n_insert_cols = 21;
 			}
 
 			/* insert into database */
@@ -862,8 +864,8 @@ void b2bl_db_update(b2bl_tuple_t* tuple)
 
 	qvals[0].val.str_val = *tuple->key;
 
-	qvals[3].val.int_val  = tuple->state;
-	qvals[4].val.int_val = tuple->lifetime -get_ticks() + (int)(unsigned long)time(NULL);
+	qvals[2].val.int_val = tuple->state;
+	qvals[3].val.int_val = tuple->lifetime - get_ticks() + (int)(unsigned long)time(NULL);
 	ci = 4;
 
 	for(i = 0; i< 3; i++)


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!
In order to consider and evaluate your PR, it is mandatory to provide detailed information about (1) what is the issue the PR addresses, (2) how the PR is solving the issue (logic and coding), (3) what are (if any) limitations of the proposed PR and (4) if there are any known side-effects/ backward compatibility issues/SIP interoperability issues.
Note that if the PR is missing information, it might take longer to be merged, as extra resources have to be allocated by the maintainers to reverse engineer the changes, understand them, understand the motivation, etc. That is why it is important to provide as much information as possible.
-->

**Summary**
It is fixing the shift of columns by one when value of ci was mistakenly written into lifetime column.
It is also fixing the fields storage when bridge_entities[2] is set by using next available column index and providing correct n_insert_cols

**Details**
We investigated the scenario with Rǎzvan and discovered that value "4" was saved as lifetime in the MySQL. This results in call getting dropped after scenario executed, if value was recovered from database before scenario.

**Solution**
It is fixing the shift of columns by one when value of ci was mistakenly written into lifetime column.

**Compatibility**
Not a breaking change.

**Closing issues**
closes internal #7885