### PR TITLE
dialog: handle late PRACK received in conversation

### DIFF
--- a/modules/dialog/dlg_handlers.c
+++ b/modules/dialog/dlg_handlers.c
@@ -2311,7 +2311,7 @@ after_unlock5:
 		return;
 	}
 
-	if ( (event==DLG_EVENT_REQ || event==DLG_EVENT_REQACK)
+	if ( (event==DLG_EVENT_REQ || event==DLG_EVENT_REQACK || event==DLG_EVENT_REQPRACK)
 	&& (new_state==DLG_STATE_CONFIRMED || new_state==DLG_STATE_CONFIRMED_NA) ) {
 		LM_DBG("sequential request successfully processed (dst_leg=%d)\n",
 			dst_leg);


### PR DESCRIPTION
**Summary**
Handle late PRACK received in conversation while using topology_hiding module.

**Details**
Related to #3919

**Solution**
Handle PRACK in conversation.