### PR TITLE
ci: make rtp.io pipeline more robust

### DIFF
--- a/.github/workflows/.rtp.io.yml
+++ b/.github/workflows/.rtp.io.yml
@@ -23,11 +23,18 @@ on:
         default: debian_12-slim
 
 jobs:
+  get_container_platforms:
+    name: Get Container Platforms
+    uses: sippy/cimagic/.github/workflows/GetContainerPlatforms.yml@v3
+    with:
+      image: ${{ inputs.rtpp-repo }}-${{ inputs.rtpp-tag }}
+
   set_env:
     name: Set Environment
+    needs: get_container_platforms
     runs-on: ubuntu-latest
     env:
-      BASE_IMAGE: ${{ inputs.rtpp-repo }}-${{ inputs.rtpp-tag }}
+      RAW_PLATFORMS: ${{ needs.get_container_platforms.outputs.platforms }}
     outputs:
       platforms: ${{ steps.set-env.outputs.platforms }}
       build-matrix: ${{ steps.set-env.outputs.build-matrix }}
@@ -42,9 +49,8 @@ jobs:
       id: set-env
       run: |
         BUILD_OS="`echo ${{ inputs.rtpp-tag }} | sed 's|-.*|| ; s|_|:|g'`"
-        PLATFORMS="`docker manifest inspect ${{ env.BASE_IMAGE }} | \
-          jq -r '.manifests[] | "\(.platform.os)/\(.platform.architecture)\(if .platform.variant != null then "/\(.platform.variant)" else "" end)"' | \
-          sort -u | grep -v unknown | BUILD_OS="${BUILD_OS}" ./scripts/build/get-arch-buildargs.rtp.io fltplatforms | paste -sd ','`"
+        PLATFORMS="`echo "${RAW_PLATFORMS}" | tr ',' '\n' | \
+          BUILD_OS="${BUILD_OS}" ./scripts/build/get-arch-buildargs.rtp.io fltplatforms | paste -sd ','`"
         BUILD_MATRIX="`echo ${PLATFORMS} | tr ',' '\n'  | jq -R . | jq -s . | tr '\n' ' '`"
         GIT_BRANCH="${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}"
         GIT_BRANCH="${GIT_BRANCH#refs/tags/}"
@@ -273,10 +279,13 @@ jobs:
           echo "TEST_SET_MIGHTFAIL=early_cancel_lost100,early_cancel" >> $GITHUB_ENV
         fi
 
+    - name: Pull ${{ env.TARGETPLATFORM }} image
+      run: docker pull --platform ${TARGETPLATFORM} ${BUILD_IMAGE}
+
     - name: Test ${{ env.TARGETPLATFORM }}
       run: |
-        docker pull ${BUILD_IMAGE}
-        docker run --platform ${TARGETPLATFORM} --env TEST_SET_MIGHTFAIL --name test --cap-add=SYS_PTRACE \
+        docker run --platform ${TARGETPLATFORM} --env TEST_SET_MIGHTFAIL \
+         --name test --cap-add=SYS_PTRACE \
          --privileged --sysctl net.ipv6.conf.all.disable_ipv6=0 ${BUILD_IMAGE}
       timeout-minutes: 3
 


### PR DESCRIPTION
**Summary**

Make rtp.io pipeline more robust

**Details**

Current pipeline runs both pull and test in one step, which may fail if the registry is overloaded and pushes test beyond 3-minute timeout.

**Solution**

Split pull into a separate step so it does not contribute to the timeout.