### PR TITLE
dialog: add options_ping_max_retries parameter for OPTIONS ping retries

### DIFF
--- a/modules/dialog/README.md
+++ b/modules/dialog/README.md
@@ -446,6 +446,32 @@ modparam("dialog", "options_ping_interval", 20)
 ```
 
 
+#### options_ping_max_retries (integer)
+
+
+The number of additional in-dialog OPTIONS pings to send when the
+previous OPTIONS transaction times out, before declaring the dialog leg
+unreachable. Retries are sent immediately after each transaction timeout,
+without waiting for the next `options_ping_interval` tick. The retry counter
+is maintained independently for each dialog leg and is reset by any final
+response other than 408 or 481. A 481 response is considered definitive and
+is not retried.
+
+The maximum time needed to detect an unreachable peer is approximately
+`(options_ping_max_retries + 1) * fr_timeout`, where `fr_timeout` is configured
+by the "tm" module.
+
+
+*Default value is "0" (no additional retries).*
+
+
+```opensips title="Set options_ping_max_retries parameter"
+...
+modparam("dialog", "options_ping_max_retries", 2)
+...
+```
+
+
 #### reinvite_ping_interval (integer)
 
 

--- a/modules/dialog/dialog.c
+++ b/modules/dialog/dialog.c
@@ -72,6 +72,7 @@ static char* profiles_nv_s = NULL;
 int dlg_bulk_del_no = 1; /* delete one by one */
 int seq_match_mode = SEQ_MATCH_FALLBACK;
 int options_ping_interval = 30;      /* seconds */
+int options_ping_max_retries = 0;    /* extra OPTIONS pings to send on timeout before declaring leg dead */
 int reinvite_ping_interval = 300;    /* seconds */
 int dlg_del_delay = 0;               /* in seconds, default off */
 str dlg_extra_hdrs = {NULL,0};
@@ -302,6 +303,7 @@ static const param_export_t mod_params[]={
 	{ "rr_param",              STR_PARAM, &rr_param.s               },
 	{ "default_timeout",       INT_PARAM, &default_timeout          },
 	{ "options_ping_interval", INT_PARAM, &options_ping_interval    },
+	{ "options_ping_max_retries", INT_PARAM, &options_ping_max_retries },
 	{ "reinvite_ping_interval",INT_PARAM, &reinvite_ping_interval   },
 	{ "delete_delay",          INT_PARAM, &dlg_del_delay            },
 	{ "dlg_extra_hdrs",        STR_PARAM, &dlg_extra_hdrs.s         },
@@ -790,6 +792,11 @@ static int mod_init(void)
 
 	if (options_ping_interval<=0 || reinvite_ping_interval<=0) {
 		LM_ERR("Non-positive ping interval not accepted!!\n");
+		return -1;
+	}
+
+	if (options_ping_max_retries < 0) {
+		LM_ERR("Negative options_ping_max_retries not accepted!!\n");
 		return -1;
 	}
 

--- a/modules/dialog/dialog.c
+++ b/modules/dialog/dialog.c
@@ -72,6 +72,7 @@ static char* profiles_nv_s = NULL;
 int dlg_bulk_del_no = 1; /* delete one by one */
 int seq_match_mode = SEQ_MATCH_FALLBACK;
 int options_ping_interval = 30;      /* seconds */
+int options_ping_max_retries = 0;    /* extra OPTIONS pings to send on timeout before declaring leg dead */
 int reinvite_ping_interval = 300;    /* seconds */
 int dlg_del_delay = 0;               /* in seconds, default off */
 str dlg_extra_hdrs = {NULL,0};
@@ -310,6 +311,7 @@ static const param_export_t mod_params[]={
 	{ "rr_param",              STR_PARAM, &rr_param.s               },
 	{ "default_timeout",       INT_PARAM, &default_timeout          },
 	{ "options_ping_interval", INT_PARAM, &options_ping_interval    },
+	{ "options_ping_max_retries", INT_PARAM, &options_ping_max_retries },
 	{ "reinvite_ping_interval",INT_PARAM, &reinvite_ping_interval   },
 	{ "delete_delay",          INT_PARAM, &dlg_del_delay            },
 	{ "dlg_extra_hdrs",        STR_PARAM, &dlg_extra_hdrs.s         },
@@ -802,6 +804,11 @@ static int mod_init(void)
 
 	if (options_ping_interval<=0 || reinvite_ping_interval<=0) {
 		LM_ERR("Non-positive ping interval not accepted!!\n");
+		return -1;
+	}
+
+	if (options_ping_max_retries < 0) {
+		LM_ERR("Negative options_ping_max_retries not accepted!!\n");
 		return -1;
 	}
 

--- a/modules/dialog/dlg_hash.h
+++ b/modules/dialog/dlg_hash.h
@@ -112,6 +112,7 @@ struct dlg_leg {
 	struct dlg_leg_cseq_map *cseq_maps; /* used when translating ACKs */
 	char reply_received;
 	char reinvite_confirmed;
+	unsigned char ping_retries;	/* failed OPTIONS pings since last success */
 	const struct socket_info *bind_addr;
 };
 

--- a/modules/dialog/dlg_hash.h
+++ b/modules/dialog/dlg_hash.h
@@ -113,6 +113,7 @@ struct dlg_leg {
 	struct dlg_leg_cseq_map *cseq_maps; /* used when translating ACKs */
 	char reply_received;
 	char reinvite_confirmed;
+	unsigned char ping_retries;	/* failed OPTIONS pings since last success */
 	const struct socket_info *bind_addr;
 };
 

--- a/modules/dialog/dlg_timer.c
+++ b/modules/dialog/dlg_timer.c
@@ -40,6 +40,12 @@ str invite_str=str_init("INVITE");
 
 extern int reinvite_ping_interval;
 extern int options_ping_interval;
+extern int options_ping_max_retries;
+
+/* forward declarations for OPTIONS ping retry from inside the reply callback */
+void reply_from_caller(struct cell* t, int type, struct tmcb_params* ps);
+void reply_from_callee(struct cell* t, int type, struct tmcb_params* ps);
+void unref_dlg_cb(void *dlg);
 
 /* for the dlg timer, there are 3 possible states :
  * prev=next=0 -> dialog not in timer list
@@ -753,6 +759,36 @@ int dlg_handle_seq_reply(struct dlg_cell *dlg, struct sip_msg* rpl,
 	LM_DBG("Status Code received =  [%d]\n", statuscode);
 
 	if (rpl == FAKED_REPLY || statuscode == 408) {
+		/* OPTIONS ping timeout: optionally retry immediately before giving up.
+		 * Re-INVITE ping path is unchanged. */
+		if (!is_reinvite_rpl &&
+		    dlg->legs[leg].ping_retries < (unsigned char)options_ping_max_retries) {
+			dlg_request_callback *cb;
+
+			dlg->legs[leg].ping_retries++;
+			LM_INFO("OPTIONS ping timeout on %s leg, retry %u/%d, "
+			        "ci: [%.*s]\n",
+			        leg == DLG_CALLER_LEG ? "caller" : "callee",
+			        dlg->legs[leg].ping_retries, options_ping_max_retries,
+			        dlg->callid.len, dlg->callid.s);
+
+			/* clear the gate so a new in-flight ping can be tracked */
+			*ping_status = DLG_PING_SUCCESS;
+
+			cb = (leg == DLG_CALLER_LEG) ? reply_from_caller : reply_from_callee;
+			ref_dlg(dlg, 1);
+			if (send_leg_msg(dlg, &options_str, other_leg(dlg, leg), leg,
+			        0, 0, cb, dlg, unref_dlg_cb,
+			        &dlg->legs[leg].reply_received) < 0) {
+				LM_ERR("failed to send OPTIONS retry on %s leg\n",
+				       leg == DLG_CALLER_LEG ? "caller" : "callee");
+				unref_dlg(dlg, 1);
+				/* leave ping_retries as-is; the next interval-driven ping
+				 * will continue from the current retry count */
+			}
+			return 0;
+		}
+
 		/* timeout occurred, nothing else to do now
 		 * next time timer fires, it will detect ping reply was not received
 		 */
@@ -776,6 +812,8 @@ int dlg_handle_seq_reply(struct dlg_cell *dlg, struct sip_msg* rpl,
 	}
 
 	*ping_status = DLG_PING_SUCCESS;
+	if (!is_reinvite_rpl)
+		dlg->legs[leg].ping_retries = 0;
 	if (is_reinvite_rpl && statuscode < 300 && send_leg_msg(dlg, &ack,
 			other_leg(dlg, leg), leg, NULL, NULL, NULL, NULL, NULL, NULL) < 0)
 		LM_ERR("cannot send ACK message!\n");

--- a/modules/dialog/dlg_timer.c
+++ b/modules/dialog/dlg_timer.c
@@ -38,6 +38,13 @@ struct dlg_reinvite_ping_timer *reinvite_ping_timer=0;
 str options_str=str_init("OPTIONS");
 str invite_str=str_init("INVITE");
 
+extern int options_ping_max_retries;
+
+/* forward declarations for OPTIONS ping retry from inside the reply callback */
+void reply_from_caller(struct cell* t, int type, struct tmcb_params* ps);
+void reply_from_callee(struct cell* t, int type, struct tmcb_params* ps);
+void unref_dlg_cb(void *dlg);
+
 /* for the dlg timer, there are 3 possible states :
  * prev=next=0 -> dialog not in timer list
  * prev=0 -> dialog expired
@@ -765,6 +772,36 @@ int dlg_handle_seq_reply(struct dlg_cell *dlg, struct sip_msg* rpl,
 	LM_DBG("Status Code received =  [%d]\n", statuscode);
 
 	if (rpl == FAKED_REPLY || statuscode == 408) {
+		/* OPTIONS ping timeout: optionally retry immediately before giving up.
+		 * Re-INVITE ping path is unchanged. */
+		if (!is_reinvite_rpl &&
+		    dlg->legs[leg].ping_retries < (unsigned char)options_ping_max_retries) {
+			dlg_request_callback *cb;
+
+			dlg->legs[leg].ping_retries++;
+			LM_INFO("OPTIONS ping timeout on %s leg, retry %u/%d, "
+			        "ci: [%.*s]\n",
+			        leg == DLG_CALLER_LEG ? "caller" : "callee",
+			        dlg->legs[leg].ping_retries, options_ping_max_retries,
+			        dlg->callid.len, dlg->callid.s);
+
+			/* clear the gate so a new in-flight ping can be tracked */
+			*ping_status = DLG_PING_SUCCESS;
+
+			cb = (leg == DLG_CALLER_LEG) ? reply_from_caller : reply_from_callee;
+			ref_dlg(dlg, 1);
+			if (send_leg_msg(dlg, &options_str, other_leg(dlg, leg), leg,
+			        0, 0, cb, dlg, unref_dlg_cb,
+			        &dlg->legs[leg].reply_received) < 0) {
+				LM_ERR("failed to send OPTIONS retry on %s leg\n",
+				       leg == DLG_CALLER_LEG ? "caller" : "callee");
+				unref_dlg(dlg, 1);
+				/* leave ping_retries as-is; the next interval-driven ping
+				 * will continue from the current retry count */
+			}
+			return 0;
+		}
+
 		/* timeout occurred, nothing else to do now
 		 * next time timer fires, it will detect ping reply was not received
 		 */
@@ -788,6 +825,8 @@ int dlg_handle_seq_reply(struct dlg_cell *dlg, struct sip_msg* rpl,
 	}
 
 	*ping_status = DLG_PING_SUCCESS;
+	if (!is_reinvite_rpl)
+		dlg->legs[leg].ping_retries = 0;
 	if (is_reinvite_rpl && statuscode < 300 && send_leg_msg(dlg, &ack,
 			other_leg(dlg, leg), leg, NULL, NULL, NULL, NULL, NULL, NULL) < 0)
 		LM_ERR("cannot send ACK message!\n");

--- a/modules/dialog/doc/dialog_admin.xml
+++ b/modules/dialog/doc/dialog_admin.xml
@@ -521,6 +521,10 @@ modparam("dialog", "db_update_period", 120)
 		OPTIONS pings for one or both of the involved parties.
 		</para>
 		<para>
+		See also <xref linkend="param_options_ping_max_retries"/> for tuning
+		the behavior on lost OPTIONS replies (e.g. over UDP).
+		</para>
+		<para>
 		<emphasis>
 			Default value is <quote>30</quote>.
 		</emphasis>
@@ -530,6 +534,52 @@ modparam("dialog", "db_update_period", 120)
 		<programlisting format="linespecific">
 ...
 modparam("dialog", "options_ping_interval", 20)
+...
+</programlisting>
+		</example>
+	</section>
+
+<section id="param_options_ping_max_retries" xreflabel="options_ping_max_retries">
+		<title><varname>options_ping_max_retries</varname> (integer)</title>
+		<para>
+		The number of additional in-dialog OPTIONS pings to send when the
+		previous OPTIONS transaction times out, before declaring the leg dead
+		and terminating the dialog. The default value of <quote>0</quote>
+		preserves the historical behavior: a single failed OPTIONS ping
+		(no final reply within the <varname>tm</varname> module's
+		<varname>fr_timeout</varname>) immediately terminates the dialog.
+		</para>
+		<para>
+		Each retry is sent <emphasis>immediately</emphasis> after the previous
+		attempt times out (from inside the reply callback) -- it does
+		<emphasis>not</emphasis> wait for the next
+		<varname>options_ping_interval</varname> tick. Therefore the
+		worst-case time to detect an unreachable peer is approximately
+		<emphasis>(options_ping_max_retries + 1) * fr_timeout</emphasis>,
+		independent of <varname>options_ping_interval</varname>.
+		</para>
+		<para>
+		The retry counter is per-leg (caller and callee can fail
+		independently) and is reset whenever a successful reply
+		(any non-481 final response other than 408) is received.
+		A 481 reply is treated as a definitive failure and is
+		<emphasis>not</emphasis> retried.
+		</para>
+		<para>
+		This is primarily useful for UDP deployments where an OPTIONS
+		request or its 200 OK can be lost end-to-end and a single missed
+		ping should not tear down an otherwise healthy call.
+		</para>
+		<para>
+		<emphasis>
+			Default value is <quote>0</quote> (no retries).
+		</emphasis>
+		</para>
+		<example>
+		<title>Set <varname>options_ping_max_retries</varname> parameter</title>
+		<programlisting format="linespecific">
+...
+modparam("dialog", "options_ping_max_retries", 2)
 ...
 </programlisting>
 		</example>


### PR DESCRIPTION
Summary

Add a new options_ping_max_retries module parameter to the dialog module that allows configuring additional OPTIONS ping attempts before declaring a dialog leg dead and terminating the call.

Details

In UDP deployments, a single OPTIONS ping request or its 200 OK response can be lost in transit. With the current behavior, one lost packet immediately terminates an otherwise healthy call, which can be disruptive for end users.

This is particularly problematic in networks with occasional packet loss where calls are functioning normally but a single missed keepalive ping triggers unnecessary call teardown.

Solution

Introduce a new parameter options_ping_max_retries (default: 0) that specifies how many additional OPTIONS pings to send after a timeout before declaring the leg dead:

When an OPTIONS ping times out (408/FAKED_REPLY), the module now checks if retries remain
Retries are sent immediately from the reply callback, not waiting for the next options_ping_interval tick
A per-leg ping_retries counter tracks failed attempts and resets on any successful response
481 responses are treated as definitive failures and not retried
Worst-case detection time: (options_ping_max_retries + 1) * fr_timeout
Changes:

Added options_ping_max_retries parameter in dialog.c
Added ping_retries field to dlg_leg structure
Implemented retry logic in dlg_handle_seq_reply() in dlg_timer.c
Added comprehensive documentation in dialog_admin.xml
Example usage:

Compatibility

Fully backward compatible. The default value of 0 preserves the existing behavior where a single failed OPTIONS ping immediately terminates the dialog.