### PR TITLE
drouting: fix random GW selection when all weights are zero

### DIFF
--- a/modules/drouting/drouting.c
+++ b/modules/drouting/drouting.c
@@ -2997,9 +2997,9 @@ static int weight_based_sort(pgw_list_t *pgwl, int size, unsigned short *idx)
 				// return -1;
 			}
 		} else {
-			/* randomly select index */
-			//	i = (unsigned int)((size-first)*((double)rand()/((double)RAND_MAX)));
-			i = first;
+			/* all remaining gateways have weight 0, treat them as equal
+			   and randomly select one with uniform distribution */
+			i = first + (unsigned int)((size - first) * ((double)rand() / ((double)RAND_MAX + 1.0)));
 		}
 		LM_DBG("selecting element %d with weight %d\n",
 				idx[i], pgwl[ idx[i] ].weight);


### PR DESCRIPTION
## Summary

Fix the `weight_based_sort()` function in the **drouting** module so that gateways with weight 0 are selected randomly with uniform distribution, instead of always picking the first one.

## Details

When all remaining gateways in a routing group have `weight == 0`, the total `weight_sum` becomes 0. In this case the code fell through to an `else` branch that was supposed to randomly pick one of the equally-weighted gateways. However the random selection line was commented out and replaced with `i = first;`, which deterministically selected the first gateway every time.

This means that in any drouting rule where **all** gateways have weight 0 (or where the remaining unselected gateways all have weight 0), traffic was never distributed — it always went to the same gateway.

## Solution

Restore and correct the random selection in the `else` branch of `weight_based_sort()`:

```c
i = first + (unsigned int)((size - first) * ((double)rand() / ((double)RAND_MAX + 1.0)));
```

Key points:
- The `+ first` offset ensures we only pick among the remaining (not yet sorted) gateways.
- The `+ 1.0` on `RAND_MAX` prevents an out-of-bounds index when `rand() == RAND_MAX` (the result stays strictly in `[first, size-1]`).

## Compatibility

No configuration or API changes. The fix only affects the runtime behavior of weight-based gateway selection when `weight_sum == 0`, restoring the intended uniform random distribution. Existing configurations with non-zero weights are completely unaffected.

## Closing issues

Closes https://github.com/OpenSIPS/opensips/issues/3863