### PR TITLE
dialog: enhance debug logs

### DIFF
--- a/lib/dbg/struct_hist.h
+++ b/lib/dbg/struct_hist.h
@@ -49,7 +49,7 @@
  *    remain available inside the global history list for a while
  */
 
-#define MAX_SHLOG_SIZE 80 /* longer log lines will get truncated */
+#define MAX_SHLOG_SIZE 128 /* longer log lines will get truncated */
 
 /**
  * To be freely extended by any piece of OpenSIPS code which makes use of

--- a/modules/dialog/dlg_hash.h
+++ b/modules/dialog/dlg_hash.h
@@ -302,11 +302,11 @@ void destroy_dlg(struct dlg_cell *dlg);
 
 #ifdef DBG_DIALOG
 #define DBG_REF(dlg, cnt) \
-	sh_log((dlg)->hist, DLG_REF, "h=%d, ref %d with +%d", \
-	       (dlg)->h_entry, (dlg)->ref, (cnt));
+	sh_log((dlg)->hist, DLG_REF, "h=%d, state=%d, flags=0x%x, ref %d with +%d", \
+	       (dlg)->h_entry, (dlg)->state, (dlg)->flags, (dlg)->ref, (cnt));
 #define DBG_UNREF(dlg, cnt) \
-	sh_log((dlg)->hist, DLG_UNREF, "h=%d, unref %d with -%d", \
-	       (dlg)->h_entry, (dlg)->ref, (cnt));
+	sh_log((dlg)->hist, DLG_UNREF, "h=%d, state=%d, flags=0x%x, unref %d with -%d", \
+	       (dlg)->h_entry, (dlg)->state, (dlg)->flags, (dlg)->ref, (cnt));
 #define DBG_FLUSH(dlg) sh_flush((dlg)->hist)
 #else
 #define DBG_REF(dlg, cnt)


### PR DESCRIPTION
Adding dlg state and dlg flags to sh_log for better troubleshooting.
Increasing the size of the sh_log to avoid logs being truncated.