### PR TITLE
mid_registrar: persist TCP connections for absorbed REGISTERs

### DIFF
--- a/modules/mid_registrar/save.c
+++ b/modules/mid_registrar/save.c
@@ -90,6 +90,39 @@ void calc_contact_expires(struct sip_msg* _m, param_t* _ep, int* _e,
 	LM_DBG("expires: %d\n", *_e);
 }
 
+static void persist_tcp_connection(struct sip_msg *msg)
+{
+	contact_t *ct;
+	struct sip_uri uri;
+	int expires, max_expires = 0;
+
+	if (!is_tcp_based_proto(msg->rcv.proto) ||
+	    !(msg->flags & tcp_persistent_flag))
+		return;
+
+	for (ct = get_first_contact(msg); ct; ct = get_next_contact(ct)) {
+		calc_contact_expires(msg, ct->expires, &expires, 1);
+		if (expires <= 0)
+			continue;
+
+		if (parse_uri(ct->uri.s, ct->uri.len, &uri) < 0) {
+			LM_ERR("failed to parse contact <%.*s>\n",
+			       ct->uri.len, ct->uri.s);
+			continue;
+		}
+
+		if (is_tcp_based_proto(uri.proto) && expires > max_expires)
+			max_expires = expires;
+	}
+
+	if (max_expires > 0) {
+		LM_DBG("ensure TCP conn lifetime of at least %d sec\n",
+		       max_expires + 10);
+		trans_set_dst_attr(&msg->rcv, DST_FCNTL_SET_LIFETIME,
+		                   (void *)(long)(max_expires + 10));
+	}
+}
+
 /* with the optionally added outgoing timeout extension
  *
  * @_e: output param (UNIX timestamp) - expiration time on the main registrar
@@ -2694,6 +2727,8 @@ quick_reply:
 
 	if (unlock_udomain)
 		ul.unlock_udomain(d, &sctx.aor);
+
+	persist_tcp_connection(msg);
 
 	/* quick SIP reply */
 	if (!(sctx.flags & REG_SAVE_NOREPLY_FLAG))


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!
In order to consider and evaluate your PR, it is mandatory to provide detailed information about (1) what is the issue the PR addresses, (2) how the PR is solving the issue (logic and coding), (3) what are (if any) limitations of the proposed PR and (4) if there are any known side-effects/ backward compatibility issues/SIP interoperability issues.
Note that if the PR is missing information, it might take longer to be merged, as extra resources have to be allocated by the maintainers to reverse engineer the changes, understand them, understand the motivation, etc. That is why it is important to provide as much information as possible.
-->

**Summary**
When `tcp_persistent_flag` is enabled, TCP connection lifetime is updated only after a forwarded REGISTER receives a successful response.

Absorbed REGISTERs return a local 200 OK without extending the receiving connection, leaving new or refreshed connections at the default lifetime.

**Details**
<!--
Details about the content of the PR - is it a bug fix, a new feature or perhaps a hack? Explain the **motivation** for making this change.
What existing problem does the pull request solve? Is this a particular problem (i.e. only some particular scenarios are affected, only some UACs, etc) or a generic one?
Do not assume others understand what you're trying to do and provide as much information as you may have.
-->

**Solution**
Apply the UAC Contact expiration to the TCP connection in the `quick_reply` path, matching the existing behavior for forwarded registrations.

**Compatibility**
<!-- Does your change break other scenarios, or do they need to be migrated in order to work similarly? -->

**Closing issues**
<!-- Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). -->