### PR TITLE
CI: Speed-up rtp.io pipeline, handle job cancellations and notifications correctly, use latest debian

### DIFF
--- a/.github/workflows/.notify.yml
+++ b/.github/workflows/.notify.yml
@@ -15,12 +15,13 @@ on:
 
 jobs:
   notify_slack:
+    if: ${{ inputs.job_result == 'failure' && github.repository == 'OpenSIPS/opensips' }}
     runs-on: ubuntu-latest
     env:
       SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
     steps:
       - name: Notify slack fail
-        if: ${{ inputs.job_result == 'failure' && github.repository == 'OpenSIPS/opensips' && env.SLACK_BOT_TOKEN != '' }}
+        if: ${{ env.SLACK_BOT_TOKEN != '' }}
         uses: slackapi/slack-github-action@v3.0.3
         with:
           method: chat.postMessage
@@ -39,7 +40,6 @@ jobs:
                     text: "<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|Open this run in GitHub Actions>"
 
       - name: Post Fail
-        if: ${{ inputs.job_result == 'failure' }}
         run: |
           echo "💥 \"${{ inputs.job_name }}\" failed – marking workflow 💩" >&2
           exit 1

--- a/.github/workflows/.rtp.io.yml
+++ b/.github/workflows/.rtp.io.yml
@@ -20,7 +20,11 @@ on:
       rtpp-tag:
         required: false
         type: string
-        default: debian_12-slim
+        default: debian_13-slim
+      pipcache-repo:
+        required: false
+        type: string
+        default: ghcr.io/sippy/b2bua/sippy-wheelset:latest
 
 jobs:
   get_container_platforms:
@@ -81,6 +85,7 @@ jobs:
       packages: write
     env:
       BASE_IMAGE: ${{ inputs.rtpp-repo }}-${{ inputs.rtpp-tag }}
+      PIPCACHE_IMAGE: ${{ inputs.pipcache-repo }}-${{ inputs.rtpp-tag }}
       BUILD_OS: ${{ needs.set_env.outputs.build-os }}
       PLATFORMS: ${{ needs.set_env.outputs.platforms }}
       BUILD_IMAGE: ${{ needs.set_env.outputs.build-image }}
@@ -154,6 +159,7 @@ jobs:
         file: ./docker/Dockerfile.rtp.io
         build-args: |
           BASE_IMAGE=${{ env.BASE_IMAGE }}
+          PIPCACHE_IMAGE=${{ env.PIPCACHE_IMAGE }}
           BUILD_OS=${{ env.BUILD_OS }}
           LLVM_VER=${{ inputs.llvm-version }}
           LLVM_VER_OLD=${{ inputs.llvm-version-old }}
@@ -174,6 +180,7 @@ jobs:
         platform: ${{ fromJSON(needs.set_env.outputs.build-matrix) }}
     env:
       BASE_IMAGE: ${{ inputs.rtpp-repo }}-${{ inputs.rtpp-tag }}
+      PIPCACHE_IMAGE: ${{ inputs.pipcache-repo }}-${{ inputs.rtpp-tag }}
       BUILD_OS: ${{ needs.set_env.outputs.build-os }}
 
     steps:
@@ -226,6 +233,7 @@ jobs:
         file: ./docker/Dockerfile.rtp.io
         build-args: |
           BASE_IMAGE=${{ env.BASE_IMAGE }}
+          PIPCACHE_IMAGE=${{ env.PIPCACHE_IMAGE }}
           BUILD_OS=${{ env.BUILD_OS }}
           LLVM_VER=${{ inputs.llvm-version }}
           LLVM_VER_OLD=${{ inputs.llvm-version-old }}

--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -32,4 +32,4 @@ jobs:
       job_result: ${{ needs.Fuzzing.result }}
     secrets:
       SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
-    if: ${{ always() }}
+    if: ${{ always() && !cancelled() }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -86,4 +86,4 @@ jobs:
       job_result: ${{ needs.build.result }}
     secrets:
       SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
-    if: ${{ always() }}
+    if: ${{ always() && !cancelled() }}

--- a/.github/workflows/multiarch.yml
+++ b/.github/workflows/multiarch.yml
@@ -78,4 +78,4 @@ jobs:
       job_result: ${{ needs.build_multiarch.result }}
     secrets:
       SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
-    if: ${{ always() }}
+    if: ${{ always() && !cancelled() }}

--- a/.github/workflows/rtp.io.yml
+++ b/.github/workflows/rtp.io.yml
@@ -129,7 +129,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        rtpp-tag: [debian_12-slim, ubuntu_latest]
+        rtpp-tag: [debian_13-slim, ubuntu_latest]
 
   all_done:
     needs: build_test_rtp_io_dock

--- a/.github/workflows/rtp.io.yml
+++ b/.github/workflows/rtp.io.yml
@@ -139,4 +139,4 @@ jobs:
       job_result: ${{ needs.build_test_rtp_io_dock.result }}
     secrets:
       SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
-    if: ${{ always() }}
+    if: ${{ always() && !cancelled() }}

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -127,4 +127,4 @@ jobs:
       job_result: ${{ needs.build_and_test.result }}
     secrets:
       SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
-    if: ${{ always() }}
+    if: ${{ always() && !cancelled() }}

--- a/docker/Dockerfile.rtp.io
+++ b/docker/Dockerfile.rtp.io
@@ -1,7 +1,8 @@
 # syntax=docker/dockerfile:1.7-labs
 
 ARG BASE_IMAGE="sippylabs/rtpproxy:latest"
-FROM --platform=$TARGETPLATFORM $BASE_IMAGE AS build
+ARG PIPCACHE_IMAGE="scratch"
+FROM --platform=$TARGETPLATFORM $BASE_IMAGE AS base
 LABEL maintainer="Maksym Sobolyev <sobomax@sippysoft.com>"
 
 USER root
@@ -10,6 +11,18 @@ USER root
 ENV DEBIAN_FRONTEND=noninteractive
 
 WORKDIR /src
+
+ENV CACHE_HOME="/root"
+ENV CACHE_ROOT="${CACHE_HOME}/.cache"
+RUN mkdir -p ${CACHE_ROOT}
+
+FROM ${PIPCACHE_IMAGE} AS cache
+COPY --from=base /root/.cache/ /root/.cache/
+
+FROM base AS build
+COPY --from=cache /root/.cache /root/.cache
+
+RUN find /root/.cache -type f
 
 ARG LLVM_VER=18
 ARG LLVM_VER_OLD=16
@@ -24,7 +37,6 @@ RUN --mount=type=bind,source=scripts/build,target=scripts/build \
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
  apt-get install -y gpp python-is-python3 python3-pip
 RUN --mount=type=bind,source=dist/voiptests/requirements.txt,target=requirements.txt \
- --mount=type=cache,target=/root/.cache/pip,sharing=locked \
  python -m pip install --break-system-packages -U -r requirements.txt
 
 COPY --exclude=.git --exclude=.github --exclude=docker --exclude=dist \

--- a/scripts/build/get-arch-buildargs.rtp.io
+++ b/scripts/build/get-arch-buildargs.rtp.io
@@ -37,13 +37,6 @@ fltplatforms() {
 platformopts() {
   out="COMPILER=clang-${LLVM_VER} LINKER=lld-${LLVM_VER}"
   case "${BUILD_OS}" in
-  debian:*)
-    case "${TARGETPLATFORM}" in
-    linux/ppc64le | linux/arm/v7 | linux/mips64le | linux/arm/v5)
-      out="COMPILER=clang-${LLVM_VER_OLD} LINKER=lld-${LLVM_VER_OLD}"
-      ;;
-    esac
-    ;;
   ubuntu*)
     case "${TARGETPLATFORM}" in
     linux/arm64/v8)


### PR DESCRIPTION
**Summary**

Speed-up rtp.io pipeline, handle job cancellations and notifications correctly

**Details**

1. The current rtp.io/voiptests pipeline builds python wheels needed each time, which takes significant amount of time
2. debian-12 is getting old
3. The notification hook runs always even when the run has been cancelled or runs in a custom fork

**Solution**

1. Use pip wheels cached by the sippy pipeline
2. Switch to using debian-13.
3. Don't run notification if the job is cancelled, skip notification entirely if a custom fork or PR.
