### PR TITLE
rtpproxy: add rtpp_bind_local support for the offer/answer/engage.

### DIFF
--- a/modules/rtpproxy/README
+++ b/modules/rtpproxy/README
@@ -30,6 +30,7 @@ rtpproxy Module
               1.5.13. generated_sdp_port_min (integer)
               1.5.14. generated_sdp_port_max (integer)
               1.5.15. generated_sdp_media_ip (string)
+              1.5.16. rtpp_bind_local_avp (string)
 
         1.6. Exported Functions
 
@@ -470,6 +471,15 @@ modparam("rtpproxy", "generated_sdp_port_max", 30000)
 modparam("rtpproxy", "generated_sdp_media_ip", "10.0.0.1")
 ...
 
+1.5.16. rtpp_bind_local_avp (string)
+
+   The pseudo-variable used to read the local bind value which is
+   appended as l<value> to the RTPProxy U/L command when set. For
+   example, use "$socket_out(ip)" to bind based on the outbound
+   socket.
+
+   Default value is “$avp(rtpp_bind_local)”.
+
 1.6. Exported Functions
 
 1.6.1.  rtpproxy_engage([[flags][, [ip_address][, [set_id][,
@@ -603,6 +613,11 @@ if (is_method("INVITE") && has_totag()) {
    is the function uses its content as the body to challenge, and
    returns the resulted body in it. If not used, the message's
    body is used, and the outgoing body is changed.
+
+   If the pseudo-variable set by rtpp_bind_local_avp is set to a string, its
+   value is appended as l<value> to the RTPProxy U/L command (for
+   example, "[1:2:3]" for IPv6). This applies to both
+   rtpproxy_offer() and rtpproxy_answer().
 
    This function can be used from REQUEST_ROUTE, ONREPLY_ROUTE,
    FAILURE_ROUTE, BRANCH_ROUTE.

--- a/modules/rtpproxy/doc/rtpproxy_admin.xml
+++ b/modules/rtpproxy/doc/rtpproxy_admin.xml
@@ -552,6 +552,27 @@ modparam("rtpproxy", "generated_sdp_media_ip", "10.0.0.1")
 		</example>
 	</section>
 
+	<section id="param_rtpp_bind_local_avp" xreflabel="rtpp_bind_local_avp">
+		<title><varname>rtpp_bind_local_avp</varname> (string)</title>
+		<para>
+			The pseudo-variable used to read the local bind value which is
+			appended as <emphasis>l&lt;value&gt;</emphasis> to the RTPProxy U/L
+			command when set.
+		</para>
+
+		<para>
+		<emphasis>Default value is <quote>$avp(rtpp_bind_local)</quote>.</emphasis>
+		</para>
+		<example>
+		<title>Set <varname>rtpp_bind_local_avp</varname> parameter</title>
+		<programlisting format="linespecific">
+...
+modparam("rtpproxy", "rtpp_bind_local_avp", "$socket_out(ip)")
+...
+		</programlisting>
+		</example>
+	</section>
+
 </section>
 
 
@@ -739,6 +760,14 @@ if (is_method("INVITE") &amp;&amp; has_totag()) {
 					it is the function uses its content as the body to challenge,
 					and returns the resulted body in it. If not used, the message's
 					body is used, and the outgoing body is changed.
+				</para>
+				<para>
+					If the pseudo-variable set by <varname>rtpp_bind_local_avp</varname>
+					is set to a string, its value is appended as
+					<emphasis>l&lt;value&gt;</emphasis> to the RTPProxy U/L command
+					(for example, "[1:2:3]" for IPv6). This applies to both
+					<function>rtpproxy_offer()</function> and
+					<function>rtpproxy_answer()</function>.
 				</para>
 			<para>
 		This function can be used from REQUEST_ROUTE, ONREPLY_ROUTE,
@@ -1264,4 +1293,3 @@ $ opensips-cli -x mi rtpproxy_reload
 </section>
 
 </chapter>
-


### PR DESCRIPTION
**Summary**

This PR adds more flexible control over socket that RTPProxy picks for a new or existing media session. The existing mechanism with I/E designators is a bit crude and limiting.

**Details**

When `rtpp_bind_local` AVP is set, its value would be provided to the rtpproxy with "l" modifier, allowing proper address to be selected for the session.

**Solution**

This can be used either globally by setting the rtpproxy module parameter:

```
modparam("rtpproxy", "rtpp_bind_local_avp", "$socket_out(ip)")
```

Or on logic level by setting up the AVP:

```
route[] {
...
   $avp(rtpp_bind_local) = '1.2.3.4';
   rpproxy_engage();
...
```

**Compatibility**

Should be none, it's a new API.

**Closing issues**

None