### PR TITLE
net/tcp: close write-worker fd on async write error (fix #3711)

### DIFF
--- a/net/net_tcp_proc.c
+++ b/net/net_tcp_proc.c
@@ -308,6 +308,7 @@ again:
 						"handle write, err, state: %d, att: %d",
 						con->state, con->msg_attempts);
 					tcpconn_release_error(con, 1,"Write error");
+					close(s); /* we always close the socket received for writing */
 					break;
 				} else if (resp==1) {
 					sh_log(con->hist, TCP_SEND2MAIN,


### PR DESCRIPTION
Problem

  **Issue #3711 reports fd leaks when TLS connections fail to establish. PR #3634 fixed the immediate failure path (n < 0 — cert verify error returned synchronously), but a second path still leaks: the async handshake timeout path (n = 0).**

  **Root cause**

  When tls_async_connect returns 0 (handshake timer fired), the connection is queued via ASYNC_WRITE_GENW and handed to the TCP write worker. The worker receives fd s via SCM_RIGHTS — an independent fd copy — then calls tls_async_write, which fails and returns -1.

  In handle_io's IO_WATCH_WRITE handler (net/net_tcp_proc.c), the resp < 0 branch breaks before reaching the close(s) that success/pending paths hit:

  tcpconn_release_error(con, 1,"Write error");
  break;  // ← jumps past close(s) below
  // ...
  close(s);  // only success/pending paths reach here

  tcpconn_release_error() signals main to close main's copy. The worker's copy s is never closed → one fd leaked per failed async write.

  Fix

  Single line, cherry-pick of master commit bffcf0035:

  tcpconn_release_error(con, 1,"Write error");
  close(s); /* we always close the socket received for writing */
  break;

  Verification on 3.4.14

  Mock server accepts TCP but withholds TLS data (forces tls_async_handshake_timeout to fire):

A server presenting an untrusted cert (immediate SSL error) hits the n < 0 path covered by #3634 and does not reproduce this leak. The mock server must hold TCP open without completing TLS to trigger the timeout path.

  Scope : Master already has this via bffcf0035. Backport to 3.4. Same fix likely needed in 3.5.x/3.6.x.
