### PR TITLE
docs: fix code block titles

### DIFF
--- a/modules/aaa_diameter/README.md
+++ b/modules/aaa_diameter/README.md
@@ -235,7 +235,7 @@ before an Answer could be processed)
 This function can be used from any route.
 
 
-``` title="dictionary.opensips extended syntax"
+```
 # Example of defining custom Diameter AVPs, Application IDs,
 # Requests and Replies in the "dictionary.opensips" file
 

--- a/modules/aka_av_diameter/README.md
+++ b/modules/aka_av_diameter/README.md
@@ -136,7 +136,7 @@ modparam("aka_av_diameter", "server_uri", "sip:scscf.ims.mnc001.mcc001.3gppnetwo
 File that should be provided to the *aaa_diameter* connection.
 
 
-``` title="Diameter Commands File Example"
+```
 VENDOR 10415 TGPP
 
 ATTRIBUTE Public-Identity                     601 string     10415

--- a/modules/db_http/README.md
+++ b/modules/db_http/README.md
@@ -435,7 +435,7 @@ If the query produced an error the server must reply with a
 HTTP 500 reply,	or with a corresponding error code (404, 401).
 
 
-``` title="Example Reply."
+```
 ...
 int;string;blob
 6;something=something;1000
@@ -461,7 +461,7 @@ it must be placed under quotes. A quote delimiter inside a value
 must be preceded by another quote delimiter.
 
 
-``` title="Quoting Example."
+```
 ...
 int;string;blob
 6;|ana;maria|;1000


### PR DESCRIPTION
- drop `title="..."` from fenced code blocks that declare no language; without a language the info string is not parsed, so the title rendered as part of the block
