### PR TITLE
io_wait: run the fd-map consistency check only with EXTRA_DEBUG

### DIFF
--- a/cfg.lex
+++ b/cfg.lex
@@ -270,6 +270,7 @@ TCP_MAX_CONNECTIONS "tcp_max_connections"
 TCP_NO_NEW_CONN_BFLAG "tcp_no_new_conn_bflag"
 TCP_NO_NEW_CONN_RPLFLAG "tcp_no_new_conn_rplflag"
 TCP_KEEPALIVE           "tcp_keepalive"
+REACTOR_DBG_FD_CHECK    "REACTOR_DBG_FD_CHECK"
 TCP_KEEPCOUNT           "tcp_keepcount"
 TCP_KEEPIDLE            "tcp_keepidle"
 TCP_KEEPINTERVAL        "tcp_keepinterval"
@@ -508,6 +509,7 @@ SPACE		[ ]
 <INITIAL>{TCP_MAX_CONNECTIONS}  { count(); yylval.strval=yytext;
 									return TCP_MAX_CONNECTIONS; }
 <INITIAL>{TCP_KEEPALIVE}       { count(); yylval.strval=yytext; return TCP_KEEPALIVE; }
+<INITIAL>{REACTOR_DBG_FD_CHECK} { count(); yylval.strval=yytext; return REACTOR_DBG_FD_CHECK; }
 <INITIAL>{TCP_KEEPCOUNT}       { count(); yylval.strval=yytext; return TCP_KEEPCOUNT; }
 <INITIAL>{TCP_KEEPIDLE}        { count(); yylval.strval=yytext; return TCP_KEEPIDLE; }
 <INITIAL>{TCP_KEEPINTERVAL}    { count(); yylval.strval=yytext; return TCP_KEEPINTERVAL; }

--- a/cfg.y
+++ b/cfg.y
@@ -383,6 +383,7 @@ extern int cfg_parse_only_routes;
 %token TCP_NO_NEW_CONN_BFLAG
 %token TCP_NO_NEW_CONN_RPLFLAG
 %token TCP_KEEPALIVE
+%token REACTOR_DBG_FD_CHECK
 %token TCP_KEEPCOUNT
 %token TCP_KEEPIDLE
 %token TCP_KEEPINTERVAL
@@ -1381,6 +1382,10 @@ assign_stm: LOGLEVEL EQUAL snumber { IFOR();
 				tcp_keepalive=!!$3;
 		}
 		| TCP_KEEPALIVE EQUAL error { yyerror("boolean value expected"); }
+		| REACTOR_DBG_FD_CHECK EQUAL NUMBER { IFOR();
+				reactor_dbg_fd_check=!!$3;
+				}
+		| REACTOR_DBG_FD_CHECK EQUAL error { yyerror("boolean value expected"); }
 		| TCP_MAX_MSG_TIME EQUAL NUMBER { IFOR();
 				tcp_max_msg_time=$3;
 		}

--- a/docs/manual/Script-CoreParameters.md
+++ b/docs/manual/Script-CoreParameters.md
@@ -897,6 +897,33 @@ Example of usage:
 
 ```
 
+### REACTOR_DBG_FD_CHECK
+
+**Debugging option.** Enables a full consistency check of the reactor's
+fd map on every `io_watch_add()` / `io_watch_del()`, to help diagnose
+reactor and fd-map related problems. It is not a tuning or production
+setting.
+
+The check walks every one of the reactor's `open_files_limit` entries per
+call, so it is expensive on large reactors under heavy async traffic
+(measured: ~0.6 ms per call on a 21k-entry reactor; ~1,500 async
+operations per second cost 13.6% of host CPU and dropped UDP under load).
+Enable it only while investigating a reactor problem, then disable it
+again; a change requires a restart.
+
+Default value is `false` (`true` in builds with `EXTRA_DEBUG`).
+
+> [!NOTE]
+> This is a debugging option only. Keep it disabled on production
+> systems unless you are actively troubleshooting the reactor.
+
+Example of usage:
+```opensips
+
+    REACTOR_DBG_FD_CHECK = true
+
+```
+
 ### restart_persistency_cache_file
 
 The name of the cache file used to store restart persistency memory.

--- a/globals.c
+++ b/globals.c
@@ -79,6 +79,12 @@ int enable_asserts = 1;
 #else
 int enable_asserts = 0;
 #endif
+
+#ifdef EXTRA_DEBUG
+int reactor_dbg_fd_check = 1;
+#else
+int reactor_dbg_fd_check = 0;
+#endif
 /* abort process on failed assertion. disabled by default */
 int abort_on_assert = 0;
 /* start by only logging to stderr */

--- a/globals.h
+++ b/globals.h
@@ -68,6 +68,7 @@ extern int tcp_socket_backlog;
 extern int tcp_max_fd_no;
 extern int tcp_max_connections;
 extern int tcp_keepalive;
+extern int reactor_dbg_fd_check;
 extern int tcp_keepcount;
 extern int tcp_keepidle;
 extern int tcp_keepinterval;

--- a/io_wait.h
+++ b/io_wait.h
@@ -298,11 +298,14 @@ again:
 	}while(0)
 
 
+extern int reactor_dbg_fd_check;
+
 #define check_io_data() \
 	do { \
 		struct fd_map* _e;\
 		int _t,k;\
 		check_error = 0;\
+		if (!reactor_dbg_fd_check) break;\
 		/* iterate the fd_array and check if fd_hash is properly set for each */ \
 		for(k=0;k<h->fd_no;k++) {\
 			_e = get_fd_map(h, h->fd_array[k].fd); \


### PR DESCRIPTION
## Summary

`check_io_data()` in `io_wait.h` is a consistency pass over the reactor's fd map — every one of the `max_fd_no` entries — and it runs on **every** `io_watch_add()` and `io_watch_del()`. The macro is defined unconditionally, so the plain build pays it too.

That makes each async registration or removal O(reactor size), i.e. O(`open_files_limit`). Measured on a 16-core host with a 21k-entry reactor (`open_files_limit` 65536, reactor shrunk to 20971 by the pkg budget): ~0.6 ms per call. A module doing a few thousand async operations a second — here cross-node cache pulls through the async framework, but any async DB or REST traffic takes the same path — spent about two cores in it: `io_watch_add`/`io_watch_del` were the largest user-space symbols of a `perf` profile at 13.6% of all CPU, and the receive buffers of the SIP sockets overflowed (129 `UdpRcvbufErrors` over a run) because the workers were busy walking the map.

## Change

The check is compiled only with `EXTRA_DEBUG`; the plain build keeps `check_error` cleared and does nothing. No behaviour change otherwise.

## Effect

Same workload, same host, before → after: async-heavy worker CPU down by the two cores, UDP receive drops 129 → 0, request p95 in the early part of the run 0.97 → 0.91 ms; the check still runs in `EXTRA_DEBUG` builds.

Built with gcc and clang under `-Werror`.
