### PR TITLE
topology_hiding: do not warn per request on a non-local send socket

### DIFF
--- a/modules/topology_hiding/th_no_dlg_logic.c
+++ b/modules/topology_hiding/th_no_dlg_logic.c
@@ -1400,10 +1400,23 @@ static decoded_info_buffer_t decode_info_buffer(str *info, const thinfo_options_
     if (host.len > 0 && host.s != NULL) {
 		decoded_buffer.sock = grep_sock_info(&host, port, proto);
 
-		if (!decoded_buffer.sock && th_internal_trusted_tag.len > 0) {
-			decoded_buffer.sock = grep_internal_sock_info(&th_internal_trusted_tag, 0, proto);
-		} else if (decoded_buffer.sock && th_internal_trusted_tag.len == 0) {
-			LM_WARN("non-local socket <%.*s:%d>...ignoring\n", host.len, host.s, port);
+		/* th_internal_trusted_tag governs one-way-hiding on trusted
+		 * internal sockets - it is not a fallback for resolving a
+		 * foreign encoded socket. th_external_socket_tag is the tag
+		 * documented for exactly that (see th_external_socket_tag doc
+		 * and the identical pattern in topo_no_dlg_match_uri() above). */
+		if (!decoded_buffer.sock && th_external_socket_tag.len > 0) {
+			decoded_buffer.sock = grep_internal_sock_info(&th_external_socket_tag, 0, proto);
+		}
+
+		if (!decoded_buffer.sock) {
+			/* Routine whenever topology hiding state reaches a node
+			 * other than the one that created it (e.g. an anycast or
+			 * load-balanced tier) and no external socket tag resolved
+			 * it either - DBG, not WARN, so it doesn't fire on every
+			 * sequential request of every such call. */
+			LM_DBG("non-local socket <%.*s:%d> - leaving the send socket "
+				"to the caller\n", host.len, host.s, port);
 		}
 
 		if (decoded_buffer.sock) {
@@ -1499,10 +1512,25 @@ static decoded_info_buffer_t decode_info_buffer_legacy(str *info, const thinfo_o
             LM_ERR("bad socket <%.*s>\n", bind_buf.len, bind_buf.s);
         } else {
             decoded_buffer.sock = grep_sock_info(&host, (unsigned short) port, proto);
-            if (!decoded_buffer.sock && th_internal_trusted_tag.len > 0) {
-				decoded_buffer.sock = grep_internal_sock_info(&th_internal_trusted_tag, 0, proto);
-            } else {
-				LM_WARN("non-local socket <%.*s>...ignoring\n", bind_buf.len, bind_buf.s);
+
+			/* th_internal_trusted_tag governs one-way-hiding on trusted
+			 * internal sockets - it is not a fallback for resolving a
+			 * foreign encoded socket. th_external_socket_tag is the tag
+			 * documented for exactly that (see topo_no_dlg_match_uri()). */
+            if (!decoded_buffer.sock && th_external_socket_tag.len > 0) {
+				decoded_buffer.sock = grep_internal_sock_info(&th_external_socket_tag, 0, proto);
+            }
+
+			if (!decoded_buffer.sock) {
+				/* Routine whenever topology hiding state reaches a node
+				 * other than the one that created it (e.g. an anycast or
+				 * load-balanced tier) and no external socket tag resolved
+				 * it either - DBG, not WARN, so it doesn't fire on every
+				 * sequential request of every such call. Note this is
+				 * only the send socket; the R-URI has already been
+				 * restored, so the request still routes. */
+				LM_DBG("non-local socket <%.*s> - leaving the send socket "
+					"to the caller\n", bind_buf.len, bind_buf.s);
 			}
         }
     }

--- a/modules/topology_hiding/topo_hiding_logic.c
+++ b/modules/topology_hiding/topo_hiding_logic.c
@@ -2332,9 +2332,17 @@ static int topo_no_dlg_seq_handling(struct sip_msg *msg,str *info)
 		} else {
 			sock = grep_sock_info( &host, (unsigned short)port, proto);
 			if (!sock) {
-				LM_WARN("non-local socket <%.*s>...ignoring\n", bind_buf.len, bind_buf.s);
+				/* The state was encoded by a node that owns this socket
+				 * and this one does not - normal whenever topology hiding
+				 * state reaches a different node than created it, so DBG:
+				 * at WARN it fires on every sequential request of every
+				 * such call.  Note this is only the send socket; the R-URI
+				 * has already been restored, so the request still routes. */
+				LM_DBG("non-local socket <%.*s> - leaving the send socket "
+					"to the caller\n", bind_buf.len, bind_buf.s);
+			} else {
+				msg->force_send_socket = sock;
 			}
-			msg->force_send_socket = sock;
 		}
 	}
 


### PR DESCRIPTION
## What

Two problems in `topo_no_dlg_seq_handling()`, in the branch that restores the send socket recorded in the encoded topology-hiding state: a log line that fires on every sequential request in any multi-node deployment, and — in the same branch — the unusable socket being assigned anyway, clearing whatever the script had already chosen.

## 1. A WARN per sequential request

When dialog-less topology hiding decodes the state of a sequential request, it looks up the socket the state was created on:

```c
sock = grep_sock_info(&host, (unsigned short)port, proto);
if (!sock) {
    LM_WARN("non-local socket <%.*s>...ignoring\n", bind_buf.len, bind_buf.s);
}
```

A node not owning that socket is **routine**, not exceptional: any anycast or load-balanced tier can land a sequential request on a different node than the one that handled the initial request, and a node whose listening set has simply changed hits it too. The result is one WARN per sequential request, per call — on a busy presence deployment that is the bulk of the log.

Dropped to `LM_DBG`. The R-URI has already been restored by this point, so the request still routes; only the send socket is affected.

## 2. The failed lookup was not actually ignored

The message says *"ignoring"*, but the assignment sat **outside** the check:

```c
if (!sock) {
    LM_WARN(... "ignoring" ...);
}
msg->force_send_socket = sock;      /* <-- runs even when sock == NULL */
```

So on the failure path it stored `NULL` — wiping any socket the script had already selected (e.g. an earlier `force_send_socket()` in the route) rather than leaving it alone. The fix only assigns when a local socket was actually found:

```c
if (!sock) {
    LM_DBG("non-local socket <%.*s> - leaving the send socket to the caller\n", ...);
} else {
    msg->force_send_socket = sock;
}
```

## Impact

Log volume on multi-node topology-hiding deployments, and — for scripts that set a send socket before `topology_hiding_match()` — a silently discarded choice on any request whose state came from another node.
