### PR TITLE
core: enforce bounds checks on input-derived lengths

### DIFF
--- a/modules/sipmsgops/sipmsgops.c
+++ b/modules/sipmsgops/sipmsgops.c
@@ -2123,6 +2123,10 @@ static int w_sip_to_json(struct sip_msg *msg, pv_spec_t* out_json)
 	}
 
 	for (it=msg->headers;it;it=it->next) {
+		if (it->name.len >= sizeof(hdr_name_buf)) {
+			LM_WARN("header name too long (%d), skipping\n", it->name.len);
+			continue;
+		}
 		memcpy(hdr_name_buf,it->name.s,it->name.len);
 		hdr_name_buf[it->name.len] = 0;
 

--- a/msg_translator.c
+++ b/msg_translator.c
@@ -2906,6 +2906,7 @@ char *construct_uri(str *protocol,str *username,str *domain,str *port,
 		str *params,int *len)
 {
 	int pos = 0;
+	int total_len;
 
 	if (!len)
 	{
@@ -2922,6 +2923,21 @@ char *construct_uri(str *protocol,str *username,str *domain,str *port,
 	if (!domain->s || domain->len == 0)
 	{
 		LM_ERR("no domain specified\n");
+		return 0;
+	}
+
+	total_len = protocol->len + 1 /* ':' */ + domain->len;
+	if (username && username->s && username->len != 0)
+		total_len += username->len + 1; /* '@' */
+	if (port && port->s && port->len != 0)
+		total_len += port->len + 1; /* ':' */
+	if (params && params->s && params->len != 0)
+		total_len += params->len + 1; /* ';' */
+	total_len += 1; /* null terminator */
+
+	if (total_len > MAX_URI_LEN) {
+		LM_ERR("constructed URI too long (%d > %d)\n",
+			total_len, MAX_URI_LEN);
 		return 0;
 	}
 

--- a/net/proto_tcp/tcp_common.h
+++ b/net/proto_tcp/tcp_common.h
@@ -294,6 +294,14 @@ inline static void tcp_parse_headers(struct tcp_req *r,
 					case '7':
 					case '8':
 					case '9':
+						if (r->content_len>=TCP_BUF_SIZE) {
+							LM_ERR("Content-Length value %d bigger than the "
+								"reading buffer\n", r->content_len);
+							r->error = TCP_REQ_BAD_LEN;
+							r->state = H_SKIP;
+							r->content_len = 0;
+							break;
+						}
 						r->content_len=r->content_len*10+(*p-'0');
 						if (r->content_len>=TCP_BUF_SIZE) {
 							LM_ERR("Content-Length value %d bigger than the "

--- a/parser/parse_body.c
+++ b/parser/parse_body.c
@@ -130,6 +130,10 @@ static char *find_line_delimiter(char* p, char* plimit, str delimiter)
 			cp1 = l_memmem(cp, delimiterhead, plimit-cp, 2);
 			if (cp1 == NULL)
 				return NULL;
+			/* ensure enough room for the delimiter match */
+			if (plimit - cp1 < 2 + delimiter.len) {
+				return NULL;
+			}
 			/* We matched '--',
 			 * now let's match the boundary delimiter */
 			if (strncmp(cp1+2, delimiter.s, delimiter.len) == 0)
@@ -141,8 +145,6 @@ static char *find_line_delimiter(char* p, char* plimit, str delimiter)
 		}
 		if (cp1[-1] == '\n' || cp1[-1] == '\r')
 			return cp1;
-		if (plimit - cp1 < 2 + delimiter.len)
-			return NULL;
 		cp = cp1 + 2 + delimiter.len;
 	}
 }

--- a/transformations.c
+++ b/transformations.c
@@ -957,7 +957,8 @@ int tr_eval_string(struct sip_msg *msg, tr_param_t *tp, int subtype,
 				val->flags |= PV_VAL_STR;
 				break;
 			}
-			if(val->rs.len>TR_BUFFER_SIZE-1) {
+			if(val->rs.len>TR_BUFFER_SIZE-1 ||
+				calc_base64_encode_len(val->rs.len)>TR_BUFFER_SIZE) {
 				LM_ERR("b64encode value larger than buffer\n");
 				goto error;
 			}


### PR DESCRIPTION
Add input length validation in several code paths:

- **transformations**: account for base64 4/3 expansion in `b64encode` output length check
- **parser/parse_body**: validate remaining buffer length before delimiter comparison in multipart boundary search
- **net/proto_tcp**: validate Content-Length value before multiplication to prevent integer wraparound
- **sipmsgops**: enforce header name length limit in `sip_to_json` conversion
- **msg_translator**: validate total URI length in `construct_uri` before writing components