### PR TITLE
b2b_entities: save AVPs while sending in-dialog requests

### DIFF
--- a/modules/b2b_entities/dlg.c
+++ b/modules/b2b_entities/dlg.c
@@ -2293,6 +2293,7 @@ int b2b_send_indlg_req(b2b_dlg_t* dlg, enum b2b_entity_type et, str* b2b_key,
 	}
 	else
 	{
+		td->avps = clone_avp_list( *get_avp_list() );
 		td->T_flags = T_NO_AUTOACK_FLAG|T_PASS_PROVISIONAL_FLAG;
 		result= tmb.t_request_within
 			(method,            /* method*/


### PR DESCRIPTION
 - required for in-dialog authentication w/ AVPs