### PR TITLE
Fix sip instance in REGISTER reply

### DIFF
--- a/modules/registrar/reply.c
+++ b/modules/registrar/reply.c
@@ -163,7 +163,7 @@ static inline unsigned int calc_buf_len(ucontact_t* c,int build_gruu,
 				/* sip.instance */
 				len += SIP_INSTANCE_SIZE
 					+ 1 /* quote */
-					+ (c->instance.len - 2)
+					+ c->instance.len
 					+ 1 /* quote */
 					;
 			}
@@ -341,8 +341,8 @@ int build_contact(ucontact_t* c,struct sip_msg *_m)
 				memcpy(p,SIP_INSTANCE,SIP_INSTANCE_SIZE);
 				p += SIP_INSTANCE_SIZE;
 				*p++ = '\"';
-				memcpy(p,c->instance.s+1,c->instance.len-2);
-				p += c->instance.len-2;
+				memcpy(p,c->instance.s,c->instance.len);
+				p += c->instance.len;
 				*p++ = '\"';
 			}
 		}


### PR DESCRIPTION
The SIP Instance of the 200 OK response is not correctly formatted.

It should be surrounded by angle brackets following section 4.1 from RFC
5626:
    
      [RFC3840] defines equality rules for callee capabilities parameters,
      and according to that specification, the "sip.instance" media feature
      tag will be compared by case- sensitive string comparison.  This means
      that the URN will be encapsulated by angle brackets ("<" and ">") when
      it is placed within the quoted string value of the "+sip.instance"
      Contact header field parameter.


**Summary**
<!-- Summary of the PR - what the PR is aiming to solve -->

**Details**
<!--
Details about the content of the PR - is it a bug fix, a new feature or perhaps a hack? Explain the **motivation** for making this change.
What existing problem does the pull request solve? Is this a particular problem (i.e. only some particular scenarios are affected, only some UACs, etc) or a generic one?
Do not assume others understand what you're trying to do and provide as much information as you may have.
-->

**Solution**
<!-- Explain how your PR fixes the problem. Are there any remaining concerns that might need to be addressed? -->

**Compatibility**
<!-- Does your change break other scenarios, or do they need to be migrated in order to work similarly? -->

**Closing issues**
<!-- Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). -->
