### PR TITLE
docs/evi: fix doubled (nested) GitHub alert in Core Events (2.4)

### DIFF
--- a/docs/manual/Interface-CoreEvents.md
+++ b/docs/manual/Interface-CoreEvents.md
@@ -31,11 +31,8 @@ Parameters:
 * **size**: the total amount of private memory.
 * **pid**: the pid of the process that raises the event.
 
-> [!IMPORTANT]
->
-> > [!NOTE]
-> > If the event_pkg_threshold is not specified or 0, then this event is disabled.
->
+> [!NOTE]
+> If the event_pkg_threshold is not specified or 0, then this event is disabled.
 
 ## E_CORE_SHM_THRESHOLD
 
@@ -49,8 +46,5 @@ Parameters:
 * **used**: the amount of shared memory used.
 * **size**: the total amount of shared memory.
 
-> [!IMPORTANT]
->
-> > [!NOTE]
-> > If the event_shm_threshold is not specified or 0, then this event is disabled.
->
+> [!NOTE]
+> If the event_shm_threshold is not specified or 0, then this event is disabled.


### PR DESCRIPTION
The `E_CORE_PKG_THRESHOLD` and `E_CORE_SHM_THRESHOLD` notes in `docs/manual/Interface-CoreEvents.md` wrap a `[!NOTE]` alert inside an empty `[!IMPORTANT]` alert. GitHub (and the docs site renderer) do not support nested alerts, so the inner marker renders as literal `[!NOTE]` text and the outer box is empty. This collapses each to a single `[!NOTE]`.

Backport of #3957 (master).