### PR TITLE
Fix memory leaks in stir_shaken module

### DIFF
--- a/modules/stir_shaken/stir_shaken.c
+++ b/modules/stir_shaken/stir_shaken.c
@@ -503,11 +503,13 @@ static int add_date_hf(struct sip_msg *msg, time_t *date_ts)
 	anchor = anchor_lump(msg, msg->unparsed - msg->buf, 0);
 	if (!anchor) {
 		LM_ERR("Failed to get anchor lump\n");
+		pkg_free(buf);
 		return -1;
 	}
 
 	if (!insert_new_lump_before(anchor, buf, DATE_HDR_L+len+CRLF_LEN, 0)) {
 		LM_ERR("Failed to insert lump\n");
+		pkg_free(buf);
 		return -1;
 	}
 
@@ -1299,7 +1301,7 @@ static int w_stir_auth(struct sip_msg *msg, str *attest, str *origid,
 			goto error;
 		}
 	} else if (out_p->type == AUTH_APPEND_TO_RPL) {
-		if (!add_lump_rpl(msg, hdr_buf->s, hdr_buf->len, LUMP_RPL_HDR)) {
+		if (!add_lump_rpl(msg, hdr_buf->s, hdr_buf->len, LUMP_RPL_HDR|LUMP_RPL_NODUP)) {
 			LM_ERR("unable to add reply lump\n");
 			rc = -1;
 			goto error;


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!
In order to consider and evaluate your PR, it is mandatory to provide detailed information about (1) what is the issue the PR addresses, (2) how the PR is solving the issue (logic and coding), (3) what are (if any) limitations of the proposed PR and (4) if there are any known side-effects/ backward compatibility issues/SIP interoperability issues.
Note that if the PR is missing information, it might take longer to be merged, as extra resources have to be allocated by the maintainers to reverse engineer the changes, understand them, understand the motivation, etc. That is why it is important to provide as much information as possible.
-->

**Summary**
<!-- Summary of the PR - what the PR is aiming to solve -->
The stir-shaken module would leak memory any time a signature was added to a reply instead of the request or returned in a variable. This commit makes sure the Identity header lump does not get duplicated and freed only once. Also fixed possible memory leaks in case of issues while adding a date header to a request without one.

**Details**
<!--
Details about the content of the PR - is it a bug fix, a new feature or perhaps a hack? Explain the **motivation** for making this change.
What existing problem does the pull request solve? Is this a particular problem (i.e. only some particular scenarios are affected, only some UACs, etc) or a generic one?
Do not assume others understand what you're trying to do and provide as much information as you may have.
-->
When implementing a STIR/SHAKEN signature server using OpenSIPS, whenever OpenSIPS was returning the SHAKEN signature in a `302` response, memory would be leaked causing a lack of `PKG` memory after some time. Increasing the `P_MEMORY` would only extend the time before opensips processes would run out of memory and be unable to process requests.

**Solution**
<!-- Explain how your PR fixes the problem. Are there any remaining concerns that might need to be addressed? -->
This patches adds the `LUMP_RPL_NODUP` flag to the `add_lump_rpl()` call to prevent that function from duplicating the header. When the lumps are freed, the header created in the `build_identity_hf()` function is now freed too.

**Compatibility**
<!-- Does your change break other scenarios, or do they need to be migrated in order to work similarly? -->
Does not break anything.

**Closing issues**
<!-- Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). -->
