### PR TITLE
net_tcp: reject NULL message buffer with non-zero length in tcp_dispatch_msg()

### DIFF
--- a/net/net_tcp.c
+++ b/net/net_tcp.c
@@ -303,6 +303,10 @@ int tcp_dispatch_msg(char *msg, int len,
 		LM_BUG("negative TCP message length: %d\n", len);
 		return -1;
 	}
+	if (len && !msg) {
+		LM_BUG("NULL TCP message buffer with non-zero length: %d\n", len);
+		return -1;
+	}
 	if (data_len < 0) {
 		LM_BUG("negative TCP dispatch data length: %d\n", data_len);
 		return -1;


### PR DESCRIPTION
### What

`tcp_dispatch_msg()` (`net/net_tcp.c`) guards against a negative `len`, a negative `data_len`, and
a missing `data` buffer for a non-zero `data_len` — but not against a NULL `msg` with a non-zero
`len`, which reaches `memcpy(payload->msg_buf, msg, len)` a few lines below, unchecked.

This adds the missing check, in the same style as the existing three:

```c
if (len && !msg) {
    LM_BUG("NULL TCP message buffer with non-zero length: %d\n", len);
    return -1;
}
```

### Why

Observed live: `proto_ws`'s `ws_process()` (`WS_OP_TEXT`/`WS_OP_BIN` case) called
`tcp_dispatch_msg(msg_buf, msg_len, &local_rcv, NULL, 0)` with `msg_buf == NULL`
(`req->tcp.body`) and `msg_len` a large garbage value, crashing the whole process with SIGSEGV.
Full report in #4217.

We were not able to conclusively pin the exact sequence in `ws_parse()` that leaves
`req->tcp.body` NULL at that point — every code path we traced sets it before the "packet
complete" check, or exits before reaching it — so we're not proposing a speculative fix there.
This PR instead hardens the shared dispatch function itself, which protects every current and
future caller against the same failure mode regardless of which one has the bug: fail safe
(`LM_BUG` + `return -1`) instead of crashing the process.

### Testing

- Confirmed this exact guard would have caught the observed crash (the recorded parameters at
  the crash site were `msg=0x0, len=872728144`).
- No functional change for any well-formed caller — every existing caller in the tree passes a
  non-NULL `msg` whenever `len > 0`.

Fixes #4217

---
Diagnosed and prepared jointly by Giovanni Maruzzelli (gmaruzz) and Claude (Anthropic).

