### PR TITLE
opentelemetry: support building on non-x86 architectures

### DIFF
--- a/modules/opentelemetry/opentelemetry.cpp
+++ b/modules/opentelemetry/opentelemetry.cpp
@@ -52,8 +52,16 @@ namespace otelotlp = opentelemetry::exporter::otlp;
 #ifdef __cplusplus
 /* Relax C-only headers for C++ compilation. */
 #define class class_keyword
-#undef HAVE_STDATOMIC
 #undef HAVE_GENERICS
+/* atomic.h defines atomic_t using the C11 keyword `_Atomic(T)` when
+ * HAVE_STDATOMIC is set. `_Atomic` is C-only and not valid in C++, so
+ * we shim it to std::atomic<T> for this C++ translation unit. With
+ * the shim, atomic.h's typedef resolves as
+ *     typedef std::atomic<unsigned long> atomic_t;
+ * on every architecture. HAVE_STDATOMIC itself is set by Makefile.defs
+ * or compiler auto-detection, so no change to its value is needed here. */
+#include <atomic>
+#define _Atomic(T) std::atomic<T>
 #endif
 
 extern "C" {


### PR DESCRIPTION
Building the new opentelemetry module on aarch64 (Jetson Thor, Debian trixie, GCC 14) fails with:

    pt.h:92:9: error: 'atomic_t' does not name a type

Looking into it, this turns out to be an issue on every non-x86 architecture, not just aarch64.

Root cause

opentelemetry.cpp is a C++ translation unit, but it includes C headers from the core (pt.h, statistics.h, ...). Those headers reach atomic.h, which defines atomic_t two different ways:

  1. When HAVE_STDATOMIC is set, via the C11 keyword: typedef _Atomic(unsigned long) atomic_t;
  2. Otherwise, via a hand-rolled fallback: typedef struct { volatile unsigned long counter; } atomic_t;

`_Atomic` is a C-only keyword and is not part of C++. The module currently undef's HAVE_STDATOMIC at the top of the C++ source so that atomic.h takes path (2). That works on __CPU_i386 and __CPU_x86_64, which are the architectures where atomic.h provides the fallback typedef. On aarch64, arm, ppc, mips, riscv, s390x, and others, atomic.h has no fallback, so atomic_t ends up undefined and every header that references it (pt.h, statistics.h) fails to compile.

Proposed approach

Rather than undef'ing HAVE_STDATOMIC — which forces a path that does not exist for most architectures — another option is to keep HAVE_STDATOMIC in whatever state the build system picked (it is set by Makefile.defs or compiler auto-detection as appropriate) and shim the C11 `_Atomic(T)` keyword to std::atomic<T> for this C++ translation unit:

    #ifdef __cplusplus
    #include <atomic>
    #define _Atomic(T) std::atomic<T>
    #endif

atomic.h's typedef now resolves to `std::atomic<unsigned long> atomic_t` under C++ on every architecture.

Why this should be ABI-safe

`std::atomic<T>` and C11 `_Atomic(T)` have identical memory layout on every GCC/Clang target that supports both — it is a guarantee of the standard library implementation (std::atomic<T> is `alignas(T) T` when T is lock-free, which mirrors _Atomic(T)). The C headers only ever treat atomic_t as an opaque type — they take its address and pass it to helper functions like atomic_inc() / atomic_set(), and they never read .counter directly from a C++ compile unit. So even though the C side may see path (2)'s struct layout and the C++ side now sees std::atomic<T>'s layout, the two interoperate correctly because neither side reaches into the other's representation.

If the maintainers prefer a different approach (for example, extending atomic.h with a fallback for the remaining architectures), we are happy to adjust.

Tested on
  - aarch64 (Jetson Thor, Debian trixie, GCC 14): the original failure is gone; opentelemetry.so builds and loads into a running OpenSIPS; spans export to an OTLP/HTTP collector; SIP attributes (sip.method, sip.call_id, sip.ruri, net.peer.ip, ...) populate correctly on spans produced by request and event routes.
  - x86_64 (Debian trixie, GCC 14.2.0): no regression. The module still builds and links cleanly against the Debian-packaged opentelemetry-cpp 1.19.0 and libabsl-dev.

<!--
Thanks for submitting a pull request!
In order to consider and evaluate your PR, it is mandatory to provide detailed information about (1) what is the issue the PR addresses, (2) how the PR is solving the issue (logic and coding), (3) what are (if any) limitations of the proposed PR and (4) if there are any known side-effects/ backward compatibility issues/SIP interoperability issues.
Note that if the PR is missing information, it might take longer to be merged, as extra resources have to be allocated by the maintainers to reverse engineer the changes, understand them, understand the motivation, etc. That is why it is important to provide as much information as possible.
-->

**Summary**
<!-- Summary of the PR - what the PR is aiming to solve -->

**Details**
<!--
Details about the content of the PR - is it a bug fix, a new feature or perhaps a hack? Explain the **motivation** for making this change.
What existing problem does the pull request solve? Is this a particular problem (i.e. only some particular scenarios are affected, only some UACs, etc) or a generic one?
Do not assume others understand what you're trying to do and provide as much information as you may have.
-->

**Solution**
<!-- Explain how your PR fixes the problem. Are there any remaining concerns that might need to be addressed? -->

**Compatibility**
<!-- Does your change break other scenarios, or do they need to be migrated in order to work similarly? -->

**Closing issues**
<!-- Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). -->
