### PR TITLE
ci: do not publish documentation on tag pushes

### DIFF
--- a/.github/workflows/publish-web.yml
+++ b/.github/workflows/publish-web.yml
@@ -1,7 +1,14 @@
 name: Publish opensips.org documentation
 
 on:
+  # master and the release branches only. Without a branch filter a tag push
+  # triggers this too (GitHub ignores the paths below for tags), and a tag has
+  # no "before" commit, so every component looks changed and the whole
+  # documentation is republished under a version (4.0.1) the site rejects.
   push:
+    branches:
+      - master
+      - '[0-9]+.[0-9]+'
     paths:
       - 'examples/**'
       - 'modules/*/samples/**'


### PR DESCRIPTION
The `Publish opensips.org documentation` workflow has a `paths:` filter but no `branches:` filter, so it also runs on tag pushes — GitHub ignores path filters for tags. On a tag there is no `github.event.before`, so `changed-components` falls back to `git ls-tree -r`, sees the entire tree as changed, and dispatches samples + manual + every module to opensips-web, passing `github.ref_name` (`4.0.1`, `3.6.8`) as the version.

That happened for the 4.0.1 and 3.6.8 tags: the manual/modules dispatches failed on the web side with `bad version '4.0.1'` / `bad version '3.6.8'`, and the samples dispatches needlessly republished the config samples twice.

Restricting the push trigger to `master` and the release branches keeps branch pushes working exactly as before (both filters apply) and stops tags from matching at all. It also keeps feature-branch pushes out, which would otherwise dispatch with a branch name as the version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)