### PR TITLE
cgrates: add null terminator to modparam deps array

### DIFF
--- a/modules/cgrates/cgrates.c
+++ b/modules/cgrates/cgrates.c
@@ -138,6 +138,7 @@ static const dep_export_t deps = {
 		{ MOD_TYPE_NULL, NULL, 0 },
 	},
 	{ /* modparam dependencies */
+		{ NULL, NULL },
 	},
 };
 


### PR DESCRIPTION
**Summary**

Add the missing { NULL, NULL } sentinel to the modparam dependencies array in the cgrates module.

Details

`cgrates` was the only module declaring an empty `{ /* modparam dependencies */ }` block with no terminator. On arm64 the module segfaults on load.
