### PR TITLE
sipcapture: fix modparam typo (promiscious_on)

### DIFF
--- a/modules/sipcapture/examples/opensips.cfg
+++ b/modules/sipcapture/examples/opensips.cfg
@@ -45,8 +45,8 @@ modparam("sipcapture", "raw_moni_capture_on", 0)
 /* My table name*/
 modparam("sipcapture", "table_name", "sip_capture")
 modparam("sipcapture", "raw_sock_children", 4)
-/* Promiscious mode */
-modparam("sipcapture", "promiscious_on", 1)
+/* Promiscuous mode */
+modparam("sipcapture", "promiscuous_on", 1)
 
 ####### Routing Logic ########
 

--- a/modules/sipcapture/sipcapture.c
+++ b/modules/sipcapture/sipcapture.c
@@ -597,7 +597,9 @@ static const param_export_t params[] = {
 	{"raw_moni_capture_on",		INT_PARAM|USE_FUNC_PARAM,
 		(void*)sipcapture_set_moni_capture   },
 	{"raw_interface",     		STR_PARAM, &raw_interface.s   },
+        /* kept for backwards-compatibility */
         {"promiscious_on",  		INT_PARAM, &promisc_on   },
+        {"promiscuous_on",  		INT_PARAM, &promisc_on   },
         {"raw_moni_bpf_on",  		INT_PARAM, &bpf_on   },
 	{"hep_route",		STR_PARAM, &hep_route_name},
 	{0, 0, 0}


### PR DESCRIPTION
**Summary**

`sipcapture` registers `promiscious_on`; its README documents `promiscuous_on`. Unlike
#4243, where the two sides had agreed for seventeen years and diverged last month, both
spellings arrived here in the same commit — c259878f1e, 18 November 2011 — so the
documented name has never worked. A configuration written from the page does not start.

This is the last member of the class announced in #4241's *Scope* section: a parameter
where the code carries the misspelling and the page is the one spelled correctly. A fresh
sweep of all 193 modules against 08e7f1c37a finds no others.

**Why the code and not the documentation**

- the misspelling is confined to one string literal. The variable it writes to is already
  spelled correctly — `promisc_on`, `sipcapture.c:443` — and is used under that name at
  `:1019` and `:2365`;
- the sibling project agrees. `sipcapture` came to both projects from the Homer Project,
  and Kamailio carried the same typo through its 3.2, 3.3, 4.0, 4.4, 5.0 and 5.1 branches.
  From 5.2 onwards it registers `promiscuous_on`, with the old spelling dropped rather than
  kept. Two forks of one file, arriving independently at the same conclusion about which
  name was intended;
- the documented spelling is the project's own, not mine. `doc/sipcapture_admin.xml` from
  the 2011 commit already reads `promiscuous_on`, in the heading, the example title and
  the example line — all three survive into today's `README.md:272`, `:282` and `:284`.

**What this changes**

`params[]` registers both names against the same variable:

```c
/* kept for backwards-compatibility */
{"promiscious_on",  		INT_PARAM, &promisc_on   },
{"promiscuous_on",  		INT_PARAM, &promisc_on   },
```

The old name is kept, unlike Kamailio: it is the only name that has ever worked in
OpenSIPS, so every configuration setting it in the field is setting the misspelling.

The module's own sample, `modules/sipcapture/examples/opensips.cfg:49`, is switched to the
documented name — it was the one file in the tree teaching the misspelling. The comment
directly above it, in the same hunk, said *Promiscious mode*; that word is corrected too.

No documentation change is needed: the README already documents the correct name, and
after this it is true.

**Reproduced**

Debian 12, `opensips 4.1.0-dev` built from source, `sipcapture` loaded with `db_text` and
the UDP transport. A temporary probe at the top of `mod_init()` printed the variable, and
was thrown away afterwards:

| configuration | value in `promisc_on` |
|---|---|
| no `modparam` | 0 (the default) |
| `promiscious_on` = 42 | 42 |
| `promiscuous_on` = 7 | 7 |
| both, 42 then 7 | 7 |

The last row is the point: the two names write to one variable, so the later assignment
wins. On stock `master` the third row does not get that far:

```
$ opensips -C -f t.cfg
ERROR:core:set_mod_param_regex: parameter <promiscuous_on> not found in module <sipcapture>
CRITICAL:core:yyerror: parse error in t.cfg:11:19-20: Parameter <promiscuous_on> not found in module <sipcapture> - can't set
```

Two controls after the change: `promiscuos_on` and `promiscuous_off` are still refused
with that same message, so the module gained exactly the one name and not a loose match.
The module compiles with no new warning.

**Compatibility**

None broken. A configuration setting `promiscious_on` keeps working and keeps writing the
same variable. The parameter is not set anywhere else in the repository, and the one
sample that did set it is updated in this commit — it works either way now.

This is a functional change, so CI runs on it — no `[skip ci]`.

---

**AI assistance disclosure.** This change and its wording were produced with AI assistance.
Every item was checked against the source before submission:

- the registered name and the variable — `sipcapture.c:600` and `:443`, the variable used
  at `:1019` and `:2365`;
- both spellings date to the same commit — `git log -S` over the full history returns only
  c259878f1e for either, and that commit's `doc/sipcapture_admin.xml` is quoted above;
- the three occurrences in today's page — `README.md:272`, `:282`, `:284`;
- Kamailio's spelling per branch — the `sipcapture.c` served for each of 3.2, 3.3, 4.0,
  4.4, 5.0, 5.1 and 5.2. I could not pin the commit that changed it: blame stops at a 2024
  reformat and the change is not in the file's history between the 5.1 and 5.2 branch
  points, so this says "from 5.2 onwards" and no more;
- that this is the last of the class — the sweep re-run against 08e7f1c37a over every
  module's Exported Parameters section, each candidate confirmed by a repository-wide grep
  for the literal;
- the precedent, including that it kept the old name — 36a09ee7ab, and our own #4243;
- the four configurations and the two controls were run against a build of this branch,
  and the failing case against a build of `master` — the output is quoted above.

