### PR TITLE
uac: the RR dependency is not conditional on restore_mode

### DIFF
--- a/modules/uac/README.md
+++ b/modules/uac/README.md
@@ -28,8 +28,14 @@ The following modules must be loaded before this module:
 
 
 - *TM - Transaction Module*.
-- *RR - Record-Route Module*, but only if
-restore mode for FROM URI is set to "auto".
+- *RR - Record-Route Module*, if restore mode for FROM
+URI is set to "auto", or if uac_auth() is used anywhere in the
+configuration script. In both cases the "append_fromtag" parameter of
+the rr module must be enabled: uac needs the from-tag in the
+Record-Route to tell the direction of sequential requests and increment
+the CSeq accordingly. It defaults to 1, but the opensips.cfg shipped
+with the packages and the scripts under examples/templates/ set it
+to 0.
 - *UAC_AUTH - UAC Authentication Module*.
 - *Dialog Module*, if "force_dialog"
 module parameter is enabled, or a dialog is created from the


### PR DESCRIPTION
**Summary**

The `uac` Dependencies section states that RR is required "only if restore mode for FROM
URI is set to `auto`". It is also required, unconditionally, whenever `uac_auth()` appears
in the configuration script. The section also never mentions `append_fromtag`, which both
paths require, and which the packaged `opensips.cfg` disables.

**Details**

`mod_init()` has a second branch, guarded by `is_script_func_used("uac_auth", -1)` and not
by `restore_mode` (`uac.c:308-326`). It loads the RR API and then refuses to start:

```c
if (is_script_func_used("uac_auth", -1)) {
    ...
    if (!uac_rrb.append_fromtag) {
        LM_ERR("'append_fromtag' RR param is not enabled!"
        " - required by uac_auth() restore mode\n");
        goto error;
    }
```

The error names `restore mode`, which sends the reader to a Dependencies line saying the
dependency does not apply to them.

**Why this bites the default path.** `append_fromtag` defaults to `1`, so this looks like a
corner case. It is not: `etc/opensips.cfg` — the file installed as
`/etc/opensips/opensips.cfg` — sets it to `0` at line 61, as do all three scripts under
`examples/templates/`. Across the repository 27 configuration files set it to `0` and one
sets it to `1`. Anyone who starts from the shipped configuration or a template and adds
carrier authentication hits this.

**Reproduced on the stock configuration**, not on a contrived one: the official
`opensips/opensips:4.0` image, `opensips-auth-modules` installed, `/etc/opensips/opensips.cfg`
untouched except for loading `uac_auth`/`uac` with `restore_mode` `"none"` and calling
`uac_auth()` in a `failure_route`.

```
$ opensips -C -f /etc/opensips/opensips.cfg
NOTICE:core:main: config file ok, exiting...

$ opensips -F -f /etc/opensips/opensips.cfg
ERROR:uac:mod_init: 'append_fromtag' RR param is not enabled! - required by uac_auth() restore mode
ERROR:core:main: failed to initialize modules!
NOTICE:core:main: Exiting....
```

Changing only `append_fromtag` to `1` starts normally.

**Where the requirement comes from, measured.** `uac_auth()` may be called from
`REQUEST_ROUTE`, `BRANCH_ROUTE` or `FAILURE_ROUTE` (`uac.c:115`). All three fail with
`append_fromtag` disabled. Three negative controls start normally: `uac_registrant` loaded
without a script call, `uac_replace_from()` with `restore_mode` `"none"`, and the modules
loaded with nothing called. So the trigger is the presence of the `uac_auth()` call, not the
module, the route type, or the restore mode.

**Solution**

Restate the dependency to cover both paths and name `append_fromtag`, with the reason it
exists. That reason is not mine — it is the explanation given in #773, where this same
error was reported as a bogus dependency and closed as `invalid`:

> The dependency is actually correct as the uac module has to determine the direction of the
> sequential requests (after an auth answer) in order to increase the cseq numbers.

This PR does not revisit that conclusion. The dependency is correct; the documentation
describes it incorrectly. Documentation only, no behaviour change.

**Compatibility**

None affected. The text is identical in `master`, `4.0` and `3.6`, and none of the three
mentions `append_fromtag`.

---

**AI assistance disclosure.** The defect list and the wording of this change were produced
with AI assistance. Every item was checked against the source before submission:

- the second branch and its unconditional check — `uac.c:308-326`;
- the route types `uac_auth()` is exported for — `uac.c:115`;
- `append_fromtag`'s default of 1 — `modules/rr/rr_mod.c:73`;
- the shipped configuration setting it to 0 — `etc/opensips.cfg:61`, and
  `dpkg -S /etc/opensips/opensips.cfg` reports the `opensips` package;
- the 27-against-1 count — repository-wide grep over `*.cfg` and `*.m4`;
- the failure and the negative controls were run, not inferred — the commands and their
  output are quoted above;
- the reason for the dependency is quoted from #773 rather than restated.
