### PR TITLE
Fix format specifier warnings on 32-bit architectures (i686)

### DIFF
--- a/modules/aaa_diameter/dm_impl.c
+++ b/modules/aaa_diameter/dm_impl.c
@@ -20,6 +20,7 @@
 
 #include <freeDiameter/extension.h>
 #include <sys/eventfd.h>
+#include <inttypes.h>
 
 #include "../../ut.h"
 #include "../../lib/list.h"
@@ -481,7 +482,7 @@ static int dm_avps2json(void *root, cJSON *avps)
 			break;
 
 		case AVP_TYPE_INTEGER64:
-			LM_DBG("%2d. got int64   AVP %s (%u), value: %ld\n", i, dm_avp.avp_name, h->avp_code, h->avp_value->i64);
+			LM_DBG("%2d. got int64   AVP %s (%u), value: %" PRId64 "\n", i, dm_avp.avp_name, h->avp_code, h->avp_value->i64);
 			num_val = (double)h->avp_value->i64;
 			break;
 
@@ -491,7 +492,7 @@ static int dm_avps2json(void *root, cJSON *avps)
 			break;
 
 		case AVP_TYPE_UNSIGNED64:
-			LM_DBG("%2d. got uint64  AVP %s (%u), value: %lu\n", i, dm_avp.avp_name, h->avp_code, h->avp_value->u64);
+			LM_DBG("%2d. got uint64  AVP %s (%u), value: %" PRIu64 "\n", i, dm_avp.avp_name, h->avp_code, h->avp_value->u64);
 			num_val = (double)h->avp_value->u64;
 			break;
 

--- a/modules/http2d/server.c
+++ b/modules/http2d/server.c
@@ -635,7 +635,7 @@ static int on_frame_recv_callback(nghttp2_session *session,
 	switch (frame->hd.type) {
 	case NGHTTP2_DATA:
 	case NGHTTP2_HEADERS:
-		LM_DBG("h2 header [%d], %p %ld\n", frame->hd.type, frame->headers.nva, frame->headers.nvlen);
+		LM_DBG("h2 header [%d], %p %zu\n", frame->hd.type, frame->headers.nva, frame->headers.nvlen);
 		/* Check that the client request has finished */
 		if (frame->hd.flags & NGHTTP2_FLAG_END_STREAM) {
 			stream_data =


### PR DESCRIPTION
**Summary**
Fix format specifier warnings on 32-bit architectures (i686) with GCC 15

**Details**
This PR fixes compilation warnings that appear on 32-bit architectures (i686) when using GCC 15. The warnings are caused by using incorrect format specifiers for `size_t`, `int64_t`, and `uint64_t` types, which have different sizes on 32-bit vs 64-bit platforms.

On x86_64, `size_t` and `int64_t` are aliases for `unsigned long` and `long int` respectively, so `%ld` and `%lu` work fine. However, on i686 (32-bit):
- `size_t` is `unsigned int` (4 bytes), not `unsigned long`
- `int64_t` is `long long int` (8 bytes), not `long int`
- `uint64_t` is `unsigned long long int` (8 bytes), not `unsigned long int`

This causes GCC to emit `-Wformat` warnings on 32-bit builds, as the format specifiers don't match the actual argument types.

Affected modules:
- **http2d**: Incorrect `%ld` for `size_t` in server.c
- **aaa_diameter**: Incorrect `%ld`/`%lu` for `int64_t`/`uint64_t` in dm_impl.c

**Solution**
Replace architecture-specific format specifiers with portable C99 standard specifiers:

1. Use `%zu` for `size_t` (defined in C99, works on all architectures)
2. Use `%" PRId64` for `int64_t` (from `<inttypes.h>`, expands to correct specifier per platform)
3. Use `%" PRIu64` for `uint64_t` (from `<inttypes.h>`, expands to correct specifier per platform)

These portable specifiers automatically adapt to the platform:
- On 64-bit: `%zu` → format as `unsigned long`, `PRId64` → `"ld"`, `PRIu64` → `"lu"`
- On 32-bit: `%zu` → format as `unsigned int`, `PRId64` → `"lld"`, `PRIu64` → `"llu"`

**Compatibility**
No compatibility impact. This is purely a build-time fix that doesn't change runtime behavior or APIs. The same values are printed, just with correct format specifiers.

**Closing issues**
N/A