### PR TITLE
httpd: fix the misspelled access handler callback typedef

### DIFF
--- a/modules/httpd/README.md
+++ b/modules/httpd/README.md
@@ -371,7 +371,7 @@ setcap 'cap_net_bind_service=+ep' /usr/local/sbin/opensips
 ### Available Functions
 
 
-#### register_httpdcb (module, root_path, httpd_access_handler_cb, httpd_flush_data_cb, httpd_init_proc_cb)
+#### register_httpdcb (module, root_path, httpd_access_handler_cb, httpd_flush_data_cb, HTTPD_CONTENT_TYPE, httpd_init_proc_cb)
 
 
 Register a new http root with it's associated callbacks into the httpd module.
@@ -388,6 +388,8 @@ Meaning of the parameters is as follows:
 			- handler to the callback method to be called on root path match;
 - *httpd_flush_data_cb f2*
 			- handler to the callback method to be called for sending extra data (at a later time);
+- *enum HTTPD_CONTENT_TYPE type*
+			- the Content-Type header to be set on the responses sent for this root path; HTTPD_STD_CNT_TYPE leaves it as text/html;
 - *httpd_init_proc_cb f3*
 			- handler to the callback method to be called during httpd process init;
 <!-- CONTRIBUTORS -->

--- a/modules/httpd/httpd.c
+++ b/modules/httpd/httpd.c
@@ -237,7 +237,7 @@ static void destroy(void)
 
 
 int httpd_register_httpdcb(const char *module, str *http_root,
-			httpd_acces_handler_cb f1,
+			httpd_access_handler_cb f1,
 			httpd_flush_data_cb f2,
 			enum HTTPD_CONTENT_TYPE type,
 			httpd_init_proc_cb f3)
@@ -252,7 +252,7 @@ int httpd_register_httpdcb(const char *module, str *http_root,
 		LM_ERR("NULL http root path\n"); return -1;
 	}
 	if (!f1) {
-		LM_ERR("NULL acces handler cb\n"); return -1;
+		LM_ERR("NULL access handler cb\n"); return -1;
 	}
 	if (!f2) {
 		LM_ERR("NULL flush data cb\n"); return -1;

--- a/modules/httpd/httpd_load.h
+++ b/modules/httpd/httpd_load.h
@@ -65,7 +65,7 @@ enum HTTPD_CONTENT_TYPE {
  *             callback (see httpd_flush_data_cb)
  * @returns code the HTTP code to be returned to the client
  */
-typedef int (httpd_acces_handler_cb) (void *cls, void *connection, const char *url,
+typedef int (httpd_access_handler_cb) (void *cls, void *connection, const char *url,
 				const char *method, const char *version,
 				const char *upload_data, size_t upload_data_size,
 				void **con_cls,
@@ -112,7 +112,7 @@ typedef void (httpd_init_proc_cb) (void);
 struct httpd_cb {
 	const char *module;
 	str *http_root;
-	httpd_acces_handler_cb *callback;
+	httpd_access_handler_cb *callback;
 	httpd_flush_data_cb *flush_data_callback;
 	httpd_init_proc_cb *init_proc_callback;
 	enum HTTPD_CONTENT_TYPE type;
@@ -126,12 +126,8 @@ void lookup_arg(void *connection, const char *key,
 typedef void (*lookup_arg_f)(void *connection, const char *key,
 			void *con_cls, str *val);
 
-int register_httpdcb(const char *mod, str *root_path,
-			httpd_acces_handler_cb f1,
-			httpd_flush_data_cb f2,
-			httpd_init_proc_cb f3);
 typedef int (*register_httpdcb_f)(const char *mod, str *root_path,
-			httpd_acces_handler_cb f1,
+			httpd_access_handler_cb f1,
 			httpd_flush_data_cb f2,
 			enum HTTPD_CONTENT_TYPE type,
 			httpd_init_proc_cb f3);


### PR DESCRIPTION
**Summary**

The `httpd` module declares its access handler callback as `httpd_acces_handler_cb`,
missing an `s`. It is the last misspelled identifier left in the tree, and since 5 August
it is also a contradiction: the README spells the callback correctly and the header does
not, so the published Developer Guide names a type that does not compile.

Correcting it opened two older defects in the same three lines of the same page. All three
are fixed here.

| # | Defect | Since |
|---|---|---|
| 1 | `httpd_acces_handler_cb` is misspelled in the header and the implementation | 9e86d39d9, 2012 |
| 2 | `httpd_load.h` declares `register_httpdcb()`, a function that has never existed | 9e86d39d9, 2012 |
| 3 | The Developer Guide documents that dead prototype, one parameter short | 02638044d, 2013 |

**Details**

**1. The typedef.** Five occurrences: `httpd_load.h:68` (the typedef), `:115` (the
`struct httpd_cb` member), `:130` and `:134` (two declarations), and `httpd.c:240` (the
implementation's signature). A sixth is the error message beside the check that uses it,
`httpd.c:255` — `"NULL acces handler cb"`.

For fourteen years the documentation matched the code. e941906dd9 (*docs: fix README.md
typos*, 5 Aug 2026) corrected the page, which is right about English and leaves the two
sides disagreeing: `docs.opensips.org/manual/devel/modules/httpd/` and `/manual/4-1/`
publish `httpd_access_handler_cb` today, and a module written from that page does not
build. This PR closes the gap from the other side rather than reverting that commit.

It is the last one of its kind. Sweeping `.c` and `.h` for the usual misspellings —
`lenght`, `recieve`, `seperat`, `occured`, `sucess`, `paramater`, `treshold`, `adress`,
`priviledge`, `notifiy`, `defualt` — every surviving hit is in a comment or a log string.
`treshold`, `adress` and `paramater` were removed from identifiers years ago;
`httpd_acces_handler_cb` is the only one still in an identifier.

**2. A prototype with no function.** `httpd_load.h:129-133` declared

```c
int register_httpdcb(const char *mod, str *root_path,
			httpd_acces_handler_cb f1,
			httpd_flush_data_cb f2,
			httpd_init_proc_cb f3);
```

No such function exists, and none ever has. The implementation is `httpd_register_httpdcb`
(`httpd.c:240`), assigned to the api struct at `httpd.c:302`, and the five consumers reach
it as `httpd_api.register_httpdcb(...)`. `nm -D` on `httpd.so` lists
`httpd_register_httpdcb` and no `register_httpdcb`, so nothing could ever have linked
against the declaration.

**3. The documented signature is one parameter short.** 02638044d (2013) added
`enum HTTPD_CONTENT_TYPE type` to the `register_httpdcb_f` pointer that modules actually
call, and updated neither the prototype above nor the page. The Developer Guide section
was written in 2012 against the dead five-parameter prototype — it is unchanged since,
including through the move from `doc/httpd_devel.xml` to `README.md`. All five call sites
in the tree pass six arguments.

**Solution**

Rename the typedef to `httpd_access_handler_cb` and fix the same word in the error
message. Remove the dead prototype rather than correct it: a corrected prototype would
still be a declaration with no definition. Document `type` in its real position, between
`f2` and `f3`; the callback's name on that page is already correct and is left alone.

**Reproduced**

Debian 12, `opensips 4.1.0-dev` built from this branch:

- the core and every module that uses the API — `httpd`, `mi_http`, `mi_html`,
  `mi_xmlrpc`, `pi_http`, `prometheus` — compile with no warning and no error;
- **the exported symbols do not change.** `nm -D --defined-only httpd.so`, built from
  `master` and from this branch, is identical — 31 symbols. A typedef exists only at
  compile time, so there is no ABI effect to weigh;
- it still works at runtime. `httpd` + `mi_http`, MI over HTTP:

```
$ curl -s -X POST -d '{"jsonrpc":"2.0","id":1,"method":"version"}' http://127.0.0.1:8888/mi/
{"jsonrpc":"2.0","result":{"Server":"OpenSIPS (4.1.0-dev (aarch64/linux))"},"id":1}

$ curl -s -o /dev/null -D - -X POST -d '...' http://127.0.0.1:8888/mi/ | grep -i content-type
Content-Type: application/json
```

That header is what the newly documented `type` parameter selects — `mi_http` registers
with `HTTPD_APPLICATION_JSON_CNT_TYPE`.

**Where else this text appears**

`master` only. On `4.0` and `3.6` the header and the README both say `acces`, so the
contradiction this PR resolves does not exist there, and renaming a type mid-release
branch would be a change without a reason. Defects 2 and 3 are on those branches as well;
whether they are worth the same patch is the maintainers' call, not something I have
assumed.

**Compatibility**

Nothing breaks. The typedef is compile-time only, no module outside `httpd` names it, and
`make install` does not install module headers — no package exposes the old spelling to
anything built out of tree. No compatibility `#define` is kept, following 36a09ee7ab
(*dispatcher: Fix modparam typo*), which renamed the C variable outright and kept the old
spelling only for the script-facing `modparam`; there is no script-facing name here. If
you would rather have one, say so and I will add it.

This is a functional change, so CI runs on it — no `[skip ci]`.

---

**AI assistance disclosure.** This change and its wording were produced with AI assistance.
Every item was checked against the source before submission:

- the five occurrences and the log message — `httpd_load.h:68`, `:115`, `:130`, `:134`,
  `httpd.c:240` and `:255`;
- the typo dates to the module's first commit — the header has fifteen commits in its full
  history and 9e86d39d9 (2012-01-25) already carries it;
- the documentation matched the code until e941906dd9 — at its parent commit
  `README.md:374` and `:387` read `acces`;
- what the site serves today — `docs.opensips.org/manual/devel/modules/httpd/` and
  `/manual/4-1/` show `access`, `/manual/4-0/` still shows `acces`;
- the census of surviving misspellings — repository-wide grep over `*.c` and `*.h` for
  eleven common misspellings, each hit classified as identifier or prose;
- `register_httpdcb` has never been defined — `git log -S` over the full history returns
  only the 2012 commit that added the declaration, and `nm -D` confirms it is not
  exported;
- the missing parameter and its date — 02638044d (2013); the original 2012
  `doc/httpd_devel.xml` documents the same five parameters as the page does now;
- the builds, the symbol comparison and the HTTP request were run, not inferred — the
  output is quoted above;
- the precedent, including that it kept no alias for the C identifier — 36a09ee7ab.

