### PR TITLE
topology_hiding: keep the dialog-less state in a shared store (fixes long Contact / SUBSCRIBE)

### DIFF
--- a/modules/topology_hiding/README
+++ b/modules/topology_hiding/README
@@ -24,6 +24,9 @@ topology_hiding Module
               1.3.9. th_contact_caller_username_var (string)
               1.3.10. th_contact_callee_username_var (string)
               1.3.11. th_callid_loop_protection (int)
+              1.3.12. th_state_url (string)
+              1.3.13. th_state_ttl (int)
+              1.3.14. th_state_ttl_short (int)
 
         1.4. Exported Functions
 
@@ -63,11 +66,14 @@ topology_hiding Module
    1.9. Set th_contact_caller_username_var parameter
    1.10. Set th_contact_callee_username_var parameter
    1.11. Set th_callid_loop_protection parameter
-   1.12. topology_hiding usage
-   1.13. Calling topology_hiding_match() function for topology
+   1.12. Set th_state_url parameter
+   1.13. Set th_state_ttl parameter
+   1.14. Set th_state_ttl_short parameter
+   1.15. topology_hiding usage
+   1.16. Calling topology_hiding_match() function for topology
           hiding sequential requests
 
-   1.14. topology_hiding_match_dialog() usage
+   1.17. topology_hiding_match_dialog() usage
 
 Chapter 1. Admin Guide
 
@@ -257,6 +263,210 @@ ding_username_var__")
 modparam("topology_hiding", "th_callid_loop_protection", 1)
 ...
 
+1.3.12. th_state_url (string)
+
+   The URL of a cachedb backend where the topology hiding state of
+   dialog-less calls is to be kept.
+
+   When topology hiding runs without a dialog, the whole encoded
+   state normally travels inside the Contact URI parameter (see
+   th_contact_encode_param), which makes that URI long. Some user
+   agents cannot cope with it and truncate the parameter, after
+   which topology_hiding_match() can no longer decode it and the
+   sequential requests of those calls are lost. This is most
+   visible for non-INVITE dialogs, such as SUBSCRIBE, as those can
+   never be given a dialog to hold the state - the dialog module
+   only handles INVITE based dialogs.
+
+   With this parameter set, the state is stored in the given
+   backend under a short key, and only that key travels in the
+   Contact URI, keeping it short regardless of how large the
+   hidden topology is. Off the wire the obfuscation and URI-safe
+   encoding a Contact-borne state carries serve no purpose, so the
+   stored copy holds neither: it is kept as plain, length-prefixed
+   text.
+
+   A state is only ever kept on the server side when the message
+   it belongs to tells how long its dialog is going to live, since
+   a state which expires from under a dialog which is still up
+   cannot be matched anymore, and takes down everything that was
+   still to be routed through it - the BYE of a call, most
+   notably. A subscription is bounded by its expires, and the
+   messages which open no dialog only live as long as their
+   transaction, so those are stored. A call is not bounded by
+   anything, unless the session timers are in use, so the state of
+   a call which has none keeps travelling in its Contact, where it
+   cannot expire - exactly as it does without this parameter. Both
+   may well be in use at the same time, as this is decided for
+   each dialog as its Contact is encoded.
+
+   Note that a call which is given a dialog never gets here at
+   all: the dialog module holds its state and bounds it for
+   exactly as long as the call lives, and its Contact carries just
+   the dialog id, so it is already both short and correct.
+   Engaging a dialog for the calls (see force_dialog) is therefore
+   a better answer for them than this parameter could ever be,
+   which is left to serve what a dialog cannot: everything that is
+   not INVITE based.
+
+   The state must be readable by whichever node receives the
+   sequential requests, so when the traffic is distributed or
+   fails over between several OpenSIPS instances, the backend must
+   be shared between them (e.g. a common cachedb_redis instance or
+   cluster). For a single instance, a local backend such as
+   cachedb_local is enough - it is kept in shared memory, so all
+   the OpenSIPS workers do see it, but its contents are lost on
+   restart and are not visible to the other nodes.
+
+   Security: the state kept in the backend is stored in the clear.
+   It is not encrypted, and - unlike the copy that travels inside
+   a Contact - it is not obfuscated either, so anyone able to read
+   the backend can see the topology it hides: the real Contact,
+   the route set and the receiving socket of each call. This is
+   intentional. The store is meant to be a trusted, internal
+   backend reachable only by the OpenSIPS nodes that share it:
+   deploy it on a private or DMZ network, bind it to the internal
+   interface, enable the backend's own authentication, and keep it
+   off any untrusted network. Do not point th_state_url at a
+   backend that is reachable beyond that trust boundary.
+
+   The state is immutable, so re-encoding a Contact on a
+   sequential request only pushes its expiration further out. To
+   spare the backend a write on every such request, each node
+   keeps a small in-memory record of what it last stored and skips
+   the write while the state still has enough of its lifetime left
+   - a write that would actually shorten a state (a subscription
+   being torn down) is never skipped. This is transparent and
+   needs no configuration.
+
+   A state is only ever removed from the backend when it expires
+   (see th_state_ttl), therefore the backend must implement the
+   expiration of the values it stores. All the cachedb backends
+   do, except for cachedb_mongodb, which silently ignores it -
+   using it here would pile up the states forever, so it is
+   rejected at startup.
+
+   By default this parameter is not set, and the state travels in
+   the Contact URI.
+
+   Example 1.12. Set th_state_url parameter
+...
+# a single instance - state kept in its own shared memory
+loadmodule "cachedb_local.so"
+modparam("topology_hiding", "th_state_url", "local://topohiding")
+
+# several instances sharing a Redis server
+loadmodule "cachedb_redis.so"
+modparam("topology_hiding", "th_state_url", "redis://127.0.0.1:6379/0")
+
+# a password protected Redis cluster - one node is enough,
+# the rest of the cluster is discovered from it
+modparam("topology_hiding", "th_state_url",
+         "redis://:secretpass@10.0.0.20:6379/0")
+
+# a Memcached server
+loadmodule "cachedb_memcached.so"
+modparam("topology_hiding", "th_state_url",
+         "memcached://127.0.0.1:11211/")
+...
+
+1.3.13. th_state_ttl (int)
+
+   For how long, in seconds, a topology hiding state is kept in
+   the backend configured through th_state_url. It should be at
+   least as long as the calls whose topology is hidden are
+   expected to last, as a call whose state has expired can no
+   longer have its sequential requests matched.
+
+   Whenever a message which keeps its dialog alive is matched, the
+   state it was sent to has its expiration pushed further, for as
+   long as that message says the dialog is going to live. This
+   matters because the party which sent it only learns of a new
+   state if the reply it gets back carries a Contact of its own -
+   otherwise it goes on using the state it already knows, which
+   therefore has to outlive its original expiration. Only the
+   messages which do carry the lifetime of their dialog may
+   refresh it - a SUBSCRIBE or NOTIFY through its expires, an
+   INVITE or UPDATE through its Session-Expires - so that, say, an
+   in-dialog OPTIONS cannot cut the state of the call it runs into
+   down to th_state_ttl_short.
+
+   A state is stored each time a Contact is encoded, and is
+   otherwise only removed when it expires, so the module tries not
+   to keep any state for longer than it may be needed:
+     * for SUBSCRIBE and NOTIFY, the state has to outlive the
+       subscription, so its duration is taken from the very
+       message being encoded (plus a small margin, to cover the
+       refresh). A NOTIFY reports how long the subscription
+       actually has left in its Subscription-State header (RFC
+       6665 4.1.3), which is what the notifier granted rather than
+       what the subscriber asked for, so it is preferred. Failing
+       that, it is looked for as an “expires” parameter of the
+       Contact first and as the Expires header afterwards, the
+       parameter taking precedence over the header. This matters
+       because a notifier is free to grant a shorter subscription
+       than the one asked for, and its NOTIFYs are what bring the
+       state of a subscription back in line with what was really
+       granted. Note that a subscription may last much longer than
+       this parameter, in which case its state is kept for longer
+       as well. A message which ends a subscription (an expires of
+       “0”, or a NOTIFY reporting it as “terminated”) drops the
+       state it was sent to right away, instead of leaving it
+       behind for as long as the subscription was going to last -
+       the Contact it gets encoded with still takes
+       th_state_ttl_short, so that the final NOTIFY may be routed
+       back;
+     * for INVITE and UPDATE, when the session timers are in use,
+       the session gets refreshed every Session-Expires seconds
+       (RFC 4028) and each refresh encodes the Contact anew, so
+       the state only has to survive one interval - that value
+       (plus the margin) is used then. Should a refresh not come,
+       the session is torn down anyway, so this can never expire
+       the state of a live call. Note that the Expires header is
+       deliberately not used here: on an INVITE it limits the
+       validity of the invitation, not the duration of the call it
+       may lead to;
+     * OPTIONS, MESSAGE, INFO and PUBLISH neither open a dialog
+       nor refresh the target of one, so their Contact is only of
+       interest while their transaction is running - they get
+       th_state_ttl_short;
+     * everything else, and any of the above whose expiry could
+       not be told (no session timers, no Expires), may last for
+       any amount of time, so it gets this parameter.
+
+   This parameter is only used when th_state_url is set.
+
+   Default value is “3600” (one hour).
+
+   Example 1.13. Set th_state_ttl parameter
+...
+# hide the topology of calls which may last up to 12 hours
+modparam("topology_hiding", "th_state_ttl", 43200)
+...
+
+1.3.14. th_state_ttl_short (int)
+
+   For how long, in seconds, to keep the topology hiding state of
+   the messages which do not open a dialog nor refresh the target
+   of one - see th_state_ttl for the exact list. Their Contact is
+   only used while their transaction is alive, so keeping their
+   state for as long as a call's would needlessly fill up the
+   storage.
+
+   It only needs to cover the lifetime of a transaction. Raise it
+   to the value of th_state_ttl if you have user agents which
+   wrongly latch onto the Contact of such a request and keep using
+   it afterwards.
+
+   This parameter is only used when th_state_url is set.
+
+   Default value is “60”.
+
+   Example 1.14. Set th_state_ttl_short parameter
+...
+modparam("topology_hiding", "th_state_ttl_short", 120)
+...
+
 1.4. Exported Functions
 
 1.4.1.  topology_hiding()
@@ -322,7 +532,7 @@ modparam("topology_hiding", "th_callid_loop_protection", 1)
    is advertised on both legs. If the separator is being used, you
    can control the username put in contact per leg.
 
-   Example 1.12. topology_hiding usage
+   Example 1.15. topology_hiding usage
 ...
 if(!has_totag() && is_method("INVITE")) {
         topology_hiding();
@@ -355,7 +565,7 @@ if(!has_totag() && is_method("INVITE")) {
 }
 ...
 
-   Example 1.13. Calling topology_hiding_match() function for
+   Example 1.16. Calling topology_hiding_match() function for
    topology hiding sequential requests
 ...
 if (has_totag())
@@ -384,7 +594,7 @@ ogy hiding dialog\n");
 
    This function can be used from REQUEST_ROUTE.
 
-   Example 1.14. topology_hiding_match_dialog() usage
+   Example 1.17. topology_hiding_match_dialog() usage
 ...
     if (has_totag()) {
         if (!topology_hiding_match() ) {

--- a/modules/topology_hiding/README
+++ b/modules/topology_hiding/README
@@ -164,6 +164,12 @@ ram;custom_param")
    not already created ). This will only work for INVITE based
    dialogs, and the dialog module must be loaded.
 
+   This only controls whether the module creates a dialog of its
+   own. A dialog created by the script itself, with
+   create_dialog(), has the same effect: once a dialog exists, it
+   carries the topology hiding state. See th_state_url for when
+   that is what you want and when it is not.
+
    Default value is “0”
 
    Example 1.5. Set force_dialog parameter
@@ -303,11 +309,41 @@ modparam("topology_hiding", "th_callid_loop_protection", 1)
    Note that a call which is given a dialog never gets here at
    all: the dialog module holds its state and bounds it for
    exactly as long as the call lives, and its Contact carries just
-   the dialog id, so it is already both short and correct.
-   Engaging a dialog for the calls (see force_dialog) is therefore
-   a better answer for them than this parameter could ever be,
-   which is left to serve what a dialog cannot: everything that is
-   not INVITE based.
+   the dialog id, so it is already both short and correct. The
+   rule is simply whether a dialog exists by the time
+   topology_hiding() runs: if one does, the dialog carries the
+   state and this parameter is not consulted for that call.
+   force_dialog only governs whether the module creates a dialog
+   when none exists yet - a script that calls create_dialog()
+   itself, as most do for accounting, BYE handling or sharing
+   tags, puts its INVITEs on the dialog path whatever force_dialog
+   is set to.
+
+   Where a call is going to have a dialog anyway, that is the
+   better place for its state. The dialog's lifetime is the call's
+   own, rather than a timer: the cached state can only approximate
+   it from Session-Expires, or fall back to th_state_ttl when the
+   call is not session timed, whereas a dialog is torn down with
+   the call instead of waiting out a TTL. A dialog is also
+   replicated by the dialog module's own clustering, and two of
+   this module's features - hiding the Call-ID, and carrying the
+   dialog id in the Contact user - are dialog-only, and are
+   skipped with a warning when no dialog is engaged. This
+   parameter is left to serve what a dialog cannot: everything
+   that is not INVITE based.
+
+   The reverse holds where dialogs are not wanted in the first
+   place. A load balancer or other high-throughput proxy that has
+   no use for dialog state - no accounting, no BYE handling,
+   nothing to replicate to its peers - still pays for every dialog
+   it creates, in shared memory and in the work of creating,
+   matching and expiring it, and at high call rates that cost is
+   the dominant one. Such a deployment is better off leaving
+   force_dialog at 0, not creating dialogs from the script, and
+   pointing this parameter at a fast local backend instead:
+   cachedb_perf is built for this traffic shape and keeps lookups
+   flat as the number of concurrent calls grows, where
+   cachedb_local degrades once its fixed hash table is outgrown.
 
    The state must be readable by whichever node receives the
    sequential requests, so when the traffic is distributed or

--- a/modules/topology_hiding/doc/topology_hiding_admin.xml
+++ b/modules/topology_hiding/doc/topology_hiding_admin.xml
@@ -281,6 +281,273 @@ modparam("topology_hiding", "th_callid_loop_protection", 1)
 		</example>
 	</section>
 
+	<section id="param_th_state_url" xreflabel="th_state_url">
+		<title><varname>th_state_url</varname> (string)</title>
+		<para>
+			The URL of a <emphasis>cachedb</emphasis> backend where the
+			topology hiding state of dialog-less calls is to be kept.
+		</para>
+		<para>
+			When topology hiding runs without a dialog, the whole encoded
+			state normally travels inside the Contact URI parameter (see
+			<xref linkend="param_th_contact_encode_param"/>), which makes
+			that URI long. Some user agents cannot cope with it and truncate
+			the parameter, after which
+			<xref linkend="func_topology_hiding_match"/> can no longer decode
+			it and the sequential requests of those calls are lost. This is
+			most visible for non-INVITE dialogs, such as SUBSCRIBE, as those
+			can never be given a dialog to hold the state - the
+			<emphasis>dialog</emphasis> module only handles INVITE based
+			dialogs.
+		</para>
+		<para>
+			With this parameter set, the state is stored in the given backend
+			under a short key, and only that key travels in the Contact URI,
+			keeping it short regardless of how large the hidden topology is.
+			Off the wire the obfuscation and URI-safe encoding a Contact-borne
+			state carries serve no purpose, so the stored copy holds neither:
+			it is kept as plain, length-prefixed text.
+		</para>
+		<para>
+			A state is only ever kept on the server side when the message it
+			belongs to tells how long its dialog is going to live, since a
+			state which expires from under a dialog which is still up cannot
+			be matched anymore, and takes down everything that was still to be
+			routed through it - the BYE of a call, most notably. A
+			subscription is bounded by its expires, and the messages which
+			open no dialog only live as long as their transaction, so those
+			are stored. A call is not bounded by anything, unless the session
+			timers are in use, so the state of a call which has none keeps
+			travelling in its Contact, where it cannot expire - exactly as it
+			does without this parameter. Both may well be in use at the same
+			time, as this is decided for each dialog as its Contact is
+			encoded.
+		</para>
+		<para>
+			Note that a call which is given a dialog never gets here at all:
+			the <emphasis>dialog</emphasis> module holds its state and bounds
+			it for exactly as long as the call lives, and its Contact carries
+			just the dialog id, so it is already both short and correct.
+			Engaging a dialog for the calls (see
+			<xref linkend="param_force_dialog"/>) is therefore a better answer
+			for them than this parameter could ever be, which is left to serve
+			what a dialog cannot: everything that is not INVITE based.
+		</para>
+		<para>
+			The state must be readable by whichever node receives the
+			sequential requests, so when the traffic is distributed or fails
+			over between several &osips; instances, the backend must be shared
+			between them (e.g. a common <emphasis>cachedb_redis</emphasis>
+			instance or cluster). For a single instance, a local backend such
+			as <emphasis>cachedb_local</emphasis> is enough - it is kept in
+			shared memory, so all the &osips; workers do see it, but its
+			contents are lost on restart and are not visible to the other
+			nodes.
+		</para>
+		<para>
+			<emphasis role="bold">Security:</emphasis> the state kept in the
+			backend is stored in the clear. It is not encrypted, and - unlike
+			the copy that travels inside a Contact - it is not obfuscated
+			either, so anyone able to read the backend can see the topology it
+			hides: the real Contact, the route set and the receiving socket of
+			each call. This is intentional. The store is meant to be a trusted,
+			internal backend reachable only by the &osips; nodes that share it:
+			deploy it on a private or DMZ network, bind it to the internal
+			interface, enable the backend's own authentication, and keep it off
+			any untrusted network. Do not point
+			<varname>th_state_url</varname> at a backend that is reachable
+			beyond that trust boundary.
+		</para>
+		<para>
+			The state is immutable, so re-encoding a Contact on a sequential
+			request only pushes its expiration further out. To spare the
+			backend a write on every such request, each node keeps a small
+			in-memory record of what it last stored and skips the write while
+			the state still has enough of its lifetime left - a write that
+			would actually shorten a state (a subscription being torn down)
+			is never skipped. This is transparent and needs no configuration.
+		</para>
+		<para>
+			A state is only ever removed from the backend when it expires
+			(see <xref linkend="param_th_state_ttl"/>), therefore the backend
+			must implement the expiration of the values it stores. All the
+			cachedb backends do, except for
+			<emphasis>cachedb_mongodb</emphasis>, which silently ignores it -
+			using it here would pile up the states forever, so it is rejected
+			at startup.
+		</para>
+		<para>
+			<emphasis>
+				By default this parameter is not set, and the state travels
+				in the Contact URI.
+			</emphasis>
+		</para>
+		<example>
+		<title>Set <varname>th_state_url</varname> parameter</title>
+		<programlisting format="linespecific">
+...
+# a single instance - state kept in its own shared memory
+loadmodule "cachedb_local.so"
+modparam("topology_hiding", "th_state_url", "local://topohiding")
+
+# several instances sharing a Redis server
+loadmodule "cachedb_redis.so"
+modparam("topology_hiding", "th_state_url", "redis://127.0.0.1:6379/0")
+
+# a password protected Redis cluster - one node is enough,
+# the rest of the cluster is discovered from it
+modparam("topology_hiding", "th_state_url",
+         "redis://:secretpass@10.0.0.20:6379/0")
+
+# a Memcached server
+loadmodule "cachedb_memcached.so"
+modparam("topology_hiding", "th_state_url",
+         "memcached://127.0.0.1:11211/")
+...
+</programlisting>
+		</example>
+	</section>
+
+	<section id="param_th_state_ttl" xreflabel="th_state_ttl">
+		<title><varname>th_state_ttl</varname> (int)</title>
+		<para>
+			For how long, in seconds, a topology hiding state is kept in the
+			backend configured through <xref linkend="param_th_state_url"/>.
+			It should be at least as long as the calls whose topology is
+			hidden are expected to last, as a call whose state has expired can
+			no longer have its sequential requests matched.
+		</para>
+		<para>
+			Whenever a message which keeps its dialog alive is matched, the
+			state it was sent to has its expiration pushed further, for as
+			long as that message says the dialog is going to live. This
+			matters because the party which sent it only learns of a new state
+			if the reply it gets back carries a Contact of its own - otherwise
+			it goes on using the state it already knows, which therefore has
+			to outlive its original expiration. Only the messages which do
+			carry the lifetime of their dialog may refresh it - a
+			<emphasis>SUBSCRIBE</emphasis> or <emphasis>NOTIFY</emphasis>
+			through its expires, an <emphasis>INVITE</emphasis> or
+			<emphasis>UPDATE</emphasis> through its
+			<emphasis>Session-Expires</emphasis> - so that, say, an in-dialog
+			OPTIONS cannot cut the state of the call it runs into down to
+			<xref linkend="param_th_state_ttl_short"/>.
+		</para>
+		<para>
+			A state is stored each time a Contact is encoded, and is otherwise
+			only removed when it expires, so the module tries not to keep any
+			state for longer than it may be needed:
+		</para>
+		<itemizedlist>
+			<listitem><para>
+				for <emphasis>SUBSCRIBE</emphasis> and
+				<emphasis>NOTIFY</emphasis>, the state has to outlive the
+				subscription, so its duration is taken from the very message
+				being encoded (plus a small margin, to cover the refresh). A
+				NOTIFY reports how long the subscription actually has left in
+				its <emphasis>Subscription-State</emphasis> header (RFC 6665
+				4.1.3), which is what the notifier granted rather than what
+				the subscriber asked for, so it is preferred. Failing that, it
+				is looked for as an <quote>expires</quote> parameter of the
+				Contact first and as the <emphasis>Expires</emphasis> header
+				afterwards, the parameter taking precedence over the header.
+				This matters because a notifier is free to grant a shorter
+				subscription than the one asked for, and its NOTIFYs are what
+				bring the state of a subscription back in line with what was
+				really granted.
+				Note that a subscription may last much longer than this
+				parameter, in which case its state is kept for longer as
+				well. A message which ends a subscription (an expires of
+				<quote>0</quote>, or a NOTIFY reporting it as
+				<quote>terminated</quote>) drops the state it was sent to
+				right away,
+				instead of leaving it behind for as long as the subscription
+				was going to last - the Contact it gets encoded with still
+				takes <xref linkend="param_th_state_ttl_short"/>, so that the
+				final NOTIFY may be routed back;
+			</para></listitem>
+			<listitem><para>
+				for <emphasis>INVITE</emphasis> and
+				<emphasis>UPDATE</emphasis>, when the session timers are in
+				use, the session gets refreshed every
+				<emphasis>Session-Expires</emphasis> seconds (RFC 4028) and
+				each refresh encodes the Contact anew, so the state only has
+				to survive one interval - that value (plus the margin) is used
+				then. Should a refresh not come, the session is torn down
+				anyway, so this can never expire the state of a live call.
+				Note that the <emphasis>Expires</emphasis> header is
+				deliberately <emphasis>not</emphasis> used here: on an INVITE
+				it limits the validity of the invitation, not the duration of
+				the call it may lead to;
+			</para></listitem>
+			<listitem><para>
+				<emphasis>OPTIONS</emphasis>, <emphasis>MESSAGE</emphasis>,
+				<emphasis>INFO</emphasis> and <emphasis>PUBLISH</emphasis>
+				neither open a dialog nor refresh the target of one, so their
+				Contact is only of interest while their transaction is
+				running - they get
+				<xref linkend="param_th_state_ttl_short"/>;
+			</para></listitem>
+			<listitem><para>
+				everything else, and any of the above whose expiry could not
+				be told (no session timers, no Expires), may last for any
+				amount of time, so it gets this parameter.
+			</para></listitem>
+		</itemizedlist>
+		<para>
+			This parameter is only used when
+			<xref linkend="param_th_state_url"/> is set.
+		</para>
+		<para>
+		<emphasis>
+			Default value is <quote>3600</quote> (one hour).
+		</emphasis>
+		</para>
+		<example>
+		<title>Set <varname>th_state_ttl</varname> parameter</title>
+		<programlisting format="linespecific">
+...
+# hide the topology of calls which may last up to 12 hours
+modparam("topology_hiding", "th_state_ttl", 43200)
+...
+</programlisting>
+		</example>
+	</section>
+
+	<section id="param_th_state_ttl_short" xreflabel="th_state_ttl_short">
+		<title><varname>th_state_ttl_short</varname> (int)</title>
+		<para>
+			For how long, in seconds, to keep the topology hiding state of the
+			messages which do not open a dialog nor refresh the target of one
+			- see <xref linkend="param_th_state_ttl"/> for the exact list.
+			Their Contact is only used while their transaction is alive, so
+			keeping their state for as long as a call's would needlessly fill
+			up the storage.
+		</para>
+		<para>
+			It only needs to cover the lifetime of a transaction. Raise it to
+			the value of <xref linkend="param_th_state_ttl"/> if you have user
+			agents which wrongly latch onto the Contact of such a request and
+			keep using it afterwards.
+		</para>
+		<para>
+			This parameter is only used when
+			<xref linkend="param_th_state_url"/> is set.
+		</para>
+		<para>
+		<emphasis>
+			Default value is <quote>60</quote>.
+		</emphasis>
+		</para>
+		<example>
+		<title>Set <varname>th_state_ttl_short</varname> parameter</title>
+		<programlisting format="linespecific">
+...
+modparam("topology_hiding", "th_state_ttl_short", 120)
+...
+</programlisting>
+		</example>
+	</section>
 
 	</section>
 	<section id="exported_functions" xreflabel="exported_functions">

--- a/modules/topology_hiding/doc/topology_hiding_admin.xml
+++ b/modules/topology_hiding/doc/topology_hiding_admin.xml
@@ -138,6 +138,14 @@ modparam("topology_hiding", "th_passed_contact_params", "paramname1;myparam;cust
 			If set to 1, the module will internally create the dialog ( if not already created ). This will only work for INVITE based dialogs, and the dialog module must be loaded.
 		</para>
 		<para>
+			This only controls whether the module creates a dialog of its
+			own. A dialog created by the script itself, with
+			<function>create_dialog()</function>, has the same effect: once a
+			dialog exists, it carries the topology hiding state. See
+			<xref linkend="param_th_state_url"/> for when that is what you
+			want and when it is not.
+		</para>
+		<para>
 		<emphasis>
 			Default value is <quote>0</quote>
 		</emphasis>
@@ -327,11 +335,45 @@ modparam("topology_hiding", "th_callid_loop_protection", 1)
 			Note that a call which is given a dialog never gets here at all:
 			the <emphasis>dialog</emphasis> module holds its state and bounds
 			it for exactly as long as the call lives, and its Contact carries
-			just the dialog id, so it is already both short and correct.
-			Engaging a dialog for the calls (see
-			<xref linkend="param_force_dialog"/>) is therefore a better answer
-			for them than this parameter could ever be, which is left to serve
-			what a dialog cannot: everything that is not INVITE based.
+			just the dialog id, so it is already both short and correct. The
+			rule is simply whether a dialog exists by the time
+			<function>topology_hiding()</function> runs: if one does, the
+			dialog carries the state and this parameter is not consulted for
+			that call. <xref linkend="param_force_dialog"/> only governs
+			whether the module creates a dialog when none exists yet - a
+			script that calls <function>create_dialog()</function> itself,
+			as most do for accounting, BYE handling or sharing tags, puts its
+			INVITEs on the dialog path whatever
+			<varname>force_dialog</varname> is set to.
+		</para>
+		<para>
+			Where a call is going to have a dialog anyway, that is the better
+			place for its state. The dialog's lifetime is the call's own,
+			rather than a timer: the cached state can only approximate it
+			from <emphasis>Session-Expires</emphasis>, or fall back to
+			<xref linkend="param_th_state_ttl"/> when the call is not session
+			timed, whereas a dialog is torn down with the call instead of
+			waiting out a TTL. A dialog is also replicated by the dialog
+			module's own clustering, and two of this module's features -
+			hiding the Call-ID, and carrying the dialog id in the Contact
+			user - are dialog-only, and are skipped with a warning when no
+			dialog is engaged. This parameter is left to serve what a dialog
+			cannot: everything that is not INVITE based.
+		</para>
+		<para>
+			The reverse holds where dialogs are not wanted in the first
+			place. A load balancer or other high-throughput proxy that has no
+			use for dialog state - no accounting, no BYE handling, nothing to
+			replicate to its peers - still pays for every dialog it creates,
+			in shared memory and in the work of creating, matching and
+			expiring it, and at high call rates that cost is the dominant
+			one. Such a deployment is better off leaving
+			<varname>force_dialog</varname> at 0, not creating dialogs from
+			the script, and pointing this parameter at a fast local backend
+			instead: <emphasis>cachedb_perf</emphasis> is built for this
+			traffic shape and keeps lookups flat as the number of concurrent
+			calls grows, where <emphasis>cachedb_local</emphasis> degrades
+			once its fixed hash table is outgrown.
 		</para>
 		<para>
 			The state must be readable by whichever node receives the

--- a/modules/topology_hiding/th_store.c
+++ b/modules/topology_hiding/th_store.c
@@ -1,0 +1,452 @@
+/*
+ * Copyright (C) 2026 OpenSIPS Solutions
+ *
+ * This file is part of opensips, a free SIP server.
+ *
+ * opensips is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version
+ *
+ * opensips is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+#include <string.h>
+
+#include "../../dprint.h"
+#include "../../mem/mem.h"
+#include "../../mem/shm_mem.h"
+#include "../../locking.h"
+#include "../../ut.h"
+#include "../../md5utils.h"
+#include "../../cachedb/cachedb.h"
+#include "th_store.h"
+
+str th_state_url = {NULL, 0};
+int th_state_ttl = 3600;
+int th_state_ttl_short = 60;
+
+static enum th_store_type th_store_be = TH_STORE_NONE;
+
+static cachedb_funcs th_cdbf;
+static cachedb_con *th_cdbc;
+
+/* the stored keys are prefixed, so that the storage may be shared with
+ * other users without clashing over the key names */
+#define TH_KEY_PREFIX     "th:"
+#define TH_KEY_PREFIX_LEN (sizeof(TH_KEY_PREFIX)-1)
+
+int th_store_enabled(void)
+{
+	return th_store_be != TH_STORE_NONE;
+}
+
+
+/*
+ * Write-coalescing cache (shared memory, one per node).
+ *
+ * The stored state is immutable, so re-storing it on every sequential
+ * request of a dialog only ever pushes its expiration further out. This
+ * cache remembers, per key, the expiry this node last wrote, and lets
+ * th_store_put()/th_store_refresh() skip the backend write while the state
+ * still has plenty of life left - turning a busy dialog's stream of
+ * identical writes into an occasional TTL bump. With anycast/ECMP a
+ * dialog's requests reach the same node, whose workers share this cache,
+ * so the repeats are seen and collapsed.
+ *
+ * Skipping only ever drops a *redundant* write: a request that asks for a
+ * shorter life than is stored (a teardown lowering the TTL) still writes,
+ * and a stale or evicted entry just causes one extra write. The only
+ * residual effect is that, across a node change, a state might expire
+ * slightly early - which the user agent recovers from by re-establishing.
+ * It is a plain best-effort hint, so a single small lock guards it.
+ */
+#define TH_WC_BITS  12
+#define TH_WC_SIZE  (1 << TH_WC_BITS)
+#define TH_WC_MASK  (TH_WC_SIZE - 1)
+
+struct th_wc_entry {
+	char   key[TH_KEY_LEN];
+	int    used;
+	time_t deadline;   /* absolute expiry this node last stored */
+};
+
+static struct th_wc_entry *th_wc;        /* direct-mapped, in shm */
+static gen_lock_t         *th_wc_lock;
+
+static unsigned int th_wc_slot(const char *s)
+{
+	unsigned int h = 2166136261u;   /* FNV-1a over the wire key */
+	int i;
+
+	for (i = 0; i < TH_KEY_LEN; i++)
+		h = (h ^ (unsigned char)s[i]) * 16777619u;
+
+	return h & TH_WC_MASK;
+}
+
+/*
+ * Whether the state under @key still has to be written to last @ttl more
+ * seconds. Returns 1 to write (and records the new expiry), 0 to skip
+ * because a write this node already made covers it.
+ */
+static int th_wc_need_write(str *key, int ttl)
+{
+	struct th_wc_entry *e;
+	time_t now;
+	int    write;
+
+	if (!th_wc || key->len != TH_KEY_LEN)
+		return 1;
+
+	now = time(NULL);
+	e = &th_wc[th_wc_slot(key->s)];
+
+	lock_get(th_wc_lock);
+	if (e->used && memcmp(e->key, key->s, TH_KEY_LEN) == 0 &&
+	    now + ttl >= e->deadline &&      /* not asking for a shorter life */
+	    e->deadline - now >= ttl / 2) {  /* still at least half of it left */
+		write = 0;
+	} else {
+		memcpy(e->key, key->s, TH_KEY_LEN);
+		e->used = 1;
+		e->deadline = now + ttl;
+		write = 1;
+	}
+	lock_release(th_wc_lock);
+
+	return write;
+}
+
+static void th_wc_forget(str *key)
+{
+	struct th_wc_entry *e;
+
+	if (!th_wc || key->len != TH_KEY_LEN)
+		return;
+
+	e = &th_wc[th_wc_slot(key->s)];
+	lock_get(th_wc_lock);
+	if (e->used && memcmp(e->key, key->s, TH_KEY_LEN) == 0)
+		e->used = 0;
+	lock_release(th_wc_lock);
+}
+
+
+/*
+ * The states are only ever removed by the expiration of the stored value,
+ * so a backend which does not implement it would pile them up forever.
+ * The cachedb interface has no way of telling whether a backend honours
+ * the expire argument of its set(), hence the check on the URL scheme.
+ */
+static int th_store_check_scheme(void)
+{
+	str scheme;
+	char *p;
+
+	p = memchr(th_state_url.s, ':', th_state_url.len);
+	if (!p) {
+		LM_ERR("cannot extract the backend out of th_state_url %s\n",
+			db_url_escape(&th_state_url));
+		return -1;
+	}
+
+	scheme.s = th_state_url.s;
+	scheme.len = p - th_state_url.s;
+
+	if (str_casematch_nt(&scheme, "mongodb")) {
+		LM_ERR("the mongodb backend ignores the expiration of the values "
+			"it stores, so the topology hiding states would never be "
+			"removed from it - use a backend which expires its values, "
+			"such as redis, memcached or local\n");
+		return -1;
+	}
+
+	return 0;
+}
+
+
+int th_store_init(void)
+{
+	if (!th_state_url.s)
+		return 0;
+
+	th_state_url.len = strlen(th_state_url.s);
+
+	if (th_store_check_scheme() < 0)
+		return -1;
+
+	if (cachedb_bind_mod(&th_state_url, &th_cdbf) < 0) {
+		LM_ERR("cannot bind functions for th_state_url %s\n",
+			db_url_escape(&th_state_url));
+		return -1;
+	}
+
+	if (!CACHEDB_CAPABILITY(&th_cdbf,
+	CACHEDB_CAP_GET|CACHEDB_CAP_SET|CACHEDB_CAP_REMOVE)) {
+		LM_ERR("the cachedb backend of th_state_url does not provide "
+			"the needed get/set/remove support\n");
+		return -1;
+	}
+
+	if (th_state_ttl <= 0) {
+		LM_ERR("th_state_ttl must be a positive value\n");
+		return -1;
+	}
+	if (th_state_ttl_short <= 0) {
+		LM_ERR("th_state_ttl_short must be a positive value\n");
+		return -1;
+	}
+
+	th_store_be = TH_STORE_CACHEDB;
+
+	/* Best-effort write-coalescing cache. If it cannot be set up, leave it
+	 * off (th_wc == NULL) and simply write on every request - a slower but
+	 * equally correct fallback, so this never fails mod_init. */
+	th_wc_lock = lock_alloc();
+	if (th_wc_lock && lock_init(th_wc_lock)) {
+		th_wc = shm_malloc(TH_WC_SIZE * sizeof *th_wc);
+		if (th_wc) {
+			memset(th_wc, 0, TH_WC_SIZE * sizeof *th_wc);
+		} else {
+			lock_destroy(th_wc_lock);
+			lock_dealloc(th_wc_lock);
+			th_wc_lock = NULL;
+			LM_WARN("no shm for the write-coalescing cache - will store on "
+				"every request\n");
+		}
+	} else {
+		if (th_wc_lock)
+			lock_dealloc(th_wc_lock);
+		th_wc_lock = NULL;
+		LM_WARN("cannot init the write-coalescing lock - will store on "
+			"every request\n");
+	}
+
+	LM_INFO("topology hiding state kept in the shared store, "
+		"ttl %d s (%d s for the dialog-less methods)\n",
+		th_state_ttl, th_state_ttl_short);
+
+	return 0;
+}
+
+
+int th_store_child_init(void)
+{
+	if (!th_store_enabled())
+		return 0;
+
+	th_cdbc = th_cdbf.init(&th_state_url);
+	if (!th_cdbc) {
+		LM_ERR("cannot connect to th_state_url %s\n",
+			db_url_escape(&th_state_url));
+		return -1;
+	}
+
+	return 0;
+}
+
+
+void th_store_destroy(void)
+{
+	if (th_cdbc) {
+		th_cdbf.destroy(th_cdbc);
+		th_cdbc = NULL;
+	}
+	if (th_wc) {
+		shm_free(th_wc);
+		th_wc = NULL;
+	}
+	if (th_wc_lock) {
+		lock_destroy(th_wc_lock);
+		lock_dealloc(th_wc_lock);
+		th_wc_lock = NULL;
+	}
+}
+
+
+/*
+ * Derive the wire key of a state from the given seeds, straight into
+ * @out (which must hold TH_KEY_LEN bytes).
+ *
+ * The key is deterministic on purpose: the seeds identify the dialog leg
+ * whose state this is (its stable identifiers - the call and the tag of
+ * the party the state belongs to), so every refresh of that same leg
+ * derives the very same key. Its stored value is then simply overwritten
+ * and its expiration pushed further, instead of a fresh random key being
+ * piled up next to the previous one on each refresh - those would then
+ * linger in the store until they expired, with no dialog to ever clean
+ * them up (this mode exists precisely because there is no dialog).
+ *
+ * One of the seeds is expected to be a secret (the contact-encoding
+ * password), which is what keeps the key impossible to guess from one
+ * dialog to another: without it, knowing a dialog's call-id and tags -
+ * which travel in the clear - would hand out its hidden topology.
+ */
+void th_store_make_key(str seeds[], int n, char *out)
+{
+	char md5[MD5_LEN];
+
+	MD5StringArray(md5, seeds, n);
+	/* MD5StringArray emits MD5_LEN(32) hex chars; TH_KEY_LEN of them
+	 * make for a 64-bit key, as wide as the former random one */
+	memcpy(out, md5, TH_KEY_LEN);
+}
+
+
+/* build the full storage key ("th:" + wire key) into @buf */
+static inline void th_store_key(str *key, char *buf, str *out)
+{
+	memcpy(buf, TH_KEY_PREFIX, TH_KEY_PREFIX_LEN);
+	memcpy(buf + TH_KEY_PREFIX_LEN, key->s, key->len);
+	out->s = buf;
+	out->len = TH_KEY_PREFIX_LEN + key->len;
+}
+
+
+int th_store_put(str *blob, str *key, int ttl)
+{
+	char buf[TH_KEY_PREFIX_LEN + TH_KEY_LEN];
+	str full_key;
+
+	if (!th_store_enabled()) {
+		LM_BUG("no topology hiding storage configured\n");
+		return -1;
+	}
+	if (!th_cdbc) {
+		LM_ERR("not connected to the topology hiding storage\n");
+		return -1;
+	}
+	if (ttl <= 0) {
+		LM_BUG("bad ttl %d for the topology hiding state\n", ttl);
+		return -1;
+	}
+
+	if (!th_wc_need_write(key, ttl)) {
+		LM_DBG("topology hiding state under the key is already stored with "
+			"enough TTL, skipping the write\n");
+		return 0;
+	}
+
+	th_store_key(key, buf, &full_key);
+
+	if (th_cdbf.set(th_cdbc, &full_key, blob, ttl) < 0) {
+		LM_ERR("failed to store the topology hiding state under <%.*s>\n",
+			full_key.len, full_key.s);
+		return -1;
+	}
+
+	LM_DBG("stored %d bytes of topology hiding state under <%.*s>, "
+		"expiring in %d s\n", blob->len, full_key.len, full_key.s, ttl);
+	return 0;
+}
+
+
+int th_store_get(str *key, str *blob)
+{
+	char buf[TH_KEY_PREFIX_LEN + TH_KEY_LEN];
+	str full_key;
+
+	if (!th_store_enabled()) {
+		LM_BUG("no topology hiding storage configured\n");
+		return -1;
+	}
+	if (!th_cdbc) {
+		LM_ERR("not connected to the topology hiding storage\n");
+		return -1;
+	}
+
+	if (key->len != TH_KEY_LEN) {
+		LM_DBG("bad topology hiding key length %d, expected %d - the "
+			"user agent may have truncated it\n", key->len, TH_KEY_LEN);
+		return -1;
+	}
+
+	th_store_key(key, buf, &full_key);
+
+	blob->s = NULL;
+	blob->len = 0;
+
+	if (th_cdbf.get(th_cdbc, &full_key, blob) < 0) {
+		LM_ERR("failed to fetch the topology hiding state of <%.*s>\n",
+			full_key.len, full_key.s);
+		return -1;
+	}
+	if (!blob->s || !blob->len) {
+		LM_WARN("no topology hiding state found for <%.*s> - it may have "
+			"expired, check the th_state_ttl* parameters against the "
+			"lifetime of the hidden calls\n", full_key.len, full_key.s);
+		if (blob->s) {
+			pkg_free(blob->s);
+			blob->s = NULL;
+		}
+		return -1;
+	}
+
+	LM_DBG("fetched %d bytes of topology hiding state for <%.*s>\n",
+		blob->len, full_key.len, full_key.s);
+	return 0;
+}
+
+
+void th_store_refresh(str *key, str *blob, int ttl)
+{
+	char buf[TH_KEY_PREFIX_LEN + TH_KEY_LEN];
+	str full_key;
+
+	if (!th_store_enabled() || !th_cdbc)
+		return;
+	if (key->len != TH_KEY_LEN || !blob->s || !blob->len || ttl <= 0)
+		return;
+
+	if (!th_wc_need_write(key, ttl)) {
+		LM_DBG("topology hiding state already refreshed with enough TTL, "
+			"skipping\n");
+		return;
+	}
+
+	th_store_key(key, buf, &full_key);
+
+	/* there is no way of just pushing the expiration of a value further
+	 * through the cachedb interface, so store it again as it is */
+	if (th_cdbf.set(th_cdbc, &full_key, blob, ttl) < 0)
+		LM_WARN("failed to refresh the topology hiding state of <%.*s>, "
+			"it may expire while still in use\n",
+			full_key.len, full_key.s);
+	else
+		LM_DBG("refreshed the topology hiding state of <%.*s> for "
+			"another %d s\n", full_key.len, full_key.s, ttl);
+}
+
+
+void th_store_del(str *key)
+{
+	char buf[TH_KEY_PREFIX_LEN + TH_KEY_LEN];
+	str full_key;
+
+	if (!th_store_enabled() || !th_cdbc)
+		return;
+	if (key->len != TH_KEY_LEN)
+		return;
+
+	/* forget any cached expiry, so a later re-create of this key writes */
+	th_wc_forget(key);
+
+	th_store_key(key, buf, &full_key);
+
+	/* the state expires on its own anyway, so a failure here is not
+	 * worth failing the request over */
+	if (th_cdbf.remove(th_cdbc, &full_key) < 0)
+		LM_WARN("failed to drop the topology hiding state of <%.*s>, "
+			"leaving it to expire\n", full_key.len, full_key.s);
+	else
+		LM_DBG("dropped the topology hiding state of <%.*s>\n",
+			full_key.len, full_key.s);
+}

--- a/modules/topology_hiding/th_store.h
+++ b/modules/topology_hiding/th_store.h
@@ -1,0 +1,140 @@
+/*
+ * Copyright (C) 2026 OpenSIPS Solutions
+ *
+ * This file is part of opensips, a free SIP server.
+ *
+ * opensips is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version
+ *
+ * opensips is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+#ifndef TH_STORE_H
+#define TH_STORE_H
+
+#include "../../str.h"
+
+/*
+ * Server-side storage for the topology hiding state of dialog-less calls.
+ *
+ * In the default (stateless) mode, the whole encoded state travels in the
+ * Contact URI parameter, which makes that URI long. Some user agents cannot
+ * cope with it and truncate the parameter, so the state can no longer be
+ * decoded when they send a sequential request.
+ *
+ * In this mode, the state is kept on the server side under a short key, and
+ * only that key travels in the Contact URI. Off the wire the obfuscation and
+ * URI-safe encoding serve no purpose, so the stored copy carries neither: its
+ * fields are simply length-prefixed in a printable "<length>:<bytes>" form,
+ * which keeps it inspectable in the store (only the state that still travels
+ * inline in a Contact is obfuscated and encoded). The state must be readable
+ * by whichever node receives the sequential request, so the storage is
+ * expected to be shared between all the nodes handling the same traffic.
+ */
+
+/* length of the key travelling on the wire (hex chars => 64 bits) */
+#define TH_KEY_LEN 16
+
+/*
+ * A key travels in the Contact URI parameter prefixed by this marker, so
+ * that it can never be taken for an encoded state travelling in that same
+ * parameter instead - both are in use at once, as it is decided per dialog
+ * which of the two it gets (see th_state_storable()).
+ *
+ * The marker has to satisfy two things, and '_' is picked because it
+ * provably does:
+ *
+ * 1) No encoded state may ever start with it, or a state would be looked
+ *    up in the storage as if it were a key. The state is emitted by
+ *    word64encode() or word32encode(), whose alphabets are word64digits
+ *    "A-Za-z0-9+." and base32digits "A-Z2-7" (see ut.c), and both pad
+ *    with '-'. So an encoded state is always within [A-Za-z0-9+.-], which
+ *    '_' is not part of. Note this holds whatever its length: telling the
+ *    two apart by length instead would rest on nothing more than the
+ *    minimum size of what gets packed, which no rule keeps true.
+ *
+ *    Mind that word64 is not the usual base64: it ends in "+." where
+ *    base64 ends in "+/", so '.' - the tempting choice - is one of the
+ *    characters a state can be made of, and would not do here.
+ *
+ * 2) It must be legal, unescaped, in the parameter of a SIP URI. Per the
+ *    grammar of RFC 3261 25.1:
+ *
+ *      pvalue     =  1*paramchar
+ *      paramchar  =  param-unreserved / unreserved / escaped
+ *      unreserved =  alphanum / mark
+ *      mark       =  "-" / "_" / "." / "!" / "~" / "*" / "'" / "(" / ")"
+ *
+ *    which puts '_' in mark, hence in unreserved, hence in paramchar.
+ *
+ * The marker only ever has to be unambiguous inside the value of our own
+ * parameter: whatever else the URI carries is matched by parameter name
+ * (see topology_hiding_match()), so no other parameter can shadow it.
+ */
+#define TH_KEY_MARKER '_'
+
+/* what a key takes up in the Contact, marker included */
+#define TH_KEY_WIRE_LEN (1 + TH_KEY_LEN)
+
+/* storage backends */
+enum th_store_type {
+	TH_STORE_NONE = 0,   /* stateless - state travels in the Contact */
+	TH_STORE_CACHEDB,    /* shared key-value store */
+};
+
+extern str th_state_url;
+extern int th_state_ttl;
+extern int th_state_ttl_short;
+
+/* added on top of a subscription's Expires, to cover the refresh */
+#define TH_STATE_TTL_MARGIN 30
+
+/* is a server-side storage configured? */
+int th_store_enabled(void);
+
+/* bind the storage backend - to be called from mod_init */
+int th_store_init(void);
+/* connect to the storage backend - to be called from child_init */
+int th_store_child_init(void);
+void th_store_destroy(void);
+
+/*
+ * Derive the wire key of a state from @seeds into @out, which must hold
+ * TH_KEY_LEN bytes. The key is deterministic, so that every refresh of the
+ * same dialog leg lands on it again - see the definition for the rationale.
+ */
+void th_store_make_key(str seeds[], int n, char *out);
+
+/*
+ * Store @blob for @ttl seconds under @key. The caller provides the key,
+ * already filled in (TH_KEY_LEN bytes, e.g. via th_store_make_key), so
+ * that refreshing a leg overwrites its state in place rather than piling
+ * up a new one.
+ */
+int th_store_put(str *blob, str *key, int ttl);
+
+/*
+ * Fetch the blob stored under @key. On success, @blob->s is allocated in
+ * pkg memory and must be freed by the caller.
+ */
+int th_store_get(str *key, str *blob);
+
+/* Drop the blob stored under @key, once it is known to be of no use. */
+void th_store_del(str *key);
+
+/*
+ * Keep the blob already stored under @key around for another @ttl
+ * seconds. @blob must be the value it currently holds.
+ */
+void th_store_refresh(str *key, str *blob, int ttl);
+
+#endif /* TH_STORE_H */

--- a/modules/topology_hiding/topo_hiding_logic.c
+++ b/modules/topology_hiding/topo_hiding_logic.c
@@ -25,7 +25,10 @@
 */
 
 #include "../../ut.h"
+#include "../../parser/parse_expires.h"
+#include "../../parser/parse_sst.h"
 #include "topo_hiding_logic.h"
+#include "th_store.h"
 
 extern int force_dialog;
 extern struct tm_binds tm_api;
@@ -63,8 +66,11 @@ static void th_down_onreply(struct cell* t, int type,struct tmcb_params *param);
 static void th_up_onreply(struct cell* t, int type, struct tmcb_params *param);
 static void th_no_dlg_onreply(struct cell* t, int type, struct tmcb_params *param);
 static void th_no_dlg_user_onreply(struct cell* t, int type, struct tmcb_params *param);
-static int topo_no_dlg_encode_contact(struct sip_msg *req,int flags,str *routes,str *ct_user);
+static int topo_no_dlg_encode_contact(struct sip_msg *req,int flags,str *routes,str *ct_user,int store_state);
 static int topo_no_dlg_seq_handling(struct sip_msg *msg,str *info);
+static int th_state_msg_ttl(struct sip_msg *msg);
+static int th_state_storable(struct sip_msg *msg);
+static str *th_msg_key_tag(struct sip_msg *msg);
 static int dlg_th_onreply(struct dlg_cell *dlg, struct sip_msg *rpl, struct sip_msg *req,
 		int init_req, int dir, int dst_leg);
 
@@ -895,7 +901,8 @@ static void _th_no_dlg_onreply(struct cell* t, int type, struct tmcb_params *par
 
 	if ( !(rpl->REPLY_STATUS>=300 && rpl->REPLY_STATUS<400) ) {
 		if (topo_no_dlg_encode_contact(rpl,flags,
-				(p?&p->routes:NULL),(p?&p->username:NULL)) < 0) {
+				(p?&p->routes:NULL),(p?&p->username:NULL),
+				-1/*decide from the reply*/) < 0) {
 			LM_ERR("Failed to encode contact header \n");
 			return;
 		}
@@ -986,7 +993,8 @@ static int topo_hiding_no_dlg(struct sip_msg *req,
 		return -1;
 	}
 
-	if (topo_no_dlg_encode_contact(req,extra_flags,NULL, &params->ct_caller_user) < 0) {
+	if (topo_no_dlg_encode_contact(req,extra_flags,NULL, &params->ct_caller_user,
+	-1/*decide from the request*/) < 0) {
 		LM_ERR("Failed to encode contact header \n");
 		return -1;
 	}
@@ -1758,14 +1766,16 @@ error:
 
 /* We encode the RR headers, the actual Contact and the socket str for this leg */
 /* Via headers will be restored using the TM module, no need to save anything for them */
-static char* build_encoded_contact_suffix(struct sip_msg* msg, str *routes, int *suffix_len, int flags)
+static char* build_encoded_contact_suffix(struct sip_msg* msg, str *routes, int *suffix_len, int flags, int store_state)
 {
 	short rr_len,ct_len,addr_len,flags_len;
-	char *suffix_plain,*suffix_enc,*p,*s;
+	char *suffix_plain = NULL,*suffix_enc = NULL,*p,*s;
 	str rr_set = {NULL, 0};
 	str contact;
 	str flags_str;
-	int i,total_len,enc_len;
+	int i,total_len,enc_len,wire_len;
+	char *blob_buf = NULL;
+	str blob, key;
 	struct sip_uri ctu;
 	struct th_ct_params* el;
 	param_t *it;
@@ -1817,14 +1827,20 @@ static char* build_encoded_contact_suffix(struct sip_msg* msg, str *routes, int 
 	if (topo_ct_short_len(msg->rcv.bind_address->sock_str.len,
 			&addr_len, "bind address") < 0)
 		goto error;
-	local_len += rr_len + ct_len + flags_len + addr_len; 
+	local_len += rr_len + ct_len + flags_len + addr_len;
 	enc_len = th_ct_enc_scheme == ENC_BASE64 ?
 		calc_word64_encode_len(local_len) : calc_word32_encode_len(local_len);
-	total_len = enc_len +  
-		1 /* ; */ + 
-		th_contact_encode_param.len + 
-		1 /* = */  + 
-		1 /* > */;	 
+	/* a sequential request keeps whatever its dialog is already using,
+	 * anything else is decided upon here */
+	if (store_state < 0)
+		store_state = th_state_storable(msg);
+	/* with a server-side storage, only the key travels in the Contact */
+	wire_len = store_state ? TH_KEY_WIRE_LEN : enc_len;
+	total_len = wire_len +
+		1 /* ; */ +
+		th_contact_encode_param.len +
+		1 /* = */  +
+		1 /* > */;
 
 	if (th_param_list) {
 		if ( parse_contact(msg->contact)<0 ||
@@ -1894,20 +1910,103 @@ static char* build_encoded_contact_suffix(struct sip_msg* msg, str *routes, int 
 	p+= sizeof(short);
 	memcpy(p,msg->rcv.bind_address->sock_str.s,msg->rcv.bind_address->sock_str.len);
 	p+= msg->rcv.bind_address->sock_str.len;
-	for (i=0;i<(int)(p-suffix_plain);i++)
-		suffix_plain[i] ^= topo_hiding_ct_encode_pw.s[i%topo_hiding_ct_encode_pw.len];
 
 	s = suffix_enc;
 	*s++ = ';';
 	memcpy(s,th_contact_encode_param.s,th_contact_encode_param.len);
 	s+= th_contact_encode_param.len;
 	*s++ = '=';
-	if (th_ct_enc_scheme == ENC_BASE64)
-		word64encode((unsigned char*)s,(unsigned char *)suffix_plain,p-suffix_plain);
-	else
-		word32encode((unsigned char*)s,(unsigned char *)suffix_plain,p-suffix_plain);
-	s = s+enc_len;
-	
+	if (store_state) {
+		/* the state is kept on the server side under a key. It never
+		 * travels on the wire, so it needs neither the XOR obfuscation
+		 * nor the URI-safe word encoding a Contact-borne state does -
+		 * keep it printable and inspectable in the store, framed as
+		 * length-prefixed "<decimal-len>:<bytes>" fields in the same
+		 * order (route set, contact, flags, receiving socket). */
+		char *b, *ls;
+		int   ll;
+
+		blob_buf = pkg_malloc(local_len + 4*6);
+		if (!blob_buf) {
+			LM_ERR("no more pkg\n");
+			goto error;
+		}
+		b = blob_buf;
+		#define __put_ascii_field(_f) \
+			do { \
+				ls = int2str((unsigned long)(_f).len, &ll); \
+				memcpy(b, ls, ll); b += ll; \
+				*b++ = ':'; \
+				if ((_f).len) { memcpy(b, (_f).s, (_f).len); b += (_f).len; } \
+			} while (0)
+		__put_ascii_field(rr_set);
+		__put_ascii_field(contact);
+		__put_ascii_field(flags_str);
+		__put_ascii_field(msg->rcv.bind_address->sock_str);
+		#undef __put_ascii_field
+		blob.s = blob_buf;
+		blob.len = b - blob_buf;
+
+		/* mark the key, so that it can never be taken for an encoded
+		 * state travelling in the Contact instead */
+		*s = TH_KEY_MARKER;
+
+		/* the key is derived straight into the Contact buffer */
+		key.s = s + 1;
+		key.len = TH_KEY_LEN;
+
+		/*
+		 * Key the state on the dialog leg it belongs to, so that a
+		 * refresh of that leg derives the very same key and just
+		 * overwrites its state, instead of leaving a new one behind on
+		 * every request (no dialog holds these, so nothing else would
+		 * ever reclaim them). The leg is the party whose Contact we are
+		 * hiding: its call and its own tag - the From tag of a request
+		 * it sends, the To tag of a reply it sends - both stable for as
+		 * long as the dialog lives. The encoding password is mixed in to
+		 * keep the key from being guessable out of the clear-text call-id
+		 * and tags.
+		 */
+		{
+			str seeds[3];
+			str *own_tag = th_msg_key_tag(msg);
+
+			if (!own_tag) {
+				/* th_state_storable() only lets a message reach here
+				 * once it can be keyed (has both a call-id and its
+				 * leg's tag); the sole caller which forces the state
+				 * to be stored - a sequential request being re-encoded
+				 * - is in-dialog and thus always has both */
+				LM_BUG("no call-id or tag to key the topology hiding "
+					"state on\n");
+				goto error;
+			}
+
+			seeds[0] = topo_hiding_ct_encode_pw;
+			seeds[1] = msg->callid->body;
+			seeds[2] = *own_tag;
+			th_store_make_key(seeds, 3, key.s);
+		}
+
+		if (th_store_put(&blob, &key, th_state_msg_ttl(msg)) < 0) {
+			LM_ERR("failed to store the topology hiding state\n");
+			goto error;
+		}
+		pkg_free(blob_buf);
+		blob_buf = NULL;
+	} else {
+		/* the state travels inline in the Contact - obfuscate it and
+		 * then URI-safe encode it onto the wire */
+		for (i=0;i<(int)(p-suffix_plain);i++)
+			suffix_plain[i] ^= topo_hiding_ct_encode_pw.s[i%topo_hiding_ct_encode_pw.len];
+		if (th_ct_enc_scheme == ENC_BASE64)
+			word64encode((unsigned char*)s,(unsigned char *)suffix_plain,p-suffix_plain);
+		else
+			word32encode((unsigned char*)s,(unsigned char *)suffix_plain,p-suffix_plain);
+	}
+	s = s+wire_len;
+
+
 	if (th_param_list) {
 		for (el=th_param_list;el;el=el->next) {
 			/* we just iterate over the unknown params */
@@ -1941,10 +2040,364 @@ static char* build_encoded_contact_suffix(struct sip_msg* msg, str *routes, int 
 error:
 	if (rr_set.s && free_rr_set)
 		pkg_free(rr_set.s);
+	if (blob_buf)
+		pkg_free(blob_buf);
+	if (suffix_plain)
+		pkg_free(suffix_plain);
+	if (suffix_enc)
+		pkg_free(suffix_enc);
 	return NULL;
 }
 
-static int topo_no_dlg_encode_contact(struct sip_msg *msg,int flags, str *routes, str *ct_user)
+/*
+ * How long the state of @msg has to outlive it.
+ *
+ * The states are only removed when they expire, and a new one is stored
+ * for each request whose Contact gets encoded, so keeping them for longer
+ * than needed just piles them up in the storage.
+ */
+/* the method @msg is about, be it a request or the reply to one */
+static int th_msg_method(struct sip_msg *msg)
+{
+	if (msg->first_line.type == SIP_REQUEST)
+		return msg->first_line.u.request.method_value;
+
+	return (msg->cseq && get_cseq(msg)) ?
+		get_cseq(msg)->method_id : METHOD_UNDEF;
+}
+
+
+/*
+ * The expires @msg is subject to, or -1 if it carries none. It may be
+ * given either as an "expires" Contact parameter or as the Expires
+ * header, the parameter taking precedence (RFC 3261 10.2.1.1).
+ */
+static int th_msg_expires(struct sip_msg *msg)
+{
+	exp_body_t *exp;
+	contact_t *ct;
+	unsigned int ct_exp;
+
+	if (msg->contact ||
+	(parse_headers(msg, HDR_CONTACT_F, 0) == 0 && msg->contact)) {
+		if (msg->contact->parsed || parse_contact(msg->contact) == 0) {
+			ct = ((contact_body_t *)msg->contact->parsed)->contacts;
+			if (ct && ct->expires && ct->expires->body.len &&
+			str2int(&ct->expires->body, &ct_exp) == 0) {
+				LM_DBG("expires in %us, per the Contact\n", ct_exp);
+				return (int)ct_exp;
+			}
+		}
+	}
+
+	if (parse_headers(msg, HDR_EXPIRES_F, 0) == 0 && msg->expires) {
+		if (msg->expires->parsed || parse_expires(msg->expires) == 0) {
+			exp = (exp_body_t *)msg->expires->parsed;
+			if (exp && exp->valid) {
+				LM_DBG("expires in %ds, per the Expires header\n",
+					exp->val);
+				return exp->val;
+			}
+		}
+		LM_DBG("unparsable Expires header\n");
+	}
+
+	return -1;
+}
+
+
+#define SUB_STATE_HDR     "Subscription-State"
+#define SUB_STATE_HDR_LEN (sizeof(SUB_STATE_HDR)-1)
+
+/*
+ * What a NOTIFY has to say about the lifetime of its subscription.
+ *
+ * A NOTIFY carries it in its Subscription-State header rather than in an
+ * Expires one (RFC 6665 4.1.3), and the value is the one the notifier
+ * actually granted, which may well be shorter than what the subscriber
+ * had asked for.
+ *
+ * Returns the seconds the subscription still has, 0 if it is over, or -1
+ * if the message says nothing about it.
+ */
+static int th_notify_sub_expires(struct sip_msg *msg)
+{
+	struct hdr_field *hf;
+	param_hooks_t hooks;
+	param_t *params = NULL, *p;
+	str body, state;
+	unsigned int val;
+	int ret = -1;
+	char *sep;
+
+	if (parse_headers(msg, HDR_EOH_F, 0) < 0)
+		return -1;
+
+	/* not one of the headers the parser knows about */
+	for (hf = msg->headers; hf; hf = hf->next)
+		if (hf->type == HDR_OTHER_T &&
+		hf->name.len == SUB_STATE_HDR_LEN &&
+		strncasecmp(hf->name.s, SUB_STATE_HDR, SUB_STATE_HDR_LEN) == 0)
+			break;
+	if (!hf)
+		return -1;
+
+	body = hf->body;
+	trim(&body);
+	if (!body.len)
+		return -1;
+
+	sep = memchr(body.s, ';', body.len);
+
+	state = body;
+	if (sep)
+		state.len = sep - body.s;
+	trim(&state);
+
+	/* a subscription which is over is not going to come back */
+	if (state.len == 10 && strncasecmp(state.s, "terminated", 10) == 0)
+		return 0;
+
+	if (!sep)
+		return -1;
+
+	/* the parameters start past the separator */
+	body.len -= sep - body.s + 1;
+	body.s = sep + 1;
+	if (body.len <= 0)
+		return -1;
+
+	if (parse_params(&body, CLASS_ANY, &hooks, &params) < 0) {
+		LM_DBG("unparsable " SUB_STATE_HDR " parameters\n");
+		return -1;
+	}
+
+	for (p = params; p; p = p->next)
+		if (p->name.len == 7 &&
+		strncasecmp(p->name.s, "expires", 7) == 0) {
+			if (str2int(&p->body, &val) == 0) {
+				LM_DBG("subscription has %us left, per " SUB_STATE_HDR "\n",
+					val);
+				ret = (int)val;
+			}
+			break;
+		}
+
+	free_params(params);
+	return ret;
+}
+
+
+/*
+ * The lifetime the subscription @msg belongs to still has, or -1 if it
+ * carries nothing about it. A NOTIFY reports the granted value, so it is
+ * preferred over anything the subscriber may have merely asked for.
+ */
+static int th_sub_expires(struct sip_msg *msg, int method)
+{
+	int expires = -1;
+
+	if (method == METHOD_NOTIFY)
+		expires = th_notify_sub_expires(msg);
+
+	if (expires < 0)
+		expires = th_msg_expires(msg);
+
+	return expires;
+}
+
+
+/* does @msg tear down the subscription it belongs to? */
+static int th_msg_ends_subscription(struct sip_msg *msg)
+{
+	int method = th_msg_method(msg);
+
+	if (method != METHOD_SUBSCRIBE && method != METHOD_NOTIFY)
+		return 0;
+
+	return th_sub_expires(msg, method) == 0;
+}
+
+
+/*
+ * Does @msg push the lifetime of the dialog it belongs to further, and
+ * by how much? Returns 0 if it does not say anything about it.
+ *
+ * Only the messages which do carry the lifetime of their dialog may
+ * answer here: refreshing a state off, say, an in-dialog OPTIONS would
+ * cut the state of the call it runs into down to a minute.
+ */
+static int th_msg_refreshes_state(struct sip_msg *msg)
+{
+	struct session_expires se;
+	int expires, method;
+
+	method = th_msg_method(msg);
+
+	switch (method) {
+	case METHOD_SUBSCRIBE:
+	case METHOD_NOTIFY:
+		expires = th_sub_expires(msg, method);
+		/* an ending subscription drops its state instead */
+		if (expires <= 0)
+			return 0;
+		return expires + TH_STATE_TTL_MARGIN;
+
+	case METHOD_INVITE:
+	case METHOD_UPDATE:
+		if (parse_session_expires(msg, &se) == parse_sst_success &&
+		se.interval > 0)
+			return (int)se.interval + TH_STATE_TTL_MARGIN;
+		return 0;
+
+	default:
+		return 0;
+	}
+}
+
+
+/*
+ * May the state of @msg be kept on the server side?
+ *
+ * Only if @msg tells us how long its dialog is going to live: a state
+ * which expires from under a dialog which is still up cannot be matched
+ * anymore, and takes down everything that was still to be routed through
+ * it - the BYE of a call, most notably. Whatever cannot be bounded keeps
+ * travelling in the Contact instead, where it never expires.
+ *
+ * Note that a call which does get a dialog never reaches here: the
+ * dialog holds its state and bounds it for exactly as long as it lives,
+ * which is a better answer than this mode could ever give it.
+ */
+/*
+ * The stable identifier of the dialog leg whose Contact @msg carries -
+ * the tag the party owns: its From tag when it sends a request, its To
+ * tag when it sends a reply. Both last as long as the dialog, so every
+ * message of that leg derives the same storage key off it.
+ *
+ * Returns NULL when the state cannot be keyed - either the call-id or the
+ * tag is missing. The latter is most notably the reply of an
+ * out-of-dialog transaction (a 200 OK to an OPTIONS keepalive, say),
+ * which carries a Contact but never a To tag. Such a state is not stored:
+ * it travels in the Contact instead (there is no sequential traffic to
+ * match it against anyway).
+ */
+static str *th_msg_key_tag(struct sip_msg *msg)
+{
+	str *tag;
+
+	/* the key is derived from the call-id and the leg's tag, so both
+	 * have to be there - the call-id of any message, and the tag its
+	 * leg owns */
+	if ((!msg->callid && parse_headers(msg, HDR_CALLID_F, 0) < 0) ||
+	!msg->callid)
+		return NULL;
+
+	if (msg->first_line.type == SIP_REQUEST) {
+		if (parse_from_header(msg) < 0 || !msg->from || !get_from(msg))
+			return NULL;
+		tag = &get_from(msg)->tag_value;
+	} else {
+		if (parse_to_header(msg) < 0 || !msg->to || !get_to(msg))
+			return NULL;
+		tag = &get_to(msg)->tag_value;
+	}
+
+	return tag->len ? tag : NULL;
+}
+
+
+static int th_state_storable(struct sip_msg *msg)
+{
+	struct session_expires se;
+
+	if (!th_store_enabled())
+		return 0;
+
+	/* the state is keyed on the call-id and the leg's tag; with no way
+	 * to key it, it cannot be stored and stays in the Contact instead */
+	if (!th_msg_key_tag(msg))
+		return 0;
+
+	switch (th_msg_method(msg)) {
+	case METHOD_INVITE:
+	case METHOD_UPDATE:
+		/* a call lasts for as long as it pleases, unless the session
+		 * timers bound it */
+		if (parse_session_expires(msg, &se) == parse_sst_success &&
+		se.interval > 0)
+			return 1;
+		LM_DBG("no session timers on this call - keeping its state in "
+			"the Contact, as it may outlive any expiration\n");
+		return 0;
+
+	default:
+		/* a subscription is bounded by its expires, and the rest only
+		 * lives as long as its transaction */
+		return 1;
+	}
+}
+
+
+static int th_state_msg_ttl(struct sip_msg *msg)
+{
+	struct session_expires se;
+	int method, expires;
+
+	method = th_msg_method(msg);
+
+	switch (method) {
+	case METHOD_SUBSCRIBE:
+	case METHOD_NOTIFY:
+		/* The state is needed for as long as the subscription lives,
+		 * and a subscription may very well outlive the generic
+		 * th_state_ttl. */
+		expires = th_sub_expires(msg, method);
+		if (expires < 0)
+			return th_state_ttl;
+		/* a subscription being torn down only needs its transaction to
+		 * complete, and the final NOTIFY to be routed back */
+		if (expires == 0)
+			return th_state_ttl_short;
+		return expires + TH_STATE_TTL_MARGIN;
+
+	case METHOD_INVITE:
+	case METHOD_UPDATE:
+		/* When the session timers are in use, the session is refreshed
+		 * every Session-Expires seconds (RFC 4028), and each refresh
+		 * encodes the Contact anew, so the state only has to survive
+		 * one interval. Should a refresh not come, the session is torn
+		 * down anyway, hence the state of a live call can never be
+		 * expired from under it. Without the header, the call may last
+		 * for as long as it wants to.
+		 *
+		 * Note the value is negotiated, but each message carries the
+		 * one it is subject to, and both the request and the reply are
+		 * encoded from their own message. */
+		if (parse_session_expires(msg, &se) == parse_sst_success &&
+		se.interval > 0) {
+			LM_DBG("session refreshed every %us, per Session-Expires\n",
+				se.interval);
+			return (int)se.interval + TH_STATE_TTL_MARGIN;
+		}
+		return th_state_ttl;
+
+	case METHOD_OPTIONS:
+	case METHOD_MESSAGE:
+	case METHOD_INFO:
+	case METHOD_PUBLISH:
+		/* these neither open a dialog nor refresh the target of one
+		 * (RFC 3261 12.2.1.2), so their Contact is only of interest
+		 * while their transaction is running */
+		return th_state_ttl_short;
+
+	default:
+		return th_state_ttl;
+	}
+}
+
+
+static int topo_no_dlg_encode_contact(struct sip_msg *msg,int flags, str *routes, str *ct_user, int store_state)
 {
 	struct lump* lump;
 	char *prefix=NULL,*suffix=NULL,*ct_username=NULL;
@@ -2011,7 +2464,8 @@ static int topo_no_dlg_encode_contact(struct sip_msg *msg,int flags, str *routes
 	/* make sure we do not free this string in case of a further error */
 	prefix = NULL;
 
-	if (!(suffix = build_encoded_contact_suffix(msg, routes, &suffix_len, flags))) {
+	if (!(suffix = build_encoded_contact_suffix(msg, routes, &suffix_len, flags,
+	store_state))) {
 		LM_ERR("Failed to build suffix \n");
 		goto error;
 	}
@@ -2057,6 +2511,10 @@ static int topo_no_dlg_seq_handling(struct sip_msg *msg,str *info)
 	str route_buf = {0, 0};
 	struct th_no_dlg_param *param = NULL;
 	transaction_cb* used_cb;
+	str stored_blob = {NULL, 0};
+	str consumed_key = {NULL, 0};
+	int ttl;
+	int from_storage = 0;
 
 	/* parse all headers to be sure that all RR and Contact hdrs are found */
 	if (parse_headers(msg, HDR_EOH_F, 0)< 0) {
@@ -2064,48 +2522,115 @@ static int topo_no_dlg_seq_handling(struct sip_msg *msg,str *info)
 		return -1;
 	}
 
+	/*
+	 * The state either travels in the Contact or was left in the
+	 * storage, and both may be in use at the same time, as it is
+	 * decided per dialog when its Contact is encoded. A key is told
+	 * apart by its marker, which none of the encodings of an actual
+	 * state can produce.
+	 */
+	if (th_store_enabled() && info->len == TH_KEY_WIRE_LEN &&
+	info->s[0] == TH_KEY_MARKER) {
+		/* the Contact only carried the key of the state - fetch the
+		 * actual encoded state and go on decoding it as usual. Keep
+		 * the key around, it still points into the request */
+		consumed_key.s = info->s + 1;
+		consumed_key.len = TH_KEY_LEN;
+		if (th_store_get(&consumed_key, &stored_blob) < 0)
+			return -1;
+		info = &stored_blob;
+		from_storage = 1;
+	}
+
 	/* delete vias */
 	if(topo_delete_vias(msg) < 0) {
 		LM_ERR("Failed to remove via headers\n");
-		return -1;
+		goto err_free_blob;
 	}
 
 	/* delete record route */
 	for (it=msg->record_route;it;it=it->sibling) {
 		if (del_lump(msg, it->name.s - buf, it->len, 0) == 0) {
 			LM_ERR("del_lump failed\n");
-			return -1;
+			goto err_free_blob;
 		}
 	}
 
-	max_size = th_ct_enc_scheme == ENC_BASE64 ?
-		calc_max_word64_decode_len(info->len) :
-		calc_max_word32_decode_len(info->len);
-	dec_buf = pkg_malloc(max_size);
-	if (dec_buf==NULL) {
-		LM_ERR("No more pkg\n");
-		return -1;
+	if (from_storage) {
+		/* a stored state is kept raw, so it needs no URI-safe decode and
+		 * no de-obfuscation - use the fetched buffer as-is. Its ownership
+		 * passes to dec_buf here (see the refresh block below), so there
+		 * is nothing to copy and nothing extra to free. */
+		dec_buf = stored_blob.s;
+		dec_len = stored_blob.len;
+	} else {
+		max_size = th_ct_enc_scheme == ENC_BASE64 ?
+			calc_max_word64_decode_len(info->len) :
+			calc_max_word32_decode_len(info->len);
+		dec_buf = pkg_malloc(max_size);
+		if (dec_buf==NULL) {
+			LM_ERR("No more pkg\n");
+			goto err_free_blob;
+		}
+
+		if (th_ct_enc_scheme == ENC_BASE64)
+			dec_len = word64decode((unsigned char *)dec_buf,
+				(unsigned char *)info->s,info->len);
+		else
+			dec_len = word32decode((unsigned char *)dec_buf,
+				(unsigned char *)info->s,info->len);
+		for (i=0;i<dec_len;i++)
+			dec_buf[i] ^= topo_hiding_ct_encode_pw.s[i%topo_hiding_ct_encode_pw.len];
 	}
 
-	if (th_ct_enc_scheme == ENC_BASE64)
-		dec_len = word64decode((unsigned char *)dec_buf,
-			(unsigned char *)info->s,info->len);
-	else
-		dec_len = word32decode((unsigned char *)dec_buf,
-			(unsigned char *)info->s,info->len);
-	for (i=0;i<dec_len;i++)
-		dec_buf[i] ^= topo_hiding_ct_encode_pw.s[i%topo_hiding_ct_encode_pw.len]; 
+	/* the fetched state now backs dec_buf directly (aliased above) */
+	if (stored_blob.s) {
+		/*
+		 * A dialog which is being kept alive has to keep its state
+		 * alive as well: the party which sent us here may well go on
+		 * using this very state - it only learns a new one if the
+		 * reply it gets carries a Contact of its own.
+		 */
+		ttl = th_msg_refreshes_state(msg);
+		if (ttl > 0)
+			th_store_refresh(&consumed_key, &stored_blob, ttl);
 
+		/* dec_buf owns this buffer now - hand it over instead of
+		 * freeing it, and drop our reference so the error path (which
+		 * frees dec_buf and then stored_blob.s) cannot free it twice. */
+		stored_blob.s = NULL;
+		info = NULL;
+	}
+
+	/* A field is length-prefixed: a raw 2-byte short for a state that
+	 * came inline in the Contact, or a printable "<decimal-len>:" for one
+	 * read back from the store (see build_encoded_contact_suffix). Parse
+	 * in place either way - the field just points into the decode buffer. */
 	#define __extract_len_and_buf(_p, _len, _s) \
 		do { \
-			(_s).len = *(short *)p;\
-			if ((_s).len<0 || (_s).len>_len) {\
+			if (from_storage) { \
+				int _n = 0; \
+				while ((_len) > 0 && *(_p) >= '0' && *(_p) <= '9') { \
+					_n = _n*10 + (*(_p) - '0'); (_p)++; (_len)--; \
+				} \
+				if ((_len) <= 0 || *(_p) != ':') { \
+					LM_ERR("bad length framing in stored contact\n"); \
+					goto err_free_buf; \
+				} \
+				(_p)++; (_len)--; \
+				(_s).len = _n; \
+			} else { \
+				(_s).len = *(short *)(_p); \
+				(_p) += sizeof(short); \
+				(_len) -= sizeof(short); \
+			} \
+			if ((_s).len<0 || (_s).len>(_len)) {\
 				LM_ERR("bad length %d in encoded contact\n", (_s).len);\
 				goto err_free_buf;\
 			}\
-			(_s).s = _p + sizeof(short);\
-			_p += sizeof(short) + (_s).len;\
-			_len -= sizeof(short) + (_s).len;\
+			(_s).s = (_p);\
+			(_p) += (_s).len;\
+			(_len) -= (_s).len;\
 		} while(0)
 
 	p = dec_buf;
@@ -2342,7 +2867,19 @@ static int topo_no_dlg_seq_handling(struct sip_msg *msg,str *info)
 		free_rr(&head);
 	pkg_free(dec_buf);
 
-	if (topo_no_dlg_encode_contact(msg,flags,NULL,NULL) < 0) {
+	/*
+	 * A subscription being torn down will not be sending anything to
+	 * this state again, so drop it now rather than leaving it behind
+	 * for as long as the subscription it belonged to was going to last.
+	 * The Contact encoded below gets a state of its own, which is what
+	 * routes the final NOTIFY back.
+	 */
+	if (consumed_key.s && th_msg_ends_subscription(msg))
+		th_store_del(&consumed_key);
+
+	/* keep this dialog on whichever of the two it came in with */
+	if (topo_no_dlg_encode_contact(msg,flags,NULL,NULL,
+	consumed_key.s ? 1 : 0) < 0) {
 		LM_ERR("Failed to encode contact header \n");
 		return -1;
 	}
@@ -2357,5 +2894,8 @@ err_free_head:
 		free_rr(&head);
 err_free_buf:
 	pkg_free(dec_buf);
+err_free_blob:
+	if (stored_blob.s)
+		pkg_free(stored_blob.s);
 	return -1;
 }

--- a/modules/topology_hiding/topo_hiding_logic.c
+++ b/modules/topology_hiding/topo_hiding_logic.c
@@ -66,10 +66,9 @@ static void th_down_onreply(struct cell* t, int type,struct tmcb_params *param);
 static void th_up_onreply(struct cell* t, int type, struct tmcb_params *param);
 static void th_no_dlg_onreply(struct cell* t, int type, struct tmcb_params *param);
 static void th_no_dlg_user_onreply(struct cell* t, int type, struct tmcb_params *param);
-static int topo_no_dlg_encode_contact(struct sip_msg *req,int flags,str *routes,str *ct_user,int store_state,
-		struct sip_msg *ttl_src);
+static int topo_no_dlg_encode_contact(struct sip_msg *req,int flags,str *routes,str *ct_user,int store_state);
 static int topo_no_dlg_seq_handling(struct sip_msg *msg,str *info);
-static int th_state_msg_ttl(struct sip_msg *msg, struct sip_msg *ttl_src);
+static int th_state_msg_ttl(struct sip_msg *msg);
 static int th_state_storable(struct sip_msg *msg);
 static str *th_msg_key_tag(struct sip_msg *msg);
 static int dlg_th_onreply(struct dlg_cell *dlg, struct sip_msg *rpl, struct sip_msg *req,
@@ -903,8 +902,7 @@ static void _th_no_dlg_onreply(struct cell* t, int type, struct tmcb_params *par
 	if ( !(rpl->REPLY_STATUS>=300 && rpl->REPLY_STATUS<400) ) {
 		if (topo_no_dlg_encode_contact(rpl,flags,
 				(p?&p->routes:NULL),(p?&p->username:NULL),
-				-1/*decide from the reply*/,
-				req/*the reply may omit the lifetime*/) < 0) {
+				-1/*decide from the reply*/) < 0) {
 			LM_ERR("Failed to encode contact header \n");
 			return;
 		}
@@ -996,7 +994,7 @@ static int topo_hiding_no_dlg(struct sip_msg *req,
 	}
 
 	if (topo_no_dlg_encode_contact(req,extra_flags,NULL, &params->ct_caller_user,
-	-1/*decide from the request*/, NULL) < 0) {
+	-1/*decide from the request*/) < 0) {
 		LM_ERR("Failed to encode contact header \n");
 		return -1;
 	}
@@ -1768,8 +1766,7 @@ error:
 
 /* We encode the RR headers, the actual Contact and the socket str for this leg */
 /* Via headers will be restored using the TM module, no need to save anything for them */
-static char* build_encoded_contact_suffix(struct sip_msg* msg, str *routes, int *suffix_len, int flags, int store_state,
-		struct sip_msg *ttl_src)
+static char* build_encoded_contact_suffix(struct sip_msg* msg, str *routes, int *suffix_len, int flags, int store_state)
 {
 	short rr_len,ct_len,addr_len,flags_len;
 	char *suffix_plain = NULL,*suffix_enc = NULL,*p,*s;
@@ -1991,7 +1988,7 @@ static char* build_encoded_contact_suffix(struct sip_msg* msg, str *routes, int 
 			th_store_make_key(seeds, 3, key.s);
 		}
 
-		if (th_store_put(&blob, &key, th_state_msg_ttl(msg, ttl_src)) < 0) {
+		if (th_store_put(&blob, &key, th_state_msg_ttl(msg)) < 0) {
 			LM_ERR("failed to store the topology hiding state\n");
 			goto error;
 		}
@@ -2342,19 +2339,7 @@ static int th_state_storable(struct sip_msg *msg)
 }
 
 
-/*
- * How long the state encoded out of @msg has to stay alive.
- *
- * @ttl_src, when given, is the request @msg is a reply to.  A reply does not
- * always carry the dialog's lifetime while the request it answers does - a
- * 200 OK to a NOTIFY has neither an Expires header nor a Subscription-State,
- * yet the NOTIFY carries the notifier-granted expiry, and a 200 OK may answer
- * an INVITE whose Session-Expires it does not repeat.  Consulting it keeps a
- * leg's state from being stamped with the generic th_state_ttl just because
- * the message that happened to re-encode it was uninformative.  It is only
- * ever a fallback: a reply that does carry the lifetime still wins.
- */
-static int th_state_msg_ttl(struct sip_msg *msg, struct sip_msg *ttl_src)
+static int th_state_msg_ttl(struct sip_msg *msg)
 {
 	struct session_expires se;
 	int method, expires;
@@ -2368,8 +2353,6 @@ static int th_state_msg_ttl(struct sip_msg *msg, struct sip_msg *ttl_src)
 		 * and a subscription may very well outlive the generic
 		 * th_state_ttl. */
 		expires = th_sub_expires(msg, method);
-		if (expires < 0 && ttl_src)
-			expires = th_sub_expires(ttl_src, th_msg_method(ttl_src));
 		if (expires < 0)
 			return th_state_ttl;
 		/* a subscription being torn down only needs its transaction to
@@ -2397,12 +2380,6 @@ static int th_state_msg_ttl(struct sip_msg *msg, struct sip_msg *ttl_src)
 				se.interval);
 			return (int)se.interval + TH_STATE_TTL_MARGIN;
 		}
-		if (ttl_src && parse_session_expires(ttl_src, &se) == parse_sst_success &&
-		se.interval > 0) {
-			LM_DBG("session refreshed every %us, per the request's "
-				"Session-Expires\n", se.interval);
-			return (int)se.interval + TH_STATE_TTL_MARGIN;
-		}
 		return th_state_ttl;
 
 	case METHOD_OPTIONS:
@@ -2420,8 +2397,7 @@ static int th_state_msg_ttl(struct sip_msg *msg, struct sip_msg *ttl_src)
 }
 
 
-static int topo_no_dlg_encode_contact(struct sip_msg *msg,int flags, str *routes, str *ct_user, int store_state,
-		struct sip_msg *ttl_src)
+static int topo_no_dlg_encode_contact(struct sip_msg *msg,int flags, str *routes, str *ct_user, int store_state)
 {
 	struct lump* lump;
 	char *prefix=NULL,*suffix=NULL,*ct_username=NULL;
@@ -2489,7 +2465,7 @@ static int topo_no_dlg_encode_contact(struct sip_msg *msg,int flags, str *routes
 	prefix = NULL;
 
 	if (!(suffix = build_encoded_contact_suffix(msg, routes, &suffix_len, flags,
-	store_state, ttl_src))) {
+	store_state))) {
 		LM_ERR("Failed to build suffix \n");
 		goto error;
 	}
@@ -2903,7 +2879,7 @@ static int topo_no_dlg_seq_handling(struct sip_msg *msg,str *info)
 
 	/* keep this dialog on whichever of the two it came in with */
 	if (topo_no_dlg_encode_contact(msg,flags,NULL,NULL,
-	consumed_key.s ? 1 : 0, NULL) < 0) {
+	consumed_key.s ? 1 : 0) < 0) {
 		LM_ERR("Failed to encode contact header \n");
 		return -1;
 	}

--- a/modules/topology_hiding/topo_hiding_logic.c
+++ b/modules/topology_hiding/topo_hiding_logic.c
@@ -66,9 +66,10 @@ static void th_down_onreply(struct cell* t, int type,struct tmcb_params *param);
 static void th_up_onreply(struct cell* t, int type, struct tmcb_params *param);
 static void th_no_dlg_onreply(struct cell* t, int type, struct tmcb_params *param);
 static void th_no_dlg_user_onreply(struct cell* t, int type, struct tmcb_params *param);
-static int topo_no_dlg_encode_contact(struct sip_msg *req,int flags,str *routes,str *ct_user,int store_state);
+static int topo_no_dlg_encode_contact(struct sip_msg *req,int flags,str *routes,str *ct_user,int store_state,
+		struct sip_msg *ttl_src);
 static int topo_no_dlg_seq_handling(struct sip_msg *msg,str *info);
-static int th_state_msg_ttl(struct sip_msg *msg);
+static int th_state_msg_ttl(struct sip_msg *msg, struct sip_msg *ttl_src);
 static int th_state_storable(struct sip_msg *msg);
 static str *th_msg_key_tag(struct sip_msg *msg);
 static int dlg_th_onreply(struct dlg_cell *dlg, struct sip_msg *rpl, struct sip_msg *req,
@@ -902,7 +903,8 @@ static void _th_no_dlg_onreply(struct cell* t, int type, struct tmcb_params *par
 	if ( !(rpl->REPLY_STATUS>=300 && rpl->REPLY_STATUS<400) ) {
 		if (topo_no_dlg_encode_contact(rpl,flags,
 				(p?&p->routes:NULL),(p?&p->username:NULL),
-				-1/*decide from the reply*/) < 0) {
+				-1/*decide from the reply*/,
+				req/*the reply may omit the lifetime*/) < 0) {
 			LM_ERR("Failed to encode contact header \n");
 			return;
 		}
@@ -994,7 +996,7 @@ static int topo_hiding_no_dlg(struct sip_msg *req,
 	}
 
 	if (topo_no_dlg_encode_contact(req,extra_flags,NULL, &params->ct_caller_user,
-	-1/*decide from the request*/) < 0) {
+	-1/*decide from the request*/, NULL) < 0) {
 		LM_ERR("Failed to encode contact header \n");
 		return -1;
 	}
@@ -1766,7 +1768,8 @@ error:
 
 /* We encode the RR headers, the actual Contact and the socket str for this leg */
 /* Via headers will be restored using the TM module, no need to save anything for them */
-static char* build_encoded_contact_suffix(struct sip_msg* msg, str *routes, int *suffix_len, int flags, int store_state)
+static char* build_encoded_contact_suffix(struct sip_msg* msg, str *routes, int *suffix_len, int flags, int store_state,
+		struct sip_msg *ttl_src)
 {
 	short rr_len,ct_len,addr_len,flags_len;
 	char *suffix_plain = NULL,*suffix_enc = NULL,*p,*s;
@@ -1988,7 +1991,7 @@ static char* build_encoded_contact_suffix(struct sip_msg* msg, str *routes, int 
 			th_store_make_key(seeds, 3, key.s);
 		}
 
-		if (th_store_put(&blob, &key, th_state_msg_ttl(msg)) < 0) {
+		if (th_store_put(&blob, &key, th_state_msg_ttl(msg, ttl_src)) < 0) {
 			LM_ERR("failed to store the topology hiding state\n");
 			goto error;
 		}
@@ -2339,7 +2342,19 @@ static int th_state_storable(struct sip_msg *msg)
 }
 
 
-static int th_state_msg_ttl(struct sip_msg *msg)
+/*
+ * How long the state encoded out of @msg has to stay alive.
+ *
+ * @ttl_src, when given, is the request @msg is a reply to.  A reply does not
+ * always carry the dialog's lifetime while the request it answers does - a
+ * 200 OK to a NOTIFY has neither an Expires header nor a Subscription-State,
+ * yet the NOTIFY carries the notifier-granted expiry, and a 200 OK may answer
+ * an INVITE whose Session-Expires it does not repeat.  Consulting it keeps a
+ * leg's state from being stamped with the generic th_state_ttl just because
+ * the message that happened to re-encode it was uninformative.  It is only
+ * ever a fallback: a reply that does carry the lifetime still wins.
+ */
+static int th_state_msg_ttl(struct sip_msg *msg, struct sip_msg *ttl_src)
 {
 	struct session_expires se;
 	int method, expires;
@@ -2353,6 +2368,8 @@ static int th_state_msg_ttl(struct sip_msg *msg)
 		 * and a subscription may very well outlive the generic
 		 * th_state_ttl. */
 		expires = th_sub_expires(msg, method);
+		if (expires < 0 && ttl_src)
+			expires = th_sub_expires(ttl_src, th_msg_method(ttl_src));
 		if (expires < 0)
 			return th_state_ttl;
 		/* a subscription being torn down only needs its transaction to
@@ -2380,6 +2397,12 @@ static int th_state_msg_ttl(struct sip_msg *msg)
 				se.interval);
 			return (int)se.interval + TH_STATE_TTL_MARGIN;
 		}
+		if (ttl_src && parse_session_expires(ttl_src, &se) == parse_sst_success &&
+		se.interval > 0) {
+			LM_DBG("session refreshed every %us, per the request's "
+				"Session-Expires\n", se.interval);
+			return (int)se.interval + TH_STATE_TTL_MARGIN;
+		}
 		return th_state_ttl;
 
 	case METHOD_OPTIONS:
@@ -2397,7 +2420,8 @@ static int th_state_msg_ttl(struct sip_msg *msg)
 }
 
 
-static int topo_no_dlg_encode_contact(struct sip_msg *msg,int flags, str *routes, str *ct_user, int store_state)
+static int topo_no_dlg_encode_contact(struct sip_msg *msg,int flags, str *routes, str *ct_user, int store_state,
+		struct sip_msg *ttl_src)
 {
 	struct lump* lump;
 	char *prefix=NULL,*suffix=NULL,*ct_username=NULL;
@@ -2465,7 +2489,7 @@ static int topo_no_dlg_encode_contact(struct sip_msg *msg,int flags, str *routes
 	prefix = NULL;
 
 	if (!(suffix = build_encoded_contact_suffix(msg, routes, &suffix_len, flags,
-	store_state))) {
+	store_state, ttl_src))) {
 		LM_ERR("Failed to build suffix \n");
 		goto error;
 	}
@@ -2879,7 +2903,7 @@ static int topo_no_dlg_seq_handling(struct sip_msg *msg,str *info)
 
 	/* keep this dialog on whichever of the two it came in with */
 	if (topo_no_dlg_encode_contact(msg,flags,NULL,NULL,
-	consumed_key.s ? 1 : 0) < 0) {
+	consumed_key.s ? 1 : 0, NULL) < 0) {
 		LM_ERR("Failed to encode contact header \n");
 		return -1;
 	}

--- a/modules/topology_hiding/topology_hiding.c
+++ b/modules/topology_hiding/topology_hiding.c
@@ -29,6 +29,7 @@
 
 
 #include "topo_hiding_logic.h"
+#include "th_store.h"
 
 struct tm_binds tm_api;
 struct dlg_binds dlg_api;
@@ -48,6 +49,7 @@ str th_contact_callee_var = str_init("_th_contact_callee_username_var_");
 int th_ct_enc_scheme;
 
 static int mod_init(void);
+static int child_init(int rank);
 static void mod_destroy(void);
 static int fixup_mmode(void **param);
 static int fixup_th_params(void **param);
@@ -79,6 +81,9 @@ static const param_export_t params[] = {
 	{ "th_contact_caller_username_var", STR_PARAM, &th_contact_caller_var.s  },
 	{ "th_contact_callee_username_var", STR_PARAM, &th_contact_callee_var.s  },
 	{ "th_callid_loop_protection",      INT_PARAM, &th_loop_protection       },
+	{ "th_state_url",                STR_PARAM, &th_state_url.s              },
+	{ "th_state_ttl",                INT_PARAM, &th_state_ttl                },
+	{ "th_state_ttl_short",          INT_PARAM, &th_state_ttl_short          },
 	{0, 0, 0}
 };
 
@@ -106,6 +111,7 @@ static const dep_export_t deps = {
 	},
 	{ /* modparam dependencies */
 		{ "force_dialog",		get_deps_dialog },
+		{ "th_state_url",		get_deps_cachedb_url },
 		{ NULL, NULL },
 	},
 };
@@ -129,7 +135,7 @@ struct module_exports exports= {
 	mod_init,         /* module initialization function */
 	(response_function) 0,
 	mod_destroy,
-	0,                /* per-child init function */
+	child_init,       /* per-child init function */
 	0                 /* reload confirm function */
 };
 
@@ -163,6 +169,11 @@ static int mod_init(void)
 		goto error;
 	}
 
+
+	if (th_store_init() < 0) {
+		LM_ERR("failed to initialize the topology hiding state storage\n");
+		goto error;
+	}
 
 	/* loading dependencies */
 	if (load_tm_api(&tm_api)!=0) {
@@ -202,9 +213,19 @@ error:
 	return -1;
 }
 
+static int child_init(int rank)
+{
+	if (th_store_child_init() < 0) {
+		LM_ERR("failed to connect to the topology hiding state storage\n");
+		return -1;
+	}
+
+	return 0;
+}
+
 static void mod_destroy(void)
 {
-	return;
+	th_store_destroy();
 }
 
 static int fixup_mmode(void **param)


### PR DESCRIPTION
## Problem

When topology hiding runs **without a dialog**, the whole encoded state (route set, original Contact, flags, bind address) rides in the Contact URI parameter — making it long. Some UAs (e.g. Cisco CP-88xx) truncate it, after which `topology_hiding_match()` can't decode it and every sequential request of that call is lost. This is unavoidable for **non-INVITE dialogs like SUBSCRIBE**: `dlg_create_dialog()` is INVITE-only, so a SUBSCRIBE can never get a dialog to hold its state server-side, and the payload is dominated by the route set.

## What this adds

An opt-in mode for the dialog-less path: when **`th_state_url`** points at a `cachedb` backend, the state is stored there under a short key and only the key travels in the Contact:

```
stateless:  ;thinfo=VG9JbzAdIFsyPz0MNS9yRmdPY31kQWFVd0djUGtSVF9CbzYQIFtiYWNBYEFzWmFbZmZiWQ--   (72 chars)
stateful:   ;thinfo=_9ea80d5443fe5c5a                                                           (17 chars)
```

The Contact stays short regardless of topology size, making SUBSCRIBE (and long route sets) workable on constrained endpoints. When `th_state_url` is unset, the encoding path is **byte-for-byte unchanged**. A call that *does* get a dialog never reaches this mode — the dialog holds its state and puts only the dialog id in the Contact, so `force_dialog=1` is the better answer for calls; this mode serves what a dialog cannot.

The full detail — the marker-safety proof, the notifier-granted-expires handling, the measured TTLs, and the per-backend matrix — is in the module docs (admin.xml / README). This is the summary.

## Design

- **In-Contact path unchanged.** A state that still rides in a Contact is XOR-obfuscated + word-encoded as before; a stored state skips both (pointless off the wire) and is kept as plain length-prefixed text. Decode tells them apart by a marker on the key; the restore logic is shared, not duplicated.
- **The state is immutable** (route set / contact / socket are fixed at call creation), so a plain KV store with a TTL is the right fit — no update or conflict path.
- **One key per dialog leg, not per request.** The key is derived (not random) from the leg it belongs to — the call-id + that party's own tag, keyed with the contact-encoding password — so every re-encode overwrites the **same** key. A live dialog holds exactly two states (one per leg) however often it refreshes; the password keeps the key unguessable from the clear-text call-id/tags. A message that cannot be keyed — no call-id, or no tag, as with the reply of an out-of-dialog transaction (a 200 OK to an OPTIONS keepalive carries a Contact but no To tag) — is simply not stored: its state stays inline in the Contact, and it has no sequential traffic to be matched against anyway.
- **Coalesced writes.** Since the state is immutable, a re-store only bumps the TTL. Each node keeps a small shm record of the expiry it last wrote per key and skips the backend write while the state still has enough life left — collapsing a busy dialog's identical writes into occasional refreshes. A write that would *shorten* a state (teardown) is never skipped.
- **Availability.** A sequential request may land on any node, so the backend must be shared (e.g. `cachedb_redis`); `cachedb_local` is fine for a single instance. The storage sits behind a small `th_store.h` interface (backend enum), so a clusterer-replication backend can be added later without touching the encode/decode sites.

## State lifetime

A state is stored every time a Contact is encoded, but the deterministic key overwrites in place (no pile-up), and each write takes its TTL **from the message**, not a flat value:

| Message | State lifetime |
|---|---|
| `SUBSCRIBE` / `NOTIFY` | subscription expires + 30 s (NOTIFY's granted `Subscription-State` wins, else Contact `;expires`, else `Expires`) |
| expires `0` / `Subscription-State: terminated` | matched state dropped now; the outgoing Contact gets `th_state_ttl_short` (routes the final NOTIFY) |
| `OPTIONS` / `MESSAGE` / `INFO` / `PUBLISH` | `th_state_ttl_short` (default 60) — transaction-only, no target refresh |
| `INVITE` / `UPDATE` with session timers | `Session-Expires` + 30 s (the `Expires` ring timeout is deliberately not used) |
| `INVITE` / `UPDATE` without session timers | **not stored** — stays inline in the Contact (a call bounded by nothing must not be able to expire) |
| any message that cannot be keyed (no call-id/tag, e.g. an OPTIONS 200 OK with no To tag) | **not stored** — stays inline in the Contact |
| anything else | `th_state_ttl` (default 3600) |

A message that carries its dialog's lifetime also **refreshes** the state it was sent to, in place — so a long-lived subscription that only ever re-SUBSCRIBEs doesn't lose the state it keeps using. An in-dialog OPTIONS does *not* refresh (its short TTL would otherwise cut a call to a minute). All of this is measured end-to-end against Redis; the full TTL / refresh / notifier-granted tables and the `_`-marker safety proof are in the docs.

## Security

The stored state is **in the clear** — not encrypted, and (unlike the in-Contact copy) not obfuscated — so anyone who can read the backend sees the topology this hides (real Contact, route set, receiving socket). This is intentional: off the wire the obfuscation/encoding serve no purpose, and plain text is inspectable. The store is expected to be a **trusted, internal backend** reachable only by the OpenSIPS nodes that share it — deploy it on a private / DMZ network, bind it to the internal interface, enable the backend's own auth, and do not point `th_state_url` at anything reachable beyond that trust boundary.

## Backend compatibility

Any `cachedb` backend that honours the `expires` argument of `set()` (and provides `remove()`) works — verified against `cachedb_redis` and `cachedb_local`, and applies to memcached / cassandra / couchbase / dynamodb / sql.

**Recommended backend.** For a single node, `cachedb_perf` (#4118) is the backend to prefer, and it exists because of this feature: the measurements below showed `cachedb_local`'s fixed-size hash table degrading as the live-state count grows (finding 3), which is precisely what that module was written to remove. It keeps lookups flat as the table fills, and at 100 000 held calls a `cachedb_perf`-backed `th_state_url` costs about as much as doing no topology hiding at all. Use a shared backend (`cachedb_redis`) when sequential requests can land on a different node than the initial one; use `cachedb_perf` when they cannot, or in front of a shared store. **`cachedb_mongodb` silently ignores the TTL** (states would never expire), so it is **rejected at startup** by a URL-scheme check (the cachedb interface has no "supports expiration" capability — a general gap left out of this PR).

## Configuration

```opensips
loadmodule "cachedb_redis.so"
loadmodule "topology_hiding.so"
modparam("topology_hiding", "th_state_url", "redis://127.0.0.1:6379/0")  # shared, TTL-expiring backend
modparam("topology_hiding", "th_state_ttl", 3600)        # calls with no bound + fallback
modparam("topology_hiding", "th_state_ttl_short", 60)    # OPTIONS/MESSAGE/INFO/PUBLISH

route {
    if (has_totag()) {
        if (!topology_hiding_match())
            xlog("L_WARN", "no topology hiding state for $ru\n");
    } else {
        record_route();
        topology_hiding();   # works for SUBSCRIBE, no dialog needed
    }
}
```

`cachedb_local://` (single instance) and a password-protected `redis://:pass@host/db` cluster are also supported. On a single node, prefer `cachedb_perf` (#4118), which was built for this workload:

```opensips
loadmodule "cachedb_perf.so"
modparam("cachedb_perf", "cache_collections", "th=16")
modparam("topology_hiding", "th_state_url", "perf:///th")
```

## Testing

Against `cachedb_redis` (and `cachedb_local`, confirming backend-agnostic):

- A dialog-less SUBSCRIBE gets its state stored; the Contact param shrinks **72 → 17 chars** (a 16-hex key plus its `_` marker); a sequential request carrying only the key is matched, decoded, and the R-URI restored to the original endpoint.
- **Stateless mode unchanged** — same 72-char Contact, nothing written.
- Per-message TTLs measured correct (subscription expires, session timers, short-TTL for OPTIONS, teardown removal, notifier-granted correction); the `mongodb://` guard refuses startup.

## Pending follow-up — an allocation-free read (waits on #4118)

The sequential path fetches the hidden state through the cachedb `get()`, which returns a `pkg` buffer the caller must free — a `pkg_malloc` + `pkg_free` on **every in-dialog request**. #4118 adds an optional `get_buf()` cachedb endpoint that reads into a buffer the caller already owns (no allocation, one copy instead of two); against `cachedb_perf` it takes the lookup from **397.7 to 290.1 ns/op** at the median (~27%).

![get vs get_buf](https://raw.githubusercontent.com/Lt-Flash/opensips/cachedb-perf-assets/getbuf-ab.png)

The topology_hiding side of that change — `th_store_get_buf()`, which reads into a stack buffer where the backend supports it and falls back to an allocated read otherwise, with ownership tracked explicitly so no error path can free a borrowed address — **is written and tested end-to-end** (both the in-place and the fallback path, with the R-URI correctly restored and no leak or double free). It is **deliberately not in this PR**: it calls `get_buf()`, which does not exist until #4118 lands, so it would not compile here. **It will be pushed to this PR once #4118 is merged.** Nothing in the current PR depends on it — this is purely an optimisation for a later commit.

## Roadmap (not in this PR)

- **Clusterer replication backend** — keep states in shm and replicate to peers (mirroring `dlg_replication.c`), for deployments that don't want an external store in the signalling path; the immutable state makes it simpler (create / read / expire only).
- **A `CACHEDB_CAP_EXPIRES` capability** so TTL-ignoring backends are rejected through the interface rather than by a URL-scheme match (touches the core plus every backend).

## Notes

- New files `th_store.c` / `th_store.h`; docs + regenerated README included. `th_state_url` declares a `cachedb_url` dependency so the backend module loads first.

---

# Measured cost

The design section above says the state backend is a choice (`cachedb_local` for a single instance, a
shared store otherwise). That choice has a concrete price, so here it is measured, together with the
alternatives it competes with.

## Test environment

| | |
|---|---|
| Host | KVM guest, **8 vCPU** |
| CPU | **Intel(R) Xeon(R) CPU E5-2699 v4 @ 2.20GHz** (Broadwell), `hypervisor` flag present |
| Memory | **7.8 GB** |
| OS / kernel | Debian 13 (trixie) / 6.12.96-amd64 |
| OpenSIPS | **4.0.0** &mdash; `STATS: On, DISABLE_NAGLE, USE_MCAST, SHM_MMAP, PKG_MALLOC, Q_MALLOC, F_MALLOC, HP_MALLOC, F_PARALLEL_MALLOC, FAST_LOCK-ADAPTIVE_WAIT` |
| Runtime | `-m 4096` shm, `-M 32` pkg, `udp_workers=8` (= vCPU count), `tcp_workers=4` |
| Generator | SIPp 3.6.0, 4 parallel UAC processes; SIPp UAS pool selected via `dispatcher` (weighted round-robin) |

## What was exercised

A dual-homed proxy: upstream leg and downstream pool on separate interfaces. Every call is a complete
`INVITE -> 100 -> 200 -> ACK -> BYE -> 200` carrying `Session-Expires`, so a **storable** state is produced
on **every** call &mdash; deliberately the heaviest path for this feature. `topology_hiding()` runs on the
initial INVITE and `topology_hiding_match()` on every sequential request; a call is only counted as
successful if its BYE was matched and answered, so the decode path is verified, not just the encode.

Two measurement notes for anyone reproducing this: CPU must be sampled over a **steady-state mid-run
window** (including the call-teardown tail dilutes it badly &mdash; 46% vs the real 67% in one run), and a
single SIPp UAC process saturates one core at roughly 4.8k CPS, so the load has to be generated from
several processes or you measure the generator instead of the proxy.

## UDP &mdash; what the state backend costs

![LB CPU vs achieved throughput for five topology-hiding backends](https://raw.githubusercontent.com/Lt-Flash/opensips/pr4114-assets/charts/th-cpu-vs-cps.png)

![Throughput ceiling and CPU cost at 3000 CPS by backend](https://raw.githubusercontent.com/Lt-Flash/opensips/pr4114-assets/charts/th-ceiling-and-cost.png)

| Backend | CPU @3k CPS | CPU @6k CPS | Ceiling |
|---|---|---|---|
| no TH (plain record-route) | 8 % | ~47 % | **~10 000 CPS** |
| TH + dialog (`force_dialog=1`) | 10 % | ~73 % | **~9 000 CPS** |
| TH + `cachedb_local` | 7 % | 77 % | **~7 100 CPS** |
| TH + `cachedb_redis`, loopback | 48 % | 80 % | **~6 900 CPS** |
| TH + `cachedb_redis`, 3-master LAN cluster | 54 % | &mdash;* | **~5 300 CPS** |

\* the LAN-cluster case never becomes CPU-bound &mdash; it caps at ~65%, see findings.

### Findings (UDP)

1. **The encode/decode is not what costs &mdash; the backend round-trip is.** Holding the same state in a
   dialog runs at 10% CPU at 3k CPS; putting it through a loopback Redis costs 48% for identical calls,
   and the ceiling falls from ~9k to ~6.9k CPS. The per-call `SET`/`GET` dominates, not the topology
   hiding itself.
2. **`cachedb_local` is the cheapest option at low/medium load but walls early.** At 3k CPS it is the
   lowest of all five (7%), because it avoids both the socket round-trip and dialog bookkeeping. Then CPU
   goes 9% -> 77% -> 100% between 4k and 7.1k CPS: the shared cache hash serialises the workers, so it
   caps ~2k CPS *below* the dialog path despite being cheaper per call. A good single-instance choice up
   to a few thousand CPS; not the one to pick for peak throughput.
3. **A remote store is latency-bound, not CPU-bound.** The LAN cluster caps at ~5.3k CPS while the proxy
   still has ~35% CPU idle. The cachedb call is synchronous, so a worker blocks for the whole round-trip
   and stops draining its socket &mdash; every extra millisecond of backend RTT comes straight off the
   ceiling. Colocate the store where possible; this is also exactly what the coalesced-write path is
   worth the most for.
4. **These are worst-case numbers for this feature.** `Session-Expires` on every call means a state was
   stored for every call. Real traffic has far fewer storable messages, so production cost sits between
   the no-TH and TH lines &mdash; nearer the former the fewer states are actually stored. Note also that
   each call used a distinct key, so write coalescing is *not* what these figures measure.
5. **The load is ~50/50 user/system CPU.** At these rates a UDP proxy is as much kernel/packet-path bound
   as application bound; all workers share one UDP socket, which is why even the no-TH line plateaus
   around 83-97% rather than pinning all 8 cores.
6. **Worker count should track core count.** Raising `udp_workers` 8 -> 32 on the same 8 vCPU made things
   worse: ~1.6x the CPU for equal throughput and 2.5% call loss at only 1000 CPS (shared-socket
   contention plus scheduler churn), for a ~13% ceiling gain.

## TCP &mdash; connection ceiling

Not specific to this PR &mdash; transport characterisation of the same box, included for completeness.
Connections were opened at a steady ~76/sec and held:

![TCP connection saturation: linear climb stopping dead at 2048](https://raw.githubusercontent.com/Lt-Flash/opensips/pr4114-assets/charts/tcp-saturation.png)

### Findings (TCP)

1. **Simultaneous TCP connections cap at `tcp_max_connections` (default 2048).** At that point OpenSIPS
   logs `maximum number of connections exceeded` and refuses new connections. The failure is graceful:
   **existing connections and UDP signalling keep working** &mdash; only new TCP is rejected.
2. **A much lower limit bites first for bursts: `tcp_socket_backlog` defaults to 10.** The accept queue
   overflows on rapid arrivals (`listen queue of a socket overflowed` in `netstat -s`) long before 2048 is
   approached; reaching the real ceiling at all required raising it. For a public-facing edge proxy a
   backlog of 10 is easy to overrun with a reconnect storm or a burst of TLS handshakes &mdash; this may be
   worth revisiting as a default.
3. **Kernel SYN handling was not implicated.** No `Possible SYN flooding` messages, and
   `tcp_max_syn_backlog` (512) is far above the 10-deep accept queue; the constraint is purely the
   application's `listen()` backlog. File-descriptor limits were also not a factor (65536 available).

---

# Under concurrent load: 50 000 calls held

The figures above ramp the call rate with calls torn down immediately, which measures the cost of
*establishing* state. This second test measures the cost of *holding* it: the hold time is set to
`50000 / rate`, so once the ramp completes there are ~50 000 calls in flight, and the load is then
sustained. Concurrency is verified rather than assumed - it is the summed in-flight call count reported
by the load generators, and it lands within 0.3% of 50 000 on every valid rung.

**These numbers are not directly comparable to the section above.** That test failed any call whose
response took over 8 s; this one allows 120 s, because calls are held deliberately. The proxy therefore
posts higher call rates here at considerably worse latency. They are two different measurements, not a
revision of the same one.

A rung counts only where the proxy actually kept pace: under 5% failures **and** in-flight calls still
near 50 000. That second condition matters. Judged on failure rate alone the loopback-Redis case appears
to reach 9 829 CPS at 1.7% failures - but its in-flight count had grown to 112 000, meaning calls were
arriving faster than they cleared. That is a growing backlog, not 50 000 calls being held, so it is not
counted.

![LB CPU vs throughput while holding 50,000 concurrent calls](https://raw.githubusercontent.com/Lt-Flash/opensips/pr4114-assets/charts/conc50k-cpu-vs-cps.png)

![Sustained call rate and CPU cost per backend at 50,000 concurrent calls](https://raw.githubusercontent.com/Lt-Flash/opensips/pr4114-assets/charts/conc50k-summary.png)

| Backend | Sustained CPS | at CPU | in-flight | CPU @4 000 CPS | Memory @4 000 CPS |
|---|---|---|---|---|---|
| no TH (plain record-route) | **11 788** | 93 % | 64 k | 8 % | 870 MB |
| TH + dialog (`force_dialog=1`) | **9 875** | 90 % | 54 k | 17 % | 1 203 MB |
| TH + `cachedb_redis`, loopback | **6 000** | 80 % | 56 k | 57 % | 924 MB |
| TH + `cachedb_local`, `th=16` | **5 944** | 89 % | 51 k | 29 % | 1 014 MB |
| TH + `cachedb_local`, default | **5 907** | 97 % | 52 k | 45 % | 913 MB |
| TH + `cachedb_redis`, 3-master LAN cluster | **3 996** | 57 % | 52 k | 57 % | 918 MB |

### Findings (50 000 held calls)

1. **Holding state in a dialog is the strongest option once concurrency is high** — *of the backends
   measured here*. 9 875 CPS against ~6 000 for every cachedb variant, and 17% CPU against 45-57% for
   identical traffic at 4 000 CPS. The ranking is the same as in the first test, but the gap widens
   sharply with in-flight state.
   **This reverses at higher concurrency with a backend that scales.** Re-running the same comparison at
   **100 000** held calls against `cachedb_perf` (#4118) put cache-backed topology hiding *ahead* of the
   dialog: 93% CPU at 4 000 CPS and tracking the no-topology-hiding curve, while dialog-TH saturated by
   3 000 CPS, broke at 4 000 (8.2% failures) and carried ~2.5x the resident memory. The dialog's advantage
   here is real but bounded — it comes from the cachedb backends of the day degrading with live-state
   count, not from the dialog scaling better.
2. **A remote store degrades furthest.** The LAN cluster sustains 3 996 CPS and never exceeds 57-63% CPU
   - roughly a third of the machine stays idle while workers block on the synchronous round-trip. Backend
   RTT, not proxy CPU, sets that ceiling, which is the case the coalesced-write path helps most.
3. **`cachedb_local`'s default collection is undersized for tens of thousands of live states.** The
   default is `1 << HASH_SIZE_DEFAULT` = 512 buckets, so ~50 000 entries means ~100-entry chains walked
   under each bucket lock. Setting `modparam("cachedb_local", "cache_collections", "th=16")` (65 536
   buckets) cut CPU from **45% to 29%** at 4 000 CPS. It barely moved the ceiling (5 907 -> 5 944), so it
   buys headroom below saturation rather than a higher wall - but it is a one-line change and worth
   documenting for anyone using `cachedb_local` to hold TH state at scale. This finding is what led to
   `cachedb_perf` (#4118): a table that resizes itself at runtime, so the cliff cannot form and no
   collection has to be hand-sized in the first place.
4. **Dialog pays for its CPU advantage in memory**: 1 203 MB at 4 000 CPS versus ~915 MB for the cachedb
   variants, growing to 2 304 MB by 10 000 CPS. Holding 50 000 calls costs roughly 350 MB of shared
   memory even with no topology hiding at all, from the in-flight transactions alone.
5. **Failure counts alone are a misleading ceiling metric under sustained concurrency.** Three of the six
   configurations post low failure rates at rungs where in-flight calls had doubled or tripled past the
   target. Any figure quoted from this kind of test should be paired with the in-flight count.



