### PR TITLE
#3798 Don't require certificate for TLS clients

### DIFF
--- a/modules/tls_openssl/openssl_config.c
+++ b/modules/tls_openssl/openssl_config.c
@@ -831,14 +831,16 @@ int openssl_init_tls_dom(struct tls_domain *d, int init_flags)
 		}
 
 		/*
-		 * load certificate
+		 * load certificate (optional for client domains per RFC 8446 4.4.2.4)
 		 */
-		if (!(d->flags & DOM_FLAG_DB) || init_flags & TLS_DOM_CERT_FILE_FL) {
-			if (load_certificate(((void**)d->ctx)[i], d->cert.s) < 0)
-				return -1;
-		} else
-			if (load_certificate_db(((void**)d->ctx)[i], &d->cert) < 0)
-				return -1;
+		if (d->cert.s) {
+			if (!(d->flags & DOM_FLAG_DB) || init_flags & TLS_DOM_CERT_FILE_FL) {
+				if (load_certificate(((void**)d->ctx)[i], d->cert.s) < 0)
+					return -1;
+			} else
+				if (load_certificate_db(((void**)d->ctx)[i], &d->cert) < 0)
+					return -1;
+		}
 
 		/**
 		 * load crl from directory

--- a/modules/tls_wolfssl/wolfssl_config.c
+++ b/modules/tls_wolfssl/wolfssl_config.c
@@ -532,12 +532,15 @@ int _wolfssl_init_tls_dom(struct tls_domain *d, int init_flags)
 		goto end;
 	}
 
-	if (!(d->flags & DOM_FLAG_DB) || init_flags & TLS_DOM_CERT_FILE_FL) {
-		if (load_certificate(d->ctx, d->cert.s) < 0)
-			goto end;
-	} else {
-		if (load_certificate_db(d->ctx, &d->cert) < 0)
-			goto end;
+	/* load certificate (optional for client domains per RFC 8446 4.4.2.4) */
+	if (d->cert.s) {
+		if (!(d->flags & DOM_FLAG_DB) || init_flags & TLS_DOM_CERT_FILE_FL) {
+			if (load_certificate(d->ctx, d->cert.s) < 0)
+				goto end;
+		} else {
+			if (load_certificate_db(d->ctx, &d->cert) < 0)
+				goto end;
+		}
 	}
 
 	if (d->crl_directory && load_crl(d->ctx, d->crl_directory,


### PR DESCRIPTION
**Summary**
Implements a fix for https://github.com/OpenSIPS/opensips/issues/3798 

**Details**
OpenSIPS requires a certificate when configuring a client_domain, even if mTLS is not required. As a result it's easiest to use the server certificate. However, this means that OpenSIPS will send this certificate (these will be without a clientAuth EKU) if the server requests a client certificate. It should be possible to establish the connection without the Client Certificate (see RFC 8446 4.4.2.4 and RFC 5426 7.4.6 ("If no suitable certificate is available, the client MUST send a certificate message containing no certificates. That is, the certificate_list structure has a length of zero")

**Solution**

Server domains: Continue to require certificates (using defaults if not specified), should be no change to behaviour here. 

Client domains: Can now be configured without certificate and private_key parameters.

When the destination TLS server requests a client certificate but one isn't configured, an empty certificate message is sent per RFC 8446 / 5246 

**Compatibility**
Tested with OpenSIPS 3.6 + LibreSSL 3.3.6
Not tested with WolfSSL

**Closing issues**
Closes #3798 
