### PR TITLE
cfgutils: fix async sleep()/usleep() doc examples

### DIFF
--- a/modules/cfgutils/README
+++ b/modules/cfgutils/README
@@ -738,7 +738,7 @@ if(shuffle_avps( $avp(foo) ))
    Example 1.27. async sleep usage
 {
 ...
-async( sleep("5"), after_sleep );
+async( sleep(5), after_sleep );
 }
 
 route[after_sleep] {
@@ -759,7 +759,7 @@ route[after_sleep] {
    Example 1.28. async usleep usage
 {
 ...
-async( usleep("1000"), after_usleep );
+async( usleep(1000), after_usleep );
 }
 
 route[after_usleep] {

--- a/modules/cfgutils/README.md
+++ b/modules/cfgutils/README.md
@@ -800,7 +800,7 @@ online Manual.
 ```opensips title="async sleep usage"
 {
 ...
-async( sleep("5"), after_sleep );
+async( sleep(5), after_sleep );
 }
 
 route[after_sleep] {
@@ -827,7 +827,7 @@ online Manual.
 ```opensips title="async usleep usage"
 {
 ...
-async( usleep("1000"), after_usleep );
+async( usleep(1000), after_usleep );
 }
 
 route[after_usleep] {

--- a/modules/cfgutils/doc/cfgutils_admin.xml
+++ b/modules/cfgutils/doc/cfgutils_admin.xml
@@ -908,7 +908,7 @@ if(shuffle_avps( $avp(foo) ))
 		<programlisting format="linespecific">
 {
 ...
-async( sleep("5"), after_sleep );
+async( sleep(5), after_sleep );
 }
 
 route[after_sleep] {
@@ -939,7 +939,7 @@ route[after_sleep] {
 		<programlisting format="linespecific">
 {
 ...
-async( usleep("1000"), after_usleep );
+async( usleep(1000), after_usleep );
 }
 
 route[after_usleep] {


### PR DESCRIPTION
The async sleep/usleep examples still used the pre-3.0 string-style parameters (sleep("5"), usleep("1000")). Since the typed module interface, both functions declare CMD_PARAM_INT, so the quoted form fails at startup with:

  ERROR:core:fix_cmd: Param [1] expected to be an integer or variable
  ERROR:core:fix_actions: Failed to fix command <sleep>

Use integer parameters, matching the synchronous examples.

<!--
Thanks for submitting a pull request!
In order to consider and evaluate your PR, it is mandatory to provide detailed information about (1) what is the issue the PR addresses, (2) how the PR is solving the issue (logic and coding), (3) what are (if any) limitations of the proposed PR and (4) if there are any known side-effects/ backward compatibility issues/SIP interoperability issues.
Note that if the PR is missing information, it might take longer to be merged, as extra resources have to be allocated by the maintainers to reverse engineer the changes, understand them, understand the motivation, etc. That is why it is important to provide as much information as possible.
-->

**Summary**
<!-- Summary of the PR - what the PR is aiming to solve -->

**Details**
<!--
Details about the content of the PR - is it a bug fix, a new feature or perhaps a hack? Explain the **motivation** for making this change.
What existing problem does the pull request solve? Is this a particular problem (i.e. only some particular scenarios are affected, only some UACs, etc) or a generic one?
Do not assume others understand what you're trying to do and provide as much information as you may have.
-->

**Solution**
<!-- Explain how your PR fixes the problem. Are there any remaining concerns that might need to be addressed? -->

**Compatibility**
<!-- Does your change break other scenarios, or do they need to be migrated in order to work similarly? -->

**Closing issues**
<!-- Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). -->
