### PR TITLE
dispatcher: fix Samples section heading in README [skip ci]

### DIFF
--- a/modules/dispatcher/README.md
+++ b/modules/dispatcher/README.md
@@ -1317,7 +1317,7 @@ the destination gets activated or *inactive* if the
 destination is detected unresponsive.
 
 
-### Installation and Running
+## Samples
 
 [samples](./samples/samples.md "include")
 


### PR DESCRIPTION
- use `## Samples` heading for the samples section (was `### Installation and Running`)