### PR TITLE
compression: fix the documented parameter name and example

### DIFF
--- a/modules/compression/README.md
+++ b/modules/compression/README.md
@@ -74,7 +74,7 @@ running OpenSIPS with this module loaded:
 ### Exported Parameters
 
 
-#### mc_level (int)
+#### compression_level (int)
 
 
 This parameter ranges from 1 to 9 and it specifies the level of compression you want to do.
@@ -83,9 +83,9 @@ If, by mistake, you set a lower or a higher level, the default, 6, will be used,
 receive a warning.
 
 
-```opensips title="Set mc_level parameter"
+```opensips title="Set compression_level parameter"
 ...
-modparam("mc", "mc_level", "3")
+modparam("compression", "compression_level", 3)
 ...
 		
 ```


### PR DESCRIPTION
**Summary**

The `compression` module's Exported Parameters section documents a parameter name the
module does not register, and its only example is unusable as written. A configuration
copied from it does not start.

**Details**

Three separate errors, all in the same short section:

- The heading reads `mc_level`. That is the module's static `int`
  (`compression.c:119`); the parameter it registers is `compression_level`
  (`compression.c:158`).
- The example is `modparam("mc", …)`. The module's name is `compression`
  (`compression.c:187`) — `mc` is the prefix carried by its exported functions
  (`mc_compact`, `mc_compress`, `mc_decompress`), not a module name.
- The example passes `"3"` as a string, while the parameter is `INT_PARAM`.

Everything else in the section is accurate and is left alone: the 1–9 range and the
default of 6 match `compression.c:119`, and the clamp-with-a-warning behaviour matches
`compression.c:411-413`.

**Verified by running it.** OpenSIPS 4.0.1, `compression.so` from
`opensips-compression-module` 4.0.1-1, `opensips -C` on a minimal config that loads the
module. Each of the three is independently fatal:

| Line under test | Result |
|---|---|
| `modparam("mc", "mc_level", "3")` — the section as written | `ERROR:core:set_mod_param_regex: no module matching mc found` |
| `modparam("compression", "mc_level", 3)` | `ERROR: parameter <mc_level> not found in module <compression>` |
| `modparam("compression", "compression_level", "3")` | `ERROR: type mismatch for parameter <compression_level> in module <compression>` |
| `modparam("compression", "compression_level", 3)` — as proposed | `NOTICE:core:main: config file ok` |

Each failing case ends in `CRITICAL:core:yyerror: parse error … can't set`, then
`bad config file (1 errors)` and `failed to parse config file`. The first argument to
`modparam` is an anchored, case-insensitive regular expression matched against
`exports->name` (`modparam.c:56-71`), and the type is matched by mask
(`PARAM_TYPE_MASK(param->type) & type`, `modparam.c:82`), which is why a quoted value
cannot reach an `INT_PARAM`.

**Solution**

Rename the heading to the registered parameter name and correct the example to
`modparam("compression", "compression_level", 3)`. Documentation only, no functional
change. No file in the repository links to the old `#mc_level` anchor.

**Where else this text appears**

The same three errors are in the `4.0` and `3.6` branches, and
`docs.opensips.org/html/docs/modules/4.0.x/compression.html` serves them today — the
published page shows the heading `mc_level (int)` and the example
`modparam("mc", "mc_level", "3")`. This PR targets `master`; whether the release
branches are worth the same change is the maintainers' call, not something I have
assumed.

**Compatibility**

None affected. Nothing that works today stops working: the documented spelling could
never have loaded.

---

**AI assistance disclosure.** The defect list and the wording of this change were
produced with AI assistance. Every item was checked against the source before
submission:

- the registered parameter name is `compression_level` — `compression.c:158`;
- `mc_level` is the static int it writes to — `compression.c:119`;
- the module's name is `compression` — `exports.name`, `compression.c:187`, while `mc`
  is the prefix of its exported functions in `cmds[]`;
- the parameter is `INT_PARAM`, so the value is unquoted — `compression.c:158`;
- all three were then confirmed by running `opensips -C` against each spelling, rather
  than by reading the source alone — the four results are in the table above;
- the range, the default of 6 and the clamp-with-a-warning are correct as written and
  were left alone — `compression.c:119` and `:411-413`;
- no file in the repository references the `#mc_level` anchor.
