### PR TITLE
CI/rtp.io: handle "/" in branch names (i.e feature/xyz) correctly

### DIFF
--- a/.github/workflows/.rtp.io.yml
+++ b/.github/workflows/.rtp.io.yml
@@ -48,7 +48,8 @@ jobs:
         BUILD_MATRIX="`echo ${PLATFORMS} | tr ',' '\n'  | jq -R . | jq -s . | tr '\n' ' '`"
         GIT_BRANCH="${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}"
         GIT_BRANCH="${GIT_BRANCH#refs/tags/}"
-        BUILD_IMAGE="${{ inputs.ghcr-repo }}:rtp.io-${{ inputs.rtpp-tag }}-${GIT_BRANCH}"
+        BI_BRANCH="`echo ${GIT_BRANCH} | sed 's~/~_~g'`"
+        BUILD_IMAGE="${{ inputs.ghcr-repo }}:rtp.io-${{ inputs.rtpp-tag }}-${BI_BRANCH}"
         echo "Platforms: ${PLATFORMS}"
         for _p in `echo ${PLATFORMS} | tr ',' '\n'`; \
         do \

--- a/scripts/build/start_container.sh
+++ b/scripts/build/start_container.sh
@@ -16,6 +16,7 @@ then
   ${SUDO} apt-get install -y docker.io
 fi
 docker run --rm --privileged tonistiigi/binfmt:latest -install all
+docker run --privileged --rm tonistiigi/binfmt --version
 docker run --cidfile /tmp/docker_opensips.cid -d --restart=always \
  --platform linux/${DOCKR_PLATFORM} -v sources:`pwd` "${BUILD_OS}" \
  tail -f /dev/null


### PR DESCRIPTION
**Summary**

CI/rtp.io: handle "/" in branch names (i.e feature/xyz) correctly

**Details**

This pull request makes minor adjustments to Docker-related build scripts and workflow configuration. The changes improve image tagging for branch names containing slashes and add a version check for the `binfmt` tool.

Docker build and workflow improvements:

* Updated the image tagging logic in `.github/workflows/.rtp.io.yml` to replace slashes in branch names with underscores, preventing issues with Docker image tags. Fixes:
  https://github.com/OpenSIPS/opensips/actions/runs/22914875002/job/66498568285#step:8:201

* Added a command in `scripts/build/start_container.sh` to display the version of `tonistiigi/binfmt`, ensuring clarity about the installed tool version.

**Compatibility**
None

**Closing issues**
None
