### PR TITLE
Fix libbson deprecated API warning with version compatibility

### DIFF
--- a/modules/cachedb_mongodb/cachedb_mongodb_dbase.c
+++ b/modules/cachedb_mongodb/cachedb_mongodb_dbase.c
@@ -40,11 +40,15 @@ extern int compat_mode_24;
 #define HEX_OID_SIZE 25
 char *hex_oid_id;
 
+#if !MONGOC_CHECK_VERSION(1, 29, 0)
+#define bson_as_legacy_extended_json bson_as_json
+#endif
+
 #define dbg_bson(_prepend_txt, __bson_ptr__) \
 	do { \
 		char *__bson_str__; \
 		if (is_printable(L_DBG)) { \
-			__bson_str__ = bson_as_json(__bson_ptr__, NULL); \
+			__bson_str__ = bson_as_legacy_extended_json(__bson_ptr__, NULL); \
 			LM_DBG("%s%s\n", _prepend_txt, __bson_str__); \
 			bson_free(__bson_str__); \
 		} \
@@ -1309,11 +1313,11 @@ int mongo_db_query_trans(cachedb_con *con, const str *table, const db_key_t *_k,
 	                                   namespace);
 
 	if (is_printable(L_DBG)) {
-		strf = bson_as_json(filter, NULL);
+		strf = bson_as_legacy_extended_json(filter, NULL);
 #if MONGOC_CHECK_VERSION(1, 5, 0)
-		stro = bson_as_json(opts, NULL);
+		stro = bson_as_legacy_extended_json(opts, NULL);
 #else
-		stro = bson_as_json(fields, NULL);
+		stro = bson_as_legacy_extended_json(fields, NULL);
 #endif
 		LM_DBG("query doc:\n%s\n%s\n", strf, stro);
 		bson_free(strf);


### PR DESCRIPTION
**Summary**
Fix libbson deprecated API warning with version compatibility

**Details**
This PR fixes deprecation warnings that appear when compiling the cachedb_mongodb module with mongo-c-driver >= 1.29.0. The `bson_as_json()` function was deprecated in favor of `bson_as_legacy_extended_json()` in mongo-c-driver version 1.29.0 (released October 2024).

The warning appears during compilation:
```
warning: 'bson_as_json' is deprecated: Use bson_as_legacy_extended_json instead [-Wdeprecated-declarations]
```

The deprecation was introduced to clarify which JSON format is being produced - legacy extended JSON vs. canonical extended JSON. The function signatures are identical, making this a straightforward API update.

However, many LTS distributions still ship older versions of mongo-c-driver (< 1.29.0), so the code needs to maintain backward compatibility with both the old and new API.

**Solution**
Add a compatibility macro at the top of `modules/cachedb_mongodb/cachedb_mongodb_dbase.c` that maps the new function name to the old one on older versions:
```c
/* Compatibility wrapper for libbson < 1.29.0 */
#if !MONGOC_CHECK_VERSION(1, 29, 0)
#define bson_as_legacy_extended_json bson_as_json
#endif
```

Then update all `bson_as_json()` calls to `bson_as_legacy_extended_json()` throughout the file.

This approach:
- Uses the new API name everywhere in the code (clean, future-proof)
- Automatically works with older versions via the macro alias
- No behavioral changes - both functions produce identical output
- Maintains compatibility with all mongo-c-driver versions

**Compatibility**
Fully backward compatible. The macro ensures the code works with:
- mongo-c-driver >= 1.29.0: Uses new `bson_as_legacy_extended_json()` API
- mongo-c-driver < 1.29.0: Transparently uses old `bson_as_json()` via macro

No runtime behavior changes - the same JSON is produced on all versions.

**Closing issues**
N/A