### PR TITLE
tls_openssl: fix per-thread state double-free across fork()

### DIFF
--- a/modules/tls_openssl/openssl.c
+++ b/modules/tls_openssl/openssl.c
@@ -29,6 +29,7 @@
 #include <openssl/opensslv.h>
 #include <openssl/err.h>
 #include <openssl/rand.h>
+#include <pthread.h>
 
 #include "../../dprint.h"
 #include "../../mem/shm_mem.h"
@@ -159,6 +160,30 @@ static int mod_load(void)
 static void openssl_on_exit(int status, void *param)
 {
 	_exit(status);
+}
+#endif
+
+#if OPENSSL_VERSION_NUMBER >= 0x10100000L
+/*
+ * Clean up OpenSSL per-thread state (ERR_STATE, DRBG, etc.) in the parent
+ * process before fork().  CRYPTO_set_mem_functions() routes all OpenSSL
+ * allocations to shared memory, but per-thread structures use thread-local
+ * storage pointers that are inherited across fork().  Without this cleanup,
+ * child processes inherit a stale pointer to the parent's per-thread state
+ * in shared memory; if the parent frees or re-creates that state, the
+ * child's next OpenSSL call triggers a double-free (detected by
+ * QM_MALLOC_DBG as SIGABRT).
+ *
+ * After OPENSSL_thread_stop(), the thread-local pointer is NULL.  Both
+ * parent and child lazily allocate fresh per-thread state on the next
+ * OpenSSL call.
+ *
+ * This complements the on_exit(_exit) workaround above, which prevents the
+ * same class of double-free at process *exit* time.
+ */
+static void openssl_pre_fork(void)
+{
+	OPENSSL_thread_stop();
 }
 #endif
 
@@ -295,6 +320,13 @@ static int mod_init(void)
 
 #ifdef __OPENSSL_ON_EXIT
 	on_exit(openssl_on_exit, NULL);
+#endif
+
+#if OPENSSL_VERSION_NUMBER >= 0x10100000L
+	if (pthread_atfork(openssl_pre_fork, NULL, NULL) != 0) {
+		LM_ERR("failed to register atfork handler for OpenSSL cleanup\n");
+		return -1;
+	}
 #endif
 
 	return 0;


### PR DESCRIPTION
## Summary

OpenSIPS crashes with SIGABRT during child process initialization when
`tls_openssl` is loaded and any module triggers OpenSSL operations before
`fork()` (e.g., `cachedb_redis` with `use_tls=1`).

```
CRITICAL:core:qm_free_dbg: freeing already freed pointer,
  first free: ../crypto/err/err_local.h: os_free(93) - aborting
```

## Details

`mod_load()` calls `CRYPTO_set_mem_functions(os_malloc, os_realloc, os_free)`,
routing all OpenSSL allocations to shared memory. OpenSSL's per-thread
structures (`ERR_STATE`, DRBG) are allocated in shared memory but referenced
via thread-local storage pointers (created internally by `pthread_key_create`).

After `fork()`, child processes inherit the parent's thread-local pointer to
the shared-memory `ERR_STATE`. If the parent frees or re-creates that state
between forks, the child's next OpenSSL call operates on a stale pointer,
causing a double-free. The debug allocator (`Q_MALLOC_DBG`) detects this as
SIGABRT; release builds may silently corrupt the heap.

The existing `on_exit(_exit)` handler (line 158) prevents the same class of
double-free at process *exit* time but does not cover process *init*.

## Solution

Register a `pthread_atfork` prepare handler that calls `OPENSSL_thread_stop()`
in the parent before each `fork()`. This frees the per-thread OpenSSL state
and NULLs the thread-local pointer. After `fork()`, both parent and child
lazily allocate fresh per-thread state on their next OpenSSL call.

The handler is guarded by `OPENSSL_VERSION_NUMBER >= 0x10100000L` since
`OPENSSL_thread_stop()` was introduced in OpenSSL 1.1.0.

Changes are limited to `modules/tls_openssl/openssl.c` (25 lines added,
0 lines modified).

### Testing

Tested on OpenSIPS 4.0-dev (commit 397a6b115) with OpenSSL 3.0.15 on
Debian 12, built with `Q_MALLOC_DBG`.

**Without fix:** Immediate SIGABRT on startup. All worker processes crash.

**With fix:**

SIP TLS functional tests (16/16 passed):
- TLS handshake + OPTIONS (TLSv1.2, ECDHE-RSA-AES256-GCM-SHA384)
- Full INVITE/ACK/BYE call flow over TLS
- 5 concurrent TLS connections
- 10-call TLS INVITE burst (10/10 OK)
- SIP TLS + Redis TLS coexistence (cache_store/fetch/remove via MI)
- SIP-to-Redis roundtrip (INVITE over TLS triggers Redis store, values verified)

Memory leak test (500 SIP TLS + 500 Redis TLS + 200 mixed cycles):
- Shared memory growth: -1 KB
- SHM fragment growth: 0
- Total RSS growth: +60 KB (within noise)
- All 10 processes alive after test

Redis TLS environment: 3-node Redis 8.0.2 cluster (`port 0`, `tls-port 6379`,
`tls-auth-clients yes`) using `tls_mgm` client domain.

## Compatibility

No breaking changes. The `pthread_atfork` handler is additive — it cleans up
state that was previously left dangling. Modules not using OpenSSL before
`fork()` are unaffected (`OPENSSL_thread_stop()` is a no-op if no per-thread
state exists).

The `on_exit(_exit)` handler remains unchanged and continues to cover the
process-exit case.