### PR TITLE
docs: unify the DB module README titles

### DIFF
--- a/modules/db_berkeley/README.md
+++ b/modules/db_berkeley/README.md
@@ -1,5 +1,5 @@
 ---
-title: "Berkeley DB Module"
+title: "DB_BERKELEY Module"
 description: "This is a module which integrates the Berkeley DB into OpenSIPS. It implements the DB API defined in OpenSIPS."
 ---
 

--- a/modules/db_flatstore/README.md
+++ b/modules/db_flatstore/README.md
@@ -1,5 +1,5 @@
 ---
-title: "Flatstore Module"
+title: "DB_FLATSTORE Module"
 description: "Flatstore is one of so-called OpenSIPS database modules. It does not export any functions executable from the configuration scripts, but it exports a subset of functions from the database API and thus other module can use it instead of, for example, mysql module."
 ---
 

--- a/modules/db_mysql/README.md
+++ b/modules/db_mysql/README.md
@@ -1,5 +1,5 @@
 ---
-title: "mysql Module"
+title: "DB_MYSQL Module"
 description: "This is a module which provides MySQL connectivity for OpenSIPS. It implements the DB API defined in OpenSIPS."
 ---
 

--- a/modules/db_oracle/README.md
+++ b/modules/db_oracle/README.md
@@ -1,5 +1,5 @@
 ---
-title: "oracle Module"
+title: "DB_ORACLE Module"
 description: "This is a module which provides Oracle connectivity for OpenSIPS."
 ---
 

--- a/modules/db_perlvdb/README.md
+++ b/modules/db_perlvdb/README.md
@@ -1,5 +1,5 @@
 ---
-title: "Perl Virtual Database Module"
+title: "DB_PERLVDB Module"
 description: "The Perl Virtual Database (VDB) provides a virtualization framework for OpenSIPS's database access. It does not handle a particular database engine itself but lets the user relay database requests to arbitrary Perl functions."
 ---
 

--- a/modules/db_postgres/README.md
+++ b/modules/db_postgres/README.md
@@ -1,5 +1,5 @@
 ---
-title: "postgres Module"
+title: "DB_POSTGRES Module"
 description: "Module description"
 ---
 

--- a/modules/db_text/README.md
+++ b/modules/db_text/README.md
@@ -1,5 +1,5 @@
 ---
-title: "DBTEXT Module"
+title: "DB_TEXT Module"
 description: "The module implements a simplified database engine based on text files. It can be used by OpenSIPS DB interface instead of other database module (like MySQL)."
 ---
 

--- a/modules/db_unixodbc/README.md
+++ b/modules/db_unixodbc/README.md
@@ -1,5 +1,5 @@
 ---
-title: "unixodbc Module"
+title: "DB_UNIXODBC Module"
 description: "This module allows to use the unixodbc package with OpenSIPS."
 ---
 

--- a/modules/db_virtual/README.md
+++ b/modules/db_virtual/README.md
@@ -1,5 +1,5 @@
 ---
-title: "virtual_db Module"
+title: "DB_VIRTUAL Module"
 ---
 
 ## Admin Guide


### PR DESCRIPTION
- title every `modules/db_*` README as `<MODULE> Module`, uppercased, so they all start with `DB_`
- replaces three inconsistent forms: prose names (`Berkeley DB Module`), missing prefixes (`mysql Module`), and lowercase (`db_text Module`)
