### PR TITLE
cachedb_redis: fix safety issues in cluster redirect parsing

### DIFF
--- a/modules/cachedb_redis/cachedb_redis_dbase.c
+++ b/modules/cachedb_redis/cachedb_redis_dbase.c
@@ -565,29 +565,24 @@ static int _redis_run_command(cachedb_con *connection, redisReply **rpl, str *ke
 					node->context->errstr);
 
 				if (match_prefix(reply->str, reply->len, MOVED_PREFIX, MOVED_PREFIX_LEN)) {
-    					// It's a MOVED response
-					redis_moved *moved_info = pkg_malloc(sizeof(redis_moved));
-						if (!moved_info) {
-						LM_ERR("cachedb_redis: Unable to allocate redis_moved struct, no more pkg memory\n");
-							freeReplyObject(reply);
-							reply = NULL;
-							goto try_next_con;
-					} else {
-							if (parse_moved_reply(reply, moved_info) < 0) {
-							LM_ERR("cachedb_redis: Unable to parse MOVED reply\n");
-							pkg_free(moved_info);
-							moved_info = NULL;
-								freeReplyObject(reply);
-							goto try_next_con;
-						}
+					/* MOVED response */
+					redis_moved moved_info_s;
+					redis_moved *moved_info = &moved_info_s;
 
-						LM_DBG("cachedb_redis: MOVED slot: [%d] endpoint: [%.*s] port: [%d]\n", moved_info->slot, moved_info->endpoint.len, moved_info->endpoint.s, moved_info->port);
-						node = get_redis_connection_by_endpoint(con, moved_info);
-
-						pkg_free(moved_info);
-						moved_info = NULL;
+					if (parse_moved_reply(reply, moved_info) < 0) {
+						LM_ERR("failed to parse MOVED reply\n");
 						freeReplyObject(reply);
 						reply = NULL;
+						goto try_next_con;
+					}
+
+					LM_DBG("MOVED slot=%d endpoint=%.*s:%d\n",
+						moved_info->slot, moved_info->endpoint.len,
+						moved_info->endpoint.s, moved_info->port);
+					node = get_redis_connection_by_endpoint(con, moved_info);
+
+					freeReplyObject(reply);
+					reply = NULL;
 
 						if (node == NULL) {
 							LM_ERR("Unable to locate connection by endpoint\n");
@@ -603,9 +598,8 @@ static int _redis_run_command(cachedb_con *connection, redisReply **rpl, str *ke
 							}
 						}
 
-						i = QUERY_ATTEMPTS; // New node that is the target being MOVED to, should have the attempts reset
+						i = QUERY_ATTEMPTS;
 						continue;
-					}
 				}
 
 				freeReplyObject(reply);

--- a/modules/cachedb_redis/cachedb_redis_utils.c
+++ b/modules/cachedb_redis/cachedb_redis_utils.c
@@ -394,6 +394,7 @@ int parse_moved_reply(redisReply *reply, redis_moved *out) {
 	while (p < end && *p >= '0' && *p <= '9') {
 		slot = slot * 10 + (*p - '0');
 		p++;
+		if (slot > 16383) return ERR_INVALID_SLOT;
 	}
 	if (slot == 0 && (p == reply->str + MOVED_PREFIX_LEN || *(p - 1) < '0' || *(p - 1) > '9'))
 		return ERR_INVALID_SLOT;
@@ -426,11 +427,12 @@ int parse_moved_reply(redisReply *reply, redis_moved *out) {
 			while (p < end && *p >= '0' && *p <= '9') {
 				port = port * 10 + (*p - '0');
 				p++;
+				if (port > 65535) return ERR_INVALID_PORT;
 			}
 			if (port < 0 || port > 65535 || port_start == p)
 				return ERR_INVALID_PORT;
 		}
-	} else if (out->endpoint.s < end) {
+	} else if (p < end) {
 		out->endpoint.s = host_start;
 		out->endpoint.len = end - host_start;
 	}


### PR DESCRIPTION
## Summary

Fix several correctness and safety issues in `parse_moved_reply()` and the MOVED redirect handler.

## Details

**Integer overflow in slot parsing** — the digit accumulation loop `slot = slot * 10 + (*p - '0')` has no upper bound check. A malformed MOVED reply with a long digit string causes signed integer overflow (undefined behavior in C). Fixed by returning `ERR_INVALID_SLOT` when `slot > 16383` during parsing.

**Integer overflow in port parsing** — same issue in the port digit loop. The existing post-loop check `port > 65535` is insufficient because signed overflow is UB before the check executes. Fixed by returning `ERR_INVALID_PORT` when `port > 65535` during digit accumulation.

**Undefined behavior in no-colon fallback** — when the endpoint has no colon (no explicit port), the code compares `out->endpoint.s < end` where `out->endpoint.s` was set to `NULL` two lines above. Comparing a null pointer to a non-null pointer is undefined behavior per the C standard. Fixed by using `p < end` instead, which holds the correct scan position.

**Unnecessary heap allocation** — the `redis_moved` struct in the MOVED handler is heap-allocated via `pkg_malloc` and freed within the same scope. Since the struct is ~24 bytes and never outlives the enclosing block, this is replaced with stack allocation, eliminating the `pkg_malloc`/`pkg_free` calls and the OOM error path.

## Compatibility

No behavioral change for correctly-formed Redis replies. The overflow checks add early rejection of malformed input that would previously have caused undefined behavior.

## Closing issues

Partially addresses #2811