### PR TITLE
Fix build with OpenSSL 4.x: replace direct ASN1_STRING member access

### DIFF
--- a/modules/identity/identity.c
+++ b/modules/identity/identity.c
@@ -1420,13 +1420,13 @@ static time_t parseX509Date(ASN1_STRING * dateString)
 		return -1;
 	}
 
-	if((ASN1_UTCTIME_check(dateString)) && (dateString->length == 13))
+	if((ASN1_UTCTIME_check(dateString)) && (ASN1_STRING_length(dateString) == 13))
 	{
 		/* UTCTIME string, GMT
 		YYMMDDhhmmssZ
 		*/
 
-		tmp = dateString->data;
+		tmp = (unsigned char *)ASN1_STRING_get0_data(dateString);
 
 		tmDate.tm_year = (tmp[0] - '0') * 10 + (tmp[1] - '0');
 		if(tmDate.tm_year < 50) //see chap. 4.1.2.5.1, rfc 3280
@@ -1444,12 +1444,12 @@ static time_t parseX509Date(ASN1_STRING * dateString)
 	}
 
 	/* needed for years >= 2050 */
-	if ((ASN1_GENERALIZEDTIME_check(dateString)) && (dateString->length == 15))
+	if ((ASN1_GENERALIZEDTIME_check(dateString)) && (ASN1_STRING_length(dateString) == 15))
 	{
 		/* GENERALIZEDTIME string; GMT
 		YYYYMMDDhhmmssZ
 		*/
-		tmp = dateString->data;
+		tmp = (unsigned char *)ASN1_STRING_get0_data(dateString);
 
 		tmDate.tm_year = (tmp[0] - '0') * 1000 +
 			(tmp[1] - '0') * 100 + (tmp[2] - '0') * 10 + (tmp[3] - '0') - 1900;

--- a/modules/tls_openssl/openssl_tls_vars.c
+++ b/modules/tls_openssl/openssl_tls_vars.c
@@ -324,8 +324,8 @@ int openssl_tls_var_alt(int ind, void *ssl, str *res)
 		case GEN_EMAIL:
 		case GEN_DNS:
 		case GEN_URI:
-			text.s = (char*)nm->d.ia5->data;
-			text.len = nm->d.ia5->length;
+			text.s = (char*)ASN1_STRING_get0_data(nm->d.ia5);
+			text.len = ASN1_STRING_length(nm->d.ia5);
 			if (text.len >= 1024) {
 				LM_ERR("alternative subject text too long\n");
 				goto err;
@@ -337,9 +337,9 @@ int openssl_tls_var_alt(int ind, void *ssl, str *res)
 			break;
 
 		case GEN_IPADD:
-			ip.len = nm->d.iPAddress->length;
+			ip.len = ASN1_STRING_length(nm->d.iPAddress);
 			ip.af = (ip.len == 16) ? AF_INET6 : AF_INET;
-			memcpy(ip.u.addr, nm->d.iPAddress->data, ip.len);
+			memcpy(ip.u.addr, ASN1_STRING_get0_data(nm->d.iPAddress), ip.len);
 			text.s = ip_addr2a(&ip);
 			text.len = strlen(text.s);
 			memcpy(buf, text.s, text.len);


### PR DESCRIPTION
**Summary**

Fix build failure with OpenSSL 4.0.x where `ASN1_STRING` (`struct asn1_string_st`) is a fully opaque (incomplete) type, causing compilation errors in the `identity` and `tls_openssl` modules.

**Details**

OpenSSL has been progressively making internal structures opaque. As of OpenSSL 4.0.x (shipped in Fedora 45 / Rawhide), `struct asn1_string_st` is fully opaque. The `identity` and `tls_openssl` modules access `->data` and `->length` members directly on `ASN1_STRING`, `ASN1_IA5STRING`, `ASN1_OCTET_STRING`, and `ASN1_UTCTIME` pointers — all typedefs to `struct asn1_string_st`. This causes hard compilation errors ("invalid use of incomplete typedef") with GCC 16 on Fedora 45.

Affected functions:

- `modules/identity/identity.c`: `parseX509Date()` — accesses `dateString->length` and `dateString->data`
- `modules/tls_openssl/openssl_tls_vars.c`: `openssl_tls_var_alt()` — accesses `nm->d.ia5->data`, `nm->d.ia5->length`, `nm->d.iPAddress->data`, `nm->d.iPAddress->length`

**Solution**

Replace all direct struct member access with the public accessor API:

- `->length` → `ASN1_STRING_length()`
- `->data` → `ASN1_STRING_get0_data()`

These accessor functions have been available since OpenSSL 1.1.0 (released 2016), so this change is fully backwards-compatible with all currently supported OpenSSL versions. No `#ifdef` version guards are needed.

`ASN1_STRING_get0_data()` returns `const unsigned char *`, so a `(char *)` cast is applied where the existing code assigns to `char *` variables. This preserves the existing behavior.

**Compatibility**

No backward compatibility issues. The accessor API used in this patch has been the recommended approach since OpenSSL 1.1.0 and works on all OpenSSL versions >= 1.1.0, LibreSSL >= 2.7.0, and BoringSSL.

**Closing issues**

N/A