### PR TITLE
presence_callinfo: reject a competing line-seize while the seizure is live

### DIFF
--- a/modules/presence_callinfo/add_events.c
+++ b/modules/presence_callinfo/add_events.c
@@ -314,7 +314,7 @@ int lineseize_subs_handl(struct sip_msg* msg, struct subscription *subs, int *re
 		/* new SUBSCRIBE */
 		if (sca->seize_state!=0) {
 			/* already in seizing from a different subscrine */
-			if (sca->seize_expires < get_ticks()) {
+			if (sca->seize_expires > get_ticks()) {
 				/* old seizing still valid -> reject it */
 				*reply_code = 480;
 				reply_reason->s = "Temporarily Unavailable";


### PR DESCRIPTION
**Summary**

`lineseize_subs_handl()` rejects a competing `line-seize` SUBSCRIBE only when the existing
seizure has *already expired*, so two appearances of the same shared line can both hold it.
This backports the fix already present in master and 4.0 to the 3.6 LTS branch.

**Details**

In `modules/presence_callinfo/add_events.c`, the guard for a new initial SUBSCRIBE against
an already-seized line reads:

```c
if (sca->seize_state!=0) {
        /* already in seizing from a different subscrine */
        if (sca->seize_expires < get_ticks()) {
                /* old seizing still valid -> reject it */
                *reply_code = 480;
```

`seize_expires` is assigned `get_ticks() + subs->expires`, so it is a future timestamp
while the seizure is valid. `seize_expires < get_ticks()` is therefore true only once the
seizure has expired — the inverse of the adjacent comment. A still-valid seizure falls
through to the unconditional `sca->seize_state = idx;` and the competing SUBSCRIBE is
answered `200 OK`.

The effect is that a shared line grants itself to every seizer. It is not timing-sensitive:
in 600 trials across seize deltas of 0, 10, 50, 100, 200 and 500 ms (100 each), stock 3.6.7
produced a single winner **0 times** and issued a `480` **0 times**. Because both seizures
are accepted, the published `call-info` NOTIFY carries both indexes as seized on one line:

```
Call-Info: <sip:LINE>;appearance-index=1;appearance-state=seized;appearance-index=2;appearance-state=seized;appearance-index=*;appearance-state=idle
```

Reproduced with two software endpoints acting as appearances 1 and 2 of one line, each
subscribed to `call-info`, in internal publishing mode (`disable_dialog_support_for_sca=0`,
the mode in which `lineseize_subs_handl` is registered).

**Solution**

Flip the single comparison so the `480` is returned while the seizure is still live:

```diff
         if (sca->seize_state!=0) {
                 /* already in seizing from a different subscrine */
-                if (sca->seize_expires < get_ticks()) {
+                if (sca->seize_expires > get_ticks()) {
                         /* old seizing still valid -> reject it */
                         *reply_code = 480;
```

This is equivalent to the form already in master and 4.0 (`get_ticks() < sca->seize_expires`),
introduced in `3595af48` ("presence_callinfo: Several fixes/improvements", 2025-12-11).
That commit contains several unrelated changes, so only the one-line guard is backported
here rather than cherry-picking it whole. Branches 3.5 and 3.6 both still carry the
inverted test.

With the fix applied, the same 600 trials give exactly one `200 OK` and one
`480 Temporarily Unavailable` at every delta (600/600), and only the winning index is
published as seized.

**Compatibility**

No configuration, database or API change; the module's parameters and behaviour are
otherwise untouched. It restores the intended behaviour described by the existing comment.

Worth stating plainly: a deployment that has come to depend on the current pass-through
will begin receiving `480 Temporarily Unavailable` on competing seizures where it
previously received `200 OK`. That is the intended semantic, but it is a visible change for
anyone who had adapted to the broken behaviour.

This does not address the `FIXME` on the following line (a seize accepted for an appearance
already in an active call), which is present in master as well and is reported separately.

**Closing issues**

None — no existing issue tracks this.
