### PR TITLE
janus: fix pkg memory leaks in cJSON_Print/cJSON_Parse paths

### DIFF
--- a/modules/janus/janus_common.c
+++ b/modules/janus/janus_common.c
@@ -112,6 +112,10 @@ int janus_raise_event(janus_connection *conn, cJSON *request)
 	}
 
 	full_json = cJSON_Print(request);
+	if (!full_json) {
+		LM_ERR("cJSON_Print failed\n");
+		goto err_free_params;
+	}
 	cJSON_Minify(full_json);
 	full_json_s.s = full_json;
 	full_json_s.len = strlen(full_json);
@@ -191,10 +195,15 @@ int handle_janus_json_request(janus_connection *conn, cJSON *request)
 	}
 
 	full_json = cJSON_Print(request);
+	if (!full_json) {
+		LM_ERR("cJSON_Print failed\n");
+		return 1;
+	}
 	cJSON_Minify(full_json);
 
 	reply->text.s = shm_strdup(full_json);
 	if (reply->text.s == NULL) {
+		pkg_free(full_json);
 		/* we're out of mem, let the requestor timeout, don't disconnect janus */
 		return 1;
 	}

--- a/modules/janus/janus_mod.c
+++ b/modules/janus/janus_mod.c
@@ -208,12 +208,14 @@ static int w_janus_send_request(struct sip_msg *msg, str *janus_id,str *request,
 
 	if ((conn = get_janus_connection_by_id(janus_id)) == NULL) {
 		LM_ERR("Unknown JANUS ID %.*s\n",janus_id->len,janus_id->s);
+		cJSON_Delete(j_request);
 		return -1;
 	}
 
 	LM_DBG("Found our conn, prep to send out %.*s !! \n",request->len,request->s);
 
 	reply_id = janus_ipc_send_request(conn,j_request);
+	cJSON_Delete(j_request);  /* tree was serialized to shm; free pkg copy */
 	if (reply_id == 0) {
 		LM_ERR("Failed to queue request %.*s towards %.*s\n",
 		request->len,request->s,

--- a/modules/janus/janus_proc.c
+++ b/modules/janus/janus_proc.c
@@ -282,13 +282,22 @@ uint64_t janus_ipc_send_request(janus_connection *sock, cJSON *janus_cmd)
 	lock_stop_write(sock->lists_lk);
 
 	full_cmd.s = cJSON_Print(janus_cmd);
+	if (!full_cmd.s) {
+		shm_free(cmd);
+		LM_ERR("cJSON_Print failed (pkg OOM)\n");
+		return 0;
+	}
 	full_cmd.len = strlen(full_cmd.s);
 
 	if (shm_nt_str_dup(&cmd->janus_cmd, &full_cmd) != 0) {
+		pkg_free(full_cmd.s);
 		shm_free(cmd);
 		LM_ERR("oom\n");
 		return 0;
 	}
+
+	/* cJSON_Print() allocates from pkg via module hooks; free after shm copy */
+	pkg_free(full_cmd.s);
 
 	janus_transaction_id = cmd->janus_transaction_id;
 


### PR DESCRIPTION
**Summary**

Fix three pkg memory leaks and a potential NULL dereference crash in the janus module's cJSON usage paths.

**Details**

The janus module uses `cJSON_InitHooks()` to route all cJSON allocations through `pkg_malloc`. Three call sites had missing cleanup that leaked pkg memory on every `janus_send_request()` call (~350 bytes/request total). Under sustained load, the SIP worker pkg pool is exhausted, causing `cJSON_Print()` to return NULL and a subsequent `strlen(NULL)` crash.

Found during stress testing of the fragmentation fix for #3712 — the memory leaks are independent of the fragmentation issue.

**Solution**

1. **`janus_ipc_send_request()` in `janus_proc.c`**: `cJSON_Print()` allocates from the SIP worker's pkg pool. The result was copied to shm via `shm_nt_str_dup()` but the original was never freed. Added `pkg_free(full_cmd.s)` after the shm copy and a NULL check before `strlen()`.

2. **`w_janus_send_request()` in `janus_mod.c`**: `cJSON_Parse()` builds a cJSON tree from pkg. The tree was serialized and sent via IPC but `cJSON_Delete()` was never called. Added cleanup after `janus_ipc_send_request()` returns and on the `get_janus_connection_by_id()` error path.

3. **`janus_common.c`**: Added NULL checks after `cJSON_Print()` in `janus_raise_event()` and `handle_janus_json_request()`. Fixed missing `pkg_free(full_json)` on the `shm_strdup()` failure path.

Verified with 100k messages — zero pkg memory growth across all SIP workers (MI `pkmem:` stats flat at 228.3 kB).

**Compatibility**

No behavioral changes for correct inputs. Error paths that previously crashed now return appropriate error codes.

**Closing issues**

Related to #3712 (the memory leaks surface under sustained janus module usage)