### PR TITLE
docs: fix code block titles

### DIFF
--- a/modules/db_http/README.md
+++ b/modules/db_http/README.md
@@ -383,7 +383,7 @@ If the query produced an error the server must reply with a
 HTTP 500 reply,	or with a corresponding error code (404, 401).
 
 
-``` title="Example Reply."
+```
 ...
 int;string;blob
 6;something=something;1000
@@ -409,7 +409,7 @@ it must be placed under quotes. A quote delimiter inside a value
 must be preceeded by another quote delimiter.
 
 
-``` title="Quoting Example."
+```
 ...
 int;string;blob
 6;|ana;maria|;1000


### PR DESCRIPTION
- drop `title="..."` from fenced code blocks that declare no language; without a language the info string is not parsed, so the title rendered as part of the block
