### PR TITLE
Dialog module crash when Contact header is *

### DIFF
--- a/modules/dialog/dlg_handlers.c
+++ b/modules/dialog/dlg_handlers.c
@@ -1479,6 +1479,7 @@ static inline int dlg_update_contact(struct dlg_cell *dlg, struct sip_msg *msg,
 	str contact, new_ct, old_ct;
 	int ret = 0;
 	contact_t *ct = NULL;
+	contact_body_t *parsed_body = NULL;
 
 	if (!msg->contact &&
 		(parse_headers(msg, HDR_CONTACT_F, 0) < 0 || !msg->contact)) {
@@ -1496,7 +1497,14 @@ static inline int dlg_update_contact(struct dlg_cell *dlg, struct sip_msg *msg,
 		contact = ct->uri;
 		LM_DBG("Found unparsed contact [%.*s]\n", contact.len, contact.s);
 	} else {
-		contact = ((contact_body_t *)msg->contact->parsed)->contacts->uri;
+		parsed_body = (contact_body_t *)msg->contact->parsed;
+
+		if (parsed_body->star == 1) {
+			LM_WARN("Invalid star Contact in dialog update!\n");
+			return 0;
+		}
+
+		contact = parsed_body->contacts->uri;
 	}
 
 	/* if the same contact, don't do anything */


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!
In order to consider and evaluate your PR, it is mandatory to provide detailed information about (1) what is the issue the PR addresses, (2) how the PR is solving the issue (logic and coding), (3) what are (if any) limitations of the proposed PR and (4) if there are any known side-effects/ backward compatibility issues/SIP interoperability issues.
Note that if the PR is missing information, it might take longer to be merged, as extra resources have to be allocated by the maintainers to reverse engineer the changes, understand them, understand the motivation, etc. That is why it is important to provide as much information as possible.
-->

**Summary**
Fixes a crash in the dialog module in conjunction with the topology_hiding module where setting the `Contact` header value to `*` for `INVITE|UPDATE`

**Details**
Crash in the dialog module when `Contact` header body is set to `*` affects session modifying requests only, initial and in dialog `INVITE` is only susceptible if `sipmsg_validate("c")` is not used before doing the `topology_hiding`.

`UPDATE` is susceptible all the time because `sipmsg_validate("c")` only checks the `Contact` header for `INVITE` requests.

2xx responses to the aforementioned requests are susceptible regardless if you do `sipmsg_validate("c")` in the reply route.

The main reason this was exposed is because `*` is a valid body for `REGISTER` requests and it counts as a valid header but there is no list of uris and it references a NULL pointer and crashes.

Fix tested against 3.4 but it appears 3.2 and 3.6 are vulnerable.

**Solution**
Checks if `star` is set in the `contact_body` struct before checking if the `contact*` is not NULL before setting the Uri and exiting early if not, this leaves the dialog in a slightly inconsistent state that will expire to the  e2e `ACK` request not being able to route to the `UAS`

**Compatibility**
No incompatibilies
