### PR TITLE
Add support to use JWK format of public keys in the OpenSIPS script for JWT authentication

### DIFF
--- a/modules/auth_jwt/auth_jwt_certops.c
+++ b/modules/auth_jwt/auth_jwt_certops.c
@@ -25,13 +25,69 @@
 #include "../../usr_avp.h"
 #include "../../mod_fix.h"
 #include "../../mem/mem.h"
+#include "../../ut.h"
 
 #include <openssl/bio.h>
+#include <openssl/bn.h>
 #include <openssl/err.h>
 #include <openssl/pem.h>
+#include <openssl/rsa.h>
 #include <openssl/x509.h>
 
 #include "../tls_mgm/api.h"
+
+static inline int decode_base64url_nopad(str *in, str *out)
+{
+	char *padded = NULL;
+	int i;
+	int pad_len, dec_len;
+
+	if (!in || !in->s || in->len <= 0)
+		return -1;
+
+	for (i = 0; i < in->len; i++) {
+		if ((in->s[i] >= 'A' && in->s[i] <= 'Z') ||
+				(in->s[i] >= 'a' && in->s[i] <= 'z') ||
+				(in->s[i] >= '0' && in->s[i] <= '9') ||
+				in->s[i] == '-' || in->s[i] == '_')
+			continue;
+		LM_ERR("invalid base64url input\n");
+		return -1;
+	}
+
+	pad_len = (4 - (in->len % 4)) % 4;
+	padded = pkg_malloc(in->len + pad_len);
+	if (!padded) {
+		LM_ERR("no more pkg memory for padded b64 input\n");
+		return -1;
+	}
+
+	memcpy(padded, in->s, in->len);
+	if (pad_len)
+		memset(padded + in->len, '=', pad_len);
+
+	out->len = calc_max_base64_decode_len(in->len + pad_len);
+	out->s = pkg_malloc(out->len);
+	if (!out->s) {
+		LM_ERR("no more pkg memory for b64 output\n");
+		pkg_free(padded);
+		return -1;
+	}
+
+	dec_len = base64urldecode((unsigned char *)out->s,
+			(unsigned char *)padded, in->len + pad_len);
+	pkg_free(padded);
+
+	if (dec_len <= 0) {
+		pkg_free(out->s);
+		out->s = NULL;
+		out->len = 0;
+		return -1;
+	}
+
+	out->len = dec_len;
+	return 0;
+}
 
 int extract_pub_key_from_cert(struct sip_msg* _msg, str* cert, 
 		pv_spec_t* pub_key)
@@ -104,4 +160,116 @@ err_free:
 
 	return -1;
 	
+}
+
+int extract_pub_key_from_exp_mod(struct sip_msg* _msg, str* e, str* n,
+		pv_spec_t* pub_key)
+{
+	BIGNUM *e_bn = NULL, *n_bn = NULL;
+	BIO *bio_priv = NULL;
+	EVP_PKEY *pubkey = NULL;
+	RSA *rsa = NULL;
+	str dec_e = {0, 0}, dec_n = {0, 0}, out_pub_key = {0, 0};
+	pv_value_t pv_val;
+
+	if (!e || !n) {
+		LM_ERR("missing exponent/modulus\n");
+		goto err_free;
+	}
+
+	if (decode_base64url_nopad(e, &dec_e) < 0) {
+		LM_ERR("failed to decode exponent\n");
+		goto err_free;
+	}
+
+	if (decode_base64url_nopad(n, &dec_n) < 0) {
+		LM_ERR("failed to decode modulus\n");
+		goto err_free;
+	}
+
+	e_bn = BN_bin2bn((unsigned char *)dec_e.s, dec_e.len, NULL);
+	if (!e_bn) {
+		LM_ERR("failed to convert exponent\n");
+		goto err_free;
+	}
+
+	n_bn = BN_bin2bn((unsigned char *)dec_n.s, dec_n.len, NULL);
+	if (!n_bn) {
+		LM_ERR("failed to convert modulus\n");
+		goto err_free;
+	}
+
+	rsa = RSA_new();
+	if (!rsa) {
+		LM_ERR("failed to allocate RSA key\n");
+		goto err_free;
+	}
+
+	if (RSA_set0_key(rsa, n_bn, e_bn, NULL) != 1) {
+		LM_ERR("failed to set RSA key components\n");
+		goto err_free;
+	}
+	n_bn = NULL;
+	e_bn = NULL;
+
+	pubkey = EVP_PKEY_new();
+	if (!pubkey) {
+		LM_ERR("failed to allocate EVP key\n");
+		goto err_free;
+	}
+
+	if (EVP_PKEY_assign_RSA(pubkey, rsa) != 1) {
+		LM_ERR("failed to assign RSA key to EVP wrapper\n");
+		goto err_free;
+	}
+	rsa = NULL;
+
+	bio_priv = BIO_new(BIO_s_mem());
+	if (bio_priv == NULL) {
+		LM_ERR("Failed to allocate mem for pub key out\n");
+		goto err_free;
+	}
+
+	if (PEM_write_bio_PUBKEY(bio_priv, pubkey) < 0) {
+		LM_ERR("Failed to write mem for pub key out\n");
+		goto err_free;
+	}
+
+	out_pub_key.len = BIO_get_mem_data(bio_priv, &out_pub_key.s);
+	if (out_pub_key.len <= 0) {
+		LM_ERR("Failed to get mem for pub key out\n");
+		goto err_free;
+	}
+
+	pv_val.flags = PV_VAL_STR;
+	pv_val.rs = out_pub_key;
+	if (pv_set_value(_msg, pub_key, 0, &pv_val) != 0) {
+		LM_ERR("Failed to set pub key pvar\n");
+		goto err_free;
+	}
+
+	pkg_free(dec_e.s);
+	pkg_free(dec_n.s);
+	BIO_free(bio_priv);
+	EVP_PKEY_free(pubkey);
+
+	return 1;
+
+err_free:
+	if (dec_e.s)
+		pkg_free(dec_e.s);
+	if (dec_n.s)
+		pkg_free(dec_n.s);
+	if (e_bn)
+		BN_free(e_bn);
+	if (n_bn)
+		BN_free(n_bn);
+	if (rsa)
+		RSA_free(rsa);
+	if (pubkey)
+		EVP_PKEY_free(pubkey);
+	if (bio_priv)
+		BIO_free(bio_priv);
+
+	return -1;
 }

--- a/modules/auth_jwt/auth_jwt_certops.h
+++ b/modules/auth_jwt/auth_jwt_certops.h
@@ -28,3 +28,5 @@
 #endif /* JWTCERTOPS_H */
 
 int extract_pub_key_from_cert(struct sip_msg* _msg, str* cert,pv_spec_t* pub_key);
+int extract_pub_key_from_exp_mod(struct sip_msg* _msg, str* e,
+		str* n, pv_spec_t* pub_key);

--- a/modules/auth_jwt/authjwt_mod.c
+++ b/modules/auth_jwt/authjwt_mod.c
@@ -123,6 +123,11 @@ static const cmd_export_t cmds[] = {
 		{CMD_PARAM_STR, 0, 0},
 		{CMD_PARAM_VAR, fixup_check_outvar, 0}, {0,0,0}},
 		REQUEST_ROUTE},
+	{"extract_pub_key_from_exp_mod", (cmd_function)extract_pub_key_from_exp_mod, {
+		{CMD_PARAM_STR, 0, 0},
+		{CMD_PARAM_STR, 0, 0},
+		{CMD_PARAM_VAR, fixup_check_outvar, 0}, {0,0,0}},
+		REQUEST_ROUTE},
 	{0,0,{{0,0,0}},0}
 };
 

--- a/modules/auth_jwt/doc/auth_jwt_admin.xml
+++ b/modules/auth_jwt/doc/auth_jwt_admin.xml
@@ -472,6 +472,61 @@ if (extract_pub_key_from_cert("$avp(my_certificate)",$avp(my_pub_key))) {
 		</example>
 	</section>
 
+	<section id="func_extract_pub_key_from_exp_mod" xreflabel="extract_pub_key_from_exp_mod()">
+		<title>
+			<function moreinfo="none">extract_pub_key_from_exp_mod(e,n,out_public_key)</function>
+		</title>
+		<para>
+			The function reads a base64url-encoded RSA exponent (<emphasis>e</emphasis>) and modulus (<emphasis>n</emphasis>), then builds a PEM public key and stores it into <emphasis>out_public_key</emphasis>.
+			Return codes are : 
+			<itemizedlist>
+				<listitem>
+				<para>
+					-1 : Failure in extracting the pub key
+				</para>
+				</listitem>
+				<listitem>
+				<para>
+					1 : out_public_key succesfully populated
+				</para>
+				</listitem>
+			</itemizedlist>
+		</para>
+		<para>Meaning of the parameters is as follows:</para>
+		<itemizedlist>
+		<listitem>
+			<para><emphasis>e (string)</emphasis> - Base64url-encoded RSA exponent
+			</para>
+			<para>
+			The string may contain pseudo variables.
+			</para>
+		</listitem>
+		<listitem>
+			<para><emphasis>n (string)</emphasis> - Base64url-encoded RSA modulus
+			</para>
+			<para>
+			The string may contain pseudo variables.
+			</para>
+		</listitem>
+		<listitem>
+			<para><emphasis>out_public_key (pvar)</emphasis> - PVAR used to store the extracted public key
+			</para>
+		</listitem>
+		</itemizedlist>
+		<para>
+		This function can be used from REQUEST_ROUTE.
+		</para>
+		<example>
+		<title><function moreinfo="none">extract_pub_key_from_exp_mod</function> usage</title>
+		<programlisting format="linespecific">
+...
+if (extract_pub_key_from_exp_mod("$avp(my_exp)", "$avp(my_mod)", $avp(my_pub_key))) {
+    xlog("Succesfully extracted public key - $avp(my_pub_key) \n");
+}
+...
+</programlisting>
+		</example>
+	</section>
+
 	</section>
 </chapter>
-


### PR DESCRIPTION
**Summary**
Add support to use JWK format PUB keys in the OpenSIPS script for JWT authentication

**Details**
Many providers ( like https://www.googleapis.com/oauth2/v3/certs ) are using JWK format for specifying the keys that can be used for validating JWTs, which is using exponent & modulus format for the RSA pub key.

**Solution**
Add a new script function, extract_pub_key_from_exp_mod, that can be used for generating the corresponding PEM pub key. jwt_script_authorize can be used later for validating the JWT.

**Compatibility**
Backwards compatible

**Closing issues**
<!-- Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). -->
