### PR TITLE
cachedb_redis: fix NULL deref when redisConnect returns NULL

### DIFF
--- a/modules/cachedb_redis/cachedb_redis_dbase.c
+++ b/modules/cachedb_redis/cachedb_redis_dbase.c
@@ -58,7 +58,7 @@ static unsigned int redis_calc_escaped_len_json(str *s);
 redisContext *redis_get_ctx(char *ip, int port)
 {
 	struct timeval tv;
-	static char warned = 0;
+	static int warned = 0;
 	redisContext *ctx;
 
 	if (!port)
@@ -76,6 +76,12 @@ redisContext *redis_get_ctx(char *ip, int port)
 	if (ctx && ctx->err != REDIS_OK) {
 		LM_ERR("failed to open redis connection %s:%hu - %s\n",ip,
 				(unsigned short)port,ctx->errstr);
+		return NULL;
+	}
+
+	if (!ctx) {
+		LM_ERR("failed to connect to redis %s:%hu - out of memory\n",
+				ip, (unsigned short)port);
 		return NULL;
 	}
 


### PR DESCRIPTION
## Summary

`redis_get_ctx()` can dereference a NULL pointer when `redisConnect()` or
`redisConnectWithTimeout()` returns NULL due to allocation failure.

## Details

The existing check handles the case where `ctx` is non-NULL but has an
error (`ctx->err != REDIS_OK`). When `ctx` is NULL, the check is skipped
and execution falls through to `redisSetTimeout(ctx, tv)`, which
dereferences the NULL pointer.

## Solution

Add an explicit NULL check after the existing error-code check. Also
changes the `warned` flag from `char` to `int` to avoid undefined
behavior on signed overflow after 127 connection-timeout warnings.

## Compatibility

No breaking changes. Adds a NULL guard that was previously missing.