### PR TITLE
proto_ws: handle CRLF keep-alives in WS messages

### DIFF
--- a/modules/proto_ws/ws_common.h
+++ b/modules/proto_ws/ws_common.h
@@ -276,6 +276,18 @@ static inline int ws_send_pong(struct tcp_connection *con, struct ws_req *req)
 	return ret;
 }
 
+static inline int ws_send_crlf_pong(struct tcp_connection *con)
+{
+	static char crlf[] = "\r\n";
+	int ret;
+
+	lock_get(&con->write_lock);
+	ret = ws_send(con, con->fd, WS_OP_TEXT, crlf, sizeof(crlf) - 1);
+	lock_release(&con->write_lock);
+
+	return ret;
+}
+
 static inline int ws_send_close(struct tcp_connection *con)
 {
 	uint16_t code;
@@ -544,9 +556,18 @@ again:
 					"keeping connection \n");
 			}
 
-			if (tcp_dispatch_msg(msg_buf, msg_len,
-					&local_rcv, NULL, 0) < 0)
-				LM_ERR("failed to deliver WS message\n");
+			if (msg_len == 4 && msg_buf[0] == '\r' && msg_buf[1] == '\n' &&
+			    msg_buf[2] == '\r' && msg_buf[3] == '\n') {
+				if (ws_send_crlf_pong(con) < 0)
+					LM_ERR("cannot send CRLF pong\n");
+			} else if (msg_len == 2 && msg_buf[0] == '\r' &&
+			           msg_buf[1] == '\n') {
+				LM_DBG("Received CRLF pong\n");
+			} else {
+				if (tcp_dispatch_msg(msg_buf, msg_len,
+						&local_rcv, NULL, 0) < 0)
+					LM_ERR("failed to deliver WS message\n");
+			}
 
 			*req->tcp.parsed = bk;
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!
In order to consider and evaluate your PR, it is mandatory to provide detailed information about (1) what is the issue the PR addresses, (2) how the PR is solving the issue (logic and coding), (3) what are (if any) limitations of the proposed PR and (4) if there are any known side-effects/ backward compatibility issues/SIP interoperability issues.
Note that if the PR is missing information, it might take longer to be merged, as extra resources have to be allocated by the maintainers to reverse engineer the changes, understand them, understand the motivation, etc. That is why it is important to provide as much information as possible.
-->

**Summary**
<!-- Summary of the PR - what the PR is aiming to solve -->
Browser WebSocket APIs cannot send native WebSocket Ping frames, so browser-based SIP clients use the RFC 5626 CRLF keep-alive mechanism, as permitted by RFC 7118.

**Details**
<!--
Details about the content of the PR - is it a bug fix, a new feature or perhaps a hack? Explain the **motivation** for making this change.
What existing problem does the pull request solve? Is this a particular problem (i.e. only some particular scenarios are affected, only some UACs, etc) or a generic one?
Do not assume others understand what you're trying to do and provide as much information as you may have.
-->

**Solution**
<!-- Explain how your PR fixes the problem. Are there any remaining concerns that might need to be addressed? -->
Recognize double-CRLF pings and single-CRLF pongs carried in WebSocket data frames. Reply with a single-CRLF text frame and prevent these keep-alives from reaching the SIP parser.

This applies to both WS and WSS transports.

**Compatibility**
<!-- Does your change break other scenarios, or do they need to be migrated in order to work similarly? -->

**Closing issues**
<!-- Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). -->
