### PR TITLE
keep original flags if pause or resume recording failed

### DIFF
--- a/modules/siprec/siprec_logic.c
+++ b/modules/siprec/siprec_logic.c
@@ -825,6 +825,10 @@ int src_pause_recording(str *instance)
 	/* mark the session as being paused */
 	sess->flags |= SIPREC_PAUSED;
 	ret = src_update_recording(NULL, sess);
+	if(ret < 0) {
+		LM_ERR("cannot pause recording! session_id[%s]\n", sess->uuid);
+		sess->flags &= ~SIPREC_PAUSED;
+	}
 
 end:
 	SIPREC_UNLOCK(sess->ctx);
@@ -850,6 +854,10 @@ int src_resume_recording(str *instance)
 	}
 	sess->flags &= ~SIPREC_PAUSED;
 	ret = src_update_recording(NULL, sess);
+	if(ret < 0) {
+		LM_ERR("cannot resume recording! session_id[%s]\n", sess->uuid);
+		sess->flags |= SIPREC_PAUSED;
+	}
 
 end:
 	SIPREC_UNLOCK(sess->ctx);


### PR DESCRIPTION
Summary
siprec recording status change back if pause or resume failure

Details

When a SIPREC **pause** request is received, the `sess->flags` field is set to the pause state, and a message is sent to the SRS. However, if sending the message fails, the pause state is not reset.
The same logic applies to the SIPREC **resume** request.


Solution
change back siprec recording status if pause or resume failure

Compatibility
Should be harmless.

Closing issues
N/A