### PR TITLE
dialog: fix documentation for load_dialog_ctx()

### DIFF
--- a/modules/dialog/doc/dialog_admin.xml
+++ b/modules/dialog/doc/dialog_admin.xml
@@ -1961,7 +1961,7 @@ if ( get_dialogs_by_profile("caller",$fU,$avp(dlg_jsons),$avp(dlg_no)) ) {
 			</para>
 		</listitem>
 		<listitem>
-			<para><emphasis>id_type (integer,optional)</emphasis> - if
+			<para><emphasis>active_only (integer,optional)</emphasis> - if
 			set to something different than <emphasis>0</emphasis>,
 			it only considers active dialogs - dialogs that are not
 			deleted.


### PR DESCRIPTION
Fix documentation for the third parameter of load_dialog_ctx( dialog [, id_type] [, active_only]).
