### PR TITLE
Add KTLS support in tls_wolfssl

### DIFF
--- a/modules/tls_wolfssl/doc/tls_wolfssl_admin.xml
+++ b/modules/tls_wolfssl/doc/tls_wolfssl_admin.xml
@@ -76,4 +76,33 @@
 	</section>
 	</section>
 
+	<section>
+		<title>&osips; Exported parameters</title>
+		<para>
+		All these parameters can be used from the opensips.cfg file,
+		to configure the behavior of &osips;-TLS.
+		</para>
+
+		<section id="param_try_use_ktls" xreflabel="try_use_ktls">
+			<title><varname>try_use_ktls</varname> (integer)</title>
+			<para>
+			Try to use KTLS for RX and TX ( dependent on Kernel support and loaded modules https://docs.kernel.org/networking/tls-offload.htm )
+			If kernel support is not found, or if the cypher attempted to be used is not supported ( only AES-GCM for now ), then SSL operations will continue to be done in user-space.
+			IF NIC supports SSL offloading, that can also be enabled without any changes needed to the module https://docs.nvidia.com/doca/sdk/ktls-offloads/index.html
+			</para>
+			<para>
+				Default value is <emphasis>0</emphasis>.
+			</para>
+			<example>
+				<title>Set <varname>try_use_ktls</varname> variable</title>
+				<programlisting format="linespecific">
+...
+modparam("tls_wolfssl", "try_use_ktls", "0")
+...
+				</programlisting>
+			</example>
+		</section>
+	</section>
+
+
 </chapter>

--- a/modules/tls_wolfssl/wolfssl.h
+++ b/modules/tls_wolfssl/wolfssl.h
@@ -27,6 +27,9 @@
 struct _WOLFSSL {
 	WOLFSSL *read_ssl;
 	WOLFSSL *write_ssl;
+	unsigned char ktls_tx;
+	unsigned char ktls_rx;
+	unsigned char ktls_ulp;
 };
 
 #define _WOLFSSL_READ_SSL(_ssl) \
@@ -39,3 +42,4 @@ struct _WOLFSSL {
 #define SSL_VERSIONS_SIZE 4
 
 extern int ssl_versions[SSL_VERSIONS_SIZE];
+extern int wolfssl_try_use_ktls;


### PR DESCRIPTION
**Summary**
Add Kernel TLS support in tls_wolfssl

**Details**
Try to use KTLS for RX and TX ( dependent on Kernel support and loaded modules https://docs.kernel.org/networking/tls-offload.html )
If kernel support is not found, or if the cypher attempted to be used is not supported ( only AES-GCM for now ), then SSL operations will continue to be done in user-space.
IF NIC supports SSL offloading, that can also be enabled without any changes needed to the module https://docs.nvidia.com/doca/sdk/ktls-offloads/index.html


**Solution**
Add Kernel TLS suppor in tls_wolfssl

Easy testing with modparam("tls_wolfssl","try_use_ktls", 1)

```
printf 'OPTIONS sip:localhost SIP/2.0\r\nVia: SIP/2.0/TLS 127.0.0.1:5061;branch=z9hG4bK-1\r\nMax-Forwards: 70\r\nTo: <sip:localhost>\r\nFrom: <sip:tester@localhost>;tag=1\r\nCall-ID: options-1@localhost\r\nCSeq: 1 OPTIONS\r\nContact: <sip:tester@127.0.0.1:5061;transport=tls>\r\nContent-Length: 0\r\n\r\n' | openssl s_client -connect localhost:44433 -tls1_2 -servername localhost -ign_eof
```

Observe encryption handled in kernel-space

DBG:tls_wolfssl:_wolfssl_read: KTLS RX read 276 bytes
DBG:tls_wolfssl:_wolfssl_tls_write: KTLS write was successful (278 bytes)




**Compatibility**
Backwards compatible, try_use_ktls defaults to 0
