### PR TITLE
ib2b_logic: save AVPs while bridging calls

### DIFF
--- a/modules/b2b_logic/b2b_logic.c
+++ b/modules/b2b_logic/b2b_logic.c
@@ -975,6 +975,7 @@ static str bridge_flags[] =
 	str_init("rollback-failed"), /* B2BL_BR_FLAG_RETURN_AFTER_FAILURE */
 	str_init("hold"),            /* B2BL_BR_FLAG_HOLD */
 	str_init("no-late-sdp"),     /* B2BL_BR_FLAG_RENEW_SDP */
+	str_init("propagate_avps"),  /* B2BL_BR_FLAG_PROPAGATE_AVPS */
 	STR_NULL
 };
 static str bridge_kv_flags[] =

--- a/modules/b2b_logic/b2b_logic.h
+++ b/modules/b2b_logic/b2b_logic.h
@@ -74,11 +74,12 @@ enum b2b_tuple_state {
 #define B2BL_BR_FLAG_RETURN_AFTER_FAILURE          (1<<1)
 #define B2BL_BR_FLAG_HOLD                          (1<<2)
 #define B2BL_BR_FLAG_RENEW_SDP                     (1<<3)
-#define B2BL_BR_FLAG_DONT_DELETE_BRIDGE_INITIATOR  (1<<4)
-#define B2BL_BR_FLAG_PROV_MEDIA                    (1<<5)
-#define B2BL_BR_FLAG_NO_OLD_ENT                    (1<<6)
-#define B2BL_BR_FLAG_PENDING_SDP                   (1<<7)
-#define B2BL_BR_FLAG_BR_MSG_LATE_BYE               (1<<8)
+#define B2BL_BR_FLAG_PROPAGATE_AVPS                (1<<4)
+#define B2BL_BR_FLAG_DONT_DELETE_BRIDGE_INITIATOR  (1<<5)
+#define B2BL_BR_FLAG_PROV_MEDIA                    (1<<6)
+#define B2BL_BR_FLAG_NO_OLD_ENT                    (1<<7)
+#define B2BL_BR_FLAG_PENDING_SDP                   (1<<8)
+#define B2BL_BR_FLAG_BR_MSG_LATE_BYE               (1<<9)
 
 /* reply flags */
 #define B2BL_RPL_FLAG_PASS_CONTACT                 (1<<0)

--- a/modules/b2b_logic/bridging.c
+++ b/modules/b2b_logic/bridging.c
@@ -1302,7 +1302,8 @@ static b2bl_entity_id_t *bridging_new_client(b2bl_tuple_t* tuple,
 	if (set_maxfwd)
 		ci.maxfwd = peer_ent->init_maxfwd;
 	ci.extra_headers = tuple->extra_headers;
-	ci.avps = clone_avp_list( *get_avp_list() );
+	if (tuple->bridge_flags & B2BL_BR_FLAG_PROPAGATE_AVPS)
+		ci.avps = clone_avp_list( *get_avp_list() );
 
 	entity = b2bl_new_client(&ci, tuple, &new_ent->scenario_id,
 		new_ent->adv_contact.s ? &new_ent->adv_contact : NULL, msg);


### PR DESCRIPTION
 - required to authenticate bridged calls