### PR TITLE
pua_dialoginfo: fix early state lifetime and clean up dangling early branches

### DIFF
--- a/modules/pua_dialoginfo/pua_dialoginfo.c
+++ b/modules/pua_dialoginfo/pua_dialoginfo.c
@@ -200,7 +200,44 @@ __tm_sendpublish(struct cell *t, int type, struct tmcb_params *_params)
 	peer = &(param->peer);
 	entity = &(param->entity);
 
-	/* this is triggered only for TMCB_RESPONSE_IN */
+	if (type==TMCB_ON_FAILURE) {
+		/* the transaction completed with a failure - explicitly terminate
+		 * any branches still in "early" state which never received a final
+		 * negative reply (e.g. UAS went silent after sending 180), otherwise
+		 * their published state will linger until it expires */
+		if (get_callid(_params->req, &callid) < 0)
+			return;
+
+		if (include_tags) {
+			if(parse_from_header( _params->req )<0
+			|| parse_to_header( _params->req )<0 ) {
+				LM_ERR("failed to parse the request\n");
+				return;
+			}
+			ftag = &(get_from(_params->req)->tag_value);
+			ttag = &(get_to(_params->req)->tag_value);
+		} else {
+			ftag = ttag = NULL;
+		}
+
+		/* note: this callback runs under the transaction's reply lock,
+		 * so it is safe to test/set the bitmasks here */
+		for (branch=t->first_branch; branch<t->nr_of_outgoings; branch++) {
+			if (!BRANCH_BM_TST_IDX( param->bitmask_early, branch)
+			|| BRANCH_BM_TST_IDX( param->bitmask_failed, branch))
+				continue;
+			BRANCH_BM_SET_IDX( param->bitmask_failed, branch);
+			if (param->flags & DLG_PUB_A)
+				dialog_publish("terminated", entity, peer,
+					&callid, branch, 1, 0, ftag, ttag);
+			if (param->flags & DLG_PUB_B)
+				dialog_publish("terminated", peer, entity,
+					&callid, branch, 0, 0, ttag, ftag);
+		}
+		return;
+	}
+
+	/* from here on, handling of TMCB_RESPONSE_IN */
 	branch = tm_api.get_branch_index();
 
 	LM_DBG("TM event %d [%d/%d] received, entity [%.*s], peer [%.*s],"
@@ -266,7 +303,7 @@ __tm_sendpublish(struct cell *t, int type, struct tmcb_params *_params)
 	/* depending on the reply code, see what to publish */
 	if (_params->code<180 && _params->code>=100) {
 
-		expire = TM_BRANCH(t,branch).request.fr_timer.time_out - get_ticks();
+		expire = DEFAULT_CREATED_LIFETIME;
 		if (publish_on_trying) {
 			if (should_publish_A( param->flags, mute_val.s))
 				dialog_publish("trying", entity, peer,
@@ -292,7 +329,7 @@ __tm_sendpublish(struct cell *t, int type, struct tmcb_params *_params)
 		lock_release(&t->reply_mutex);
 
 		if (n) {
-			expire = TM_BRANCH(t,branch).request.fr_timer.time_out-get_ticks();
+			expire = DEFAULT_CREATED_LIFETIME;
 			if (should_publish_A( param->flags, mute_val.s))
 				dialog_publish(caller_confirmed?"confirmed":"early",
 					entity, peer,
@@ -1015,8 +1052,9 @@ int dialoginfo_set(struct sip_msg* msg, str* flag_s)
 		return -1;
 	}
 
-	/* register TM callback to get access to recevied replies */
-	if (tm_api.register_tmcb( msg, NULL, TMCB_RESPONSE_IN,
+	/* register TM callback to get access to recevied replies and to
+	 * the transaction failure (to clean up dangling early states) */
+	if (tm_api.register_tmcb( msg, NULL, TMCB_RESPONSE_IN|TMCB_ON_FAILURE,
 		__tm_sendpublish, (void*)param_tm, free_cb_param) != 1) {
 		LM_ERR("cannot register TM callback for incoming replies\n");
 		goto end;


### PR DESCRIPTION
Fixes #3802, as requested in https://github.com/OpenSIPS/opensips/issues/3802#issuecomment-4667146561.

This is the patch from [the Feb 13 comment](https://github.com/OpenSIPS/opensips/issues/3802#issuecomment-3894683407), tested by @andrewyager in pre-prod/prod against 3.4, rebased onto current master with the following adjustments:

* The failure-handler loop now iterates only the last set of active branches (`t->first_branch` .. `t->nr_of_outgoings`) instead of all `MAX_BRANCHES`, per @bogdan-iancu's review comment.
* Adapted to the new branch bitmask API from f0223cc93 (`BRANCH_BM_TST_IDX`/`BRANCH_BM_SET_IDX` instead of raw `long long` shifts) and to `TM_BRANCH()`.
* The handler now also sets `bitmask_failed` for each branch it terminates, so a late-arriving negative reply on that branch cannot publish a duplicate "terminated".
* The handler honors the `DLG_PUB_A`/`DLG_PUB_B` publishing flags, consistent with the rest of the callback.
* No locking in the failure path: `TMCB_ON_FAILURE` already runs under the transaction's reply lock (via `t_should_relay_response()` -> `run_failure_handlers()`), so the bitmask test/set is safe and re-taking `t->reply_mutex` would deadlock.

### Summary of the fix

1. On 1xx replies, use `DEFAULT_CREATED_LIFETIME` for the published state lifetime instead of `fr_timer.time_out - get_ticks()` — the fr_timer is updated only after `TMCB_RESPONSE_IN` runs, so a provisional reply arriving close to the timer expiration produced a near-zero lifetime and orphaned presence records.
2. Hook on `TMCB_ON_FAILURE` and publish "terminated" for any branch that entered "early" state but never received a final negative reply, so the longer lifetime cannot leave a dangling "early" state when the UAS goes silent after ringing.

### Re-validation on current master

Re-ran the scenarios from the issue against this rebased patch (master @ 4ddb8f0ed, loopback, `fr_timeout=10`, `fr_inv_timeout=15`):

* **Late 180 (8s delay):** early state published with `expires=3600` (previously 7s remainder); 200 OK then publishes confirmed with the dialog lifetime — original bug fixed.
* **Silent UAS (180 then nothing):** on `fr_inv_timeout`, "terminated" with `expires=0` is published for both directions before the failure route runs, and pua deletes the record from its hash table — no dangling early state.
* **Successful call:** no spurious "terminated" from the failure handler.
