### PR TITLE
support for libmongc/libbson version 2

### DIFF
--- a/modules/cachedb_mongodb/Makefile
+++ b/modules/cachedb_mongodb/Makefile
@@ -10,7 +10,9 @@ NAME=cachedb_mongodb.so
 include ../../lib/json/Makefile.json
 ifeq ($(CROSS_COMPILE),)
 MONGOC_BUILDER := $(shell \
-	if pkg-config --exists libmongoc-1.0; then \
+	if pkg-config --exists mongoc2; then \
+		echo 'pkg-config mongoc2'; \
+	elif pkg-config --exists libmongoc-1.0; then \
 		echo 'pkg-config libmongoc-1.0'; \
 	fi)
 endif

--- a/modules/cachedb_mongodb/cachedb_mongodb_dbase.h
+++ b/modules/cachedb_mongodb/cachedb_mongodb_dbase.h
@@ -27,8 +27,8 @@
 
 #define MONGO_HAVE_STDINT 1
 
-#include <mongoc.h>
-#include <bson.h>
+#include <mongoc/mongoc.h>
+#include <bson/bson.h>
 
 #include <stdint.h>
 

--- a/modules/cachedb_mongodb/cachedb_mongodb_json.h
+++ b/modules/cachedb_mongodb/cachedb_mongodb_json.h
@@ -23,7 +23,7 @@
 
 #include "cachedb_mongodb_dbase.h"
 
-#include <bson.h>
+#include <bson/bson.h>
 #include <stdint.h>
 
 int json_to_bson(char *json,bson_t *bb);


### PR DESCRIPTION
* allow libbson-1.0 or **bson2**
* allow libmongoc-1.0 or **mongoc2**

Notice in version 1, `mongoc.h` is a wrapper to `mongoc/mongoc.h`, `bson.h` a wrapper to `bson/bson.h`

The wrappers have been removed in version 2

This may break with very old versions of libbson/libmongoc