### PR TITLE
Remove logging of full db url when the connection fails.

### DIFF
--- a/modules/sqlops/sqlops_db.c
+++ b/modules/sqlops/sqlops_db.c
@@ -182,8 +182,9 @@ int sqlops_db_init(const str* db_table, str** db_cols)
 	for(i=0;i<no_db_urls;i++) {
 		db_urls[i].hdl = db_urls[i].dbf.init( &db_urls[i].url );
 		if (db_urls[i].hdl==0) {
-			LM_ERR("cannot initialize database connection for %s\n",
-				db_urls[i].url.s);
+			LM_ERR("cannot initialize database connection [%d]. "
+				"Check the avpops connection parameter in "
+				"the opensips config\n", i);
 			goto error;
 		}
 		if (db_urls[i].dbf.use_table(db_urls[i].hdl, db_table)<0) {


### PR DESCRIPTION
**Summary**
Prevent logging of full connection string when a database connection fails to be established. 

Logging the full connection string results in the password getting logged, which is a security concern.

**Details**
This Affects the sqlops module.

When a SQL database connection fails, the whole database URL is logged, which includes the password. This is a security issue.

Whilst it is important to log that the connection has failed, secrets should not be included/

**Solution**
This PR alters the log point to log out the index of the connection, as opposed to the full URL.

**Compatibility**
This should have no compatibility issues.

**Closing issues**
N/A
