### PR TITLE
docs: correct parameter names that the modules do not export [skip ci]

### DIFF
--- a/modules/domain/README.md
+++ b/modules/domain/README.md
@@ -117,7 +117,7 @@ modparam("domain", "attrs_col", "attributes")
 ```
 
 
-#### subdomain_col (int)
+#### accept_subdomain_col (string)
 
 
 Name of the "accept_subdomain" column in the domain table.
@@ -128,8 +128,8 @@ A 0 value means it does not.
 Default value is "accept_subdomain".
 
 
-```opensips title="Setting subdomain_col parameter"
-modparam("domain", "subdomain_col", "has_subdomain")
+```opensips title="Setting accept_subdomain_col parameter"
+modparam("domain", "accept_subdomain_col", "has_subdomain")
 ```
 
 

--- a/modules/fraud_detection/README.md
+++ b/modules/fraud_detection/README.md
@@ -179,7 +179,7 @@ modparam("fraud_detection", "prefix_col", "myprefix")
 ```
 
 
-#### start_h (string)
+#### start_h_col (string)
 
 
 The column's name in the database storing the
@@ -194,14 +194,14 @@ the format: "HH:MM"
 *Default value is "start_hour".*
 
 
-```opensips title="Set 'start_h' parameter"
+```opensips title="Set 'start_h_col' parameter"
 ...
-modparam("fraud_detection", "start_h", "the_start_time")
+modparam("fraud_detection", "start_h_col", "the_start_time")
 ...
 ```
 
 
-#### end_h (string)
+#### end_h_col (string)
 
 
 The column's name in the database storing the
@@ -216,9 +216,9 @@ the format: "HH:MM"
 *Default value is "end_hour".*
 
 
-```opensips title="Set 'end_h' parameter"
+```opensips title="Set 'end_h_col' parameter"
 ...
-modparam("fraud_detection", "end_h", "the_end_time")
+modparam("fraud_detection", "end_h_col", "the_end_time")
 ...
 ```
 

--- a/modules/http2d/README.md
+++ b/modules/http2d/README.md
@@ -95,7 +95,7 @@ modparam("http2d", "tls_cert_path", "/etc/pki/http2/cert.pem")
 ```
 
 
-#### tls_cert_key (string)
+#### tls_key_path (string)
 
 
 File path to the TLS private key, in PEM format.
@@ -104,8 +104,8 @@ File path to the TLS private key, in PEM format.
 Default value is *NULL* (not set).
 
 
-```opensips title="Setting the tls_cert_key parameter"
-modparam("http2d", "tls_cert_key", "/etc/pki/http2/private/key.pem")
+```opensips title="Setting the tls_key_path parameter"
+modparam("http2d", "tls_key_path", "/etc/pki/http2/private/key.pem")
 ```
 
 

--- a/modules/tls_mgm/README.md
+++ b/modules/tls_mgm/README.md
@@ -796,7 +796,7 @@ modparam("tls_mgm", "ca_dir_col", "ca_dir")
 ```
 
 
-#### cipher_list_col (string)
+#### ciphers_list_col (string)
 
 
 Sets the cipher list column name.
@@ -805,8 +805,8 @@ Sets the cipher list column name.
 Default value is "cipher_list".
 
 
-```opensips title="Usage of cipher_list_col block"
-modparam("tls_mgm", "cipher_list_col", "cipher_list")
+```opensips title="Usage of ciphers_list_col block"
+modparam("tls_mgm", "ciphers_list_col", "cipher_list")
 ```
 
 


### PR DESCRIPTION
**Summary**

Five parameters are documented under a name the module does not export. A configuration
written from these pages does not start — OpenSIPS rejects an unknown `modparam` rather
than ignoring it — and the error names a parameter the documentation told the reader to
set.

| Module | README documents | Code registers |
|---|---|---|
| `domain` | `subdomain_col` | `accept_subdomain_col` — `domain_mod.c:128` |
| `fraud_detection` | `start_h` | `start_h_col` — `fraud_detection.c:100` |
| `fraud_detection` | `end_h` | `end_h_col` — `fraud_detection.c:101` |
| `http2d` | `tls_cert_key` | `tls_key_path` — `http2d.c:71` |
| `tls_mgm` | `cipher_list_col` | `ciphers_list_col` — `tls_mgm.c:150` |

**Details**

Each name was checked in both directions: the documented literal appears in no `.c` or
`.h` file in the tree, and the replacement is the literal on the `param_export_t` line
named above.

Every occurrence in each README was changed — heading, prose and example — so that no
page is left carrying both spellings.

Default values and descriptions are untouched. Two of them sit close to a name in
this change and were deliberately left alone, because they are column values rather than
parameter names: `fraud_detection`'s default `start_hour`, and `tls_mgm`'s default
`cipher_list`.

One further word changed, on a line this PR already rewrites: `domain`'s heading read
`subdomain_col (int)` and the parameter is registered `STR_PARAM` (`domain_mod.c:128`), with a
string default. Leaving a type label that contradicts the code on a heading being rewritten
anyway seemed worse than the one-word inconsistency of touching it here.

Documentation only, no behaviour change.

**Reproduced**

On the official `opensips/opensips:4.0` image, one module and one `modparam` per run, with
`opensips -C`:

```
$ opensips -C -f t.cfg            # the name the README documents
ERROR:core:set_mod_param_regex: parameter <subdomain_col> not found in module <domain>
ERROR:core:parse_opensips_cfg: bad config file (1 errors)

$ opensips -C -f t.cfg            # the name the module registers
(exit 0)
```

Same result for `start_h`, `end_h`, `tls_cert_key` and `cipher_list_col`. The failure is
at configuration parsing, before any module is initialised, so `-C` catches it and the
process never starts.

Two controls: an invented parameter name fails with the identical message, and each
module with the corrected name behaves exactly as the same module with no `modparam` at
all — for `fraud_detection` that means both still stop later on an unrelated missing
dependency, which is what makes it clear the parameter itself was accepted.

`http2d` is not in that image and does not build against Debian's `libnghttp2` 1.43 — the
module uses `nghttp2_ssize`, `nghttp2_data_provider2` and `nghttp2_submit_response2`,
added in nghttp2 1.57. Its row was run on a tree built from source with the bundled
`lib/nghttp2` submodule, against the matching `4.1.0-dev` binary.

**Scope**

Every row here is a documentation defect: the code is right and the page is wrong, and a
`grep` settles each one. The same sweep also found parameters where the *code* carries a
misspelling and the README is the one spelled correctly — those need a decision about
which side to change, so they are not in this PR. Neither are the same class of defect in
the Exported Functions, MI Commands and Statistics sections, nor the names that have no
implementation anywhere in the tree. Different recipes, different severities.

---

**AI assistance disclosure.** The defect list and the wording of this change were produced
with AI assistance. Every item was checked against the source before submission:

- each documented name is absent from the whole tree — repository-wide grep for the
  literal over `*.c` and `*.h`, not only the module's own directory;
- each replacement is the literal registered in `param_export_t` — `domain_mod.c:128`,
  `fraud_detection.c:100` and `:101`, `http2d.c:71`, `tls_mgm.c:150`;
- `domain`'s type label — the parameter is `STR_PARAM` at `domain_mod.c:128` and its
  default is the string `accept_subdomain` at `domain_mod.c:74`, so `(int)` was wrong;
- the two defaults left alone are column values and not parameter names —
  `fraud_detection`'s `start_hour` and `tls_mgm`'s `cipher_list`; replacement was done on
  word boundaries so neither was touched;
- the failures and the successes were run, not inferred — the commands and their output
  are quoted above, on the official 4.0 image;
- the two controls were run as well: an invented parameter name, and each module with no
  `modparam` at all;
- `http2d` was run too, on a source build — the packaged image has neither the module nor
  a new enough `libnghttp2` for it.
