### PR TITLE
GitHub Actions(rtp.io): update clang version

### DIFF
--- a/.github/workflows/rtp.io.yml
+++ b/.github/workflows/rtp.io.yml
@@ -12,7 +12,7 @@ on:
   workflow_dispatch:
 
 env:
-  LLVM_VER: 18
+  LLVM_VER: 19
   LLVM_VER_OLD: 16
   GHCR_REPO: ghcr.io/${{ github.repository_owner }}/opensips
 


### PR DESCRIPTION
**Summary**
Update clang version for building rtp.io module to match rtpproxy container.

**Details**
We've switched to clang 19 recently which broke the build.

```
clang-18 -shared -fPIC -DPIC -flto -Wl,-O2 -Wl,-E   rtp_io.o rtp_io_host.o rtp_io_params.o rtp_io_util.o   -ldl -lresolv -pthread -Wl,--whole-archive /usr/local/lib/librtpproxy.a -Wl,--no-whole-archive -lm -lssl -lcrypto `pkg-config --libs --static libsrtp2` -pthread -rdynamic -ldl -Wl,-Bsymbolic-functions -o rtp.io.so
/usr/bin/ld: error: LLVM gold plugin has failed to create LTO module: Invalid attribute group entry (Producer: 'LLVM19.1.1' Reader: 'LLVM 18.1.3')
clang-18: error: linker command failed with exit code 1 (use -v to see invocation)
make: *** [../../Makefile.rules:42: rtp.io.so] Error 1
make: Leaving directory '/__w/opensips/opensips/modules/rtp.io'

```
**Solution**
Update version to 19.

**Compatibility**
None

**Closing issues**
