### PR TITLE
b2b_logic bridge max_duration flag fix

### DIFF
--- a/modules/b2b_logic/b2b_logic.c
+++ b/modules/b2b_logic/b2b_logic.c
@@ -199,6 +199,7 @@ struct b2b_ctx_val *local_ctx_vals;
 
 unsigned int ent_term_interval;
 struct b2b_term_timer *ent_term_timer;
+int use_lifetime_of_bridge = 0;
 
 static const cmd_export_t cmds[]=
 {
@@ -301,6 +302,7 @@ static const param_export_t params[]=
 	{"b2bl_th_init_timeout",INT_PARAM,            &b2bl_th_init_timeout      },
 	{"b2bl_early_update",INT_PARAM,				  &b2b_early_update          },
 	{"old_entity_term_delay",INT_PARAM,           &ent_term_interval         },
+	{"use_lifetime_of_bridge",INT_PARAM,          &use_lifetime_of_bridge    },
 	{0,                    0,                          0                     }
 };
 

--- a/modules/b2b_logic/bridging.c
+++ b/modules/b2b_logic/bridging.c
@@ -1643,6 +1643,7 @@ int b2bl_bridge(struct sip_msg* msg, b2bl_tuple_t* tuple,
 
 	if (lifetime)
 	{
+		tuple->lifetime_bridge_flag = lifetime;
 		tuple->lifetime = lifetime + get_ticks();
 		LM_DBG("Lifetime defined = [%d]\n", tuple->lifetime);
 	}

--- a/modules/b2b_logic/logic.c
+++ b/modules/b2b_logic/logic.c
@@ -66,6 +66,7 @@ extern struct b2b_ctx_val *local_ctx_vals;
 
 extern int req_routeid;
 extern int reply_routeid;
+extern int use_lifetime_of_bridge;
 
 struct b2bl_route_ctx cur_route_ctx;
 
@@ -161,10 +162,14 @@ int b2b_add_dlginfo(str* key, str* entity_key, int src, b2b_dlginfo_t* dlginfo, 
 		return -1;
 	}
 	/* a connected call */
-	if(max_duration)
-		tuple->lifetime = get_ticks() + max_duration;
-	else
-		tuple->lifetime = 0;
+	if (tuple->lifetime_bridge_flag && use_lifetime_of_bridge) {
+		tuple->lifetime = get_ticks() + tuple->lifetime_bridge_flag;
+	} else {
+		if(max_duration)
+			tuple->lifetime = get_ticks() + max_duration;
+		else
+			tuple->lifetime = 0;
+	}
 	entity = b2bl_search_entity(tuple, entity_key, src, &ent_head);
 	if(entity == NULL)
 	{

--- a/modules/b2b_logic/records.h
+++ b/modules/b2b_logic/records.h
@@ -125,6 +125,7 @@ typedef struct b2bl_tuple
 	struct b2bl_tuple* next;
 	struct b2bl_tuple* prev;
 	unsigned int lifetime;
+	unsigned int lifetime_bridge_flag;
 	str local_contact;
 	int db_flag;
 	int repl_flag;  /* sent/received through entities replication */


### PR DESCRIPTION
**Summary**
 The fix for max_duration flag of the b2b_bridge function in the b2b_logic module

**Details**
The max_duration flag of the b2b_bridge function in the b2b_logic module was not working as expected because the default max_duration setting was overriding the flag value. This issue has been resolved by introducing a new module parameter.

**Solution**
When b2b_bridge is triggered , the lifetime of the call was set as 5, because max_duration flag is 5:
Oct 2 07:10:35 [19] ERROR:b2b_logic:b2b_script_bridge: params->lifetime: 5 (max_duration)

When the 200 OK reply of initial INTIVE is arrived, the lifetime is updated again with default lifetime value:
Oct 2 07:10:35 [19] ERROR:b2b_logic:b2b_add_dlginfo: max_duration : 43200 tuple->lifetime 43201

The second update is prevented with the new module parameter.

**Compatibility**
If the new module parameter is set to false, the code behaves as before. The default value is false.

**Closing issues**
N/A
