### PR TITLE
sdp_ops: fix body-lump offsets once $sdp owns the body (SIGABRT/SIGSEGV)

### DIFF
--- a/modules/mediaproxy/mediaproxy.c
+++ b/modules/mediaproxy/mediaproxy.c
@@ -39,6 +39,7 @@
 #include "../../pvar.h"
 #include "../../error.h"
 #include "../../data_lump.h"
+#include "../../sdp_ops.h"
 #include "../../mem/mem.h"
 #include "../../ut.h"
 #include "../../trim.h"
@@ -1260,6 +1261,14 @@ replace_element(struct sip_msg *msg, str *old_element, str *new_element)
         return True;
     }
 
+    if (have_sdp_ops(msg)) {
+        str body;
+        if (get_body(msg, &body) != 0)
+            return False;
+        return sdp_ops_splice_body(msg, &body, old_element->s - body.s,
+                                    old_element->len, new_element) == 0;
+    }
+
     buf = pkg_malloc(new_element->len);
     if (!buf) {
         LM_ERR("out of memory\n");
@@ -1288,6 +1297,14 @@ replace_element(struct sip_msg *msg, str *old_element, str *new_element)
 static Bool
 remove_element(struct sip_msg *msg, str *element)
 {
+    if (have_sdp_ops(msg)) {
+        str body;
+        if (get_body(msg, &body) != 0)
+            return False;
+        return sdp_ops_splice_body(msg, &body, element->s - body.s,
+                                    element->len, NULL) == 0;
+    }
+
     if (!del_lump(msg, element->s - msg->buf, element->len, 0)) {
         LM_ERR("failed to delete old element\n");
         return False;

--- a/modules/rtp_relay/rtp_relay_ctx.c
+++ b/modules/rtp_relay/rtp_relay_ctx.c
@@ -27,6 +27,7 @@
 #include "../../lib/cJSON.h"
 #include "../../data_lump.h"
 #include "../../data_lump_rpl.h"
+#include "../../sdp_ops.h"
 #include "../b2b_logic/b2b_load.h"
 #include "../../parser/parse_to.h"
 #include "../../route.h"
@@ -1153,6 +1154,13 @@ static int rtp_relay_replace_body(struct sip_msg *msg, str *body)
 	oldbody = get_body_part(msg, TYPE_APPLICATION, SUBTYPE_SDP);
 	if (!oldbody)
 		return -1;
+
+	if (have_sdp_ops(msg)) {
+		if (sdp_ops_set_body(msg, body) < 0)
+			return -1;
+		pkg_free(body->s);
+		return 0;
+	}
 
 	anchor = del_lump(msg, oldbody->s - msg->buf, oldbody->len, 0);
 	if (!anchor) {

--- a/modules/rtpengine/rtpengine.c
+++ b/modules/rtpengine/rtpengine.c
@@ -54,6 +54,7 @@
 #include "../../dprint.h"
 #include "../../data_lump.h"
 #include "../../data_lump_rpl.h"
+#include "../../sdp_ops.h"
 #include "../../error.h"
 #include "../../forward.h"
 #include "../../context.h"
@@ -3565,6 +3566,12 @@ enum async_ret_code resume_async_send_rtpe_command(int fd, struct sip_msg *msg, 
 			if(pv_set_value(msg, param->bpvar, (int)EQ_T, &val)<0)
 				LM_ERR("setting PV failed\n");
 			pkg_free(newbody.s);
+		} else if (have_sdp_ops(msg)) {
+			if (sdp_ops_set_body(msg, &newbody) < 0) {
+				pkg_free(newbody.s);
+				goto error;
+			}
+			pkg_free(newbody.s);
 		} else if (extract_body(msg, &oldbody) > 0) {
 			/* otherwise directly set the body of the message */
 			anchor = del_lump(msg, oldbody.s - msg->buf, oldbody.len, 0);
@@ -4039,6 +4046,10 @@ rtpengine_offer_answer_body(struct sip_msg *msg, str *flags, str *node,
 
 	if (outbody) {
 		*outbody = newbody;
+	} else if (have_sdp_ops(msg)) {
+		if (sdp_ops_set_body(msg, &newbody) < 0)
+			goto error_free;
+		pkg_free(newbody.s);
 	} else if (!body || (extract_body(msg, &oldbody) > 0)) {
 		/* otherwise directly set the body of the message */
 		anchor = del_lump(msg, oldbody.s - msg->buf, oldbody.len, 0);

--- a/modules/sipmsgops/codecs.c
+++ b/modules/sipmsgops/codecs.c
@@ -24,6 +24,7 @@
 #include "../../parser/msg_parser.h"
 #include "../../mem/mem.h"
 #include "../../data_lump.h"
+#include "../../sdp_ops.h"
 #include "../../parser/sdp/sdp.h"
 #include "codecs.h"
 #include "../../route.h"
@@ -64,6 +65,12 @@ static int create_codec_lumps(struct sip_msg * msg)
 	struct sdp_session_cell * cur_session;
 	struct lump * tmp;
 	int count;
+
+	if (have_sdp_ops(msg)) {
+		LM_ERR("codec add/delete is not supported once $sdp/"
+		       "$sdp.line has touched this message's body\n");
+		return -1;
+	}
 
 	/* get the number of streams */
 	lumps_len = 0;

--- a/modules/textops/textops.c
+++ b/modules/textops/textops.c
@@ -46,6 +46,7 @@
 #include "../../dprint.h"
 #include "../../data_lump.h"
 #include "../../data_lump_rpl.h"
+#include "../../sdp_ops.h"
 #include "../../error.h"
 #include "../../mem/mem.h"
 #include "../../mem/shm_mem.h"
@@ -242,10 +243,12 @@ static int search_append_body_f(struct sip_msg* msg, regex_t* key, str* str2)
 		return -1;
 	}
 
-	off=body.s-msg->buf;
-
 	if (regexec(key, body.s, 1, &pmatch, 0)!=0) return -1;
 	if (pmatch.rm_so!=-1){
+		if (have_sdp_ops(msg))
+			return sdp_ops_splice_body(msg, &body, pmatch.rm_eo, 0, str2)==0 ? 1 : -1;
+
+		off=body.s-msg->buf;
 		if ((l=anchor_lump(msg, off+pmatch.rm_eo, 0))==0)
 			return -1;
 		s=pkg_malloc(str2->len);

--- a/msg_translator.c
+++ b/msg_translator.c
@@ -1940,7 +1940,8 @@ static inline void apply_msg_changes(struct sip_msg *msg,
 							unsigned int max_offset)
 {
 	unsigned int size;
-	str body;
+	str body, rcv_body = STR_NULL;
+	struct sdp_body_part_ops *ops;
 
 	/* apply changes over the SIP headers */
 	process_lumps(msg, msg->add_rm, new_buf, new_offs, orig_offs, sock, -1);
@@ -1950,8 +1951,13 @@ static inline void apply_msg_changes(struct sip_msg *msg,
 		if (get_body(msg, &body) != 0 || body.len==0)
 			return;
 
-		size = msg->body->body.s ?
-			((msg->body->body.s - msg->buf) - *orig_offs)  /* msg had body */
+		ops = msg->sdp_ops;
+		msg->sdp_ops = NULL;
+		get_body(msg, &rcv_body);
+		msg->sdp_ops = ops;
+
+		size = rcv_body.s ?
+			((rcv_body.s - msg->buf) - *orig_offs)         /* msg had body */
 			: (msg->len - *orig_offs);                     /* no body at all */
 		memcpy(new_buf+*new_offs, msg->buf+*orig_offs, size );
 		*new_offs += size;

--- a/sdp_ops.c
+++ b/sdp_ops.c
@@ -870,7 +870,7 @@ out_success:
 int pv_parse_sdp_line_name(pv_spec_p sp, const str *_in)
 {
 	str in = *_in, tok;
-	int escape = 0, i, midx = 0;
+	int escape = 0, i, midx = 0, trailing = 1;
 	struct sdp_pv_param *param;
 	struct sdp_chunk_match *matches[3];
 	char *p;
@@ -933,6 +933,7 @@ int pv_parse_sdp_line_name(pv_spec_p sp, const str *_in)
 				p = q_memchr(p, '/', in.s + in.len - p);
 				if (!p) {
 					matches[midx++]->prefix = tok;
+					trailing = 0;
 					break;
 				}
 			} else {
@@ -945,11 +946,12 @@ int pv_parse_sdp_line_name(pv_spec_p sp, const str *_in)
 			tok.s = in.s + i+1;
 		}
 
-		if ((i+1) == in.len) {
-			tok.len = i+1 - (tok.s - in.s);
-			trim_leading(&tok);
-			matches[midx++]->prefix = tok;
-		}
+	}
+
+	if (trailing && matches[midx]) {
+		tok.len = in.s + in.len - tok.s;
+		trim_leading(&tok);
+		matches[midx++]->prefix = tok;
 	}
 
 	LM_DBG("parse sdp.line name: '%.*s', c1: '%.*s/%p'[%s], c2: '%.*s/%p'[%s], c3: '%.*s/%p'[%s]\n",
@@ -969,7 +971,7 @@ done:
 int pv_parse_sdp_stream_name(pv_spec_p sp, const str *_in)
 {
 	str in = *_in, tok;
-	int escape = 0, i, midx = 0;
+	int escape = 0, i, midx = 0, trailing = 1;
 	struct sdp_pv_param *param;
 	struct sdp_chunk_match *matches[4];
 	char *p;
@@ -1033,6 +1035,7 @@ int pv_parse_sdp_stream_name(pv_spec_p sp, const str *_in)
 				p = q_memchr(p, '/', in.s + in.len - p);
 				if (!p) {
 					matches[midx++]->prefix = tok;
+					trailing = 0;
 					break;
 				}
 			} else {
@@ -1045,11 +1048,12 @@ int pv_parse_sdp_stream_name(pv_spec_p sp, const str *_in)
 			tok.s = in.s + i+1;
 		}
 
-		if ((i+1) == in.len) {
-			tok.len = i+1 - (tok.s - in.s);
-			trim_leading(&tok);
-			matches[midx++]->prefix = tok;
-		}
+	}
+
+	if (trailing && matches[midx]) {
+		tok.len = in.s + in.len - tok.s;
+		trim_leading(&tok);
+		matches[midx++]->prefix = tok;
 	}
 
 	LM_DBG("parse sdp.stream name: '%.*s',"

--- a/sdp_ops.c
+++ b/sdp_ops.c
@@ -115,11 +115,164 @@ static inline int sdp_detect_line_sep(str *sdp, char *sep, int *sep_len)
 }
 
 
+int sdp_ops_set_body(struct sip_msg *msg, str *body)
+{
+	struct sdp_body_part_ops *ops;
+	int null_before = 0;
+
+	if (!msg || !body || body->len <= 0) {
+		LM_ERR("bad parameters\n");
+		return -1;
+	}
+
+	if (!msg->sdp_ops) {
+		ops = msg->sdp_ops = mk_sdp_ops();
+		if (!ops) {
+			LM_ERR("oom\n");
+			return -1;
+		}
+	} else {
+		ops = msg->sdp_ops;
+	}
+
+	if (pkg_str_sync(&ops->sdp, body) != 0) {
+		LM_ERR("oom\n");
+		return -1;
+	}
+
+	if (ops->flags & SDP_OPS_FL_NULL) {
+		null_before = 1;
+		ops->flags &= ~SDP_OPS_FL_NULL;
+	}
+
+	if (msg->body) {
+		free_sip_body(msg->body);
+		msg->body = NULL;
+	}
+
+	if (parse_sip_body(msg) != 0) {
+		LM_ERR("bad body provided (%.*s ...), refusing to set in SIP msg\n",
+		        body->len>=40 ? 40:body->len, body->s);
+		pkg_free(ops->sdp.s);
+		ops->sdp = STR_NULL;
+		if (null_before)
+			ops->flags |= SDP_OPS_FL_NULL;
+		return -1;
+	}
+
+	if (!parse_sdp(msg)) {
+		LM_ERR("bad SDP provided (%.*s ...), refusing to set in SIP msg\n",
+		        body->len>=40 ? 40:body->len, body->s);
+		free_sip_body(msg->body);
+		msg->body = NULL;
+		pkg_free(ops->sdp.s);
+		ops->sdp = STR_NULL;
+		if (null_before)
+			ops->flags |= SDP_OPS_FL_NULL;
+		return -1;
+	}
+
+	if (!sdp_detect_line_sep(&ops->sdp, ops->sep, &ops->sep_len)) {
+		LM_ERR("failed to detect SDP separator, first 50B: '%.*s'\n",
+		        ops->sdp.len >= 50 ? 50:ops->sdp.len, ops->sdp.s);
+		free_sip_body(msg->body);
+		msg->body = NULL;
+		pkg_free(ops->sdp.s);
+		ops->sdp = STR_NULL;
+		memset(ops->sep, 0, 2);
+		if (null_before)
+			ops->flags |= SDP_OPS_FL_NULL;
+		return -1;
+	}
+
+	if (ops->sdp.s[ops->sdp.len-1] > '\r')
+		ops->flags |= SDP_OPS_FL_NO_LLF;
+
+	free_sdp_ops_lines(ops);
+	if (ops->rebuilt_sdp.s) {
+		pkg_free(ops->rebuilt_sdp.s);
+		ops->rebuilt_sdp = STR_NULL;
+	}
+
+	LM_DBG("separator: %d %d (%d)\n", ops->sdp.s[ops->sdp.len-2],
+	        ops->sdp.s[ops->sdp.len-1], ops->sep_len);
+
+	return 0;
+}
+
+
+int sdp_ops_set_null_body(struct sip_msg *msg)
+{
+	struct sdp_body_part_ops *ops;
+
+	if (!msg) {
+		LM_ERR("bad parameters\n");
+		return -1;
+	}
+
+	if (!msg->sdp_ops) {
+		ops = msg->sdp_ops = mk_sdp_ops();
+		if (!ops) {
+			LM_ERR("oom\n");
+			return -1;
+		}
+	} else {
+		ops = msg->sdp_ops;
+	}
+
+	ops->flags |= SDP_OPS_FL_NULL;
+	ops->flags &= ~SDP_OPS_FL_DIRTY;
+	if (msg->body) {
+		free_sip_body(msg->body);
+		msg->body = NULL;
+	}
+	free_sdp_ops_lines(ops);
+	pkg_free(ops->rebuilt_sdp.s);
+	ops->rebuilt_sdp.s = NULL;
+
+	return 0;
+}
+
+
+int sdp_ops_splice_body(struct sip_msg *msg, str *body, int rel_off,
+		int rel_len, str *new_content)
+{
+	str new_body;
+	int extra_len = (new_content && new_content->len > 0) ? new_content->len : 0;
+	int ret;
+
+	if (!msg || !body || rel_off < 0 || rel_len < 0
+	|| rel_off + rel_len > body->len) {
+		LM_ERR("bad parameters\n");
+		return -1;
+	}
+
+	new_body.len = body->len - rel_len + extra_len;
+	if (new_body.len == 0)
+		return sdp_ops_set_null_body(msg);
+
+	new_body.s = pkg_malloc(new_body.len);
+	if (!new_body.s) {
+		LM_ERR("oom\n");
+		return -1;
+	}
+
+	memcpy(new_body.s, body->s, rel_off);
+	if (extra_len)
+		memcpy(new_body.s + rel_off, new_content->s, extra_len);
+	memcpy(new_body.s + rel_off + extra_len, body->s + rel_off + rel_len,
+	        body->len - rel_off - rel_len);
+
+	ret = sdp_ops_set_body(msg, &new_body);
+	pkg_free(new_body.s);
+	return ret;
+}
+
+
 int pv_set_sdp(struct sip_msg *msg, pv_param_t *param,
 			int op, pv_value_t *val)
 {
 	struct sdp_body_part_ops *ops;
-	int null_before = 0;
 
 	if (!msg || !param) {
 		LM_ERR("bad parameters\n");
@@ -153,75 +306,14 @@ int pv_set_sdp(struct sip_msg *msg, pv_param_t *param,
 
 		if (!(val->flags & PV_VAL_STR) || val->rs.len <= 0) {
 			LM_ERR("non-empty str value required to set SDP body\n");
-			goto error;
-		}
-
-		if (pkg_str_sync(&ops->sdp, &val->rs) != 0) {
-			LM_ERR("oom\n");
 			return -1;
 		}
 
-		if (ops->flags & SDP_OPS_FL_NULL) {
-			null_before = 1;
-			ops->flags &= ~SDP_OPS_FL_NULL;
-		}
-
-		if (msg->body) {
-			free_sip_body(msg->body);
-			msg->body = NULL;
-		}
-
-		if (parse_sip_body(msg) != 0) {
-			LM_ERR("bad body provided (%.*s ...), refusing to set in SIP msg\n",
-			        val->rs.len>=40 ? 40:val->rs.len, val->rs.s);
-			pkg_free(ops->sdp.s);
-			ops->sdp = STR_NULL;
-			if (null_before)
-				ops->flags |= SDP_OPS_FL_NULL;
+		if (sdp_ops_set_body(msg, &val->rs) != 0)
 			return -1;
-		}
-
-		if (!parse_sdp(msg)) {
-			LM_ERR("bad SDP provided (%.*s ...), refusing to set in SIP msg\n",
-			        val->rs.len>=40 ? 40:val->rs.len, val->rs.s);
-			free_sip_body(msg->body);
-			msg->body = NULL;
-			pkg_free(ops->sdp.s);
-			ops->sdp = STR_NULL;
-			if (null_before)
-				ops->flags |= SDP_OPS_FL_NULL;
-			return -1;
-		}
-
-		if (!sdp_detect_line_sep(&ops->sdp, ops->sep, &ops->sep_len)) {
-			LM_ERR("failed to detect SDP separator, first 50B: '%.*s'\n",
-			        ops->sdp.len >= 50 ? 50:ops->sdp.len, ops->sdp.s);
-			free_sip_body(msg->body);
-			msg->body = NULL;
-			pkg_free(ops->sdp.s);
-			ops->sdp = STR_NULL;
-			memset(ops->sep, 0, 2);
-			if (null_before)
-				ops->flags |= SDP_OPS_FL_NULL;
-			return -1;
-		}
-
-		if (ops->sdp.s[ops->sdp.len-1] > '\r')
-			ops->flags |= SDP_OPS_FL_NO_LLF;
-
-		free_sdp_ops_lines(ops);
-		if (ops->rebuilt_sdp.s) {
-			pkg_free(ops->rebuilt_sdp.s);
-			ops->rebuilt_sdp = STR_NULL;
-		}
-
-		LM_DBG("separator: %d %d (%d)\n", ops->sdp.s[ops->sdp.len-2],
-		        ops->sdp.s[ops->sdp.len-1], ops->sep_len);
 	}
 
 	return 0;
-error:
-	return -1;
 }
 
 

--- a/sdp_ops.h
+++ b/sdp_ops.h
@@ -77,6 +77,13 @@ static inline int have_sdp_ops(struct sip_msg *msg)
 }
 void free_sdp_ops(struct sdp_body_part_ops *ops);
 
+int sdp_ops_set_body(struct sip_msg *msg, str *body);
+
+int sdp_ops_set_null_body(struct sip_msg *msg);
+
+int sdp_ops_splice_body(struct sip_msg *msg, str *body, int rel_off,
+		int rel_len, str *new_content);
+
 int pv_set_sdp(struct sip_msg *msg, pv_param_t *param, int op, pv_value_t *val);
 int pv_parse_sdp_name(pv_spec_p sp, const str *in);
 


### PR DESCRIPTION
Fixes #4135.

Two commits: the crash fix first, then a small parser fix found on the same path.

### 1. Body-lump offsets once `$sdp` owns the body

Once `$sdp` / `$sdp.line` / `$sdp.stream` / `$sdp.session` has touched a message, `get_body()` returns a pointer into sdp_ops' own pkg buffer rather than into `msg->buf`. Every body editor that then anchors a lump with `body.s - msg->buf` is doing pointer arithmetic between two unrelated allocations:

- `del_lump()`'s bounds check aborts the worker — the reporter's `SIGABRT`, `del_lump: offset exceeds message size (-2036890104 > 1068)` — via `rtp_relay_engage()`, `rtpengine_offer()`/`rtpengine_answer()` (sync and async paths), mediaproxy, textops `search_append_body()`, sipmsgops codec editing.
- `apply_msg_changes()` in `msg_translator.c` — a branch written for sdp_ops — makes the same subtraction and then `memcpy()`s a few GB: `SIGSEGV` in `build_req_buf_from_sip_req` (the reporter's second backtrace). This one needs **no module at all**:

```
$sdp = $sdp;
t_relay();
```

crashes a stock build.

**Fix.** sdp_ops gets a small API extracted from `pv_set_sdp()` — `sdp_ops_set_body()`, `sdp_ops_set_null_body()`, `sdp_ops_splice_body()` (offsets relative to the *current* body buffer) — and each affected call site goes through it when `have_sdp_ops(msg)` is true; the lump path is untouched otherwise. `apply_msg_changes()` recovers the received body position the way `calculate_body_diff()` already does, so the function that sizes the buffer and the one that fills it agree. `codecs.c` fails cleanly with an error instead of computing an invalid offset — its incremental multi-lump editing has no sdp_ops equivalent.

### 2. `$sdp.*` names ending with an escape

`pv_parse_sdp_line_name()` / `pv_parse_sdp_stream_name()` dropped the last name segment when the name ends with an escape (the manual's own `a=rtpmap:101/telephone-event\/`), silently turning a token match into a whole-line match — on reads and writes.

### Verification

A local reproduction rig: the reporter's script shape (`$sdp.line` reads + `rtpengine_offer()`) and the module-free `$sdp = $sdp; t_relay()` both crash on the unpatched build and relay a well-formed message with the fix (a downstream sink validates `Content-Length` against the body). Builds clean with `-Wredundant-decls -Wold-style-definition -Wmissing-field-initializers -Werror` on current master.

### Not in this PR

`modules/sngtc` has the same pattern at four sites but cannot be built without the Sangoma library, so it is left as is and named here. The token-write side of the same report (`$sdp.line(o=/[5]) = "..."` being a silent no-op) is a separate change and will follow as its own PR.
