### PR TITLE
tm: fix shm double-free of script-route refs on shared transactions

### DIFF
--- a/modules/tm/t_fwd.c
+++ b/modules/tm/t_fwd.c
@@ -59,6 +59,7 @@
 #include "t_cancel.h"
 #include "t_lookup.h"
 #include "t_fwd.h"
+#include "t_reply.h"
 #include "fix_lumps.h"
 #include "config.h"
 #include "cluster.h"
@@ -82,11 +83,7 @@ void t_on_branch( struct script_route_ref *ref )
 	 * created; if not -> use the static variable */
 	holder = (!t || t==T_UNDEFINED ) ? &goto_on_branch : &t->on_branch ;
 
-	/* if something already set, free it first */
-	if (*holder)
-		shm_free( *holder );
-
-	*holder = ref ? dup_ref_script_route_in_shm( ref, 0) : NULL;
+	tm_set_script_route_ref( t, holder, ref );
 }
 
 

--- a/modules/tm/t_reply.c
+++ b/modules/tm/t_reply.c
@@ -140,6 +140,56 @@ int t_get_picked_branch(void)
 */
 
 
+/* Safely replace a script-route reference that may live inside a shared
+   transaction cell (t->on_negative, t->on_reply, t->on_branch, ...).
+  
+   The previous code did an unlocked read-modify-write directly on the shared
+   field:
+       if (*holder) shm_free(*holder);
+       *holder = dup_ref_script_route_in_shm(ref, 0);
+   When a request route runs against an ALREADY-EXISTING transaction -- a
+   retransmitted ACK matched via t_check_trans() and processed by multiple
+   UDP workers -- two processes read the same pointer and both
+   shm_free() it. The second free aborts inside the shm allocator while holding
+   the global shm lock, blocking the whole server. Every process eventually
+   spins on the orphaned lock.
+ 
+   Here the pointer is swapped atomically under the cell's reply lock, and the
+   (now private) swapped-out pointer is freed afterwards. The shm alloc/free are
+   kept OUTSIDE LOCK_REPLIES so the reply lock is never nested around the global
+   shm lock.
+ 
+   The lock is taken only in REQUEST_ROUTE, the only context that can reach a
+   shared cell field concurrently without already holding the reply lock.
+   FAILURE_ROUTE and -- with onreply_avp_mode -- ONREPLY_ROUTE already execute
+   under LOCK_REPLIES (see run_failure_handlers() / reply_received()), and those
+   routes call t_on_reply()/t_on_failure() to re-arm handlers;
+   taking the non-recursive reply lock again there would self-deadlock. The
+   pre-transaction static holder and BRANCH_ROUTE are single-owner and need no
+   lock.
+*/
+
+
+void tm_set_script_route_ref(struct cell *t, struct script_route_ref **holder,
+		struct script_route_ref *ref)
+{
+	struct script_route_ref *old, *new_ref;
+	int locked = (t && t!=T_UNDEFINED && route_type==REQUEST_ROUTE);
+
+	/* allocate outside the lock (dup calls shm_malloc) */
+	new_ref = ref ? dup_ref_script_route_in_shm( ref, 0) : NULL;
+
+	if (locked) LOCK_REPLIES(t);
+	old = *holder;
+	*holder = new_ref;
+	if (locked) UNLOCK_REPLIES(t);
+
+	/* the swapped-out pointer is now private to us -> free outside the lock */
+	if (old)
+		shm_free( old );
+}
+
+
 void t_on_negative( struct script_route_ref *ref )
 {
 	struct cell *t = get_t();
@@ -150,11 +200,7 @@ void t_on_negative( struct script_route_ref *ref )
 	 * created; if not -> use the static variable */
 	holder = (!t || t==T_UNDEFINED ) ? &goto_on_negative : &t->on_negative ;
 
-	/* if something already set, free it first */
-	if (*holder)
-		shm_free( *holder );
-
-	*holder = ref ? dup_ref_script_route_in_shm( ref, 0) : NULL;
+	tm_set_script_route_ref( t, holder, ref );
 }
 
 
@@ -171,11 +217,7 @@ void t_on_reply( struct script_route_ref *ref  )
 		( route_type==BRANCH_ROUTE ?
 			&TM_BRANCH(t,_tm_branch_index).on_reply : &t->on_reply );
 
-	/* if something already set, free it first */
-	if (*holder)
-		shm_free( *holder );
-
-	*holder = ref ? dup_ref_script_route_in_shm( ref, 0) : NULL;
+	tm_set_script_route_ref( t, holder, ref );
 }
 
 

--- a/modules/tm/t_reply.h
+++ b/modules/tm/t_reply.h
@@ -165,6 +165,10 @@ struct script_route_ref *get_on_negative();
 void t_on_reply( struct script_route_ref *ref );
 struct script_route_ref *get_on_reply();
 
+/* atomically replace a (possibly shared-cell) script-route ref; see t_reply.c */
+void tm_set_script_route_ref(struct cell *t, struct script_route_ref **holder,
+		struct script_route_ref *ref);
+
 /* Retransmits the last sent inbound reply.
  * Returns  -1 - error
  *           1 - OK


### PR DESCRIPTION
**Summary**

Fixes a shared-memory double-free in the `tm` module that crashes a worker and, on `FAST_LOCK` builds, locks the entire opensips server until restart. More details in #4112.

`t_on_reply()`, `t_on_negative()` (script `t_on_failure`) and `t_on_branch()` update a script-route reference stored in the transaction cell with an unlocked read-modify-write:

```c
holder = (!t || t==T_UNDEFINED) ? &goto_on_reply
       : (route_type==BRANCH_ROUTE ? &TM_BRANCH(t,_tm_branch_index).on_reply : &t->on_reply);

if (*holder)
    shm_free(*holder);
*holder = ref ? dup_ref_script_route_in_shm(ref, 0) : NULL;
```

When these are called from a request route against an already-existing transaction, a retransmitted in-dialog ACK matched via `t_check_trans()` and processed by multiple UDP workers concurrently. `holder` points into the shared transaction cell. Two processes read the same pointer and both `shm_free()` it. The second free trips the allocator's double-free detector, which `abort()`s while holding the global shm lock.  on a `FAST_LOCK` build the orphaned lock then makes every process spin at 100% CPU and the server stops processing traffic (sockets stay open, nothing is handled) until it is restarted.

Found in 3.4.17, but same code for 3.5/3.6/4.0/master

**Solution**

Route the three setters through a shared helper (`tm_set_script_route_ref()`) that swaps the holder pointer atomically under the transaction reply lock and frees the swapped-out (now private) pointer afterwards. The shm alloc/free are kept outside `LOCK_REPLIES`, so the reply lock is never nested around the global shm lock.

The reply lock is taken only in `REQUEST_ROUTE`, the sole context that can reach a shared cell field concurrently without already holding the reply lock. `FAILURE_ROUTE` and, with `onreply_avp_mode`, `ONREPLY_ROUTE` already run under `LOCK_REPLIES` and may call these handlers, so acquiring the non-recursive reply lock there would probably deadlock.

An lock free approach would be to skip the update when the transaction already exists in `REQUEST_ROUTE` (setting `on_reply` on an already-created transaction is a no-op). Switch to that if preferred — the current PR keeps existing behavior and only makes the update safe.

Builds clean under gcc and clang with `-Werror` and passes the unit-test suite (`make test`). Let me know if I missed any testing that should be done prior to submitting a PR.

**Compatibility**

No script- or API-level changes; no configuration or migration required. Behavior is unchanged except that concurrent updates of the shared route-ref field are now serialized.

**Closing issues**

closes #4112
