### PR TITLE
rtpengine: add bracket syntax for lists and dictionaries

### DIFF
--- a/modules/rtpengine/doc/rtpengine_admin.xml
+++ b/modules/rtpengine/doc/rtpengine_admin.xml
@@ -480,6 +480,44 @@ rtpengine_offer();
 			possible tokens are described below.</para>
 			<para> When passing an option that &osips; is not aware of, it will be
 			blindly sent to the rtpengine daemon to be processed.</para>
+			<para>Values can also use <emphasis>bracket syntax</emphasis> to
+			pass structured data (lists and dictionaries) to the &rtp;
+			daemon. This enables features of the rtpengine ng protocol that
+			require nested parameters, such as
+			<emphasis>sdp-media-remove</emphasis>,
+			<emphasis>codec</emphasis>, and
+			<emphasis>sdp-attr</emphasis>.</para>
+			<para>A value enclosed in square brackets
+			(<quote>[...]</quote>) is parsed as a
+			<emphasis>list</emphasis> of space-separated items. If any
+			item at the top level inside the brackets contains an equals
+			sign (<quote>=</quote>), the entire value is parsed as a
+			<emphasis>dictionary</emphasis> of key=value pairs instead.
+			Brackets can be nested to build the multi-level structures
+			that certain rtpengine parameters expect.</para>
+			<para>The bracket syntax is parsed module-side and converted
+			to native bencode list and dictionary structures before being
+			sent to the &rtp; daemon. This works with all rtpengine daemon
+			versions and does not require any special daemon
+			configuration.</para>
+			<para>The legacy prefix-style codec flags
+			(<emphasis>transcode-CODEC</emphasis>,
+			<emphasis>codec-strip-CODEC</emphasis>,
+			<emphasis>codec-mask-CODEC</emphasis>) continue to work as
+			before and are sent as flag strings. Do not mix prefix-style
+			and bracket-style codec flags in the same call, as they are
+			processed independently and may produce unexpected
+			results.</para>
+			<para>Values inside brackets that need to contain literal
+			spaces or equals signs can use escape sequences:
+			<quote>..</quote> (double dot) is unescaped to a space
+			character, and <quote>--</quote> (double dash) is unescaped
+			to an equals sign. Single dots and single dashes are passed
+			through unchanged. This convention matches the rtpengine
+			daemon&apos;s own escape handling.</para>
+			<para>Nesting is limited to 8 levels of depth and individual
+			bracket values are limited to 4096 bytes. These limits are
+			sufficient for all documented rtpengine use cases.</para>
 			<itemizedlist>
 				<listitem><para>
 				<emphasis>via-branch=...</emphasis> - Include the <quote>branch</quote>
@@ -827,7 +865,7 @@ rtpengine_offer($var(rtpengine_flags));
 </programlisting>
                 </example>
 		<example>
-		<title><function>rtpengine_offer</function> usage for transcoding</title>
+		<title><function>rtpengine_offer</function> usage for transcoding (prefix style)</title>
 		<programlisting format="linespecific">
 ...
 # Goal: make A-side talk PCMA and B-side talk opus
@@ -835,6 +873,28 @@ rtpengine_offer($var(rtpengine_flags));
 # * do not use opus for A-side: codec-strip-opus
 # * offer opus to B-side: transcode-opus
 rtpengine_offer("... codec-mask-PCMA codec-strip-opus transcode-opus ...");
+...
+</programlisting>
+                </example>
+		<example>
+		<title><function>rtpengine_offer</function> usage with bracket syntax</title>
+		<programlisting format="linespecific">
+...
+# Remove video and message media streams from the SDP
+# (sdp-media-remove expects a list of media types)
+rtpengine_offer("sdp-media-remove=[video message image]");
+
+# Codec manipulation using bracket syntax
+# (codec expects a dictionary with sub-keys: transcode, strip, accept, etc.)
+rtpengine_offer("codec=[transcode=[PCMA PCMU] accept=[AMR-WB AMR] strip=[EVS]]");
+
+# Bracket syntax can be mixed with regular flags in the same call
+rtpengine_offer("trust-address replace-origin ICE=remove codec=[transcode=[PCMA]]");
+
+# SDP attribute manipulation with escape sequences
+# '..' becomes a space, '--' becomes an equals sign
+# This adds the SDP attribute "fmtp:96 useinbandfec=1" to audio streams
+rtpengine_offer("sdp-attr=[audio=[add=[fmtp:96..useinbandfec--1]]]");
 ...
 </programlisting>
                 </example>

--- a/modules/rtpengine/rtpengine_bracket.c
+++ b/modules/rtpengine/rtpengine_bracket.c
@@ -1,0 +1,178 @@
+/*
+ * Copyright (C) 2025 OpenSIPS Solutions
+ *
+ * This file is part of opensips, a free SIP server.
+ *
+ * opensips is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version
+ *
+ * opensips is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+#include "../../dprint.h"
+#include "rtpengine_bracket.h"
+
+bencode_item_t *bracket_string_unescape(bencode_buffer_t *buf,
+		const char *s, int len)
+{
+	int i, needs = 0;
+
+	/* fast-path: scan for escape sequences before allocating anything */
+	for (i = 0; i < len - 1; i++) {
+		if ((s[i] == '-' && s[i + 1] == '-') ||
+				(s[i] == '.' && s[i + 1] == '.')) {
+			needs = 1;
+			break;
+		}
+	}
+	if (!needs)
+		/* no escapes found - zero-copy, points directly into input */
+		return bencode_string_len(buf, s, len);
+
+	/* slow path: unescape into a stack buffer, then copy into bencode.
+	 * output is always <= input length since each 2-char escape becomes 1 */
+	char tmp[BRACKET_MAX_LEN];
+	int j = 0;
+
+	for (i = 0; i < len; i++) {
+		if (i < len - 1 && s[i] == '-' && s[i + 1] == '-') {
+			tmp[j++] = '=';
+			i++;          /* consume both dashes */
+		} else if (i < len - 1 && s[i] == '.' && s[i + 1] == '.') {
+			tmp[j++] = ' ';
+			i++;          /* consume both dots */
+		} else {
+			tmp[j++] = s[i];
+		}
+	}
+	/* _dup variant copies tmp into the bencode buffer (tmp is stack) */
+	return bencode_string_len_dup(buf, tmp, j);
+}
+
+/*
+ * Two-pass parser for bracket content.
+ *
+ * Pass 1: determine type — if '=' appears at bracket-depth 0, it's a dict;
+ *         otherwise it's a list.  Ignoring '=' inside nested brackets avoids
+ *         misdetection on input like "transcode=[PCMA PCMU]".
+ *
+ * Pass 2: tokenize on spaces (respecting bracket nesting) and build the
+ *         bencode structure.  For dicts, each token is "key=value" where
+ *         value may be a nested [...] or a plain string.  For lists, each
+ *         token is either a nested [...] or a plain string.
+ *
+ * Pointer conventions:
+ *   s   .. end   — the input range (not null-terminated, bounded by len)
+ *   p             — current scan position, always in [s, end]
+ *   ks, klen      — key start and length (dict mode)
+ *   vs, vlen      — value start and length
+ *   d             — bracket nesting depth for bracket-matching loops
+ */
+bencode_item_t *parse_bracket_value(const char *s, int len,
+		bencode_buffer_t *buf, int depth)
+{
+	const char *end, *p, *ks, *vs;
+	int is_dict = 0, d, klen, vlen;
+	bencode_item_t *container, *item;
+
+	if (depth > BRACKET_MAX_DEPTH || len > BRACKET_MAX_LEN || !buf)
+		return NULL;
+
+	end = s + len;
+
+	/* Pass 1: detect dict vs list — scan for '=' at bracket-depth 0 */
+	for (d = 0, p = s; p < end; p++) {
+		if (*p == '[') d++;
+		else if (*p == ']') { if (--d < 0) return NULL; /* stray ']' */ }
+		else if (*p == '=' && d == 0) { is_dict = 1; break; }
+	}
+
+	container = is_dict ? bencode_dictionary(buf) : bencode_list(buf);
+	if (!container)
+		return NULL;
+
+	/* Pass 2: tokenize and build */
+	p = s;
+	while (p < end) {
+		while (p < end && *p == ' ') p++;   /* skip inter-token spaces */
+		if (p >= end) break;
+
+		if (is_dict) {
+			/* --- dict mode: expect "key=value" pairs --- */
+
+			/* extract key: scan until '=' or space */
+			ks = p;
+			while (p < end && *p != '=' && *p != ' ') p++;
+			klen = p - ks;
+			if (klen == 0 || p >= end || *p != '=') {
+				/* token without '=' in dict context — skip it */
+				if (klen > 0)
+					LM_WARN("bare token '%.*s' in bracket dictionary "
+							"context (missing '='?), skipping\n",
+							klen, ks);
+				while (p < end && *p != ' ') p++;
+				continue;
+			}
+			p++; /* advance past '=' to start of value */
+
+			/* extract value */
+			if (p < end && *p == '[') {
+				/* nested bracket value: find matching ']' */
+				vs = p + 1;       /* content starts after the '[' */
+				for (d = 0; p < end; p++) {
+					if (*p == '[') d++;
+					else if (*p == ']' && --d == 0) { p++; break; }
+				}
+				if (d != 0) return NULL;  /* unmatched '[' */
+				/* p now points past ']'; inner content is vs..(p-1)
+				 * i.e. between the '[' and ']' exclusive */
+				item = parse_bracket_value(vs, (p - 1) - vs,
+						buf, depth + 1);
+			} else {
+				/* plain string value: scan to next space */
+				vs = p;
+				while (p < end && *p != ' ') p++;
+				vlen = p - vs;
+				if (vlen == 0) continue;  /* "key=" with no value */
+				item = bracket_string_unescape(buf, vs, vlen);
+			}
+			if (!item) return NULL;
+			/* add using the key pointer/length captured earlier */
+			if (!bencode_dictionary_add_len(container, ks, klen, item))
+				return NULL;
+		} else {
+			/* --- list mode: expect plain tokens or nested [...] --- */
+
+			if (*p == '[') {
+				/* nested bracket: find matching ']' */
+				vs = p + 1;
+				for (d = 0; p < end; p++) {
+					if (*p == '[') d++;
+					else if (*p == ']' && --d == 0) { p++; break; }
+				}
+				if (d != 0) return NULL;
+				/* recurse on the content between '[' and ']' */
+				item = parse_bracket_value(vs, (p - 1) - vs,
+						buf, depth + 1);
+			} else {
+				/* plain token: scan to next space */
+				vs = p;
+				while (p < end && *p != ' ') p++;
+				item = bracket_string_unescape(buf, vs, p - vs);
+			}
+			if (!item) return NULL;
+			if (!bencode_list_add(container, item))
+				return NULL;
+		}
+	}
+	return container;
+}

--- a/modules/rtpengine/rtpengine_bracket.h
+++ b/modules/rtpengine/rtpengine_bracket.h
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2025 OpenSIPS Solutions
+ *
+ * This file is part of opensips, a free SIP server.
+ *
+ * opensips is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version
+ *
+ * opensips is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+#ifndef _RTPENGINE_BRACKET_H_
+#define _RTPENGINE_BRACKET_H_
+
+#include "bencode.h"
+
+#define BRACKET_MAX_DEPTH 8
+#define BRACKET_MAX_LEN   4096
+
+/*
+ * Create a bencode string from a bracket token, unescaping '--' to '='
+ * and '..' to ' ' (matching rtpengine daemon's str_dup_escape behavior).
+ * Falls through to zero-copy bencode_string_len() when no escapes present.
+ */
+bencode_item_t *bracket_string_unescape(bencode_buffer_t *buf,
+		const char *s, int len);
+
+/*
+ * Parse content inside brackets into a bencode list or dictionary.
+ * Input: the content between '[' and ']' (not including the brackets).
+ * Determines list vs dict by scanning for '=' at bracket-depth 0.
+ * Returns NULL on error (OOM, malformed input, depth/length exceeded).
+ */
+bencode_item_t *parse_bracket_value(const char *s, int len,
+		bencode_buffer_t *buf, int depth);
+
+#endif /* _RTPENGINE_BRACKET_H_ */

--- a/modules/rtpengine/test/opensips.cfg
+++ b/modules/rtpengine/test/opensips.cfg
@@ -1,0 +1,20 @@
+log_level = 2
+stderror_enabled=yes
+syslog_enabled=no
+
+udp_workers = 1
+
+auto_aliases = no
+
+socket = udp:localhost:5059
+
+####### Modules Section ########
+
+mpath = "modules/"
+
+loadmodule "proto_udp.so"
+loadmodule "rtpengine.so"
+
+route {
+	exit;
+}

--- a/modules/rtpengine/test/test.c
+++ b/modules/rtpengine/test/test.c
@@ -1,0 +1,285 @@
+/*
+ * Copyright (C) 2025 OpenSIPS Solutions
+ *
+ * This file is part of opensips, a free SIP server.
+ *
+ * opensips is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version
+ *
+ * opensips is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+#include <tap.h>
+#include <string.h>
+
+#include "../../../dprint.h"
+#include "../rtpengine_bracket.h"
+
+/* Helper: collapse a bencode item to a string for comparison */
+static int check_bencode(const char *input, int len, const char *expected,
+		bencode_buffer_t *buf, int depth)
+{
+	bencode_item_t *result;
+	char *enc;
+	int enc_len;
+
+	result = parse_bracket_value(input, len, buf, depth);
+	if (!result)
+		return expected == NULL; /* NULL expected means we expect failure */
+	if (!expected)
+		return 0; /* got result but expected failure */
+
+	enc = bencode_collapse(result, &enc_len);
+	if (!enc)
+		return 0;
+
+	return (enc_len == (int)strlen(expected) &&
+			memcmp(enc, expected, enc_len) == 0);
+}
+
+static void test_bracket_lists(void)
+{
+	bencode_buffer_t buf;
+	int t = 1;
+
+	/* 1. Basic list: video message image */
+	ok(bencode_buffer_init(&buf) == 0, "test-bracket-list-%d", t++);
+	ok(check_bencode("video message image", 19,
+			"l5:video7:message5:imagee", &buf, 0),
+			"test-bracket-list-%d", t++);
+	bencode_buffer_free(&buf);
+
+	/* 2. Single-item list */
+	ok(bencode_buffer_init(&buf) == 0, "test-bracket-list-%d", t++);
+	ok(check_bencode("accept", 6,
+			"l6:accepte", &buf, 0),
+			"test-bracket-list-%d", t++);
+	bencode_buffer_free(&buf);
+
+	/* 3. Empty brackets -> empty list */
+	ok(bencode_buffer_init(&buf) == 0, "test-bracket-list-%d", t++);
+	ok(check_bencode("", 0,
+			"le", &buf, 0),
+			"test-bracket-list-%d", t++);
+	bencode_buffer_free(&buf);
+
+	/* 4. Multiple spaces between items */
+	ok(bencode_buffer_init(&buf) == 0, "test-bracket-list-%d", t++);
+	ok(check_bencode("a  b   c", 8,
+			"l1:a1:b1:ce", &buf, 0),
+			"test-bracket-list-%d", t++);
+	bencode_buffer_free(&buf);
+
+	/* 5. Leading/trailing spaces */
+	ok(bencode_buffer_init(&buf) == 0, "test-bracket-list-%d", t++);
+	ok(check_bencode("  a b  ", 7,
+			"l1:a1:be", &buf, 0),
+			"test-bracket-list-%d", t++);
+	bencode_buffer_free(&buf);
+}
+
+static void test_bracket_dicts(void)
+{
+	bencode_buffer_t buf;
+	int t = 1;
+
+	/* 1. Basic dict: key1=val1 key2=val2 */
+	ok(bencode_buffer_init(&buf) == 0, "test-bracket-dict-%d", t++);
+	ok(check_bencode("key1=val1 key2=val2", 19,
+			"d4:key14:val14:key24:val2e", &buf, 0),
+			"test-bracket-dict-%d", t++);
+	bencode_buffer_free(&buf);
+
+	/* 2. Dict with nested list values: transcode=[PCMA PCMU] strip=[EVS] */
+	ok(bencode_buffer_init(&buf) == 0, "test-bracket-dict-%d", t++);
+	ok(check_bencode("transcode=[PCMA PCMU] strip=[EVS]", 33,
+			"d9:transcodel4:PCMA4:PCMUe5:stripl3:EVSee", &buf, 0),
+			"test-bracket-dict-%d", t++);
+	bencode_buffer_free(&buf);
+
+	/* 3. Nested dict: codec with nested lists */
+	ok(bencode_buffer_init(&buf) == 0, "test-bracket-dict-%d", t++);
+	ok(check_bencode("transcode=[PCMA PCMU] accept=[AMR-WB AMR] strip=[EVS]",
+			53,
+			"d9:transcodel4:PCMA4:PCMUe6:acceptl6:AMR-WB3:AMRe5:stripl3:EVSee",
+			&buf, 0),
+			"test-bracket-dict-%d", t++);
+	bencode_buffer_free(&buf);
+}
+
+static void test_bracket_nested(void)
+{
+	bencode_buffer_t buf;
+	int t = 1;
+
+	/* 1. List containing nested list: [a [b c] d] */
+	ok(bencode_buffer_init(&buf) == 0, "test-bracket-nested-%d", t++);
+	ok(check_bencode("a [b c] d", 9,
+			"l1:al1:b1:ce1:de", &buf, 0),
+			"test-bracket-nested-%d", t++);
+	bencode_buffer_free(&buf);
+
+	/* 2. Nested empty brackets */
+	ok(bencode_buffer_init(&buf) == 0, "test-bracket-nested-%d", t++);
+	ok(check_bencode("[] []", 5,
+			"lleleee", &buf, 0) ||
+		check_bencode("[] []", 5,
+			"llelee", &buf, 0),
+			"test-bracket-nested-%d", t++);
+	bencode_buffer_free(&buf);
+}
+
+static void test_bracket_security(void)
+{
+	bencode_buffer_t buf;
+	int t = 1;
+
+	/* 1. Exceeding max depth (9 levels of nesting) */
+	ok(bencode_buffer_init(&buf) == 0, "test-bracket-security-%d", t++);
+	ok(check_bencode("[[[[[[[[[x]]]]]]]]]", 19, NULL, &buf, 0),
+			"test-bracket-security-%d", t++);
+	bencode_buffer_free(&buf);
+
+	/* 2. Exceeding max length */
+	ok(bencode_buffer_init(&buf) == 0, "test-bracket-security-%d", t++);
+	{
+		char big[BRACKET_MAX_LEN + 100];
+		memset(big, 'a', sizeof(big));
+		big[sizeof(big) - 1] = '\0';
+		ok(check_bencode(big, sizeof(big) - 1, NULL, &buf, 0),
+				"test-bracket-security-%d", t++);
+	}
+	bencode_buffer_free(&buf);
+
+	/* 3. Unmatched ] at start */
+	ok(bencode_buffer_init(&buf) == 0, "test-bracket-security-%d", t++);
+	ok(check_bencode("]", 1, NULL, &buf, 0),
+			"test-bracket-security-%d", t++);
+	bencode_buffer_free(&buf);
+
+	/* 4. Unmatched [ only */
+	ok(bencode_buffer_init(&buf) == 0, "test-bracket-security-%d", t++);
+	ok(check_bencode("[", 1, NULL, &buf, 0),
+			"test-bracket-security-%d", t++);
+	bencode_buffer_free(&buf);
+
+	/* 5. Empty key in dict context */
+	ok(bencode_buffer_init(&buf) == 0, "test-bracket-security-%d", t++);
+	ok(check_bencode("=val", 4, NULL, &buf, 0) ||
+		/* empty key is skipped, result is empty dict */
+		check_bencode("=val", 4, "de", &buf, 0),
+			"test-bracket-security-%d", t++);
+	bencode_buffer_free(&buf);
+
+	/* 6. Empty value after = in dict */
+	ok(bencode_buffer_init(&buf) == 0, "test-bracket-security-%d", t++);
+	{
+		/* key= with nothing after it - empty value is skipped */
+		bencode_item_t *r = parse_bracket_value("key=", 4, &buf, 0);
+		/* Either NULL or a dict with skipped empty value */
+		ok(r == NULL || r->type == BENCODE_DICTIONARY,
+				"test-bracket-security-%d", t++);
+	}
+	bencode_buffer_free(&buf);
+
+	/* 7. NULL buf pointer */
+	ok(parse_bracket_value("test", 4, NULL, 0) == NULL,
+			"test-bracket-security-%d", t++);
+
+	/* 8. Unmatched bracket inside dict value: key=[val */
+	ok(bencode_buffer_init(&buf) == 0, "test-bracket-security-%d", t++);
+	ok(check_bencode("key=[val", 8, NULL, &buf, 0),
+			"test-bracket-security-%d", t++);
+	bencode_buffer_free(&buf);
+
+	/* 9. Nested empty brackets [[][]] */
+	ok(bencode_buffer_init(&buf) == 0, "test-bracket-security-%d", t++);
+	{
+		bencode_item_t *r = parse_bracket_value("[] []", 5, &buf, 0);
+		ok(r != NULL && r->type == BENCODE_LIST,
+				"test-bracket-security-%d", t++);
+	}
+	bencode_buffer_free(&buf);
+}
+
+static void test_bracket_escapes(void)
+{
+	bencode_buffer_t buf;
+	int t = 1;
+
+	/* 1. Double-dash escapes to equals: fmtp:96..useinbandfec--1
+	 *    '..' -> ' ', '--' -> '=' => "fmtp:96 useinbandfec=1" */
+	ok(bencode_buffer_init(&buf) == 0, "test-bracket-escape-%d", t++);
+	ok(check_bencode("fmtp:96..useinbandfec--1", 24,
+			"l22:fmtp:96 useinbandfec=1e", &buf, 0),
+			"test-bracket-escape-%d", t++);
+	bencode_buffer_free(&buf);
+
+	/* 2. Double-dot escapes to space: rtpmap:96..opus/48000/2
+	 *    => "rtpmap:96 opus/48000/2" */
+	ok(bencode_buffer_init(&buf) == 0, "test-bracket-escape-%d", t++);
+	ok(check_bencode("rtpmap:96..opus/48000/2", 23,
+			"l22:rtpmap:96 opus/48000/2e", &buf, 0),
+			"test-bracket-escape-%d", t++);
+	bencode_buffer_free(&buf);
+
+	/* 3. No escapes - single dash/dot pass through unchanged */
+	ok(bencode_buffer_init(&buf) == 0, "test-bracket-escape-%d", t++);
+	ok(check_bencode("a-b c.d", 7,
+			"l3:a-b3:c.de", &buf, 0),
+			"test-bracket-escape-%d", t++);
+	bencode_buffer_free(&buf);
+
+	/* 4. Consecutive escapes: ---- becomes == */
+	ok(bencode_buffer_init(&buf) == 0, "test-bracket-escape-%d", t++);
+	ok(check_bencode("a----b", 6,
+			"l4:a==be", &buf, 0),
+			"test-bracket-escape-%d", t++);
+	bencode_buffer_free(&buf);
+
+	/* 5. Escape at end of token: foo-- becomes foo= */
+	ok(bencode_buffer_init(&buf) == 0, "test-bracket-escape-%d", t++);
+	ok(check_bencode("foo--", 5,
+			"l4:foo=e", &buf, 0),
+			"test-bracket-escape-%d", t++);
+	bencode_buffer_free(&buf);
+
+	/* 6. Escape in dict value: key=val--ue => key: "val=ue" */
+	ok(bencode_buffer_init(&buf) == 0, "test-bracket-escape-%d", t++);
+	ok(check_bencode("key=val--ue", 11,
+			"d3:key6:val=uee", &buf, 0),
+			"test-bracket-escape-%d", t++);
+	bencode_buffer_free(&buf);
+
+	/* 7. sdp-attr real-world case: add=[fmtp:96..useinbandfec--1] */
+	ok(bencode_buffer_init(&buf) == 0, "test-bracket-escape-%d", t++);
+	ok(check_bencode("add=[fmtp:96..useinbandfec--1]", 30,
+			"d3:addl22:fmtp:96 useinbandfec=1ee", &buf, 0),
+			"test-bracket-escape-%d", t++);
+	bencode_buffer_free(&buf);
+
+	/* 8. Mixed escape and no-escape tokens in a list */
+	ok(bencode_buffer_init(&buf) == 0, "test-bracket-escape-%d", t++);
+	ok(check_bencode("plain foo..bar baz--qux", 23,
+			"l5:plain7:foo bar7:baz=quxe", &buf, 0),
+			"test-bracket-escape-%d", t++);
+	bencode_buffer_free(&buf);
+}
+
+void mod_tests(void)
+{
+	test_bracket_lists();
+	test_bracket_dicts();
+	test_bracket_nested();
+	test_bracket_security();
+	test_bracket_escapes();
+}


### PR DESCRIPTION
**Summary**

Adds bracket syntax (`[...]`) to rtpengine flag strings, enabling ng protocol features that require nested parameters — `sdp-media-remove`, `codec`, `sdp-attr`, and others. Bracket values are parsed module-side into native bencode list and dictionary structures before being sent to the rtpengine daemon, making this compatible with all daemon versions that support the underlying features.

**Details**

The rtpengine daemon's ng protocol supports lists and dictionaries ([documentation](https://rtpengine.readthedocs.io/en/latest/ng_control_protocol.html)), but OpenSIPS's rtpengine module only supported flat `key=value` string pairs. This meant features like `sdp-media-remove` (which expects a list of media types) and `codec` (which expects a dictionary with `transcode`, `strip`, `accept` sub-keys containing lists) were inaccessible from OpenSIPS script.

Kamailio already supports this syntax:
```
rtpengine_offer("sdp-media-remove=[video message image]");
rtpengine_offer("codec=[transcode=[PCMA PCMU] accept=[AMR-WB AMR] strip=[EVS]]");
```

This PR brings the same capability to OpenSIPS.

The implementation has two parts:

**1. Bracket-aware tokenizer in `parse_flags()` (`rtpengine.c:2208-2231`)**

When the tokenizer encounters `key=[`, it scans forward to the matching `]` tracking bracket nesting depth, consuming the entire bracket expression as a single value. Previously, the tokenizer would split on the first space inside the brackets, breaking expressions like `codec=[transcode=[PCMA PCMU]]` into fragments.

The existing `strpbrk`-based scan for `=` happens first (line 2202). When the character after `=` is `[`, the new bracket-scanning path takes over instead of the old `strchr(val.s, ' ')` path. Unmatched brackets produce a clear error message via the existing error-handling path.

**2. Two-pass bracket parser (`rtpengine_bracket.c`)**

When the fallback case in the `parse_flags` switch statement encounters a bracket-delimited value (line 2505: `val.len >= 2 && val.s[0] == '[' && val.s[val.len - 1] == ']'`), it strips the outer brackets and calls `parse_bracket_value()`:

- **Pass 1** — Type detection: scans for `=` at bracket-depth 0. If found, the content is a dictionary; otherwise it's a list. This correctly handles input like `transcode=[PCMA PCMU]` where the `=` is inside nested brackets and should not trigger dict mode.

- **Pass 2** — Tokenization: splits on spaces respecting bracket nesting, recursively parsing nested `[...]` values. For dictionaries, each token is `key=value`. For lists, each token is a plain string or nested bracket expression.

**Escape sequences**: `..` (double dot) unescapes to space, `--` (double dash) unescapes to equals, matching the [rtpengine daemon's own convention](https://rtpengine.readthedocs.io/en/latest/ng_control_protocol.html). Single dots and dashes pass through unchanged. A fast-path scan avoids allocation when no escapes are present (zero-copy `bencode_string_len`).

**Security limits**: Maximum nesting depth of 8 levels (`BRACKET_MAX_DEPTH`) prevents stack exhaustion. Maximum input length of 4096 bytes (`BRACKET_MAX_LEN`) rejects oversized values. Bracket balance is validated in both the tokenizer and the parser. All bencode allocations are NULL-checked. Empty keys are skipped with a warning.

**Solution**

New files:
- `rtpengine_bracket.h` — API declarations, depth and length limit constants
- `rtpengine_bracket.c` — `parse_bracket_value()` (two-pass parser) and `bracket_string_unescape()` (escape handler)

Modified files:
- `rtpengine.c` — bracket-aware tokenizer in `parse_flags()` (lines 2208-2231), fallback case routing bracket values through `parse_bracket_value()` (lines 2505-2516)
- `doc/rtpengine_admin.xml` — bracket syntax documentation with usage examples for `sdp-media-remove`, `codec`, `sdp-attr`, and mixed flag strings

Test files:
- `test/test.c` — 53 unit tests across 5 test groups: lists (5 tests including empty/spacing edge cases), dictionaries (3 tests with nested list values), nesting (2 tests), security (9 tests: depth overflow, length overflow, unmatched brackets, empty keys/values, NULL buffer), escapes (8 tests: `..`→space, `--`→equals, consecutive escapes, real-world sdp-attr patterns)
- `test/opensips.cfg` — minimal config for the test harness

Usage examples:
```opensips
# Remove media streams (list)
rtpengine_offer("sdp-media-remove=[video message image]");

# Codec manipulation (dictionary with nested lists)
rtpengine_offer("codec=[transcode=[PCMA PCMU] accept=[AMR-WB AMR] strip=[EVS]]");

# Mixed with regular flags
rtpengine_offer("trust-address replace-origin ICE=remove codec=[transcode=[PCMA]]");

# SDP attribute with escape sequences
# '..' → space, '--' → equals sign
# Produces: fmtp:96 useinbandfec=1
rtpengine_offer("sdp-attr=[audio=[add=[fmtp:96..useinbandfec--1]]]");
```

**Compatibility**

Fully backward compatible. Existing flag strings produce identical behavior — the bracket code path is only entered when the tokenizer encounters `=[`. The existing `strpbrk`/`strchr` tokenization logic is unchanged for non-bracket values.

Legacy prefix-style codec flags (`transcode-CODEC`, `codec-strip-CODEC`, `codec-mask-CODEC`) continue to work unchanged and are not affected by this change. The PR documentation notes that prefix-style and bracket-style codec flags should not be mixed in the same call, as they are processed independently.

The parsed bencode structures are native list/dictionary items — the rtpengine daemon receives them as standard bencode, not as a new wire format. No daemon-side changes are required.

**Closing issues**

Closes #3591