### PR TITLE
fix memory leak in tls_mgm

### DIFF
--- a/modules/tls_mgm/tls_domain.c
+++ b/modules/tls_mgm/tls_domain.c
@@ -133,18 +133,14 @@ void tls_free_domain(struct tls_domain *dom)
 		while (m_it) {
 			m_tmp = m_it;
 			m_it = m_it->next;
-			if (m_tmp->s.s && m_tmp->s.len > 0) {
-				shm_free(m_tmp->s.s);
-			}
+			shm_free(m_tmp->s.s);
 			shm_free(m_tmp);
 		}
 		m_it = dom->match_addresses;
 		while (m_it) {
 			m_tmp = m_it;
 			m_it = m_it->next;
-			if (m_tmp->s.s && m_tmp->s.len > 0) {
-				shm_free(m_tmp->s.s);
-			}
+			shm_free(m_tmp->s.s);
 			shm_free(m_tmp);
 		}
 


### PR DESCRIPTION
**Summary**
tls_mgm module has memory leak after tls_reload

**Details**
in add_match_filt_to_dom funtion,  it will do shm_nt_str_dup to allocate memory and assign to match_filt->s, 
while it does not be free in tls_free_domain funtion

**Solution**
free the memory occupied by match_domains and match_addresses

**Compatibility**
N/A

**Closing issues**
N/A
