### PR TITLE
rest_client: optional response cache

### DIFF
--- a/modules/rest_client/README
+++ b/modules/rest_client/README
@@ -7,58 +7,75 @@ rest_client Module
 
         1.1. Overview
         1.2. TCP Connection Reusage
-        1.3. Dependencies
+        1.3. Response Caching
+        1.4. Dependencies
 
-              1.3.1. OpenSIPS Modules
-              1.3.2. External Libraries or Applications
+              1.4.1. OpenSIPS Modules
+              1.4.2. External Libraries or Applications
 
-        1.4. Exported Parameters
+        1.5. Exported Parameters
 
-              1.4.1. curl_timeout (integer)
-              1.4.2. connection_timeout (integer)
-              1.4.3. connect_poll_interval (integer)
-              1.4.4. max_async_transfers (integer)
-              1.4.5. max_transfer_size (integer)
-              1.4.6. ssl_verifypeer (integer)
-              1.4.7. ssl_verifyhost (integer)
-              1.4.8. ssl_capath (integer)
-              1.4.9. curl_http_version (integer)
-              1.4.10. enable_expect_100 (boolean)
-              1.4.11. no_concurrent_connects (boolean)
-              1.4.12. curl_conn_lifetime (integer)
+              1.5.1. curl_timeout (integer)
+              1.5.2. connection_timeout (integer)
+              1.5.3. connect_poll_interval (integer)
+              1.5.4. max_async_transfers (integer)
+              1.5.5. max_transfer_size (integer)
+              1.5.6. ssl_verifypeer (integer)
+              1.5.7. ssl_verifyhost (integer)
+              1.5.8. ssl_capath (integer)
+              1.5.9. curl_http_version (integer)
+              1.5.10. enable_expect_100 (boolean)
+              1.5.11. no_concurrent_connects (boolean)
+              1.5.12. curl_conn_lifetime (integer)
+              1.5.13. cachedb_url (string)
+              1.5.14. cache_policy (string)
+              1.5.15. cache_ttl (integer)
+              1.5.16. cache_max_body (integer)
 
-        1.5. Exported Functions
+        1.6. Exported Functions
 
-              1.5.1. rest_get(url, body_pv, [ctype_pv],
-                      [retcode_pv])
+              1.6.1. rest_get(url, body_pv, [ctype_pv],
+                      [retcode_pv], [source_pv])
 
-              1.5.2. rest_post(url, send_body, [send_ctype],
-                      recv_body_pv, [recv_ctype_pv], [retcode_pv])
+              1.6.2. rest_post(url, send_body, [send_ctype],
+                      recv_body_pv, [recv_ctype_pv], [retcode_pv],
+                      [source_pv])
 
-              1.5.3. rest_put(url, send_body, [send_ctype],
+              1.6.3. rest_put(url, send_body, [send_ctype],
                       recv_body_pv[, [recv_ctype_pv][,
-                      [retcode_pv]]])
+                      [retcode_pv][, [source_pv]]]])
 
-              1.5.4. rest_append_hf(txt)
-              1.5.5. rest_init_client_tls(tls_client_domain)
+              1.6.4. rest_append_hf(txt)
+              1.6.5. rest_cache_ctl(ttl)
+              1.6.6. rest_init_client_tls(tls_client_domain)
 
-        1.6. Exported Asynchronous Functions
+        1.7. Exported Asynchronous Functions
 
-              1.6.1. rest_get(url, body_pv[, [ctype_pv][,
-                      [retcode_pv]]])
+              1.7.1. rest_get(url, body_pv[, [ctype_pv][,
+                      [retcode_pv][, [source_pv]]]])
 
-              1.6.2. rest_post(url, send_body_pv, [send_ctype_pv],
+              1.7.2. rest_post(url, send_body_pv, [send_ctype_pv],
                       recv_body_pv[, [recv_ctype_pv][,
-                      [retcode_pv]]])
+                      [retcode_pv][, [source_pv]]]])
 
-              1.6.3. rest_put(url, send_body_pv, [send_ctype_pv],
+              1.7.3. rest_put(url, send_body_pv, [send_ctype_pv],
                       recv_body_pv[, [recv_ctype_pv][,
-                      [retcode_pv]]])
+                      [retcode_pv][, [source_pv]]]])
 
-        1.7. Exported script transformations
+        1.8. Exported Statistics
+        1.9. Exported script transformations
 
-              1.7.1. {rest.escape}
-              1.7.2. {rest.unescape}
+              1.9.1. {rest.escape}
+              1.9.2. {rest.unescape}
+
+        1.10. Response Cache Examples
+
+              1.10.1. An origin that sends cache headers
+              1.10.2. An origin that sends no cache headers
+              1.10.3. Overriding a single call
+              1.10.4. Per-account queries
+              1.10.5. Asynchronous calls
+              1.10.6. Knowing whether the cache is doing anything
 
    2. Contributors
 
@@ -90,16 +107,28 @@ rest_client Module
    1.10. Setting the enable_expect_100 parameter
    1.11. Setting the no_concurrent_connects parameter
    1.12. Setting the curl_conn_lifetime parameter
-   1.13. rest_get usage
-   1.14. rest_post usage
-   1.15. rest_put usage
-   1.16. rest_append_hf usage
-   1.17. rest_init_client_tls usage
-   1.18. async rest_get usage
-   1.19. async rest_post usage
-   1.20. async rest_put usage
-   1.21. rest.escape usage
-   1.22. rest.unescape usage
+   1.13. Setting the cachedb_url parameter
+   1.14. Setting the cache_policy parameter
+   1.15. Setting the cache_ttl parameter
+   1.16. Setting the cache_max_body parameter
+   1.17. rest_get usage
+   1.18. rest_post usage
+   1.19. rest_put usage
+   1.20. rest_append_hf usage
+   1.21. rest_cache_ctl() usage
+   1.22. rest_init_client_tls usage
+   1.23. async rest_get usage
+   1.24. async rest_post usage
+   1.25. async rest_put usage
+   1.26. rest.escape usage
+   1.27. rest.unescape usage
+   1.28. Response cache: loading the module with a cache backend
+   1.29. Response cache: an origin that sends cache headers
+   1.30. Response cache: an origin that sends no cache headers
+   1.31. Response cache: overriding a single call
+   1.32. Response cache: per-account queries
+   1.33. Response cache: asynchronous calls with the cache
+   1.34. Response cache: reporting where a response came from
 
 Chapter 1. Admin Guide
 
@@ -118,22 +147,89 @@ Chapter 1. Admin Guide
    These connections are not shared among OpenSIPS workers — each
    worker maintains its own set of connections.
 
-1.3. Dependencies
+1.3. Response Caching
 
-1.3.1. OpenSIPS Modules
+   When cachedb_url is set, the module keeps a local cache of the
+   HTTP responses it receives and serves repeated queries from it
+   instead of going back to the origin server.
+
+   Only GET responses are stored, in both the blocking and the
+   asynchronous flavour. rest_post() and rest_put() accept the
+   same output variable and report miss:method, but nothing they
+   fetch is ever cached: a POST or a PUT is a request to change
+   something, and the cache key does not cover the request body,
+   so two POSTs to one URL that differ only in what they send must
+   not be allowed to look alike.
+
+   The module does not replicate anything itself, so whether the
+   cache is private to one instance or shared by a cluster is
+   decided entirely by the backend you point it at, and both are
+   useful:
+     * an in-process backend (cachedb_local, cachedb_perf) gives
+       the cheapest possible hit, at the cost of each instance
+       having to warm its own cache;
+     * a shared backend (one cachedb_redis instance used by the
+       whole cluster) means a response fetched by any one node is
+       then served by all of them, which raises the hit rate and
+       cuts the load on the origin, at the cost of a network round
+       trip per hit.
+
+   The useful rule is not local-versus-remote but simply that the
+   backend should be cheaper than the call it is replacing.
+   Against an origin that answers in milliseconds, a shared redis
+   is a large win and shares the benefit across the cluster;
+   against one that answers in microseconds, only an in-process
+   backend is worth the trouble.
+
+   One backend requirement is not negotiable: it must actually
+   honour the expiry it is given. cachedb_mongodb does not - it
+   accepts the expiry argument and ignores it, so an entry written
+   there never expires and the cache would grow without bound. The
+   module stores an absolute expiry inside each entry and refuses
+   to serve one that has passed, so it will not hand out a stale
+   response on such a backend, but it cannot reclaim the space
+   either. Use a backend that expires what it is told to.
+
+   By default the module obeys the origin: a response is cached
+   only if the server's own Cache-Control and Expires headers
+   permit it, and only for as long as they allow. A response
+   carrying no-store, no-cache, private, Set-Cookie or Vary is
+   never stored; neither is a reply whose status falls outside the
+   small RFC-cacheable set (200, 203, 204, 300, 301, 308, 404,
+   405, 410, 414, 501 - with 206 deliberately excluded, as the
+   cache does not handle ranges), nor one larger than
+   cache_max_body. See cache_policy for the looser modes, and
+   rest_cache_ctl() for overriding the decision on a single call.
+
+   The cache key covers the method, the full URL and any headers
+   queued with rest_append_hf(). The headers matter: they are what
+   usually carries the Authorization or the tenant identifier, so
+   leaving them out of the key would let one subscriber's answer
+   be served to another. Two calls that differ only in an appended
+   header are therefore two distinct cache entries.
+
+   Every function accepts an optional trailing output variable
+   which reports where the answer came from — see rest_get().
+   Together with the exported statistics this is the way to tell a
+   cache that is working from one that is quietly storing nothing
+   because the origin forbids it.
+
+1.4. Dependencies
+
+1.4.1. OpenSIPS Modules
 
    The following modules must be loaded before this module:
      * No dependencies on other OpenSIPS modules..
 
-1.3.2. External Libraries or Applications
+1.4.2. External Libraries or Applications
 
    The following libraries or applications must be installed
    before running OpenSIPS with this module loaded:
      * libcurl.
 
-1.4. Exported Parameters
+1.5. Exported Parameters
 
-1.4.1. curl_timeout (integer)
+1.5.1. curl_timeout (integer)
 
    The maximum allowed time for any HTTP(S) transfer to complete.
    This interval is inclusive of the initial connect time window,
@@ -147,7 +243,7 @@ Chapter 1. Admin Guide
 modparam("rest_client", "curl_timeout", 10)
 ...
 
-1.4.2. connection_timeout (integer)
+1.5.2. connection_timeout (integer)
 
    The maximum allowed time to establish a connection with the
    server.
@@ -159,7 +255,7 @@ modparam("rest_client", "curl_timeout", 10)
 modparam("rest_client", "connection_timeout", 4)
 ...
 
-1.4.3. connect_poll_interval (integer)
+1.5.3. connect_poll_interval (integer)
 
    Only relevant with async requests. Allows complete control over
    how quickly we want to detect libcurl's completed blocking
@@ -174,7 +270,7 @@ modparam("rest_client", "connection_timeout", 4)
 modparam("rest_client", "connect_poll_interval", 2)
 ...
 
-1.4.4. max_async_transfers (integer)
+1.5.4. max_async_transfers (integer)
 
    Maximum number of asynchronous HTTP transfers a single OpenSIPS
    worker is allowed to run simultaneously. As long as this
@@ -189,7 +285,7 @@ modparam("rest_client", "connect_poll_interval", 2)
 modparam("rest_client", "max_async_transfers", 300)
 ...
 
-1.4.5. max_transfer_size (integer)
+1.5.5. max_transfer_size (integer)
 
    The maximum allowed size of a single transfer (download).
    Reaching this limit during a transfer will cause the transfer
@@ -203,7 +299,7 @@ modparam("rest_client", "max_async_transfers", 300)
 modparam("rest_client", "max_transfer_size", 64)
 ...
 
-1.4.6. ssl_verifypeer (integer)
+1.5.6. ssl_verifypeer (integer)
 
    Set this to 0 in order to disable the verification of the
    remote peer's certificate. Verification is done using a default
@@ -216,7 +312,7 @@ modparam("rest_client", "max_transfer_size", 64)
 modparam("rest_client", "ssl_verifypeer", 0)
 ...
 
-1.4.7. ssl_verifyhost (integer)
+1.5.7. ssl_verifyhost (integer)
 
    Set this to 0 in order to disable the verification that the
    remote peer actually corresponds to the server listed in the
@@ -229,7 +325,7 @@ modparam("rest_client", "ssl_verifypeer", 0)
 modparam("rest_client", "ssl_verifyhost", 0)
 ...
 
-1.4.8. ssl_capath (integer)
+1.5.8. ssl_capath (integer)
 
    An optional path for CA certificates to be used for host
    verifications.
@@ -239,7 +335,7 @@ modparam("rest_client", "ssl_verifyhost", 0)
 modparam("rest_client", "ssl_capath", "/home/opensips/ca_certificates")
 ...
 
-1.4.9. curl_http_version (integer)
+1.5.9. curl_http_version (integer)
 
    Use a specific HTTP version for all requests. Possible values:
 
@@ -267,7 +363,7 @@ modparam("rest_client", "ssl_capath", "/home/opensips/ca_certificates")
 modparam("rest_client", "curl_http_version", 3)
 ...
 
-1.4.10. enable_expect_100 (boolean)
+1.5.10. enable_expect_100 (boolean)
 
    Include a "Expect: 100-continue" HTTP header field whenever the
    body size of a POST or PUT request exceeds 1024 bytes. Once
@@ -282,7 +378,7 @@ modparam("rest_client", "curl_http_version", 3)
 modparam("rest_client", "enable_expect_100", true)
 ...
 
-1.4.11. no_concurrent_connects (boolean)
+1.5.11. no_concurrent_connects (boolean)
 
    Set to true in order to only allow one OpenSIPS worker to
    connect to a given URL hostname at a time. While a worker is
@@ -308,7 +404,7 @@ modparam("rest_client", "enable_expect_100", true)
 modparam("rest_client", "no_concurrent_connects", true)
 ...
 
-1.4.12. curl_conn_lifetime (integer)
+1.5.12. curl_conn_lifetime (integer)
 
    Only relevant when no_concurrent_connects is enabled. By
    setting this parameter, script developers can leverage the
@@ -332,9 +428,95 @@ modparam("rest_client", "no_concurrent_connects", true)
 modparam("rest_client", "curl_conn_lifetime", 1800)
 ...
 
-1.5. Exported Functions
+1.5.13. cachedb_url (string)
 
-1.5.1.  rest_get(url, body_pv, [ctype_pv], [retcode_pv])
+   URL of a cachedb backend in which to cache HTTP responses.
+   Setting it is what enables the response cache; without it, no
+   caching is performed and the module behaves exactly as before.
+
+   Any backend that expires what it is told to will do, since only
+   the generic get and set operations are used. The choice decides
+   whether the cache is private to this instance or shared by the
+   cluster, and what a hit costs - see Response Caching, which
+   also explains why cachedb_mongodb is not a suitable backend.
+
+   Only GET requests are ever cached.
+
+   Default value is “NULL” (caching disabled).
+
+   Example 1.13. Setting the cachedb_url parameter
+...
+modparam("rest_client", "cachedb_url", "perf:///rest")
+...
+
+1.5.14. cache_policy (string)
+
+   How far to go beyond what the origin server explicitly permits.
+   One of:
+     * off - never cache. Useful to disable caching without
+       removing cachedb_url from the config.
+     * strict - cache only what the origin explicitly permits,
+       taking the lifetime from its Cache-Control: max-age (or
+       s-maxage, or Expires). A response with no caching headers
+       is not cached.
+     * heuristic - as strict, but a response whose origin said
+       nothing about caching is cached for cache_ttl seconds. An
+       explicit prohibition is still honoured.
+     * force - as heuristic, but responses the origin asked not to
+       store are cached anyway, for cache_ttl seconds.
+
+   Under every policy, a response is refused if it is not a GET,
+   if its status code is not cacheable, if it carries a Vary
+   header, or if it exceeds cache_max_body.
+
+   force reinterprets every endpoint the module talks to,
+   including ones added later. Prefer rest_cache_ctl() to override
+   a single call site.
+
+   Default value is “strict”.
+
+   Example 1.14. Setting the cache_policy parameter
+...
+modparam("rest_client", "cache_policy", "heuristic")
+...
+
+1.5.15. cache_ttl (integer)
+
+   Lifetime, in seconds, applied when the origin server gave none
+   and the policy allows caching anyway. Required by the heuristic
+   and force policies - either is rejected at startup if this is
+   not positive, since it would otherwise silently cache nothing.
+
+   It is never used in place of a lifetime the origin did supply.
+
+   Default value is “0” (do not cache silent responses).
+
+   Example 1.15. Setting the cache_ttl parameter
+...
+modparam("rest_client", "cache_ttl", 300)
+...
+
+1.5.16. cache_max_body (integer)
+
+   Largest response body, in bytes, that will be stored. Anything
+   above it is returned to the script as usual but not cached, and
+   reported as miss:oversize.
+
+   Default value is “65536”.
+
+   Values above 64 KB are clamped to 64 KB with a startup warning
+   - the encoded entry lives in a fixed 64 KB buffer, so a larger
+   setting would otherwise pass startup and then silently store
+   nothing.
+
+   Example 1.16. Setting the cache_max_body parameter
+...
+modparam("rest_client", "cache_max_body", 131072)
+...
+
+1.6. Exported Functions
+
+1.6.1.  rest_get(url, body_pv, [ctype_pv], [retcode_pv], [source_pv])
 
    Perform a blocking HTTP GET on the given url and return a
    representation of the resource.
@@ -349,6 +531,13 @@ modparam("rest_client", "curl_conn_lifetime", 1800)
      * retcode_pv (var, optional) - output variable which will
        retain the status code of the HTTP response. A 0 status
        code value means no HTTP reply arrived at all.
+     * source_pv (var, optional) - output variable reporting where
+       the answer came from, when the response cache is enabled:
+       hit (served from the cache), miss (fetched and stored),
+       miss:reason (fetched but not storable - the reason is one
+       of no-store, no-cache, private, set-cookie, vary, silent,
+       status, method, oversize or expired), or bypass (the cache
+       was not consulted).
 
    Return Codes
      * 1 - Success
@@ -369,7 +558,7 @@ modparam("rest_client", "curl_conn_lifetime", 1800)
 
    This function can be used from any route.
 
-   Example 1.13. rest_get usage
+   Example 1.17. rest_get usage
 ...
 # Example of querying a REST service to get the credit of an account
 $var(rc) = rest_get("https://getcredit.org/?account=$fU",
@@ -389,8 +578,8 @@ if ($var(rcode) != 200) {
 }
 ...
 
-1.5.2.  rest_post(url, send_body, [send_ctype], recv_body_pv,
-[recv_ctype_pv], [retcode_pv])
+1.6.2.  rest_post(url, send_body, [send_ctype], recv_body_pv,
+[recv_ctype_pv], [retcode_pv], [source_pv])
 
    Perform a blocking HTTP POST on the given url.
 
@@ -413,6 +602,13 @@ if ($var(rcode) != 200) {
      * retcode_pv (var, optional) - output variable which will
        retain the status code of the HTTP response. A 0 status
        code value means no HTTP reply arrived at all.
+     * source_pv (var, optional) - output variable reporting where
+       the answer came from, when the response cache is enabled:
+       hit (served from the cache), miss (fetched and stored),
+       miss:reason (fetched but not storable - the reason is one
+       of no-store, no-cache, private, set-cookie, vary, silent,
+       status, method, oversize or expired), or bypass (the cache
+       was not consulted).
 
    Return Codes
      * 1 - Success
@@ -433,7 +629,7 @@ if ($var(rcode) != 200) {
 
    This function can be used from any route.
 
-   Example 1.14. rest_post usage
+   Example 1.18. rest_post usage
 ...
 # Creating a resource using a RESTful service with an HTTP POST request
 $var(rc) = rest_post("https://myserver.org/register_user",
@@ -452,8 +648,8 @@ if ($var(rcode) != 200) {
 ...
 
 
-1.5.3.  rest_put(url, send_body, [send_ctype], recv_body_pv[,
-[recv_ctype_pv][, [retcode_pv]]])
+1.6.3.  rest_put(url, send_body, [send_ctype], recv_body_pv[,
+[recv_ctype_pv][, [retcode_pv][, [source_pv]]]])
 
    Perform a blocking HTTP PUT on the given url.
 
@@ -476,6 +672,13 @@ if ($var(rcode) != 200) {
      * retcode_pv (var, optional) - output variable which will
        retain the status code of the HTTP response. A 0 status
        code value means no HTTP reply arrived at all.
+     * source_pv (var, optional) - output variable reporting where
+       the answer came from, when the response cache is enabled:
+       hit (served from the cache), miss (fetched and stored),
+       miss:reason (fetched but not storable - the reason is one
+       of no-store, no-cache, private, set-cookie, vary, silent,
+       status, method, oversize or expired), or bypass (the cache
+       was not consulted).
 
    Return Codes
      * 1 - Success
@@ -496,7 +699,7 @@ if ($var(rcode) != 200) {
 
    This function can be used from any route.
 
-   Example 1.15. rest_put usage
+   Example 1.19. rest_put usage
 ...
 # Creating/Updating a resource using a RESTful service with an HTTP PUT
 request
@@ -516,7 +719,7 @@ if ($var(rcode) != 200) {
 }
 ...
 
-1.5.4.  rest_append_hf(txt)
+1.6.4.  rest_append_hf(txt)
 
    Append txt to the HTTP headers of the subsequent request.
    Multiple headers can be appended by making multiple calls
@@ -530,7 +733,7 @@ if ($var(rcode) != 200) {
 
    This function can be used from any route.
 
-   Example 1.16. rest_append_hf usage
+   Example 1.20. rest_append_hf usage
 ...
 # Example of querying a REST service requiring additional headers
 
@@ -538,7 +741,40 @@ rest_append_hf("Authorization: Bearer mF_9.B5f-4.1JqM");
 $var(rc) = rest_get("http://getcredit.org/?account=$fU", $var(credit));
 ...
 
-1.5.5.  rest_init_client_tls(tls_client_domain)
+1.6.5.  rest_cache_ctl(ttl)
+
+   Overrides the cache decision for the next rest_get(),
+   rest_post() or rest_put() only, then reverts - the same
+   "applies once" behaviour as rest_append_hf(). Requires
+   cachedb_url; without it the call is ignored.
+
+   Meaning of ttl:
+     * 0 - bypass the cache entirely for that call: no lookup, no
+       store. For the one endpoint that must always be live.
+     * greater than 0 - serve that call from the cache if present,
+       and store its response for that many seconds, regardless of
+       cache_policy and of what the origin's own cache headers
+       say.
+
+   This is the recommended way to cache an endpoint whose server
+   sends unhelpful headers, in preference to cache_policy = force,
+   because it affects one call site rather than every endpoint the
+   module talks to.
+
+   This function can be used from any route.
+
+   Example 1.21. rest_cache_ctl() usage
+...
+# this rate lookup is safe to cache for five minutes, whatever it claims
+rest_cache_ctl(300);
+rest_get("http://rates/lookup", $var(body), $var(ct), $var(rc));
+
+# ...but the fraud check must always be live
+rest_cache_ctl(0);
+rest_get("http://fraud/check", $var(body), $var(ct), $var(rc));
+...
+
+1.6.6.  rest_init_client_tls(tls_client_domain)
 
    Force a specific TLS domain to be used at most once, during the
    next GET/POST/PUT request. Refer to the tls_mgm module for
@@ -552,16 +788,17 @@ $var(rc) = rest_get("http://getcredit.org/?account=$fU", $var(credit));
 
    This function can be used from any route.
 
-   Example 1.17. rest_init_client_tls usage
+   Example 1.22. rest_init_client_tls usage
 ...
 rest_init_client_tls("dom1");
 if (!rest_get("https://example.com"))
     xlog("query failed\n");
 ...
 
-1.6. Exported Asynchronous Functions
+1.7. Exported Asynchronous Functions
 
-1.6.1.  rest_get(url, body_pv[, [ctype_pv][, [retcode_pv]]])
+1.7.1.  rest_get(url, body_pv[, [ctype_pv][, [retcode_pv][,
+[source_pv]]]])
 
    Perform an asynchronous HTTP GET. This function behaves exactly
    the same as rest_get() (in terms of input, output and
@@ -569,7 +806,7 @@ if (!rest_get("https://example.com"))
    suspended until the entire content of the HTTP response is
    available.
 
-   Example 1.18. async rest_get usage
+   Example 1.23. async rest_get usage
 route {
         ...
         async(rest_get("http://getcredit.org/?account=$fU",
@@ -595,8 +832,8 @@ $fU\n");
         ...
 }
 
-1.6.2.  rest_post(url, send_body_pv, [send_ctype_pv], recv_body_pv[,
-[recv_ctype_pv][, [retcode_pv]]])
+1.7.2.  rest_post(url, send_body_pv, [send_ctype_pv], recv_body_pv[,
+[recv_ctype_pv][, [retcode_pv][, [source_pv]]]])
 
    Perform an asynchronous HTTP POST. This function behaves
    exactly the same as rest_post() (in terms of input, output and
@@ -604,7 +841,7 @@ $fU\n");
    suspended until the entire content of the HTTP response is
    available.
 
-   Example 1.19. async rest_post usage
+   Example 1.24. async rest_post usage
 route {
         ...
         async(rest_post("http://myserver.org/register_user",
@@ -630,8 +867,8 @@ route [resume] {
 }
 
 
-1.6.3.  rest_put(url, send_body_pv, [send_ctype_pv], recv_body_pv[,
-[recv_ctype_pv][, [retcode_pv]]])
+1.7.3.  rest_put(url, send_body_pv, [send_ctype_pv], recv_body_pv[,
+[recv_ctype_pv][, [retcode_pv][, [source_pv]]]])
 
    Perform an asynchronous HTTP PUT. This function behaves exactly
    the same as rest_put() (in terms of input, output and
@@ -639,7 +876,7 @@ route [resume] {
    suspended until the entire content of the HTTP response is
    available.
 
-   Example 1.20. async rest_put usage
+   Example 1.25. async rest_put usage
 route {
         ...
         async(rest_put("http://myserver.org/users/$fU", $var(userinfo),
@@ -664,7 +901,30 @@ route [resume] {
         ...
 }
 
-1.7. Exported script transformations
+1.8. Exported Statistics
+
+   The statistics are always exported; while the response cache is
+   disabled the counters simply stay at 0 and the hit rate reads
+   0.
+     * rest_cache_hits - requests served from the cache, without
+       contacting the origin.
+     * rest_cache_misses - requests that went to the origin.
+     * rest_cache_stores - responses actually written to the
+       cache.
+     * rest_cache_skipped - responses fetched but not storable,
+       because the policy, the origin's headers or the size limit
+       refused them. Worth watching: a cache that stores nothing
+       because every origin sends no-store is otherwise
+       indistinguishable from one that is misconfigured, and
+       neither the hit rate nor response times will tell you
+       apart. The per-response reason is in the debug log and in
+       the source output variable of each function.
+     * rest_cache_hit_rate - hits as a whole percentage of
+       lookups, 0 when nothing has been looked up yet. It covers
+       the lifetime of the process, so a low value shortly after a
+       restart is a cold cache rather than a problem.
+
+1.9. Exported script transformations
 
    The module also provides a way for encoding and decoding
    parameters contained in an arbitrary script variable, in
@@ -675,14 +935,14 @@ route [resume] {
    performed through libcurl API method curl_easy_escape (or
    curl_escape for libcurl < 7.15.4).
 
-1.7.1.  {rest.escape}
+1.9.1.  {rest.escape}
 
    The result of this transformation is to produce percent encoded
    string value which can be safely used in URI construction.
 
    There are no parameters for this transformation.
 
-   Example 1.21. rest.escape usage
+   Example 1.26. rest.escape usage
 ...
 # This example would produce log entry: "Output: call%40example.com%26sa
 fe%3Dfalse"
@@ -694,14 +954,14 @@ $var(rc) = rest_get("https://call-info.org/?id=$(ci{rest.escape})", $var
 (body_pv));
 ...
 
-1.7.2.  {rest.unescape}
+1.9.2.  {rest.unescape}
 
    The result of this transformation is to decode percent encoded
    string values.
 
    There are no parameters for this transformation.
 
-   Example 1.22. rest.unescape usage
+   Example 1.27. rest.unescape usage
 ...
 # This example would produce log entry: "Output: 1+1=2!"
 $var(tmp) = "1%2B1%3D2%21";
@@ -712,6 +972,142 @@ ery SIP!"
 $var(tmp) = "OpenSIPs%2C%20tastes%20better%20with%20every%20SIP%21";
 xlog("$(var(tmp){rest.unescape})\n");
 ...
+
+1.10. Response Cache Examples
+
+   The examples below all assume an in-process backend, since the
+   point of the cache is to be cheaper than the HTTP call it
+   replaces:
+
+   Example 1.28. Response cache: loading the module with a cache
+   backend
+loadmodule "cachedb_local.so"
+loadmodule "rest_client.so"
+
+modparam("rest_client", "cachedb_url", "local://")
+
+1.10.1. An origin that sends cache headers
+
+   Nothing beyond cachedb_url is needed. The default strict policy
+   caches the response for exactly as long as the server said it
+   may, and re-fetches after that:
+
+   Example 1.29. Response cache: an origin that sends cache
+   headers
+# origin answers with:  Cache-Control: max-age=300
+$var(rc) = rest_get("http://rates.internal/lookup?prefix=$rU",
+                    $var(body), $var(ct), $var(rcode));
+
+# for the next 5 minutes this same prefix is answered locally
+
+1.10.2. An origin that sends no cache headers
+
+   Many internal APIs send no Cache-Control at all. Under the
+   default policy those responses are never cached — the module
+   will not invent a lifetime the server did not give it. If you
+   know the data is safe to hold for a while, say so explicitly:
+
+   Example 1.30. Response cache: an origin that sends no cache
+   headers
+modparam("rest_client", "cache_policy", "heuristic")
+modparam("rest_client", "cache_ttl", 60)
+
+   heuristic still obeys an origin that actively refuses caching;
+   it only fills in a lifetime where the origin was silent. It is
+   rejected at startup without a positive cache_ttl, because a
+   heuristic policy with nothing to fall back on would silently
+   behave like strict.
+
+1.10.3. Overriding a single call
+
+   Different endpoints behind the same module often deserve
+   different treatment. Rather than loosening the policy globally
+   — which reinterprets every endpoint you have, including the
+   ones that were right — override the individual call:
+
+   Example 1.31. Response cache: overriding a single call
+# an expensive, rarely-changing lookup whose origin forgot the headers:
+# cache it for 5 minutes regardless of policy or origin
+rest_cache_ctl(300);
+$var(rc) = rest_get("http://rates.internal/tariff?id=$var(tid)",
+                    $var(tariff));
+
+# a fraud check must never be answered from a cache, even a warm one
+rest_cache_ctl(0);
+$var(rc) = rest_get("http://fraud.internal/score?num=$fU", $var(score));
+
+   The override applies to the next REST call only and is consumed
+   by it, in the same way as rest_append_hf(). This holds for
+   asynchronous calls too: the value is captured when the transfer
+   is dispatched, not when it completes, so a later request cannot
+   change how an in-flight one is cached.
+
+1.10.4. Per-account queries
+
+   Headers queued with rest_append_hf() are part of the cache key,
+   so a per-tenant or per-subscriber credential separates the
+   entries automatically — the two calls below never see each
+   other's response, even though the URL is identical:
+
+   Example 1.32. Response cache: per-account queries
+rest_append_hf("Authorization: Bearer $var(tenant_token)");
+$var(rc) = rest_get("http://api.internal/limits", $var(limits));
+
+   The header values are hashed into the key rather than stored in
+   it, so a bearer token never appears in the backend's key space
+   or in whatever dump/inspection tooling the backend offers.
+
+1.10.5. Asynchronous calls
+
+   The cache works identically for the asynchronous flavours. A
+   hit completes the call inline — the resume route still runs,
+   and the script sees the same variables it would have seen after
+   a real transfer:
+
+   Example 1.33. Response cache: asynchronous calls with the cache
+route {
+        async(rest_get("http://rates.internal/lookup?prefix=$rU",
+                       $var(body), $var(ct), $var(rcode), $var(src)), re
+sume);
+}
+
+route [resume] {
+        if ($rc < 0) {
+                xlog("rate lookup failed: $rc\n");
+                send_reply(500, "Server Internal Error");
+                exit;
+        }
+        xlog("rate for $rU came from: $var(src)\n");
+        ...
+}
+
+1.10.6. Knowing whether the cache is doing anything
+
+   A cache that stores nothing because every origin sends no-store
+   looks exactly like a working one from the outside: no errors,
+   and a hit rate of zero either way. The trailing output variable
+   says which it is, per call:
+
+   Example 1.34. Response cache: reporting where a response came
+   from
+$var(rc) = rest_get("http://rates.internal/lookup?prefix=$rU",
+                    $var(body), $var(ct), $var(rcode), $var(src));
+
+# $var(src) is one of:
+#   hit            served locally, the origin was not contacted
+#   miss           fetched from the origin and stored
+#   miss:no-store  fetched, but the origin forbade storing it
+#   miss:silent    fetched, but the origin gave no lifetime and the
+#                  policy is strict
+#   bypass         the cache was not consulted (disabled, or
+#                  rest_cache_ctl(0))
+if ($var(src) =~ "^miss:") {
+        xlog("L_INFO", "not cacheable ($var(src)): $rU\n");
+}
+
+   The same reasons are counted in rest_cache_skipped and logged
+   at debug level, so the question can be answered from monitoring
+   without touching the script.
 
 Chapter 2. Contributors
 

--- a/modules/rest_client/doc/rest_client_admin.xml
+++ b/modules/rest_client/doc/rest_client_admin.xml
@@ -23,6 +23,92 @@
 	</para>
 	</section>
 
+	<section id="response-caching" xreflabel="Response Caching">
+	<title>Response Caching</title>
+	<para>
+	When <xref linkend="param_cachedb_url"/> is set, the module keeps a local
+	cache of the HTTP responses it receives and serves repeated queries from it
+	instead of going back to the origin server.
+	</para>
+	<para>
+	Only <emphasis role='bold'>GET</emphasis> responses are stored, in both
+	the blocking and the asynchronous flavour.
+	<emphasis>rest_post()</emphasis> and <emphasis>rest_put()</emphasis>
+	accept the same output variable and report
+	<emphasis>miss:method</emphasis>, but nothing they fetch is ever cached:
+	a POST or a PUT is a request to change something, and the cache key does
+	not cover the request body, so two POSTs to one URL that differ only in
+	what they send must not be allowed to look alike.
+	</para>
+	<para>
+	The module does not replicate anything itself, so whether the cache is
+	private to one instance or shared by a cluster is decided entirely by the
+	backend you point it at, and both are useful:
+	</para>
+	<itemizedlist>
+		<listitem><para>
+			an <emphasis role='bold'>in-process</emphasis> backend
+			(<emphasis>cachedb_local</emphasis>,
+			<emphasis>cachedb_perf</emphasis>) gives the cheapest possible hit,
+			at the cost of each instance having to warm its own cache;
+		</para></listitem>
+		<listitem><para>
+			a <emphasis role='bold'>shared</emphasis> backend (one
+			<emphasis>cachedb_redis</emphasis> instance used by the whole
+			cluster) means a response fetched by any one node is then served by
+			all of them, which raises the hit rate and cuts the load on the
+			origin, at the cost of a network round trip per hit.
+		</para></listitem>
+	</itemizedlist>
+	<para>
+	The useful rule is not local-versus-remote but simply that the backend
+	should be cheaper than the call it is replacing.  Against an origin that
+	answers in milliseconds, a shared redis is a large win and shares the
+	benefit across the cluster; against one that answers in microseconds,
+	only an in-process backend is worth the trouble.
+	</para>
+	<para>
+	One backend requirement is not negotiable: it must actually honour the
+	expiry it is given.  <emphasis role='bold'>cachedb_mongodb does
+	not</emphasis> - it accepts the expiry argument and ignores it, so an
+	entry written there never expires and the cache would grow without
+	bound.  The module stores an absolute expiry inside each entry and
+	refuses to serve one that has passed, so it will not hand out a stale
+	response on such a backend, but it cannot reclaim the space either.  Use
+	a backend that expires what it is told to.
+	</para>
+	<para>
+	By default the module obeys the origin: a response is cached only if the
+	server's own <emphasis>Cache-Control</emphasis> and
+	<emphasis>Expires</emphasis> headers permit it, and only for as long as they
+	allow.  A response carrying <emphasis>no-store</emphasis>,
+	<emphasis>no-cache</emphasis>, <emphasis>private</emphasis>,
+	<emphasis>Set-Cookie</emphasis> or <emphasis>Vary</emphasis> is never
+	stored; neither is a reply whose status falls outside the small
+	RFC-cacheable set (200, 203, 204, 300, 301, 308, 404, 405, 410, 414,
+	501 - with 206 deliberately excluded, as the cache does not handle
+	ranges), nor one larger than
+	<xref linkend="param_cache_max_body"/>.  See
+	<xref linkend="param_cache_policy"/> for the looser modes, and
+	<xref linkend="func_rest_cache_ctl"/> for overriding the decision on a
+	single call.
+	</para>
+	<para>
+	The cache key covers the method, the full URL and any headers queued with
+	<emphasis>rest_append_hf()</emphasis>.  The headers matter: they are what
+	usually carries the Authorization or the tenant identifier, so leaving them
+	out of the key would let one subscriber's answer be served to another.  Two
+	calls that differ only in an appended header are therefore two distinct
+	cache entries.
+	</para>
+	<para>
+	Every function accepts an optional trailing output variable which reports
+	where the answer came from — see <xref linkend="func_rest_get"/>.  Together
+	with the exported statistics this is the way to tell a cache that is working
+	from one that is quietly storing nothing because the origin forbids it.
+	</para>
+	</section>
+
 	<section id="dependencies" xreflabel="Dependencies">
 	<title>Dependencies</title>
 	<section>
@@ -372,13 +458,156 @@ modparam("rest_client", "curl_conn_lifetime", 1800)
 		</example>
 	</section>
 
+
+	<section id="param_cachedb_url" xreflabel="cachedb_url">
+		<title><varname>cachedb_url</varname> (string)</title>
+		<para>
+		URL of a cachedb backend in which to cache HTTP responses.  Setting it
+		is what enables the response cache; without it, no caching is performed
+		and the module behaves exactly as before.
+		</para>
+		<para>
+		Any backend that expires what it is told to will do, since only the
+		generic <emphasis>get</emphasis> and <emphasis>set</emphasis>
+		operations are used.  The choice decides whether the cache is private
+		to this instance or shared by the cluster, and what a hit costs - see
+		<xref linkend="response-caching"/>, which also explains why
+		<emphasis>cachedb_mongodb</emphasis> is not a suitable backend.
+		</para>
+		<para>
+		Only <emphasis>GET</emphasis> requests are ever cached.
+		</para>
+		<para>
+		<emphasis>
+			Default value is <quote>NULL</quote> (caching disabled).
+		</emphasis>
+		</para>
+		<example>
+		<title>Setting the <varname>cachedb_url</varname> parameter</title>
+		<programlisting format="linespecific">
+...
+modparam("rest_client", "cachedb_url", "perf:///rest")
+...
+</programlisting>
+		</example>
+	</section>
+
+	<section id="param_cache_policy" xreflabel="cache_policy">
+		<title><varname>cache_policy</varname> (string)</title>
+		<para>
+		How far to go beyond what the origin server explicitly permits.  One of:
+		</para>
+		<itemizedlist>
+		<listitem><para>
+			<emphasis>off</emphasis> - never cache.  Useful to disable caching
+			without removing <varname>cachedb_url</varname> from the config.
+		</para></listitem>
+		<listitem><para>
+			<emphasis>strict</emphasis> - cache only what the origin explicitly
+			permits, taking the lifetime from its
+			<emphasis>Cache-Control: max-age</emphasis> (or
+			<emphasis>s-maxage</emphasis>, or <emphasis>Expires</emphasis>).  A
+			response with no caching headers is not cached.
+		</para></listitem>
+		<listitem><para>
+			<emphasis>heuristic</emphasis> - as strict, but a response whose
+			origin said nothing about caching is cached for
+			<varname>cache_ttl</varname> seconds.  An explicit prohibition is
+			still honoured.
+		</para></listitem>
+		<listitem><para>
+			<emphasis>force</emphasis> - as heuristic, but responses the origin
+			asked not to store are cached anyway, for
+			<varname>cache_ttl</varname> seconds.
+		</para></listitem>
+		</itemizedlist>
+		<para>
+		Under every policy, a response is refused if it is not a GET, if its
+		status code is not cacheable, if it carries a
+		<emphasis>Vary</emphasis> header, or if it exceeds
+		<varname>cache_max_body</varname>.
+		</para>
+		<para>
+		<emphasis>force</emphasis> reinterprets every endpoint the module talks
+		to, including ones added later.  Prefer
+		<xref linkend="func_rest_cache_ctl"/> to override a single call site.
+		</para>
+		<para>
+		<emphasis>
+			Default value is <quote>strict</quote>.
+		</emphasis>
+		</para>
+		<example>
+		<title>Setting the <varname>cache_policy</varname> parameter</title>
+		<programlisting format="linespecific">
+...
+modparam("rest_client", "cache_policy", "heuristic")
+...
+</programlisting>
+		</example>
+	</section>
+
+	<section id="param_cache_ttl" xreflabel="cache_ttl">
+		<title><varname>cache_ttl</varname> (integer)</title>
+		<para>
+		Lifetime, in seconds, applied when the origin server gave none and the
+		policy allows caching anyway.  Required by the
+		<emphasis>heuristic</emphasis> and <emphasis>force</emphasis> policies -
+		either is rejected at startup if this is not positive, since it would
+		otherwise silently cache nothing.
+		</para>
+		<para>
+		It is never used in place of a lifetime the origin did supply.
+		</para>
+		<para>
+		<emphasis>
+			Default value is <quote>0</quote> (do not cache silent responses).
+		</emphasis>
+		</para>
+		<example>
+		<title>Setting the <varname>cache_ttl</varname> parameter</title>
+		<programlisting format="linespecific">
+...
+modparam("rest_client", "cache_ttl", 300)
+...
+</programlisting>
+		</example>
+	</section>
+
+	<section id="param_cache_max_body" xreflabel="cache_max_body">
+		<title><varname>cache_max_body</varname> (integer)</title>
+		<para>
+		Largest response body, in bytes, that will be stored.  Anything above it
+		is returned to the script as usual but not cached, and reported as
+		<emphasis>miss:oversize</emphasis>.
+		</para>
+		<para>
+		<emphasis>
+			Default value is <quote>65536</quote>.
+		</emphasis>
+		</para>
+		<para>
+		Values above 64 KB are clamped to 64 KB with a startup warning - the
+		encoded entry lives in a fixed 64 KB buffer, so a larger setting would
+		otherwise pass startup and then silently store nothing.
+		</para>
+		<example>
+		<title>Setting the <varname>cache_max_body</varname> parameter</title>
+		<programlisting format="linespecific">
+...
+modparam("rest_client", "cache_max_body", 131072)
+...
+</programlisting>
+		</example>
+	</section>
+
 	</section>
 
 	<section id="exported_functions" xreflabel="exported_functions">
 	<title>Exported Functions</title>
 	<section id="func_rest_get" xreflabel="rest_get()">
 		<title>
-		<function moreinfo="none">rest_get(url, body_pv, [ctype_pv], [retcode_pv])</function>
+		<function moreinfo="none">rest_get(url, body_pv, [ctype_pv], [retcode_pv], [source_pv])</function>
 		</title>
 		<para>
 		Perform a blocking HTTP GET on the given <emphasis>url</emphasis> and
@@ -402,6 +631,20 @@ modparam("rest_client", "curl_conn_lifetime", 1800)
 				retain the status code of the HTTP response.
 				A <emphasis role='bold'>0</emphasis> status code value means no HTTP
 				reply arrived at all.
+			</para></listitem>
+			<listitem><para>
+				<emphasis>source_pv</emphasis> (var, optional) - output variable
+				reporting where the answer came from, when the response cache is
+				enabled: <emphasis>hit</emphasis> (served from the cache),
+				<emphasis>miss</emphasis> (fetched and stored),
+				<emphasis>miss:reason</emphasis> (fetched but not storable - the
+				reason is one of <emphasis>no-store</emphasis>,
+				<emphasis>no-cache</emphasis>, <emphasis>private</emphasis>,
+				<emphasis>set-cookie</emphasis>, <emphasis>vary</emphasis>,
+				<emphasis>silent</emphasis>, <emphasis>status</emphasis>,
+				<emphasis>method</emphasis>, <emphasis>oversize</emphasis> or
+				<emphasis>expired</emphasis>), or
+				<emphasis>bypass</emphasis> (the cache was not consulted).
 			</para></listitem>
 		</itemizedlist>
 
@@ -437,7 +680,7 @@ if ($var(rcode) != 200) {
 	<section id="func_rest_post" xreflabel="rest_post()">
 		<title>
 		<function moreinfo="none">rest_post(url, send_body, [send_ctype],
-				recv_body_pv, [recv_ctype_pv], [retcode_pv])
+				recv_body_pv, [recv_ctype_pv], [retcode_pv], [source_pv])
 		</function>
 		</title>
 		<para>
@@ -477,6 +720,20 @@ if ($var(rcode) != 200) {
 				A <emphasis role='bold'>0</emphasis> status code value means no HTTP
 				reply arrived at all.
 			</para></listitem>
+			<listitem><para>
+				<emphasis>source_pv</emphasis> (var, optional) - output variable
+				reporting where the answer came from, when the response cache is
+				enabled: <emphasis>hit</emphasis> (served from the cache),
+				<emphasis>miss</emphasis> (fetched and stored),
+				<emphasis>miss:reason</emphasis> (fetched but not storable - the
+				reason is one of <emphasis>no-store</emphasis>,
+				<emphasis>no-cache</emphasis>, <emphasis>private</emphasis>,
+				<emphasis>set-cookie</emphasis>, <emphasis>vary</emphasis>,
+				<emphasis>silent</emphasis>, <emphasis>status</emphasis>,
+				<emphasis>method</emphasis>, <emphasis>oversize</emphasis> or
+				<emphasis>expired</emphasis>), or
+				<emphasis>bypass</emphasis> (the cache was not consulted).
+			</para></listitem>
 		</itemizedlist>
 
 		&rest_return_codes;
@@ -510,7 +767,7 @@ if ($var(rcode) != 200) {
 	<section id="func_rest_put" xreflabel="rest_put()">
 		<title>
 		<function moreinfo="none">rest_put(url, send_body, [send_ctype],
-				recv_body_pv[, [recv_ctype_pv][, [retcode_pv]]])
+				recv_body_pv[, [recv_ctype_pv][, [retcode_pv][, [source_pv]]]])
 		</function>
 		</title>
 		<para>
@@ -548,6 +805,20 @@ if ($var(rcode) != 200) {
 				which will retain the status code of the HTTP response.
 				A <emphasis role='bold'>0</emphasis> status code value means no HTTP
 				reply arrived at all.
+			</para></listitem>
+			<listitem><para>
+				<emphasis>source_pv</emphasis> (var, optional) - output variable
+				reporting where the answer came from, when the response cache is
+				enabled: <emphasis>hit</emphasis> (served from the cache),
+				<emphasis>miss</emphasis> (fetched and stored),
+				<emphasis>miss:reason</emphasis> (fetched but not storable - the
+				reason is one of <emphasis>no-store</emphasis>,
+				<emphasis>no-cache</emphasis>, <emphasis>private</emphasis>,
+				<emphasis>set-cookie</emphasis>, <emphasis>vary</emphasis>,
+				<emphasis>silent</emphasis>, <emphasis>status</emphasis>,
+				<emphasis>method</emphasis>, <emphasis>oversize</emphasis> or
+				<emphasis>expired</emphasis>), or
+				<emphasis>bypass</emphasis> (the cache was not consulted).
 			</para></listitem>
 		</itemizedlist>
 
@@ -612,6 +883,54 @@ $var(rc) = rest_get("http://getcredit.org/?account=$fU", $var(credit));
 		</programlisting>
 		</example>
 	</section>
+	<section id="func_rest_cache_ctl" xreflabel="rest_cache_ctl()">
+		<title>
+		<function moreinfo="none">rest_cache_ctl(ttl)</function>
+		</title>
+		<para>
+		Overrides the cache decision for the <emphasis>next</emphasis>
+		rest_get(), rest_post() or rest_put() only, then reverts - the same
+		"applies once" behaviour as <xref linkend="func_rest_append_hf"/>.
+		Requires <varname>cachedb_url</varname>; without it the call is ignored.
+		</para>
+		<para>Meaning of <emphasis>ttl</emphasis>:</para>
+		<itemizedlist>
+		<listitem><para>
+			<emphasis>0</emphasis> - bypass the cache entirely for that call:
+			no lookup, no store.  For the one endpoint that must always be live.
+		</para></listitem>
+		<listitem><para>
+			<emphasis>greater than 0</emphasis> - serve that call from the
+			cache if present, and store its response for that many seconds,
+			regardless of <varname>cache_policy</varname> and of what the
+			origin's own cache headers say.
+		</para></listitem>
+		</itemizedlist>
+		<para>
+		This is the recommended way to cache an endpoint whose server sends
+		unhelpful headers, in preference to
+		<varname>cache_policy</varname> = <emphasis>force</emphasis>, because it
+		affects one call site rather than every endpoint the module talks to.
+		</para>
+		<para>
+		This function can be used from any route.
+		</para>
+		<example>
+		<title><function>rest_cache_ctl()</function> usage</title>
+		<programlisting format="linespecific">
+...
+# this rate lookup is safe to cache for five minutes, whatever it claims
+rest_cache_ctl(300);
+rest_get("http://rates/lookup", $var(body), $var(ct), $var(rc));
+
+# ...but the fraud check must always be live
+rest_cache_ctl(0);
+rest_get("http://fraud/check", $var(body), $var(ct), $var(rc));
+...
+</programlisting>
+		</example>
+	</section>
+
 	<section id="func_rest_init_client_tls" xreflabel="rest_init_client_tls()">
 		<title>
 		<function moreinfo="none">rest_init_client_tls(tls_client_domain)</function>
@@ -651,7 +970,7 @@ if (!rest_get("https://example.com"))
 	<title>Exported Asynchronous Functions</title>
 	<section id="afunc_rest_get" xreflabel="rest_get()">
 		<title>
-		<function moreinfo="none">rest_get(url, body_pv[, [ctype_pv][, [retcode_pv]]])
+		<function moreinfo="none">rest_get(url, body_pv[, [ctype_pv][, [retcode_pv][, [source_pv]]]])
 		</function>
 		</title>
 		<para>
@@ -693,7 +1012,7 @@ route [resume] {
 	<section id="afunc_rest_post" xreflabel="rest_post()">
 		<title>
 		<function moreinfo="none">rest_post(url, send_body_pv, [send_ctype_pv],
-				recv_body_pv[, [recv_ctype_pv][, [retcode_pv]]])
+				recv_body_pv[, [recv_ctype_pv][, [retcode_pv][, [source_pv]]]])
 		</function>
 		</title>
 		<para>
@@ -735,7 +1054,7 @@ route [resume] {
 	<section id="afunc_rest_put" xreflabel="rest_put()">
 		<title>
 		<function moreinfo="none">rest_put(url, send_body_pv, [send_ctype_pv],
-				recv_body_pv[, [recv_ctype_pv][, [retcode_pv]]])
+				recv_body_pv[, [recv_ctype_pv][, [retcode_pv][, [source_pv]]]])
 		</function>
 		</title>
 		<para>
@@ -773,6 +1092,45 @@ route [resume] {
 		</example>
 	</section>
 
+	</section>
+
+
+	<section id="exported_statistics" xreflabel="Exported Statistics">
+	<title>Exported Statistics</title>
+	<para>
+	The statistics are always exported; while the response cache is disabled
+	the counters simply stay at 0 and the hit rate reads 0.
+	</para>
+	<itemizedlist>
+	<listitem><para>
+		<emphasis>rest_cache_hits</emphasis> - requests served from the cache,
+		without contacting the origin.
+	</para></listitem>
+	<listitem><para>
+		<emphasis>rest_cache_misses</emphasis> - requests that went to the
+		origin.
+	</para></listitem>
+	<listitem><para>
+		<emphasis>rest_cache_stores</emphasis> - responses actually written to
+		the cache.
+	</para></listitem>
+	<listitem><para>
+		<emphasis>rest_cache_skipped</emphasis> - responses fetched but not
+		storable, because the policy, the origin's headers or the size limit
+		refused them.  Worth
+		watching: a cache that stores nothing because every origin sends
+		<emphasis>no-store</emphasis> is otherwise indistinguishable from one
+		that is misconfigured, and neither the hit rate nor response times will
+		tell you apart.  The per-response reason is in the debug log and in the
+		<emphasis>source</emphasis> output variable of each function.
+	</para></listitem>
+	<listitem><para>
+		<emphasis>rest_cache_hit_rate</emphasis> - hits as a whole percentage of
+		lookups, 0 when nothing has been looked up yet.  It covers the lifetime
+		of the process, so a low value shortly after a restart is a cold cache
+		rather than a problem.
+	</para></listitem>
+	</itemizedlist>
 	</section>
 
     <section id="exported_transformations">
@@ -841,5 +1199,182 @@ xlog("$(var(tmp){rest.unescape})\n");
         </section>
 
     </section>
+
+	<section id="cache_examples" xreflabel="Response Cache Examples">
+	<title>Response Cache Examples</title>
+	<para>
+	The examples below all assume an in-process backend, since the point of
+	the cache is to be cheaper than the HTTP call it replaces:
+	</para>
+	<example>
+	<title>Response cache: loading the module with a cache backend</title>
+	<programlisting format="linespecific">
+loadmodule "cachedb_local.so"
+loadmodule "rest_client.so"
+
+modparam("rest_client", "cachedb_url", "local://")
+</programlisting>
+	</example>
+
+	<section id="cache_example_wellbehaved">
+	<title>An origin that sends cache headers</title>
+	<para>
+	Nothing beyond <emphasis>cachedb_url</emphasis> is needed.  The default
+	<emphasis>strict</emphasis> policy caches the response for exactly as long
+	as the server said it may, and re-fetches after that:
+	</para>
+	<example>
+	<title>Response cache: an origin that sends cache headers</title>
+	<programlisting format="linespecific">
+# origin answers with:  Cache-Control: max-age=300
+$var(rc) = rest_get("http://rates.internal/lookup?prefix=$rU",
+                    $var(body), $var(ct), $var(rcode));
+
+# for the next 5 minutes this same prefix is answered locally
+</programlisting>
+	</example>
+	</section>
+
+	<section id="cache_example_silent">
+	<title>An origin that sends no cache headers</title>
+	<para>
+	Many internal APIs send no <emphasis>Cache-Control</emphasis> at all.
+	Under the default policy those responses are never cached — the module
+	will not invent a lifetime the server did not give it.  If you know the
+	data is safe to hold for a while, say so explicitly:
+	</para>
+	<example>
+	<title>Response cache: an origin that sends no cache headers</title>
+	<programlisting format="linespecific">
+modparam("rest_client", "cache_policy", "heuristic")
+modparam("rest_client", "cache_ttl", 60)
+</programlisting>
+	</example>
+	<para>
+	<emphasis>heuristic</emphasis> still obeys an origin that actively refuses
+	caching; it only fills in a lifetime where the origin was silent.  It is
+	rejected at startup without a positive <emphasis>cache_ttl</emphasis>,
+	because a heuristic policy with nothing to fall back on would silently
+	behave like <emphasis>strict</emphasis>.
+	</para>
+	</section>
+
+	<section id="cache_example_percall">
+	<title>Overriding a single call</title>
+	<para>
+	Different endpoints behind the same module often deserve different
+	treatment.  Rather than loosening the policy globally — which reinterprets
+	every endpoint you have, including the ones that were right — override the
+	individual call:
+	</para>
+	<example>
+	<title>Response cache: overriding a single call</title>
+	<programlisting format="linespecific">
+# an expensive, rarely-changing lookup whose origin forgot the headers:
+# cache it for 5 minutes regardless of policy or origin
+rest_cache_ctl(300);
+$var(rc) = rest_get("http://rates.internal/tariff?id=$var(tid)",
+                    $var(tariff));
+
+# a fraud check must never be answered from a cache, even a warm one
+rest_cache_ctl(0);
+$var(rc) = rest_get("http://fraud.internal/score?num=$fU", $var(score));
+</programlisting>
+	</example>
+	<para>
+	The override applies to the <emphasis>next</emphasis> REST call only and
+	is consumed by it, in the same way as
+	<xref linkend="func_rest_append_hf"/>.  This holds for asynchronous calls
+	too: the value is captured when the transfer is dispatched, not when it
+	completes, so a later request cannot change how an in-flight one is
+	cached.
+	</para>
+	</section>
+
+	<section id="cache_example_headers">
+	<title>Per-account queries</title>
+	<para>
+	Headers queued with <emphasis>rest_append_hf()</emphasis> are part of the
+	cache key, so a per-tenant or per-subscriber credential separates the
+	entries automatically — the two calls below never see each other's
+	response, even though the URL is identical:
+	</para>
+	<example>
+	<title>Response cache: per-account queries</title>
+	<programlisting format="linespecific">
+rest_append_hf("Authorization: Bearer $var(tenant_token)");
+$var(rc) = rest_get("http://api.internal/limits", $var(limits));
+</programlisting>
+	</example>
+	<para>
+	The header values are hashed into the key rather than stored in it, so a
+	bearer token never appears in the backend's key space or in whatever
+	dump/inspection tooling the backend offers.
+	</para>
+	</section>
+
+	<section id="cache_example_async">
+	<title>Asynchronous calls</title>
+	<para>
+	The cache works identically for the asynchronous flavours.  A hit
+	completes the call inline — the resume route still runs, and the script
+	sees the same variables it would have seen after a real transfer:
+	</para>
+	<example>
+	<title>Response cache: asynchronous calls with the cache</title>
+	<programlisting format="linespecific">
+route {
+	async(rest_get("http://rates.internal/lookup?prefix=$rU",
+	               $var(body), $var(ct), $var(rcode), $var(src)), resume);
+}
+
+route [resume] {
+	if ($rc &lt; 0) {
+		xlog("rate lookup failed: $rc\n");
+		send_reply(500, "Server Internal Error");
+		exit;
+	}
+	xlog("rate for $rU came from: $var(src)\n");
+	...
+}
+</programlisting>
+	</example>
+	</section>
+
+	<section id="cache_example_observability">
+	<title>Knowing whether the cache is doing anything</title>
+	<para>
+	A cache that stores nothing because every origin sends
+	<emphasis>no-store</emphasis> looks exactly like a working one from the
+	outside: no errors, and a hit rate of zero either way.  The trailing
+	output variable says which it is, per call:
+	</para>
+	<example>
+	<title>Response cache: reporting where a response came from</title>
+	<programlisting format="linespecific">
+$var(rc) = rest_get("http://rates.internal/lookup?prefix=$rU",
+                    $var(body), $var(ct), $var(rcode), $var(src));
+
+# $var(src) is one of:
+#   hit            served locally, the origin was not contacted
+#   miss           fetched from the origin and stored
+#   miss:no-store  fetched, but the origin forbade storing it
+#   miss:silent    fetched, but the origin gave no lifetime and the
+#                  policy is strict
+#   bypass         the cache was not consulted (disabled, or
+#                  rest_cache_ctl(0))
+if ($var(src) =~ "^miss:") {
+	xlog("L_INFO", "not cacheable ($var(src)): $rU\n");
+}
+</programlisting>
+	</example>
+	<para>
+	The same reasons are counted in
+	<emphasis>rest_cache_skipped</emphasis> and logged at debug level, so the
+	question can be answered from monitoring without touching the script.
+	</para>
+	</section>
+
+	</section>
 
 </chapter>

--- a/modules/rest_client/rest_cache.c
+++ b/modules/rest_client/rest_cache.c
@@ -1,0 +1,673 @@
+/*
+ * Copyright (C) 2026 OpenSIPS Project
+ *
+ * This file is part of opensips, a free SIP server.
+ *
+ * opensips is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * opensips is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
+ */
+
+#define _XOPEN_SOURCE 700  /* See strptime(3) - same idiom as db/db_ut.c */
+#define _DEFAULT_SOURCE    /* timegm(3) */
+
+#include <ctype.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+
+#include "../../dprint.h"
+#include "../../mem/mem.h"
+#include "../../md5utils.h"
+#include "../../ut.h"
+#include "../../trim.h"
+#include "../../pvar.h"
+
+#include "rest_cache.h"
+
+char *rcc_cdb_url;
+char *rcc_policy_str;
+int   rcc_cache_ttl;
+int   rcc_max_body = 65536;
+enum rcc_policy rcc_policy = RCC_POLICY_STRICT;
+
+int rcc_ctl_ttl = RCC_CTL_UNSET;
+
+stat_var *rcc_st_hits;
+stat_var *rcc_st_misses;
+stat_var *rcc_st_stores;
+stat_var *rcc_st_skipped;
+
+/*
+ * Hit rate over this process's lifetime, in whole percent.
+ *
+ * Read it with the same care as any cache metric: it is meaningless until there
+ * have been lookups, and a low value right after a restart is a cold cache
+ * rather than a regression.  Zero lookups reports 0, not a division by zero.
+ */
+unsigned long rcc_stat_hit_rate(void *unused)
+{
+	unsigned long h = get_stat_val(rcc_st_hits);
+	unsigned long m = get_stat_val(rcc_st_misses);
+
+	return (h + m) ? (100 * h) / (h + m) : 0;
+}
+
+static cachedb_funcs rcc_cdbf;
+static cachedb_con  *rcc_cdbc;
+
+/* the status codes RFC 9111 lists as cacheable by default */
+static int rcc_cacheable_status(int code)
+{
+	switch (code) {
+	case 200: case 203: case 204: case 300: case 301:
+	case 308: case 404: case 405: case 410: case 414: case 501:
+		return 1;
+	default:
+		return 0;
+	}
+}
+
+void rcc_ctl_reset(void)
+{
+	rcc_ctl_ttl = RCC_CTL_UNSET;
+}
+
+int rcc_enabled(void)
+{
+	return rcc_cdbc != NULL && rcc_policy != RCC_POLICY_OFF;
+}
+
+int rcc_init(void)
+{
+	str url;
+
+	if (!rcc_cdb_url)          /* the feature is off unless a backend is given */
+		return 0;
+
+	if (rcc_policy_str) {
+		if (!strcasecmp(rcc_policy_str, "off"))
+			rcc_policy = RCC_POLICY_OFF;
+		else if (!strcasecmp(rcc_policy_str, "strict"))
+			rcc_policy = RCC_POLICY_STRICT;
+		else if (!strcasecmp(rcc_policy_str, "heuristic"))
+			rcc_policy = RCC_POLICY_HEURISTIC;
+		else if (!strcasecmp(rcc_policy_str, "force"))
+			rcc_policy = RCC_POLICY_FORCE;
+		else {
+			LM_ERR("bad cache_policy '%s' - expected one of "
+				"off, strict, heuristic, force\n", rcc_policy_str);
+			return -1;
+		}
+	}
+
+	/* heuristic and force both fall back to cache_ttl when the origin is
+	 * silent (force, additionally, when it objects); without one they would
+	 * quietly cache nothing at all, which looks identical to a broken cache */
+	if ((rcc_policy == RCC_POLICY_HEURISTIC || rcc_policy == RCC_POLICY_FORCE)
+	        && rcc_cache_ttl <= 0) {
+		LM_ERR("cache_policy '%s' needs a positive cache_ttl to have any "
+			"effect\n", rcc_policy_str);
+		return -1;
+	}
+
+	if (rcc_max_body <= 0) {
+		LM_ERR("cache_max_body must be positive\n");
+		return -1;
+	}
+	if (rcc_max_body > 64 * 1024) {
+		/* the encoded entry lives in a fixed RCC_MAX_VALUE (64K + 512)
+		 * buffer; a larger cache_max_body would pass startup and then
+		 * silently store nothing */
+		LM_WARN("cache_max_body %d exceeds the 64K entry buffer - "
+			"clamping to %d\n", rcc_max_body, 64 * 1024);
+		rcc_max_body = 64 * 1024;
+	}
+
+	init_str(&url, rcc_cdb_url);
+	if (cachedb_bind_mod(&url, &rcc_cdbf) < 0) {
+		LM_ERR("cannot bind the cachedb backend for '%s'\n", rcc_cdb_url);
+		return -1;
+	}
+	if (!rcc_cdbf.get || !rcc_cdbf.set) {
+		LM_ERR("the '%s' backend lacks get/set - unusable as a response "
+			"cache\n", rcc_cdb_url);
+		return -1;
+	}
+	rcc_cdbc = rcc_cdbf.init(&url);
+	if (!rcc_cdbc) {
+		LM_ERR("cannot connect to the cachedb backend '%s'\n", rcc_cdb_url);
+		return -1;
+	}
+
+	LM_INFO("response cache on '%s', policy %s, fallback ttl %ds, max body %d\n",
+		rcc_cdb_url, rcc_policy_str ? rcc_policy_str : "strict",
+		rcc_cache_ttl, rcc_max_body);
+	return 0;
+}
+
+void rcc_destroy(void)
+{
+	if (rcc_cdbc && rcc_cdbf.destroy)
+		rcc_cdbf.destroy(rcc_cdbc);
+	rcc_cdbc = NULL;
+}
+
+/*
+ * ---- response header capture -------------------------------------------
+ * Called once per header line from header_func(), which otherwise keeps only
+ * Content-Type.  Only the directives that decide cacheability are kept.
+ */
+
+static int rcc_hdr_is(const char *line, int len, const char *name, int nlen,
+                      const char **val, int *vlen)
+{
+	const char *p;
+
+	if (len <= nlen + 1 || strncasecmp(line, name, nlen) != 0
+	        || line[nlen] != ':')
+		return 0;
+
+	p = line + nlen + 1;
+	len -= nlen + 1;
+	while (len > 0 && (*p == ' ' || *p == '\t')) { p++; len--; }
+	while (len > 0 && (p[len-1] == '\r' || p[len-1] == '\n'
+	                   || p[len-1] == ' ' || p[len-1] == '\t')) len--;
+
+	*val = p;
+	*vlen = len;
+	return 1;
+}
+
+/* case-insensitive needle inside a bounded haystack */
+static const char *rcc_memcasemem(const char *h, int hlen, const char *n)
+{
+	int nlen = strlen(n), i;
+
+	for (i = 0; i + nlen <= hlen; i++)
+		if (strncasecmp(h + i, n, nlen) == 0)
+			return h + i;
+	return NULL;
+}
+
+static long rcc_delta_after(const char *p, int left)
+{
+	while (left > 0 && (*p == ' ' || *p == '=')) { p++; left--; }
+	if (left <= 0 || !isdigit((unsigned char)*p))
+		return -1;
+	return strtol(p, NULL, 10);
+}
+
+void rcc_parse_header(struct rcc_resp_hdrs *h, const char *line, int len)
+{
+	const char *v, *p;
+	int vlen;
+
+	if (rcc_hdr_is(line, len, "Cache-Control", 13, &v, &vlen)) {
+		h->have_cc = 1;
+		if (rcc_memcasemem(v, vlen, "no-store"))  h->cc_no_store = 1;
+		if (rcc_memcasemem(v, vlen, "no-cache"))  h->cc_no_cache = 1;
+		if (rcc_memcasemem(v, vlen, "private"))   h->cc_private  = 1;
+		/* s-maxage wins over max-age; look for it first */
+		if ((p = rcc_memcasemem(v, vlen, "s-maxage"))) {
+			long d = rcc_delta_after(p + 8, vlen - (int)(p - v) - 8);
+			if (d >= 0) { h->maxage = d; h->have_maxage = 1; }
+		} else if ((p = rcc_memcasemem(v, vlen, "max-age"))) {
+			long d = rcc_delta_after(p + 7, vlen - (int)(p - v) - 7);
+			if (d >= 0) { h->maxage = d; h->have_maxage = 1; }
+		}
+		return;
+	}
+	if (rcc_hdr_is(line, len, "Expires", 7, &v, &vlen)) {
+		char tmp[64];
+		struct tm tm;
+
+		if (vlen > 0 && vlen < (int)sizeof(tmp)) {
+			memcpy(tmp, v, vlen);
+			tmp[vlen] = '\0';
+			memset(&tm, 0, sizeof tm);
+			/* RFC 9110 preferred form; the obsolete forms are rare enough
+			 * that failing to parse them simply means "no Expires" */
+			if (strptime(tmp, "%a, %d %b %Y %H:%M:%S GMT", &tm)) {
+				h->expires = timegm(&tm);
+				h->have_expires = 1;
+			}
+		}
+		return;
+	}
+	if (rcc_hdr_is(line, len, "Age", 3, &v, &vlen)) {
+		if (vlen > 0 && isdigit((unsigned char)*v))
+			h->age = strtol(v, NULL, 10);
+		return;
+	}
+	if (rcc_hdr_is(line, len, "Vary", 4, &v, &vlen)) {
+		h->have_vary = 1;
+		return;
+	}
+	if (rcc_hdr_is(line, len, "Set-Cookie", 10, &v, &vlen)) {
+		h->have_setcookie = 1;
+		return;
+	}
+}
+
+/*
+ * ---- cache key ----------------------------------------------------------
+ * The pending rest_append_hf() headers MUST take part.  They are process-global
+ * and consumed by the next request, so the same URL can legitimately be fetched
+ * with different Authorization/Accept/tenant headers and return different
+ * bodies; keying on the URL alone would serve one caller's response to another.
+ *
+ * The headers are lower-cased, trimmed and sorted so that appending the same two
+ * headers in the other order still hits the same entry, and the whole thing is
+ * hashed - a raw key would put bearer tokens somewhere perf_dump can print them.
+ */
+static int rcc_hdr_cmp(const void *a, const void *b)
+{
+	return strcmp(*(const char * const *)a, *(const char * const *)b);
+}
+
+/* publish the provenance string into the caller's variable, if it asked for one */
+void rcc_set_source(struct sip_msg *msg, void *source_pv, struct rcc_ctx *ctx)
+{
+	pv_value_t val;
+
+	if (!source_pv)
+		return;
+	memset(&val, 0, sizeof val);
+	val.flags = PV_VAL_STR;
+	val.rs.s = (char *)(ctx->src ? ctx->src : RCC_SRC_MISS);
+	val.rs.len = strlen(val.rs.s);
+	if (pv_set_value(msg, (pv_spec_p)source_pv, 0, &val) != 0)
+		LM_ERR("failed to set the cache source output variable\n");
+}
+
+int rcc_prepare(struct rcc_ctx *ctx, const char *method, const str *url,
+                struct curl_slist *extra_hdrs)
+{
+	if (!rcc_enabled() || rcc_ctl_ttl == RCC_CTL_BYPASS) {
+		ctx->enabled = 0;
+		ctx->src = RCC_SRC_BYPASS;
+		rcc_ctl_reset();
+		return 0;
+	}
+	ctx->ctl_ttl = rcc_ctl_ttl;         /* capture before the global is cleared */
+	rcc_ctl_reset();
+	if (rcc_build_key(ctx, method, url, extra_hdrs) < 0) {
+		ctx->enabled = 0;
+		return 0;
+	}
+	ctx->enabled = 1;
+	return 1;
+}
+
+int rcc_build_key(struct rcc_ctx *ctx, const char *method, const str *url,
+                  struct curl_slist *extra_hdrs)
+{
+	struct curl_slist *it;
+	char **hdrs = NULL, *low;
+	int n = 0, i, rc = -1;
+	str parts[4];
+	str joined = {NULL, 0};
+
+	for (it = extra_hdrs; it; it = it->next)
+		n++;
+
+	if (n) {
+		hdrs = pkg_malloc(n * sizeof *hdrs);
+		if (!hdrs) {
+			LM_ERR("no more pkg memory for the cache key\n");
+			return -1;
+		}
+		memset(hdrs, 0, n * sizeof *hdrs);
+		for (it = extra_hdrs, i = 0; it; it = it->next, i++) {
+			int l = it->data ? strlen(it->data) : 0;
+			int j;
+
+			low = pkg_malloc(l + 1);
+			if (!low)
+				goto out;
+			/* only the header NAME is case-insensitive; lower-casing the
+			 * value too would collapse tokens that differ only in case */
+			for (j = 0; j < l; j++) {
+				if (j && it->data[j-1] == ':') { /* value starts */
+					memcpy(low + j, it->data + j, l - j);
+					j = l;
+					break;
+				}
+				low[j] = tolower((unsigned char)it->data[j]);
+			}
+			low[l] = '\0';
+			hdrs[i] = low;
+		}
+		qsort(hdrs, n, sizeof *hdrs, rcc_hdr_cmp);
+
+		for (i = 0; i < n; i++)
+			joined.len += strlen(hdrs[i]) + 1;
+		joined.s = pkg_malloc(joined.len);
+		if (!joined.s)
+			goto out;
+		joined.len = 0;
+		for (i = 0; i < n; i++) {
+			int l = strlen(hdrs[i]);
+			memcpy(joined.s + joined.len, hdrs[i], l);
+			joined.len += l;
+			joined.s[joined.len++] = '\n';
+		}
+	}
+
+	/* The key covers the method, the URL and the appended headers, but NOT
+	 * the request body.  That is safe only because rcc_decide() stores GET
+	 * responses and nothing else: a POST key can never collide with a stored
+	 * entry because no POST response is ever written.  If storing is ever
+	 * extended to POST, the body MUST become part of the key - two POSTs to
+	 * one URL differing only in body are different resources. */
+	init_str(&parts[0], method);
+	parts[1] = *url;
+	parts[2] = joined;
+	parts[3] = joined;              /* MD5StringArray takes a fixed count */
+
+	MD5StringArray(ctx->keybuf, parts, joined.s ? 3 : 2);
+	ctx->keybuf[32] = '\0';
+	ctx->key.s = ctx->keybuf;
+	ctx->key.len = 32;
+	rc = 0;
+
+out:
+	if (joined.s)
+		pkg_free(joined.s);
+	if (hdrs) {
+		for (i = 0; i < n; i++)
+			if (hdrs[i])
+				pkg_free(hdrs[i]);
+		pkg_free(hdrs);
+	}
+	if (rc)
+		LM_ERR("no more pkg memory for the cache key\n");
+	return rc;
+}
+
+/*
+ * ---- policy -------------------------------------------------------------
+ * Decides whether this response may be stored and for how long, and records a
+ * reason when it may not.  The reason is the whole point: a cache that stores
+ * nothing because every response says no-store is otherwise indistinguishable
+ * from one that is broken or switched off.
+ */
+static void rcc_deny(struct rcc_ctx *ctx, const char *why)
+{
+	ctx->store_ttl = 0;
+	snprintf(ctx->srcbuf, sizeof ctx->srcbuf, "miss:%s", why);
+	ctx->src = ctx->srcbuf;
+	update_stat(rcc_st_skipped, 1);
+}
+
+void rcc_decide(struct rcc_ctx *ctx, const char *method, int code)
+{
+	struct rcc_resp_hdrs *h = &ctx->hdrs;
+	int forced = (ctx->ctl_ttl > 0);
+	long ttl = -1;
+
+	ctx->store_ttl = 0;
+	if (!ctx->src)
+		ctx->src = RCC_SRC_MISS;
+	/* reached only when the cache was consulted and did not serve the call,
+	 * so exactly one miss is counted per lookup that went to the origin */
+	update_stat(rcc_st_misses, 1);
+
+	/* hard invariants - no policy and no per-call override reaches these */
+	if (strcmp(method, "GET") != 0)      { rcc_deny(ctx, "method");  return; }
+	if (!rcc_cacheable_status(code))     { rcc_deny(ctx, "status");  return; }
+	if (h->have_vary)                    { rcc_deny(ctx, "vary");    return; }
+
+	/* an explicit per-call ttl overrides both the policy and the origin */
+	if (forced) {
+		ctx->store_ttl = ctx->ctl_ttl;
+		ctx->src = RCC_SRC_MISS;
+		return;
+	}
+
+	if (h->have_setcookie && rcc_policy != RCC_POLICY_FORCE) {
+		rcc_deny(ctx, "set-cookie"); return;
+	}
+	if (h->cc_no_store && rcc_policy != RCC_POLICY_FORCE) {
+		rcc_deny(ctx, "no-store");  return;
+	}
+	if (h->cc_no_cache && rcc_policy != RCC_POLICY_FORCE) {
+		rcc_deny(ctx, "no-cache");  return;
+	}
+	if (h->cc_private && rcc_policy != RCC_POLICY_FORCE) {
+		rcc_deny(ctx, "private");   return;
+	}
+
+	/* what the origin permits, in precedence order */
+	if (h->have_maxage)
+		ttl = h->maxage - (h->age > 0 ? h->age : 0);
+	else if (h->have_expires)
+		ttl = (long)(h->expires - time(NULL));
+
+	if (h->have_maxage || h->have_expires) {
+		if (ttl <= 0) {
+			/* the origin DID give a lifetime and it has already elapsed
+			 * (past Expires, Age beyond max-age, max-age=0).  That is not
+			 * silence: RFC 9111 permits heuristic freshness only where no
+			 * explicit expiration exists, so heuristic must not resuscitate
+			 * an explicitly stale response.  force still may - ignoring the
+			 * origin is its contract. */
+			if (rcc_policy != RCC_POLICY_FORCE) {
+				rcc_deny(ctx, "expired");
+				return;
+			}
+			ttl = rcc_cache_ttl;
+		}
+	} else {
+		/* the origin said nothing at all */
+		if (rcc_policy == RCC_POLICY_HEURISTIC || rcc_policy == RCC_POLICY_FORCE)
+			ttl = rcc_cache_ttl;
+		else {
+			rcc_deny(ctx, "silent");
+			return;
+		}
+	}
+
+	if (ttl <= 0) { rcc_deny(ctx, "expired"); return; }
+
+	ctx->store_ttl = (int)ttl;
+	ctx->src = RCC_SRC_MISS;
+}
+
+/*
+ * ---- value encoding -----------------------------------------------------
+ *   [u16 code][u16 ctype_len][u64 expires_at][ctype][u32 body_len][body]
+ * Length-prefixed and fixed-width up front, so a hit decodes by pointing into
+ * the buffer rather than parsing it.
+ *
+ * expires_at is an absolute wall-clock second, and it is what actually
+ * enforces freshness on a read.  The same lifetime is handed to the backend
+ * as a TTL, but a backend is not obliged to act on it - cachedb_mongodb, for
+ * one, accepts the expiry argument and ignores it - and a cache that silently
+ * serves a response for ever is a worse failure than one that does not cache
+ * at all.  Eight bytes buys correctness that does not depend on which backend
+ * the deployment picked.
+ */
+#define RCC_HDR_SZ  (2 + 2 + 8 + 4)
+
+static int rcc_encode(char *dst, int dstlen, const str *body, const str *ctype,
+                      int code, int ttl)
+{
+	unsigned short c16, ct16;
+	unsigned int b32;
+	uint64_t exp;
+	int need, ctl = ctype ? ctype->len : 0;
+
+	need = RCC_HDR_SZ + ctl + body->len;
+	if (need > dstlen)
+		return -1;
+
+	c16  = (unsigned short)code;
+	ct16 = (unsigned short)ctl;
+	b32  = (unsigned int)body->len;
+	exp  = (uint64_t)time(NULL) + (uint64_t)ttl;
+
+	memcpy(dst,      &c16,  2);
+	memcpy(dst + 2,  &ct16, 2);
+	memcpy(dst + 4,  &exp,  8);
+	if (ctl)
+		memcpy(dst + 12, ctype->s, ctl);
+	memcpy(dst + 12 + ctl, &b32, 4);
+	if (body->len)
+		memcpy(dst + RCC_HDR_SZ + ctl, body->s, body->len);
+	return need;
+}
+
+/* returns 0 on a usable entry, -1 on a malformed one, 1 on an expired one */
+static int rcc_decode(char *src, int srclen, str *body, str *ctype, int *code)
+{
+	unsigned short c16, ct16;
+	unsigned int b32;
+	uint64_t exp;
+
+	if (srclen < RCC_HDR_SZ)
+		return -1;
+	memcpy(&c16,  src,     2);
+	memcpy(&ct16, src + 2, 2);
+	memcpy(&exp,  src + 4, 8);
+	if (RCC_HDR_SZ + (int)ct16 > srclen)
+		return -1;
+	memcpy(&b32, src + 12 + ct16, 4);
+	if (RCC_HDR_SZ + (int)ct16 + (int)b32 > srclen)
+		return -1;
+
+	/* the backend was asked to expire this, but it may not have done so */
+	if ((uint64_t)time(NULL) >= exp)
+		return 1;
+
+	*code = c16;
+	if (ctype) {
+		ctype->s   = ct16 ? src + 12 : NULL;
+		ctype->len = ct16;
+	}
+	body->s   = b32 ? src + RCC_HDR_SZ + ct16 : NULL;
+	body->len = b32;
+	return 0;
+}
+
+/*
+ * ---- lookup / store -----------------------------------------------------
+ */
+/*
+ * On a hit, @body/@ctype point into a per-process scratch buffer owned by this
+ * module and valid until this process's next rcc_lookup().  The caller must NOT
+ * free them - it copies them straight into pvars, which take their own copy.
+ *
+ * Both backend paths land in the same buffer on purpose.  Returning pkg memory
+ * from one path and a borrowed pointer from the other is how the first version
+ * of this aborted with "freeing dangling pkg pointer": the get_buf path handed
+ * back a pointer into static storage and the caller pkg_free()d it.  One
+ * provenance, one rule.
+ */
+static char rcc_scratch[RCC_MAX_VALUE];
+
+int rcc_lookup(struct rcc_ctx *ctx, str *body, str *ctype, int *code)
+{
+	str val = {NULL, 0};
+	int rc, len = 0;
+
+	if (!ctx->enabled)
+		return 0;
+
+#ifdef CACHEDB_HAVE_GET_BUF
+	/* the core carries the allocation-free endpoint - use it when the backend
+	 * in use actually implements it (a core may have it, redis:// may not) */
+	if (rcc_cdbf.get_buf && CACHEDB_CAPABILITY(&rcc_cdbf, CACHEDB_CAP_GET_BUF)) {
+		unsigned int vlen = 0;
+
+		rc = rcc_cdbf.get_buf(rcc_cdbc, &ctx->key, rcc_scratch,
+		                      sizeof rcc_scratch, &vlen, NULL);
+		if (rc != 0 || !vlen)
+			return 0;
+		len = (int)vlen;
+	} else
+#endif
+	{
+		rc = rcc_cdbf.get(rcc_cdbc, &ctx->key, &val);
+		if (rc < 0 || !val.s || !val.len)
+			return 0;
+		if (val.len > (int)sizeof rcc_scratch) {
+			LM_ERR("cached entry for [%.*s] is %d bytes, larger than the "
+				"scratch - ignoring\n", ctx->key.len, ctx->key.s, val.len);
+			pkg_free(val.s);
+			return 0;
+		}
+		/* copy out and release immediately, so both paths leave the value in
+		 * the same place with the same lifetime */
+		memcpy(rcc_scratch, val.s, val.len);
+		len = val.len;
+		pkg_free(val.s);
+	}
+
+	rc = rcc_decode(rcc_scratch, len, body, ctype, code);
+	if (rc < 0) {
+		LM_ERR("corrupt cache entry for [%.*s] - ignoring\n",
+			ctx->key.len, ctx->key.s);
+		return 0;
+	}
+	if (rc > 0) {
+		/* the entry outlived its lifetime, so the backend is not enforcing
+		 * the TTL we gave it.  Treat it as a miss and refetch. */
+		LM_DBG("stale entry for [%.*s] - the backend did not expire it\n",
+			ctx->key.len, ctx->key.s);
+		return 0;
+	}
+
+	ctx->src = RCC_SRC_HIT;
+	update_stat(rcc_st_hits, 1);
+	return 1;
+}
+
+void rcc_store(struct rcc_ctx *ctx, const str *body, const str *ctype, int code)
+{
+	static char buf[RCC_MAX_VALUE];
+	str val;
+	int n;
+
+	if (!ctx->enabled || ctx->store_ttl <= 0)
+		return;
+
+	if (body->len > rcc_max_body) {
+		LM_DBG("response of %d bytes exceeds cache_max_body %d - not stored\n",
+			body->len, rcc_max_body);
+		snprintf(ctx->srcbuf, sizeof ctx->srcbuf, "miss:oversize");
+		ctx->src = ctx->srcbuf;
+		update_stat(rcc_st_skipped, 1);
+		return;
+	}
+
+	n = rcc_encode(buf, sizeof buf, body, ctype, code, ctx->store_ttl);
+	if (n < 0) {
+		snprintf(ctx->srcbuf, sizeof ctx->srcbuf, "miss:oversize");
+		ctx->src = ctx->srcbuf;
+		update_stat(rcc_st_skipped, 1);
+		return;
+	}
+
+	val.s = buf;
+	val.len = n;
+	if (rcc_cdbf.set(rcc_cdbc, &ctx->key, &val, ctx->store_ttl) < 0) {
+		LM_ERR("failed to store the response for [%.*s]\n",
+			ctx->key.len, ctx->key.s);
+	} else {
+		update_stat(rcc_st_stores, 1);
+		LM_DBG("stored %d bytes for [%.*s], ttl %ds\n",
+			n, ctx->key.len, ctx->key.s, ctx->store_ttl);
+	}
+}

--- a/modules/rest_client/rest_cache.h
+++ b/modules/rest_client/rest_cache.h
@@ -1,0 +1,137 @@
+/*
+ * Copyright (C) 2026 OpenSIPS Project
+ *
+ * This file is part of opensips, a free SIP server.
+ *
+ * opensips is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * opensips is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
+ */
+
+#ifndef _REST_CACHE_H_
+#define _REST_CACHE_H_
+
+#include "../../str.h"
+#include "../../cachedb/cachedb.h"
+#include "../../statistics.h"
+#include <curl/curl.h>
+
+/* what a lookup/store decided, reported to the script and the log */
+#define RCC_SRC_BYPASS      "bypass"
+#define RCC_SRC_HIT         "hit"
+#define RCC_SRC_MISS        "miss"
+
+/* module-wide policy: how far to go beyond what the origin explicitly allows */
+enum rcc_policy {
+	RCC_POLICY_OFF = 0,   /* never cache                                     */
+	RCC_POLICY_STRICT,    /* only what the origin explicitly permits         */
+	RCC_POLICY_HEURISTIC, /* also cache when the origin says nothing         */
+	RCC_POLICY_FORCE,     /* also cache when the origin says not to          */
+};
+
+/* per-call override, set by rest_cache_ctl() for the NEXT request only, in the
+ * same "pending state" style the module already uses for header_list */
+#define RCC_CTL_UNSET   (-1)   /* no override: module policy applies */
+#define RCC_CTL_BYPASS   (0)   /* skip the cache entirely for this call */
+
+/* upper bound on one cached response: header + ctype + body */
+#define RCC_MAX_VALUE   (64 * 1024 + 512)
+
+/*
+ * The caching directives worth keeping out of a response.  header_func() fills
+ * this in as the headers stream past; everything else is still discarded.
+ */
+struct rcc_resp_hdrs {
+	int   have_cc;          /* a Cache-Control header was seen              */
+	int   cc_no_store;
+	int   cc_no_cache;
+	int   cc_private;
+	int   have_maxage;      /* s-maxage or max-age was parsed               */
+	long  maxage;
+	int   have_expires;
+	time_t expires;         /* absolute, from the Expires header            */
+	long  age;              /* Age header, 0 if absent                      */
+	int   have_vary;
+	int   have_setcookie;
+};
+
+/* everything the cache needs to know about one in-flight request */
+struct rcc_ctx {
+	int          enabled;       /* cache consulted for this call at all     */
+	int          ctl_ttl;       /* per-call rest_cache_ctl(), captured at    */
+	                            /* dispatch: -1 none, 0 bypass, >0 force     */
+	int          store_ttl;     /* >0 = store for this many seconds         */
+	str          key;           /* MD5 hex of method+url+headers            */
+	char         keybuf[33];
+	const char  *src;           /* provenance string, see RCC_SRC_*         */
+	char         srcbuf[32];    /* holds "miss:<reason>"                    */
+	struct rcc_resp_hdrs hdrs;
+};
+
+extern char *rcc_cdb_url;
+extern char *rcc_policy_str;
+extern int   rcc_cache_ttl;
+extern int   rcc_max_body;
+extern enum rcc_policy rcc_policy;
+
+/* module life cycle */
+int  rcc_init(void);          /* parse policy, connect the backend          */
+void rcc_destroy(void);
+int  rcc_enabled(void);       /* a backend is configured and policy != off  */
+
+/* per-call override (rest_cache_ctl), cleared with the header list */
+extern int rcc_ctl_ttl;
+void rcc_ctl_reset(void);
+
+/*
+ * Build the cache key for this request.  @extra_hdrs is the pending
+ * rest_append_hf() list - it MUST take part, since the same URL can be fetched
+ * with different Authorization/Accept headers and get different answers.
+ */
+int  rcc_build_key(struct rcc_ctx *ctx, const char *method, const str *url,
+                   struct curl_slist *extra_hdrs);
+
+/*
+ * Prepare @ctx for a request: decide whether the cache applies, capture the
+ * per-call rest_cache_ctl() override, and build the key.  Returns 1 if the
+ * cache is engaged (ctx->enabled set), 0 if this call bypasses it entirely.
+ * The global override is cleared here, so it never leaks to a later request -
+ * which matters for async, whose store runs long after the next call started.
+ */
+int  rcc_prepare(struct rcc_ctx *ctx, const char *method, const str *url,
+                 struct curl_slist *extra_hdrs);
+
+/* returns 1 and fills body/ctype/code on a hit, 0 on a miss */
+int  rcc_lookup(struct rcc_ctx *ctx, str *body, str *ctype, int *code);
+
+/* decide from policy + origin headers whether to store, and for how long */
+void rcc_decide(struct rcc_ctx *ctx, const char *method, int code);
+
+/* store the response if rcc_decide() allowed it */
+void rcc_store(struct rcc_ctx *ctx, const str *body, const str *ctype, int code);
+
+/* statistics - the aggregate view of what source_pv reports per call */
+extern stat_var *rcc_st_hits;
+extern stat_var *rcc_st_misses;
+extern stat_var *rcc_st_stores;
+extern stat_var *rcc_st_skipped;
+unsigned long rcc_stat_hit_rate(void *unused);
+
+/* publish ctx->src into a script variable (no-op when source_pv is NULL) */
+struct sip_msg;
+void rcc_set_source(struct sip_msg *msg, void *source_pv, struct rcc_ctx *ctx);
+
+/* one header line, as seen by header_func() */
+void rcc_parse_header(struct rcc_resp_hdrs *h, const char *line, int len);
+
+#endif /* _REST_CACHE_H_ */

--- a/modules/rest_client/rest_cb.c
+++ b/modules/rest_client/rest_cb.c
@@ -79,9 +79,18 @@ size_t write_func(char *ptr, size_t size, size_t nmemb, void *body)
 size_t header_func(char *ptr, size_t size, size_t nmemb, void *userdata)
 {
 	int len, left;
-	str *st = (str *)userdata;
+	struct rest_hdr_sink *sink = (struct rest_hdr_sink *)userdata;
+	str *st = sink->ctype;
 
 	len = left = size * nmemb;
+
+	if (sink->cache)
+		rcc_parse_header(sink->cache, ptr, len);
+
+	if (!st) {
+		LM_DBG("Received: %.*s\n", len, ptr);
+		return len;
+	}
 
 	if (len > CONTENT_TYPE_HDR_LEN && *ptr == 'C' &&
 	    strncasecmp(ptr, HTTP_HDR_CONTENT_TYPE, CONTENT_TYPE_HDR_LEN) == 0) {

--- a/modules/rest_client/rest_cb.h
+++ b/modules/rest_client/rest_cb.h
@@ -28,6 +28,7 @@
 #include "rest_client.h"
 
 #include "../../str.h"
+#include "rest_cache.h"
 #include "../../mem/mem.h"
 #include "../../error.h"
 #include "../../dprint.h"
@@ -40,6 +41,19 @@
 #define MAX_HEADER_FIELD_LEN	 1024 /* arbitrary */
 
 size_t write_func(char *ptr, size_t size, size_t nmemb, void *userdata);
+/*
+ * What header_func() writes into.  Both members are optional: a script that asks
+ * for no content-type still needs the caching headers parsed, which is why the
+ * callback is installed unconditionally rather than only when a ctype output
+ * variable was supplied - otherwise rest_get(url,$b) and rest_get(url,$b,$ct)
+ * would cache differently, and the async path (which only installed it when a
+ * ctype was present) would never see a Cache-Control header at all.
+ */
+struct rest_hdr_sink {
+	str *ctype;                    /* Content-Type, if the caller wants it */
+	struct rcc_resp_hdrs *cache;   /* caching directives, if caching is on */
+};
+
 size_t header_func(char *ptr, size_t size, size_t nmemb, void *userdata);
 
 #endif /* _REST_CB_H_ */

--- a/modules/rest_client/rest_client.c
+++ b/modules/rest_client/rest_client.c
@@ -39,6 +39,7 @@
 #include "../tls_mgm/api.h"
 #include "rest_client.h"
 #include "rest_methods.h"
+#include "rest_cache.h"
 #include "../../pt.h"
 
 /*
@@ -87,24 +88,44 @@ static int cfg_validate(void);
  * Function headers
  */
 static int w_rest_get(struct sip_msg *msg, str *url, pv_spec_t *body_pv,
-                      pv_spec_t *ctype_pv, pv_spec_t *code_pv);
+                      pv_spec_t *ctype_pv, pv_spec_t *code_pv,
+                      pv_spec_t *source_pv);
 static int w_rest_post(struct sip_msg *msg, str *url, str *body, str *_ctype,
-					pv_spec_t *body_pv, pv_spec_t *ctype_pv, pv_spec_t *code_pv);
+					pv_spec_t *body_pv, pv_spec_t *ctype_pv, pv_spec_t *code_pv,
+					pv_spec_t *source_pv);
 static int w_rest_put(struct sip_msg *msg, str *url, str *body, str *_ctype,
-					pv_spec_t *body_pv, pv_spec_t *ctype_pv, pv_spec_t *code_pv);
+					pv_spec_t *body_pv, pv_spec_t *ctype_pv, pv_spec_t *code_pv,
+					pv_spec_t *source_pv);
 
 static int w_async_rest_get(struct sip_msg *msg, async_ctx *ctx, str *url,
-				pv_spec_t *body_pv, pv_spec_t *ctype_pv, pv_spec_t *code_pv);
+				pv_spec_t *body_pv, pv_spec_t *ctype_pv, pv_spec_t *code_pv,
+				pv_spec_t *source_pv);
 static int w_async_rest_post(struct sip_msg *msg, async_ctx *ctx,
 			str *url, str *body, str *_ctype, pv_spec_t *body_pv,
-			pv_spec_t *ctype_pv, pv_spec_t *code_pv);
+			pv_spec_t *ctype_pv, pv_spec_t *code_pv, pv_spec_t *source_pv);
 static int w_async_rest_put(struct sip_msg *msg, async_ctx *ctx,
 			str *url, str *body, str *_ctype, pv_spec_t *body_pv,
-			pv_spec_t *ctype_pv, pv_spec_t *code_pv);
+			pv_spec_t *ctype_pv, pv_spec_t *code_pv, pv_spec_t *source_pv);
 
 static int w_rest_append_hf(struct sip_msg *msg, str *hfv);
+static int w_rest_cache_ctl(struct sip_msg *msg, int *ttl);
 static int w_rest_init_client_tls(struct sip_msg *msg, str *tls_client_dom);
 int validate_curl_http_version(const int *http_version);
+
+/*
+ * Exported statistics - the aggregate companion to the per-call source
+ * variable.  rest_cache_skipped is the one worth watching: a cache that stores
+ * nothing because every origin says no-store is otherwise indistinguishable
+ * from one that is misconfigured or switched off.
+ */
+static const stat_export_t mod_stats[] = {
+	{"rest_cache_hits",     0,             &rcc_st_hits    },
+	{"rest_cache_misses",   0,             &rcc_st_misses  },
+	{"rest_cache_stores",   0,             &rcc_st_stores  },
+	{"rest_cache_skipped",  0,             &rcc_st_skipped },
+	{"rest_cache_hit_rate", STAT_IS_FUNC,  (stat_var **)rcc_stat_hit_rate},
+	{0, 0, 0}
+};
 
 /* module dependencies */
 static const dep_export_t deps = {
@@ -113,6 +134,7 @@ static const dep_export_t deps = {
 		{ MOD_TYPE_NULL, NULL, 0 }
 	},
 	{ /* modparam dependencies */
+		{ "cachedb_url", get_deps_cachedb_url },
 		{ NULL, NULL}
 	}
 };
@@ -122,6 +144,7 @@ static const acmd_export_t acmds[] = {
 		{CMD_PARAM_STR,0,0},
 		{CMD_PARAM_VAR,0,0},
 		{CMD_PARAM_VAR|CMD_PARAM_OPT,0,0},
+		{CMD_PARAM_VAR|CMD_PARAM_OPT,0,0},
 		{CMD_PARAM_VAR|CMD_PARAM_OPT,0,0}, {0,0,0}}},
 	{"rest_post",(acmd_function)w_async_rest_post, {
 		{CMD_PARAM_STR,0,0},
@@ -129,12 +152,14 @@ static const acmd_export_t acmds[] = {
 		{CMD_PARAM_STR|CMD_PARAM_OPT,0,0},
 		{CMD_PARAM_VAR,0,0},
 		{CMD_PARAM_VAR|CMD_PARAM_OPT,0,0},
+		{CMD_PARAM_VAR|CMD_PARAM_OPT,0,0},
 		{CMD_PARAM_VAR|CMD_PARAM_OPT,0,0}, {0,0,0}}},
 	{"rest_put",(acmd_function)w_async_rest_put, {
 		{CMD_PARAM_STR,0,0},
 		{CMD_PARAM_STR,0,0},
 		{CMD_PARAM_STR|CMD_PARAM_OPT,0,0},
 		{CMD_PARAM_VAR,0,0},
+		{CMD_PARAM_VAR|CMD_PARAM_OPT,0,0},
 		{CMD_PARAM_VAR|CMD_PARAM_OPT,0,0},
 		{CMD_PARAM_VAR|CMD_PARAM_OPT,0,0}, {0,0,0}}},
 	{0,0,{{0,0,0}}}
@@ -149,6 +174,7 @@ static const cmd_export_t cmds[] = {
 		{CMD_PARAM_STR,0,0},
 		{CMD_PARAM_VAR,0,0},
 		{CMD_PARAM_VAR|CMD_PARAM_OPT,0,0},
+		{CMD_PARAM_VAR|CMD_PARAM_OPT,0,0},
 		{CMD_PARAM_VAR|CMD_PARAM_OPT,0,0}, {0,0,0}},
 		ALL_ROUTES},
 	{"rest_post",(cmd_function)w_rest_post, {
@@ -156,6 +182,7 @@ static const cmd_export_t cmds[] = {
 		{CMD_PARAM_STR,0,0},
 		{CMD_PARAM_STR|CMD_PARAM_OPT,0,0},
 		{CMD_PARAM_VAR,0,0},
+		{CMD_PARAM_VAR|CMD_PARAM_OPT,0,0},
 		{CMD_PARAM_VAR|CMD_PARAM_OPT,0,0},
 		{CMD_PARAM_VAR|CMD_PARAM_OPT,0,0}, {0,0,0}},
 		ALL_ROUTES},
@@ -165,10 +192,14 @@ static const cmd_export_t cmds[] = {
 		{CMD_PARAM_STR|CMD_PARAM_OPT,0,0},
 		{CMD_PARAM_VAR,0,0},
 		{CMD_PARAM_VAR|CMD_PARAM_OPT,0,0},
+		{CMD_PARAM_VAR|CMD_PARAM_OPT,0,0},
 		{CMD_PARAM_VAR|CMD_PARAM_OPT,0,0}, {0,0,0}},
 		ALL_ROUTES},
 	{"rest_append_hf",(cmd_function)w_rest_append_hf, {
 		{CMD_PARAM_STR,0,0}, {0,0,0}},
+		ALL_ROUTES},
+	{"rest_cache_ctl",(cmd_function)w_rest_cache_ctl, {
+		{CMD_PARAM_INT,0,0}, {0,0,0}},
 		ALL_ROUTES},
 	{"rest_init_client_tls",(cmd_function)w_rest_init_client_tls, {
 		{CMD_PARAM_STR,0,0}, {0,0,0}},
@@ -203,6 +234,10 @@ static const param_export_t params[] = {
 	{ "curl_http_version",	INT_PARAM, &curl_http_version	},
 	{ "enable_expect_100",	INT_PARAM, &enable_expect_100	},
 	{ "no_concurrent_connects",	INT_PARAM, &no_concurrent_connects	},
+	{ "cachedb_url",		STR_PARAM, &rcc_cdb_url		},
+	{ "cache_policy",		STR_PARAM, &rcc_policy_str	},
+	{ "cache_ttl",			INT_PARAM, &rcc_cache_ttl	},
+	{ "cache_max_body",		INT_PARAM, &rcc_max_body	},
 	{ "curl_conn_lifetime",	INT_PARAM, &curl_conn_lifetime	},
 	{ 0, 0, 0 }
 };
@@ -221,7 +256,7 @@ struct module_exports exports = {
 	cmds,             /* Exported functions */
 	acmds,            /* Exported async functions */
 	params,           /* Exported parameters */
-	NULL,             /* exported statistics */
+	mod_stats,        /* exported statistics */
 	NULL,             /* exported MI functions */
 	NULL,             /* exported pseudo-variables */
 	trans,	          /* exported transformations */
@@ -275,6 +310,11 @@ static int mod_init(void)
 		return -1;
 	}
 
+	if (rcc_init() != 0) {
+		LM_ERR("failed to init the response cache\n");
+		return -1;
+	}
+
 	LM_INFO("Module initialized!\n");
 
 	return 0;
@@ -310,6 +350,7 @@ static int child_init(int rank)
 
 static void mod_destroy(void)
 {
+	rcc_destroy();
 	curl_global_cleanup();
 }
 
@@ -512,7 +553,8 @@ error:
 /**************************** Module functions *******************************/
 
 static int w_rest_get(struct sip_msg *msg, str *url, pv_spec_t *body_pv,
-                      pv_spec_t *ctype_pv, pv_spec_t *code_pv)
+                      pv_spec_t *ctype_pv, pv_spec_t *code_pv,
+                      pv_spec_t *source_pv)
 {
 	str url_nt;
 	int lrc = RCL_OK, rc;
@@ -527,7 +569,7 @@ static int w_rest_get(struct sip_msg *msg, str *url, pv_spec_t *body_pv,
 		return lrc;
 
 	rc = rest_sync_transfer(REST_CLIENT_GET, msg, url_nt.s, NULL, NULL,
-	                          body_pv, ctype_pv, code_pv);
+	                          body_pv, ctype_pv, code_pv, source_pv);
 
 	if (lrc == RCL_OK_LOCKED)
 		rcl_release_url(host, rc == RCL_OK);
@@ -537,7 +579,8 @@ static int w_rest_get(struct sip_msg *msg, str *url, pv_spec_t *body_pv,
 }
 
 static int w_rest_post(struct sip_msg *msg, str *url, str *body, str *_ctype,
-					pv_spec_t *body_pv, pv_spec_t *ctype_pv, pv_spec_t *code_pv)
+					pv_spec_t *body_pv, pv_spec_t *ctype_pv, pv_spec_t *code_pv,
+					pv_spec_t *source_pv)
 {
 	str ctype = { NULL, 0 };
 	str url_nt;
@@ -556,7 +599,7 @@ static int w_rest_post(struct sip_msg *msg, str *url, str *body, str *_ctype,
 		ctype = *_ctype;
 
 	rc = rest_sync_transfer(REST_CLIENT_POST, msg, url_nt.s, body, &ctype,
-	                          body_pv, ctype_pv, code_pv);
+	                          body_pv, ctype_pv, code_pv, source_pv);
 
 	if (lrc == RCL_OK_LOCKED)
 		rcl_release_url(host, rc == RCL_OK);
@@ -566,7 +609,8 @@ static int w_rest_post(struct sip_msg *msg, str *url, str *body, str *_ctype,
 }
 
 static int w_rest_put(struct sip_msg *msg, str *url, str *body, str *_ctype,
-					pv_spec_t *body_pv, pv_spec_t *ctype_pv, pv_spec_t *code_pv)
+					pv_spec_t *body_pv, pv_spec_t *ctype_pv, pv_spec_t *code_pv,
+					pv_spec_t *source_pv)
 {
 	str ctype = { NULL, 0 };
 	str url_nt;
@@ -585,7 +629,7 @@ static int w_rest_put(struct sip_msg *msg, str *url, str *body, str *_ctype,
 		ctype = *_ctype;
 
 	rc = rest_sync_transfer(REST_CLIENT_PUT, msg, url_nt.s, body, &ctype,
-	                          body_pv, ctype_pv, code_pv);
+	                          body_pv, ctype_pv, code_pv, source_pv);
 
 	if (lrc == RCL_OK_LOCKED)
 		rcl_release_url(host, rc == RCL_OK);
@@ -596,7 +640,8 @@ static int w_rest_put(struct sip_msg *msg, str *url, str *body, str *_ctype,
 
 int async_rest_method(enum rest_client_method method, struct sip_msg *msg,
                       char *url, str *body, str *ctype, async_ctx *ctx,
-                      pv_spec_p body_pv, pv_spec_p ctype_pv, pv_spec_p code_pv)
+                      pv_spec_p body_pv, pv_spec_p ctype_pv, pv_spec_p code_pv,
+                      pv_spec_p source_pv)
 {
 	rest_async_param *param;
 	pv_value_t val;
@@ -610,6 +655,48 @@ int async_rest_method(enum rest_client_method method, struct sip_msg *msg,
 		return RCL_INTERNAL_ERR;
 	}
 	memset(param, '\0', sizeof *param);
+	param->rcc.ctl_ttl = RCC_CTL_UNSET;
+
+	/* Cache lookup, while header_list is still pending (it forms the key).
+	 * A hit is served like the ASYNC_SYNC path below - fill the variables and
+	 * finish without going to the network - NOT like ASYNC_NO_IO, which is the
+	 * error path and would hand the script code 0. */
+	{
+		str u;
+
+		init_str(&u, url);
+		if (rcc_prepare(&param->rcc, rest_client_method_str(method), &u,
+		                rest_pending_headers())) {
+			str hbody = STR_NULL, hctype = STR_NULL;
+			int hcode = 0;
+
+			if (rcc_lookup(&param->rcc, &hbody, &hctype, &hcode)) {
+				LM_DBG("async %s %s [%.*s] -> hit\n",
+					rest_client_method_str(method), url,
+					param->rcc.key.len, param->rcc.key.s);
+				rest_clear_pending_headers();
+				if (code_pv) {
+					val.flags = PV_VAL_INT|PV_TYPE_INT;
+					val.ri = hcode;
+					if (pv_set_value(msg, (pv_spec_p)code_pv, 0, &val) != 0)
+						LM_ERR("failed to set output code pv\n");
+				}
+				val.flags = PV_VAL_STR;
+				val.rs = hbody;
+				if (pv_set_value(msg, (pv_spec_p)body_pv, 0, &val) != 0)
+					LM_ERR("failed to set output body pv\n");
+				if (ctype_pv && hctype.len) {
+					val.rs = hctype;
+					if (pv_set_value(msg, (pv_spec_p)ctype_pv, 0, &val) != 0)
+						LM_ERR("failed to set output ctype pv\n");
+				}
+				rcc_set_source(msg, source_pv, &param->rcc);
+				pkg_free(param);
+				async_status = ASYNC_SYNC;   /* completed inline, success */
+				return RCL_OK;
+			}
+		}
+	}
 
 	if (no_concurrent_connects && (lrc=rcl_acquire_url(url, &host)) < RCL_OK)
 		return lrc;
@@ -667,6 +754,22 @@ int async_rest_method(enum rest_client_method method, struct sip_msg *msg,
 			}
 		}
 
+		if (param->rcc.enabled) {
+			if (!code_pv)   /* http_rc not fetched above; the cache needs it */
+				curl_easy_getinfo(param->handle,
+					CURLINFO_RESPONSE_CODE, &http_rc);
+			rcc_decide(&param->rcc, rest_client_method_str(method),
+				(int)http_rc);
+			if (param->rcc.store_ttl > 0)
+				rcc_store(&param->rcc, &param->body, &param->ctype,
+					(int)http_rc);
+			LM_DBG("async %s %s [%.*s] -> %s\n",
+				rest_client_method_str(method), url,
+				param->rcc.key.len, param->rcc.key.s,
+				param->rcc.src ? param->rcc.src : "miss");
+		}
+		rcc_set_source(msg, source_pv, &param->rcc);
+
 		pkg_free(param->body.s);
 		if (ctype_pv && param->ctype.s)
 			pkg_free(param->ctype.s);
@@ -690,6 +793,7 @@ int async_rest_method(enum rest_client_method method, struct sip_msg *msg,
 	param->body_pv = (pv_spec_p)body_pv;
 	param->ctype_pv = (pv_spec_p)ctype_pv;
 	param->code_pv = (pv_spec_p)code_pv;
+	param->source_pv = (pv_spec_p)source_pv;
 	ctx->resume_param = param;
 
 	async_status = read_fd;
@@ -702,7 +806,8 @@ done:
 }
 
 static int w_async_rest_get(struct sip_msg *msg, async_ctx *ctx, str *url,
-				pv_spec_t *body_pv, pv_spec_t *ctype_pv, pv_spec_t *code_pv)
+				pv_spec_t *body_pv, pv_spec_t *ctype_pv, pv_spec_t *code_pv,
+				pv_spec_t *source_pv)
 {
 	str url_nt;
 	int rc;
@@ -716,7 +821,7 @@ static int w_async_rest_get(struct sip_msg *msg, async_ctx *ctx, str *url,
 			body_pv, ctype_pv, code_pv);
 
 	rc = async_rest_method(REST_CLIENT_GET, msg, url_nt.s, NULL, NULL, ctx,
-				body_pv, ctype_pv, code_pv);
+				body_pv, ctype_pv, code_pv, source_pv);
 
 	pkg_free(url_nt.s);
 	return rc;
@@ -724,7 +829,7 @@ static int w_async_rest_get(struct sip_msg *msg, async_ctx *ctx, str *url,
 
 static int w_async_rest_post(struct sip_msg *msg, async_ctx *ctx,
 			str *url, str *body, str *_ctype, pv_spec_t *body_pv,
-			pv_spec_t *ctype_pv, pv_spec_t *code_pv)
+			pv_spec_t *ctype_pv, pv_spec_t *code_pv, pv_spec_t *source_pv)
 {
 	str ctype = { NULL, 0 };
 	str url_nt;
@@ -742,7 +847,7 @@ static int w_async_rest_post(struct sip_msg *msg, async_ctx *ctx,
 			body_pv, ctype_pv, code_pv);
 
 	rc = async_rest_method(REST_CLIENT_POST, msg, url_nt.s, body, &ctype, ctx,
-							body_pv, ctype_pv, code_pv);
+							body_pv, ctype_pv, code_pv, source_pv);
 
 	pkg_free(url_nt.s);
 	return rc;
@@ -750,7 +855,7 @@ static int w_async_rest_post(struct sip_msg *msg, async_ctx *ctx,
 
 static int w_async_rest_put(struct sip_msg *msg, async_ctx *ctx,
 			str *url, str *body, str *_ctype, pv_spec_t *body_pv,
-			pv_spec_t *ctype_pv, pv_spec_t *code_pv)
+			pv_spec_t *ctype_pv, pv_spec_t *code_pv, pv_spec_t *source_pv)
 {
 	str ctype = { NULL, 0 };
 	str url_nt;
@@ -768,7 +873,7 @@ static int w_async_rest_put(struct sip_msg *msg, async_ctx *ctx,
 		url->len, url->s, body_pv, ctype_pv, code_pv);
 
 	rc = async_rest_method(REST_CLIENT_PUT, msg, url_nt.s, body, &ctype, ctx,
-						body_pv, ctype_pv, code_pv);
+						body_pv, ctype_pv, code_pv, source_pv);
 
 	pkg_free(url_nt.s);
 	return rc;
@@ -777,6 +882,27 @@ static int w_async_rest_put(struct sip_msg *msg, async_ctx *ctx,
 static int w_rest_append_hf(struct sip_msg *msg, str *hfv)
 {
 	return rest_append_hf_method(msg, hfv);
+}
+
+/*
+ * Override the cache decision for the NEXT rest_get/post/put only, in the same
+ * "applies once, then cleared" style as rest_append_hf().  ttl == 0 bypasses
+ * the cache entirely for that call; ttl > 0 forces the response to be served
+ * from and stored in the cache for that many seconds regardless of the module
+ * policy and of what the origin's cache headers say.
+ */
+static int w_rest_cache_ctl(struct sip_msg *msg, int *ttl)
+{
+	if (*ttl < 0) {
+		LM_ERR("rest_cache_ctl: ttl must be >= 0 (0 = bypass), got %d\n", *ttl);
+		return -1;
+	}
+	if (!rcc_enabled()) {
+		LM_DBG("rest_cache_ctl ignored - no response cache configured\n");
+		return 1;
+	}
+	rcc_ctl_ttl = *ttl;
+	return 1;
 }
 
 static int w_rest_init_client_tls(struct sip_msg *msg, str *tls_client_dom)

--- a/modules/rest_client/rest_methods.c
+++ b/modules/rest_client/rest_methods.c
@@ -40,6 +40,7 @@
 #include "rest_client.h"
 #include "rest_methods.h"
 #include "rest_cb.h"
+#include "rest_cache.h"
 
 #define REST_CORRELATION_COOKIE "RESTCORR"
 
@@ -693,7 +694,8 @@ static inline char rest_easy_perform(
  */
 int rest_sync_transfer(enum rest_client_method method, struct sip_msg *msg,
           /* in */    char *url, str *body, str *ctype,
-          /* out */   pv_spec_p body_pv, pv_spec_p ctype_pv, pv_spec_p code_pv)
+          /* out */   pv_spec_p body_pv, pv_spec_p ctype_pv, pv_spec_p code_pv,
+                      pv_spec_p source_pv)
 {
 	int ret;
 	CURLcode rc;
@@ -701,6 +703,47 @@ int rest_sync_transfer(enum rest_client_method method, struct sip_msg *msg,
 	pv_value_t pv_val;
 	rest_trace_param_t tparam;
 	str st = STR_NULL, res_body = STR_NULL, tbody, ttype;
+	struct rest_hdr_sink sink;
+	struct rcc_ctx rcc;
+
+	memset(&rcc, 0, sizeof rcc);
+
+	/* Prepare the cache here, before clean_header_list drops the pending
+	 * rest_append_hf() list - it takes part in the key. */
+	{
+		str u;
+
+		init_str(&u, url);
+		if (rcc_prepare(&rcc, rest_client_method_str(method), &u, header_list)) {
+			if (rcc_lookup(&rcc, &tbody, &ttype, &ret)) {
+				/* served without touching the network */
+				LM_DBG("%s %s [%.*s] -> hit\n",
+					rest_client_method_str(method), url,
+					rcc.key.len, rcc.key.s);
+				clean_header_list;
+
+				if (code_pv) {
+					pv_val.flags = PV_VAL_INT|PV_TYPE_INT;
+					pv_val.ri = ret;
+					if (pv_set_value(msg, code_pv, 0, &pv_val) != 0)
+						LM_ERR("Set code pv value failed!\n");
+				}
+				pv_val.flags = PV_VAL_STR;
+				pv_val.rs = tbody;
+				if (pv_set_value(msg, body_pv, 0, &pv_val) != 0)
+					LM_ERR("Set body pv value failed!\n");
+				if (ctype_pv && ttype.len) {
+					pv_val.rs = ttype;
+					if (pv_set_value(msg, ctype_pv, 0, &pv_val) != 0)
+						LM_ERR("Set content type pv value failed!\n");
+				}
+				/* tbody/ttype point into the cache scratch - owned by
+				 * rest_cache.c, already copied into the pvars above */
+				rcc_set_source(msg, source_pv, &rcc);
+				return RCL_OK;
+			}
+		}
+	}
 
 	curl_easy_reset(sync_handle);
 	if (init_transfer(sync_handle, url, 0) != 0) {
@@ -729,9 +772,11 @@ int rest_sync_transfer(enum rest_client_method method, struct sip_msg *msg,
 	w_curl_easy_setopt(sync_handle, CURLOPT_WRITEFUNCTION, write_func);
 	w_curl_easy_setopt(sync_handle, CURLOPT_WRITEDATA, &res_body);
 
+	sink.ctype = &st;
+	sink.cache = rcc.enabled ? &rcc.hdrs : NULL;
 	w_curl_easy_setopt(sync_handle, CURLOPT_HEADERFUNCTION, header_func);
 	/* coverity[bad_sizeof] */
-	w_curl_easy_setopt(sync_handle, CURLOPT_HEADERDATA, &st);
+	w_curl_easy_setopt(sync_handle, CURLOPT_HEADERDATA, &sink);
 
 	if (rest_trace_enabled())
 		init_rest_trace(sync_handle, msg, &tparam);
@@ -762,6 +807,21 @@ int rest_sync_transfer(enum rest_client_method method, struct sip_msg *msg,
 		LM_ERR("Set body pv value failed!\n");
 		return RCL_INTERNAL_ERR;
 	}
+
+	/* Store while res_body is still alive - tbody points into it, and the
+	 * content type is taken from st directly so that a script which asked for
+	 * no ctype output variable still caches the same thing. */
+	if (rcc.enabled) {
+		str cached_ct = st;
+
+		trim(&cached_ct);
+		rcc_decide(&rcc, rest_client_method_str(method), (int)http_rc);
+		if (rcc.store_ttl > 0)
+			rcc_store(&rcc, &tbody, &cached_ct, (int)http_rc);
+		LM_DBG("%s %s [%.*s] -> %s\n", rest_client_method_str(method), url,
+			rcc.key.len, rcc.key.s, rcc.src ? rcc.src : "miss");
+	}
+	rcc_set_source(msg, source_pv, &rcc);
 
 	if (res_body.s)
 		pkg_free(res_body.s);
@@ -862,10 +922,17 @@ int start_async_http_req(struct sip_msg *msg, enum rest_client_method method,
 	w_curl_easy_setopt(handle, CURLOPT_WRITEFUNCTION, write_func);
 	w_curl_easy_setopt(handle, CURLOPT_WRITEDATA, body);
 
-	if (ctype) {
-		w_curl_easy_setopt(handle, CURLOPT_HEADERFUNCTION, header_func);
-		w_curl_easy_setopt(handle, CURLOPT_HEADERDATA, ctype);
-	}
+	/* installed unconditionally: the caching headers must be parsed even when
+	 * the script asked for no content-type output variable */
+	/* when caching, capture the content-type even if the script did not ask
+	 * for it in a variable - the stored entry needs it, and param->ctype is
+	 * always present.  It is only copied to a pvar when ctype_pv was given. */
+	async_parm->hdr_sink.ctype = ctype ? ctype :
+		(async_parm->rcc.enabled ? &async_parm->ctype : NULL);
+	async_parm->hdr_sink.cache =
+		async_parm->rcc.enabled ? &async_parm->rcc.hdrs : NULL;
+	w_curl_easy_setopt(handle, CURLOPT_HEADERFUNCTION, header_func);
+	w_curl_easy_setopt(handle, CURLOPT_HEADERDATA, &async_parm->hdr_sink);
 
 	if (rest_trace_enabled()) {
 		async_parm->tparam = pkg_malloc(sizeof(rest_trace_param_t));
@@ -1196,6 +1263,25 @@ cleanup:
 
 	LM_DBG("HTTP response code: %ld\n", http_rc);
 
+	/* the response has landed - store it if the policy allows.  This is the
+	 * async store site: putting it only at the call site would cache nothing
+	 * for any transfer that actually yielded.  Deliberately the same shape as
+	 * the sync site: rcc_decide runs even on a failed transfer (http_rc 0 is
+	 * denied as miss:status) so the counters agree between the two flavours,
+	 * and the source is published unconditionally so a bypassed call reports
+	 * "bypass" from the resume route instead of leaving the variable stale. */
+	if (param->rcc.enabled) {
+		rcc_decide(&param->rcc, rest_client_method_str(param->method),
+			(int)http_rc);
+		if (param->rcc.store_ttl > 0)
+			rcc_store(&param->rcc, &param->body, &param->ctype, (int)http_rc);
+		LM_DBG("async %s [%.*s] -> %s\n",
+			rest_client_method_str(param->method),
+			param->rcc.key.len, param->rcc.key.s,
+			param->rcc.src ? param->rcc.src : "miss");
+	}
+	rcc_set_source(msg, param->source_pv, &param->rcc);
+
 out:
 	mrc = curl_multi_remove_handle(multi_handle, param->handle);
 	if (mrc != CURLM_OK) {
@@ -1238,6 +1324,18 @@ enum async_ret_code time_out_async_http_req(int fd, struct sip_msg *msg, void *_
  * @msg:		sip message struct
  * @hfv:		HTTP header field and value
  */
+/* the pending rest_append_hf() list and its reset - exposed so the async
+ * dispatcher (in rest_client.c) can key the cache on it and drop it on a hit */
+struct curl_slist *rest_pending_headers(void)
+{
+	return header_list;
+}
+
+void rest_clear_pending_headers(void)
+{
+	clean_header_list;
+}
+
 int rest_append_hf_method(struct sip_msg *msg, str *hfv)
 {
 	char buf[MAX_HEADER_FIELD_LEN];

--- a/modules/rest_client/rest_methods.h
+++ b/modules/rest_client/rest_methods.h
@@ -30,6 +30,9 @@
 #include "../../error.h"
 #include "../../mem/mem.h"
 
+#include "rest_cb.h"   /* struct rest_hdr_sink */
+#include "rest_cache.h" /* struct rcc_ctx */
+
 /* maximum size for the first line */
 #define FLINE_MAX 512
 #define BODY_MAX 1024
@@ -47,6 +50,9 @@ extern int ssl_verifyhost;
 
 extern int curl_http_version;
 extern int no_concurrent_connects;
+
+struct curl_slist *rest_pending_headers(void);
+void rest_clear_pending_headers(void);
 extern unsigned int curl_conn_lifetime;
 
 /* handle for use with synchronous reqs */
@@ -122,13 +128,20 @@ typedef struct rest_async_param_ {
 	pv_spec_p body_pv;
 	pv_spec_p ctype_pv;
 	pv_spec_p code_pv;
+	pv_spec_p source_pv;   /* where the answer came from - see rcc_ctx.src */
+
+	/* the cache travels with the transfer: the lookup happened before the
+	 * yield, the store must happen in the resume, where the body lands */
+	struct rest_hdr_sink hdr_sink;
+	struct rcc_ctx rcc;
 } rest_async_param;
 
 int init_sync_handle(void);
 int rcl_init_internals(void);
 int rest_sync_transfer(enum rest_client_method method, struct sip_msg *msg,
                        char *url, str *body, str *ctype, pv_spec_p body_pv,
-                       pv_spec_p ctype_pv, pv_spec_p code_pv);
+                       pv_spec_p ctype_pv, pv_spec_p code_pv,
+                       pv_spec_p source_pv);
 int rcl_acquire_url(const char *url, char **url_host);
 void rcl_release_url(char *url_host, int update_conn_ts);
 


### PR DESCRIPTION
### What this adds

An optional, off-by-default response cache for `rest_client`. When `cachedb_url` is set, HTTP **GET** responses are kept in a cachedb backend and repeated queries are served from it instead of going back to the origin — in both the blocking and the asynchronous flavour of the functions. Without the parameter, nothing changes.

The module had no caching of any kind, so every `rest_get()` was a fresh HTTP round trip even when the same worker had fetched the same URL a millisecond earlier. For the common OpenSIPS pattern — a per-call lookup against a rating, routing or authorization API — that round trip is usually the single most expensive thing in the request path.

**Scope:** one commit, 9 files, all under `modules/rest_client/`, no core changes (+2,131 / −130).

---

### Choosing a backend

The module replicates nothing itself, so the backend URL alone decides the scope of the cache, and both shapes are useful:

| shape | backends | hit cost | property |
|---|---|---|---|
| in-process | `cachedb_local`, `cachedb_perf` | ~1–2 µs | cheapest possible hit; each instance warms its own cache |
| shared | one `cachedb_redis` for the cluster | ~84 µs (loopback) | a response fetched by any node is served by all of them — higher hit rate, less origin load |

The rule is not local-versus-remote, only that the backend be cheaper than the call it replaces. Against an origin answering in milliseconds a shared redis is a large win and spreads it across the cluster; against a very fast origin only an in-process backend is worth the trouble.

Backend TTL support was surveyed by reading every bundled backend's `set()` implementation:

| backend | honours the expiry? | detail |
|---|---|---|
| `cachedb_local` | yes | expiry checked on read and swept (`hash.c:424`) |
| `cachedb_perf` (#4118) | yes | native TTL |
| `cachedb_redis` | yes | `SET` then `EXPIRE` — non-atomic, a crash in between leaves a key with no TTL |
| `cachedb_memcached` | yes | passed straight to `memcached_set()` |
| `cachedb_cassandra` | yes | `INSERT ... USING TTL` |
| `cachedb_couchbase` | yes | `lcb_cmdstore_expiry()` |
| `cachedb_dynamodb` | yes* | writes a TTL attribute; only effective if the table has TTL enabled, and AWS deletes lazily |
| `cachedb_sql` | partially | expiry stored, but **reads don't filter on it** — a stale row is served until the periodic cleaner runs |
| `cachedb_mongodb` | **no** | `mongo_con_set()` takes the `expires` argument and never reads it — entries live forever |

Because of that last column, **freshness does not rely on the backend**: each entry embeds an absolute expiry and a hit past it is treated as a miss and refetched (see *Storage format*). That guard covers all three failure modes above — mongodb's ignored TTL, cachedb_sql's stale-read window, redis's crash-orphaned key. `cachedb_mongodb` remains unsuitable regardless, since nothing there ever reclaims the space, and the documentation says so.

---

### Configuration

| parameter | type | default | meaning |
|---|---|---|---|
| `cachedb_url` | string | unset (cache disabled) | cachedb backend to keep responses in; setting it enables the cache and makes the backend module a load dependency |
| `cache_policy` | string | `strict` | how far to go beyond what the origin explicitly permits — see below |
| `cache_ttl` | int | 0 | fallback lifetime (s) used only where the origin gave none and the policy allows caching anyway |
| `cache_max_body` | int | 65536 | largest response body stored; larger ones are returned to the script normally but not cached (`miss:oversize`); values above 64 KB are clamped (fixed entry buffer) |

Startup validation (runs once `cachedb_url` is set; with the cache unconfigured the other parameters are ignored): an unknown `cache_policy` string fails startup; `heuristic`/`force` with `cache_ttl <= 0` fails startup (it would silently behave like `strict`); a backend that lacks `get`/`set` fails startup; `cache_max_body <= 0` fails startup, and a value above 64 KB is clamped to 64 KB with a warning — the encoded entry lives in a fixed buffer, so a larger setting would otherwise pass startup and then silently store nothing.

#### Policies

| policy | obeys `no-store` / `no-cache` / `private` / `Set-Cookie` | origin silent (no cache headers) | TTL source |
|---|---|---|---|
| `off` | — (cache never consulted) | — | — |
| `strict` *(default)* | yes — all four refuse storing | not cached (`miss:silent`) | origin only: `s-maxage` → `max-age` (minus `Age`) → `Expires` − now |
| `heuristic` | yes — all four still refuse | cached for `cache_ttl` | origin when it says something — including an already-elapsed lifetime, which stays refused (RFC 9111 allows heuristics only where no explicit expiry exists); `cache_ttl` only when truly silent |
| `force` | no — ignores all four | cached for `cache_ttl` | a positive origin lifetime still wins; `cache_ttl` fills silence and elapsed lifetimes |

Three refusals are **hard invariants** no policy and no per-call override can lift: non-GET method, a status outside the RFC 9110/9111 heuristically-cacheable set minus 206 (range responses are deliberately never cached): 200, 203, 204, 300, 301, 308, 404, 405, 410, 414, 501, and a `Vary` response header.

#### TTL precedence (highest first)

1. `rest_cache_ctl(ttl)` per-call override — captured at dispatch, overrides policy *and* origin (but not the hard invariants); `rest_cache_ctl(0)` bypasses the cache for that one call
2. `Cache-Control: s-maxage` (minus `Age`)
3. `Cache-Control: max-age` (minus `Age`)
4. `Expires` − now (RFC 9110 preferred date form)
5. `cache_ttl` modparam — `heuristic`/`force` where 2–4 are absent; under `force` also where they yielded an already-elapsed lifetime

---

### Functions

| function | flavours | signature (sync) | changed here |
|---|---|---|---|
| `rest_get` | sync + async | `rest_get(url, body_pv, [ctype_pv], [retcode_pv], [source_pv])` | + trailing `source_pv` |
| `rest_post` | sync + async | `rest_post(url, send_body, [send_ctype], recv_body_pv, [recv_ctype_pv], [retcode_pv], [source_pv])` | + trailing `source_pv` |
| `rest_put` | sync + async | `rest_put(url, send_body, [send_ctype], recv_body_pv, [recv_ctype_pv], [retcode_pv], [source_pv])` | + trailing `source_pv` |
| `rest_cache_ctl` | sync | `rest_cache_ctl(ttl)` | **new** |
| `rest_append_hf` | sync | `rest_append_hf(txt)` | untouched — but the pending headers now take part in the cache key |
| `rest_init_client_tls` | sync | `rest_init_client_tls(tls_client_domain)` | untouched |

The three transfer functions gained the optional trailing `source_pv` in both the sync and the async flavour; a script that doesn't pass it behaves exactly as before. `rest_cache_ctl()` follows the module's existing pending-state idiom (like `rest_append_hf`): it applies to the *next* REST call only and is consumed by it. The value is captured when the transfer is dispatched, not when it completes, so a later request cannot change how an in-flight async transfer is cached. A negative ttl is rejected at runtime; calling it with the cache unconfigured is a no-op.

#### `source_pv` values

| value | meaning |
|---|---|
| `hit` | served from the cache; the origin was not contacted |
| `miss` | fetched from the origin and stored |
| `bypass` | the cache was not consulted (disabled, policy `off`, or `rest_cache_ctl(0)`) |
| `miss:method` | fetched, not stored — not a GET (hard invariant) |
| `miss:status` | fetched, not stored — status not in the cacheable set (hard invariant) |
| `miss:vary` | fetched, not stored — origin sent `Vary` (hard invariant) |
| `miss:no-store` | fetched, not stored — `Cache-Control: no-store` (lifted only by `force` / per-call ttl) |
| `miss:no-cache` | fetched, not stored — `Cache-Control: no-cache` (ditto) |
| `miss:private` | fetched, not stored — `Cache-Control: private` (ditto) |
| `miss:set-cookie` | fetched, not stored — origin sent `Set-Cookie` (ditto) |
| `miss:silent` | fetched, not stored — origin gave no lifetime at all and the policy is `strict` |
| `miss:expired` | fetched, not stored — the origin's explicit lifetime had already elapsed (past `Expires`, `Age` beyond `max-age`, `max-age=0`); `force` alone overrides this with `cache_ttl` |
| `miss:oversize` | fetched, not stored — body over `cache_max_body` (or the encoded entry over the 64 KB+512 hard cap) |

This is a new output variable rather than a value folded into `$rc` (already overloaded with `RCL_OK`/`RCL_OK_LOCKED`) and rather than a module pvar reading process-global state (which would report the wrong call after an async resume).

---

### Statistics & MI

The module exports **no MI commands of its own**; the five new statistics are read through the core statistics interface (`statistics:get` / `statistics:list` / `statistics:reset`, or the legacy `get_statistics` aliases). They are always exported — with the cache disabled they simply stay 0.

| statistic | kind | meaning |
|---|---|---|
| `rest_cache_hits` | counter | requests served from the cache without contacting the origin |
| `rest_cache_misses` | counter | requests that went to the origin (consulted-but-not-served; bypassed calls count nothing) |
| `rest_cache_stores` | counter | responses actually written to the backend |
| `rest_cache_skipped` | counter | responses fetched but refused for storing — by policy, origin headers, or size |
| `rest_cache_hit_rate` | computed | `100*hits/(hits+misses)`, 0 with no lookups; process lifetime, so a low value right after restart is a cold cache, not a problem |

The counters increment at the same code sites that set `source_pv`, so the aggregate cannot drift from what a script observes — including on failed transfers, where the sync and async flavours were measured to move the counters identically. Verified read, via `statistics:get`:

```json
{
 "rest_client:rest_cache_hits": 0,
 "rest_client:rest_cache_misses": 3,
 "rest_client:rest_cache_stores": 0,
 "rest_client:rest_cache_skipped": 3,
 "rest_client:rest_cache_hit_rate": 0
}
```

`rest_cache_skipped` exists because a cache that stores nothing — every origin sends `no-store`, or every body is oversize — is otherwise indistinguishable from a misconfigured one: no errors, hit rate 0 either way.

---

### Cache key & storage format

**Key** = `MD5(method || url || canonicalised appended-header list)`, 32 hex chars.

The headers are the correctness point of the whole patch. `rest_append_hf()` queues a process-global list consumed by the next request, so the *same URL* is routinely fetched with different `Authorization` or tenant headers and legitimately returns different bodies. A URL-only key would hand one subscriber's response to another — and would pass any single-credential test. Header *names* are lowercased (values kept verbatim — case may be significant there) and the list is sorted, so append order does not matter; the whole thing is hashed rather than stored, so a bearer token never appears in the backend's key space or its dump tooling.

The key deliberately does **not** cover the request body, and that is why only GET responses are stored: `rest_post()`/`rest_put()` consult the cache and report `miss:method`, but never write. Two POSTs to one URL differing only in body are different resources; the invariant is recorded next to the key construction so extending storage to POST cannot quietly skip extending the key.

**Value** = `[u16 status][u16 ctype_len][u64 expires_at][ctype][u32 body_len][body]` — length-prefixed, so a hit decodes by pointing into a per-process buffer rather than parsing. `expires_at` is an absolute wall-clock second and is what actually enforces freshness on read; the same lifetime is handed to the backend as its TTL, but as the backend table above shows, not every backend acts on it.

---

### Measurements

Single Debian 13 host (Xeon E5-2699 v4), everything on loopback, 2,000 `rest_get()` per run, median of 4 runs after a cache-fill run. Loopback makes the uncached round trip as cheap as it can possibly be, so the ratios are a floor.

![cache speed](https://raw.githubusercontent.com/Lt-Flash/opensips/rest-cache-assets/rc-cache-speed.png)

| scenario | ns/op | vs uncached |
|---|---:|---:|
| no cache — real HTTP round trip | 272,000 | — |
| hit, `cachedb_perf` | 977 | 278× |
| hit, `cachedb_local` | 2,061 | 132× |
| hit, `cachedb_redis` (loopback) | 83,823 | 3.2× |

Read the redis row against a realistic origin, not this one: a real rating or authorization API answering in 5–50 ms makes an 84 µs shared-redis hit a 60–600× win, *and* shares it across every node in the cluster. It looks modest here only because the loopback origin is unrealistically fast.

![cache correctness](https://raw.githubusercontent.com/Lt-Flash/opensips/rest-cache-assets/rc-cache-correctness.png)

Correctness is measured by the origin's own request counter, not a stopwatch. Across 10,000 calls to an endpoint with `max-age=600` the origin was contacted **once**. Against an endpoint with `max-age=2` whose body changes on every request, sampled over five runs spaced past the TTL, the origin was contacted **five times** and the payload's sequence number changed each time — on all three backends (mixed workload: `perf` 8,150 / `local` 9,226 / `redis` 91,436 ns/op).

<details>
<summary><b>Why MD5 for the key</b> (measured)</summary>

Core-bundled implementations, same host (no SHA-NI on Broadwell):

| key input | MD5 | SHA-1 | SHA-256 |
|---|---:|---:|---:|
| 31 B (short URL) | 187 ns | 322 ns | 537 ns |
| 68 B (typical URL) | 330 ns | 468 ns | 965 ns |
| 134 B (+ bearer header) | 468 ns | 629 ns | 1,310 ns |
| 300 B (+ several headers) | 742 ns | 939 ns | 2,077 ns |

At a typical key the hash is ~a third of a 977 ns `perf://` hit, so the choice is material to the cached path. MD5's broken *collision* resistance is not what protects anything here — keeping tokens out of the key space needs only *preimage* resistance, which MD5 retains — and the core's `MD5StringArray` adds no dependency. On SHA-NI hardware the ranking changes; switching to truncated SHA-256 is a ten-line change if reviewers prefer it.
</details>

---

### Script examples

All snippets below were validated with `opensips -c`, not just proofread.

```
loadmodule "cachedb_local.so"
loadmodule "rest_client.so"
modparam("rest_client", "cachedb_url", "local://")
```

A well-behaved origin needs nothing else — `strict` caches for exactly as long as the server allows:

```
# origin answers with:  Cache-Control: max-age=300
$var(rc) = rest_get("http://rates.internal/lookup?prefix=$rU",
                    $var(body), $var(ct), $var(rcode));
```

An origin that sends no cache headers — say so explicitly instead of letting the module invent a lifetime:

```
modparam("rest_client", "cache_policy", "heuristic")
modparam("rest_client", "cache_ttl", 60)
```

Overriding a single call rather than loosening the policy for every endpoint:

```
rest_cache_ctl(300);   # cache this despite the origin's missing headers
$var(rc) = rest_get("http://rates.internal/tariff?id=$var(tid)", $var(tariff));

rest_cache_ctl(0);     # a fraud check must never be answered from a cache
$var(rc) = rest_get("http://fraud.internal/score?num=$fU", $var(score));
```

Per-account queries separate automatically, because appended headers are in the key:

```
rest_append_hf("Authorization: Bearer $var(tenant_token)");
$var(rc) = rest_get("http://api.internal/limits", $var(limits));
```

Async works identically — a hit completes inline and the resume route still runs:

```
route {
    async(rest_get("http://rates.internal/lookup?prefix=$rU",
                   $var(body), $var(ct), $var(rcode), $var(src)), resume);
}
route [resume] {
    xlog("rate for $rU came from: $var(src)\n");   # hit / miss / miss:<reason>
    exit;
}
```

---

### How it was verified

| what | method | result |
|---|---|---|
| policy matrix, sync + async | local origin emitting controlled headers; the origin's request counter is ground truth | silent+strict → 3 fetches `miss:silent`; silent+heuristic → 1 fetch then hits; no-store+heuristic → 3 fetches (origin still obeyed); no-store+force → 1 fetch then hits; `private`/`Vary`/`Set-Cookie` never cached |
| async hit semantics | 3 identical async GETs | origin contacted once; 1st misses+stores from the resume route, 2nd/3rd hit at dispatch, all with `code=200` — a hit models inline completion, never the no-I/O error path |
| `rest_cache_ctl` | ctl(0) on cacheable endpoint; ctl(300) on one `strict` refuses | 3 fetches (bypassed); 1 fetch then hits |
| statistics | known mix: 5 cacheable + 3 refused calls, read via `statistics:get` | `hits=4 misses=4 stores=1 skipped=3 hit_rate=50` — exactly as predicted |
| oversize accounting | 3 calls, `cache_max_body=100`, ~1 KB payload | `misses=3 stores=0 skipped=3`, each call `miss:oversize` |
| backend ignores TTL | backend handed ttl=0 (never expires — mongodb's exact behaviour), `max-age=2` response, re-read after 5 s | **control (no embedded expiry): served stale as `hit`**; with it: `miss`, origin sees both requests |
| TTL honoured end-to-end | volatile endpoint, 5 runs spaced past `max-age` | 5 origin fetches, payload sequence number changed each time, on `local`/`perf`/`redis` |
| use-after-free / allocator mixing | found during development | sync store moved before `pkg_free(res_body.s)`; `get_buf` and `get()` paths unified into one per-process scratch after the mixed-ownership version aborted with *freeing dangling pkg pointer* |
| header capture | found during development | async `header_func` was only installed when a ctype pvar was supplied → `rest_get(url, $b)` parsed no response headers at all; now installed unconditionally |
| explicit-stale vs silent | origin sending a past `Expires` vs no headers at all | `strict`/`heuristic` refuse the stale response (`miss:expired`, 3/3 origin fetches — heuristic does not resuscitate it); `heuristic`+silent still caches (1/3); `force`+stale caches (1/3) |
| async `bypass` provenance | `rest_cache_ctl(0)` + an origin slow enough (0.6 s) to force a genuine yield | resume route reports `bypass`, counters untouched — previously the variable was left stale on this exact path |
| sync/async stat parity on errors | transfer timed out mid-flight (`curl_timeout=1`, origin sleeps 1.5 s), both flavours | identical deltas: `misses+1`, `skipped+1`, both report `miss:status` |
| `cache_max_body` clamp | startup with `cache_max_body=1000000` | warning logged, value clamped to 65536 |
| documentation | every script snippet run through `opensips -c` (ellipsis placeholders expanded to real statements) | all parse, including the 5-arg forms and async |

---

### `get_buf` interop

If the core provides the zero-copy `get_buf` cachedb endpoint (#4118) and the configured backend advertises it (`CACHEDB_CAP_GET_BUF`), the module uses it automatically; otherwise it falls back to `get()`. Both checks are needed — a core can have the endpoint while `redis://` does not. The dependency is **soft**: this branch is based on plain master, builds and works today, and simply picks up the faster path once #4118 merges. (Measured there: 397.7 → 290.1 ns/op median on the cache read itself, ~27%.)
