### PR TITLE
net: fix connection reference leak in tcp_async_write_job()

### DIFF
--- a/net/net_tcp.c
+++ b/net/net_tcp.c
@@ -1513,6 +1513,12 @@ int tcp_async_write_job(struct tcp_connection *tcpconn)
 	cond_lock(&tcp_write_queue->cond);
 	if (tcpconn->flags & F_CONN_WRITE_QUEUED) {
 		cond_unlock(&tcp_write_queue->cond);
+		/* a write job is already queued for this connection and it owns
+		 * exactly one reference, which it releases on completion; our
+		 * callers treat success as a transfer of their own reference, so
+		 * it has to be released here, otherwise it leaks and the
+		 * connection can never be destroyed */
+		tcpconn_put(tcpconn);
 		return 0;
 	}
 


### PR DESCRIPTION
**Summary**

`tcp_async_write_job()` leaks one connection reference every time it is called for a connection that already has a write job queued. Each leaked reference makes a connection undestroyable, so it holds its shm, its fd and a `tcp_max_connections` slot for the life of the process — and enough of them will stop the proxy accepting TCP/TLS/WS/WSS connections at all.

**Details**

This is a bug fix, for a generic problem: it is transport agnostic and affects healthy, long-lived connections, not only failing ones.

In `tcp_async_write_job()` the `F_CONN_WRITE_QUEUED` branch returns success without releasing the caller's reference:

```c
	cond_lock(&tcp_write_queue->cond);
	if (tcpconn->flags & F_CONN_WRITE_QUEUED) {
		cond_unlock(&tcp_write_queue->cond);
		return 0;
	}
```

All three call sites treat a successful return as a transfer of ownership:

* `tcp_conn_release()` (`net/net_tcp_proc.c`) calls `tcpconn_put()` on every other path, but returns without it when `tcp_async_write_job()` succeeds;
* the writer reactor path takes an explicit `tcpconn_ref()` immediately before `tcp_queue_write_job()` and puts it back only if the call fails;
* the follow-up re-queue inside the job completion handler likewise puts only on failure.

That contract is correct for the normal path, where the newly queued job later releases the reference: every terminal path of the completion handler ends in `tcpconn->flags &= ~F_CONN_WRITE_QUEUED; tcpconn_put(tcpconn);`, i.e. exactly one release per job.

The dedup branch is where it breaks. No new job is queued, the already-queued job will release exactly one reference, but the caller has handed over a second one. **One reference is lost per send that overlaps an in-flight write job for the same connection.**

The impact is worse than the lost memory suggests. While a stray reference is held, `tcpconn_destroy()` cannot free the connection, since the reaper only collects at `refcnt == 0`. The connection stays in `S_CONN_BAD` with `lifetime == 0` and keeps its shm, its fd and its `tcp_max_connections` slot for the life of the process.

We observed the accumulation and the growing refcounts directly; we did not run a box to exhaustion, so the endpoint is what the code implies rather than something measured: once enough of these pile up the proxy reaches `tcp_max_connections` (default 2048) and refuses every new TCP, TLS, WS and WSS connection, with the common 1024 fd soft limit likely binding first.

Diagnosed on a live 4.0 edge proxy by walking the connection table under gdb: unreachable connections sitting at refcnt 18, 12, 8, 8 and 2, and a clusterer BIN connection climbing from 3 to 92 references during a single burst of SIP push traffic — one leaked reference per send, exactly as the code path predicts.

Introduced in 8a9f450df2 ("net: always send messages from main thread"), so **master and 4.0 are affected; 3.x is not.**

**Solution**

Release the caller's reference in the dedup branch, so that the "success means I own your reference" contract holds on both paths through the function:

```c
	if (tcpconn->flags & F_CONN_WRITE_QUEUED) {
		cond_unlock(&tcp_write_queue->cond);
		/* a write job is already queued for this connection and it owns
		 * exactly one reference, which it releases on completion; our
		 * callers treat success as a transfer of their own reference, so
		 * it has to be released here, otherwise it leaks and the
		 * connection can never be destroyed */
		tcpconn_put(tcpconn);
		return 0;
	}
```

Six lines, one file, no change to the function's return values or to any caller.

The alternative fix — returning a distinct code so each caller releases its own reference — was rejected as more invasive for no benefit: it changes the signature's meaning and touches every call site, where this keeps the contract uniform at the single point that violates it.

Remaining concern, raised for the maintainers rather than resolved here: `tcpconn_put()` is called with `tcp_write_queue->cond` already unlocked, matching the surrounding style, so a connection whose last reference this drops is destroyed on the caller's stack. That is the same situation as every other `tcpconn_put()` in these paths, but it is the one aspect worth a maintainer's eye.

**Compatibility**

No configuration, script or interface change. No effect on SIP behaviour or interoperability. Nothing to migrate.

The only behavioural difference is that connections which previously became permanently unreferenceable are now destroyed normally when their last reference goes away.

**Testing**

The change has been running since 2026-07-26 on the two edge proxies of a development and test cluster, carrying SIP over TCP, TLS, WS and WSS plus clusterer BIN traffic. Before the patch, a walk of the connection table showed a new stuck connection per overlapping send and steadily climbing refcounts; after it, the same test bursts leave zero stuck connections and idle refcounts at 0.

**Attribution**

I diagnosed this and wrote the patch working with Claude (Anthropic), which did the call-site analysis and drafted this description; the commit carries a `Co-Authored-By` trailer to that effect. The conclusions are mine and I stand behind them.

**Closing issues**

None — this was not previously reported.
