### PR TITLE
nathelper: fix Contact concatenation when fix_nated_contact() runs after topology_hiding()

### DIFF
--- a/modules/nathelper/doc/nathelper_admin.xml
+++ b/modules/nathelper/doc/nathelper_admin.xml
@@ -588,6 +588,80 @@ modparam("nathelper", "cluster_sharing_tag", "vip")
 		</example>
 	</section>
 
+	<section id="param_nated_contact_override" xreflabel="nated_contact_override">
+		<title><varname>nated_contact_override</varname> (integer)</title>
+		<para>
+		Controls the behavior of
+		<xref linkend="func_fix_nated_contact"/> when the Contact header
+		has already been rewritten by a prior function in the same route,
+		such as <function>topology_hiding()</function>.
+		</para>
+		<para>
+		When both <function>topology_hiding()</function> and
+		<function>fix_nated_contact()</function> are used in the same
+		routing script, both attempt to rewrite the Contact header. If
+		<function>topology_hiding()</function> runs first, the Contact
+		is already scheduled for replacement by the time
+		<function>fix_nated_contact()</function> executes. Without this
+		parameter, calling them in this order can produce a malformed
+		Contact header containing two concatenated SIP URIs (see
+		<ulink url="https://github.com/OpenSIPS/opensips/issues/2172">
+		GH #2172</ulink>).
+		</para>
+		<para>
+		This parameter lets you choose which rewrite wins:
+		</para>
+		<itemizedlist>
+			<listitem><para>
+			<emphasis>0</emphasis> (default) - keep the existing
+			Contact rewrite as-is. For example, if
+			<function>topology_hiding()</function> already rewrote
+			the Contact, its topology-hidden Contact will be
+			preserved and <function>fix_nated_contact()</function>
+			will be silently skipped for that Contact.
+			</para></listitem>
+			<listitem><para>
+			<emphasis>1</emphasis> - override the existing rewrite
+			with the NAT-fixed Contact from
+			<function>fix_nated_contact()</function>. The Contact
+			will contain the source IP and port of the request
+			instead of the topology-hidden address.
+			</para></listitem>
+		</itemizedlist>
+		<note><para>
+		This parameter only takes effect when a Contact conflict is
+		detected (i.e., another function has already scheduled the
+		Contact for rewriting). When
+		<function>fix_nated_contact()</function> is called on its own
+		or before other Contact-rewriting functions, this parameter
+		has no effect and <function>fix_nated_contact()</function>
+		behaves normally.
+		</para></note>
+		<para>
+		If the message contains multiple Contact URIs, the check is
+		done per-Contact: only Contacts that conflict with a prior
+		rewrite are affected by this setting. Other Contacts are
+		processed by <function>fix_nated_contact()</function> normally.
+		</para>
+		<para>
+		<emphasis>
+			Default value is 0 (keep existing rewrite).
+		</emphasis>
+		</para>
+		<example>
+		<title>Set <varname>nated_contact_override</varname> parameter</title>
+		<programlisting format="linespecific">
+...
+# Keep topology_hiding()'s Contact (default behavior)
+modparam("nathelper", "nated_contact_override", 0)
+...
+# Override with fix_nated_contact()'s NAT-fixed Contact
+modparam("nathelper", "nated_contact_override", 1)
+...
+</programlisting>
+		</example>
+	</section>
+
 </section>
 
 	<section id="exported_functions" xreflabel="exported_functions">


### PR DESCRIPTION
**Summary**

`fix_nated_contact()` called after `topology_hiding()` produces a malformed Contact header containing two concatenated SIP URIs when the Contact lacks angle-bracket enclosure (`<>`).

**Details**

Both `topology_hiding()` and `fix_nated_contact()` rewrite the Contact header using the lump mechanism. Each creates a `LUMP_DEL` entry (marking a region for deletion) with an `after` chain `LUMP_ADD` entry (inserting replacement text).

`topology_hiding()` via `delete_existing_contact()` deletes `msg->contact->body` (the full Contact body). `fix_nated_contact_f()` deletes from `c->uri.s` through the host:port portion.

The Contact parser (`parser/contact/contact.c:217-222`) strips angle brackets from `contact_t->uri`:
- **With `<>`:** `body.s` points to `<` (offset N), `uri.s` points to `sip:` (offset N+1) — offsets differ by 1
- **Without `<>`:** `body.s` and `uri.s` point to the same address — offsets are identical

In `msg_translator.c`, `process_lumps()` iterates lumps sorted by offset. It has a `last_del` exception that allows processing of multiple lumps anchored at the same deletion point:

```c
if (t->u.offset < s_offset && t->u.offset != last_del) {
    continue;
}
```

When offsets differ by 1 (with brackets), the second lump falls inside the first's deleted region and is correctly skipped. When offsets are identical (no brackets), the `last_del` exception prevents the skip, and both replacement values are emitted — producing:

```
Contact: <sip:10.0.0.40;did=282.a0601bb2>sip:alice@10.0.0.40:15060
```

The reverse call order (`fix_nated_contact()` then `topology_hiding()`) is already handled: `delete_existing_contact()` in `topo_hiding_logic.c:319-336` scans the lump list for existing Contact DEL lumps and neutralizes them. No equivalent guard exists in `fix_nated_contact_f()`.

**Solution**

Add a helper function `contact_already_rewritten()` that scans `msg->add_rm` for a prior `LUMP_DEL` of type `HDR_CONTACT_T` whose offset and length fully encompass the current Contact URI. This detects when another function (such as `topology_hiding()`) has already scheduled the Contact for rewriting.

A new module parameter `nated_contact_override` controls the behavior when a conflict is detected:

- `0` (default): skip this Contact — the prior rewrite stands. `fix_nated_contact()` returns without creating lumps for this Contact.
- `1`: override — neutralize the prior lump by setting `op = LUMP_NOP` and inserting `COND_FALSE` guards on its `before`/`after` chains (the same technique used by `delete_existing_contact()` in `topo_hiding_logic.c:331-334`). `fix_nated_contact()` then proceeds to create its own replacement.

Design notes:

- The check uses `continue` (not `return`) inside the `get_contact_uri()` loop, so only conflicting Contacts are affected; uncovered Contacts in sibling headers are processed normally.
- The lump scan exploits the sort-by-offset invariant maintained by `del_lump()` (`data_lump.c:369-377`) for early exit: once we see a DEL lump with offset past the URI start, no later lump can fully cover the URI.
- No locking is needed: `msg->add_rm` is per-process `pkg` memory owned by a single worker, processed sequentially in the routing script. This is the same concurrency model used by `delete_existing_contact()`.
- The coverage test (`crt->u.offset <= uri_off && crt->u.offset + crt->len >= uri_end`) intentionally requires full containment. Partial-overlap lumps (e.g., from a prior `fix_nated_contact()` call) are not matched — that case is already handled by the existing "URI outside buffer" check at `nathelper.c:703`.

**Compatibility**

- Default `nated_contact_override=0` preserves the current effective behavior: when `topology_hiding()` runs first, its Contact wins. The only change is that the concatenation bug is eliminated.
- No changes to core lump processing (`msg_translator.c`, `data_lump.c`). All changes are localized to the nathelper module.
- The detection is general: any `HDR_CONTACT_T` `LUMP_DEL` fully covering the URI will be detected, not only those from `topology_hiding()`. This is intentional and consistent with `delete_existing_contact()`'s general approach.
- Module documentation for the new parameter is included in `nathelper_admin.xml`.

**Closing issues**

closes #2172