### PR TITLE
docs: remove the sections of features that no longer exist

### DIFF
--- a/modules/lua/README.md
+++ b/modules/lua/README.md
@@ -128,14 +128,6 @@ the lua script.
 Disabled by default.
 
 
-#### warn_missing_free_fixup (int)
-
-
-When you call a function via moduleFunc() you could have a memleak.
-Enable this warns you when you're doing it.
-Enabled by default.
-
-
 #### lua_allocator (string)
 
 
@@ -235,12 +227,6 @@ level is one of the following:
 - NOTICE
 - INFO
 - DBG
-
-
-#### WarnMissingFreeFixup
-
-
-Dynamically change the variable warn_missing_free_fixup.
 
 
 #### getpid

--- a/modules/presence_callinfo/README.md
+++ b/modules/presence_callinfo/README.md
@@ -139,12 +139,11 @@ the script.
 
 
 To trigger the internal publishing (from the dialog module) for a
-certain call, use the "sca_set_calling_line()" or
-"sca_set_called_line()" functions from the script when handling a
-new call. These functions will do all the work (creating dialog, 
-setting the internal publishing, etc) - you just need to use them
-and eventually specify the name of the line (if other then the one
-from the SIP INVITE) - see the below documentation.
+certain call, use the "sca_set_called_line()" function from the
+script when handling a new call. This function will do all the work
+(creating dialog, setting the internal publishing, etc) - you just
+need to use it and eventually specify the name of the line (if other
+then the one from the SIP INVITE) - see the below documentation.
 
 
 LIMITATIONS : in this mode, the module does not really check if the
@@ -253,32 +252,6 @@ modparam("presence_callinfo", "line_hash_size", 128)
 
 
 ### Exported Functions
-
-
-#### sca_set_calling_line([line])
-
-
-The function (to be used only in internal publishing mode) is setting
-for the current new call (initinal INVITE) the outbound line - the line
-used for calling out.
-
-
-If no parameter is provided, the name of the line is taken from the
-SIP FROM header of the INVITE. You can override that by providing 
-the name of the line as a string parameter - be careful as the value must be
-a SIP URI !
-
-
-This function can be used from REQUEST_ROUTE.
-
-
-```opensips title="sca_set_calling_line() usage"
-...
-	if (is_method("INVITE") and !has_totag()) {
-		sca_set_calling_line();
-	}
-...
-```
 
 
 #### sca_set_called_line([line])

--- a/modules/ratelimit/README.md
+++ b/modules/ratelimit/README.md
@@ -844,27 +844,6 @@ opensips-cli -x mi ratelimit:get_pid
 ```
 
 
-#### rl_bin_status
-
-
-Dumps each destination used for replication, as well as
-the timestamp of the last message received from them.
-
-
-Name: *rl_bin_status*
-
-
-Parameters: *none*
-
-
-MI FIFO Command Format:
-
-
-```bash
-opensips-cli -x mi rl_bin_status
-```
-
-
 ### Exported Pseudo-Variables
 
 


### PR DESCRIPTION
**Summary**

Four documented names have no implementation anywhere in the tree. None is a typo and none
is a rename — there is nothing to point the documentation at, because in each case the
feature was removed by a deliberate commit that did not touch the page describing it.

| Module | Section | Documented | Removed by | When |
|---|---|---|---|---|
| `lua` | Exported Parameters | `warn_missing_free_fixup` | 4b43ab5245 *lua: fix calling of script module functions from lua code* | 2019-05-27 |
| `lua` | Available functions | `WarnMissingFreeFixup` | same commit | 2019-05-27 |
| `ratelimit` | Exported MI Functions | `rl_bin_status` | 62b279927f *ratelimit: port MI commands to jsonrpc* | 2018-12-03 |
| `presence_callinfo` | Exported Functions | `sca_set_calling_line()` | 283b529ca7 *presence_callinfo: Add support for inbound SCA call flows* | 2025-12-10 |

This removes those four sections. Documentation only.

**Details**

**`lua`.** 4b43ab5245 rewrote how script module functions are called from Lua and deleted,
in one commit, `int warn_missing_free_fixup = 1`, its `param_export_t` entry, the `extern`,
the Lua binding `l_sipstate_WarnMissingFreeFixup()` and its `luaL_Reg` entry. What the
parameter warned about went with it: the old path logged *"A fixup function was called
without corresponding free_fixup"* when `free_fixup` was absent, while the code that
replaced it calls `param->free_fixup` and fails loudly if that returns an error
(`sipapi.c:775-783`). There is no longer a case to warn about. Today `siplua_state_mylib`
(`sipstate.c:291-304`) exports twelve functions and none is `WarnMissingFreeFixup`.

**`ratelimit`.** 62b279927f ported the MI commands to JSON-RPC and dropped
`{"rl_bin_status", RLH5, mi_bin_status, MI_NO_INPUT_FLAG, 0, 0}` together with
`rl_bin_status()` itself in `ratelimit_helper.c`. The module now exports five MI commands —
`list`, `dump_pipe`, `reset_pipe`, `set_pid`, `get_pid`, each with its `rl_`-prefixed alias.

**`presence_callinfo`.** 283b529ca7 removed the prototype, the `cmd_export_t` entry and
the body of `sca_set_calling_line()`. One sentence in the Overview named it beside
`sca_set_called_line()`, which still exists; that sentence is reworded rather than dropped,
and nothing else in it is touched.

**Reproduced**

`opensips 4.1.0-dev`, Debian 12, built from source. Each of the three fails at a different
point, which is why one page cannot warn the reader about the next:

```
$ opensips -C -f l.cfg            # modparam("lua", "warn_missing_free_fixup", 1)
ERROR:core:set_mod_param_regex: parameter <warn_missing_free_fixup> not found in module <lua>

$ opensips -C -f p.cfg            # sca_set_calling_line();
CRITICAL:core:yyerror: parse error in p.cfg:9:29-30: unknown command <sca_set_calling_line>, missing loadmodule?
```

and, on a running instance with `ratelimit` and `mi_http`:

```
rl_bin_status   -> {"jsonrpc":"2.0","error":{"code":-32601,"message":"Method not found"},"id":1}
rl_list         -> {"jsonrpc":"2.0","result":{"Pipes":[],"drop_rate":0},"id":1}
ratelimit:list  -> {"jsonrpc":"2.0","result":{"Pipes":[],"drop_rate":0},"id":1}
```

`which` on that instance lists `ratelimit:list`, `ratelimit:reset_pipe`,
`ratelimit:set_pid`, `ratelimit:get_pid` and `ratelimit:dump_pipe`, and no
`rl_bin_status`.

The fourth name, the Lua-side `WarnMissingFreeFixup`, is not run: reaching it needs a Lua
script and the binding table settles it on its own — the 2019 commit removed the
`luaL_Reg` entry and nothing has added it back.

**Scope**

Deletion only, and only where the tree is unambiguous: each of the four literals appears in
no `.c`, `.h` or `.cpp` file, and `git log -S` over the full history names exactly one
commit that removed it. Nothing else on these three pages is changed apart from the single
Overview sentence that could not survive the deletion.

If any of these is meant to come back rather than to stay removed, say so and I will drop
that row instead — but each was removed as part of a refactor that replaced what it did,
not disabled pending work.

**Compatibility**

Documentation only, no behaviour change. Nothing that works today stops working: none of
the four documented names can be used, and no file in the repository links to the removed
anchors.

---

**AI assistance disclosure.** The defect list and the wording of this change were produced
with AI assistance. Every item was checked against the source before submission:

- each of the four literals is absent from the whole tree — repository-wide grep over
  `*.c`, `*.h` and `*.cpp`, not only the module's own directory;
- the removing commit for each was found with `git log -S` over the full history, and its
  diff was read rather than inferred — the removed `param_export_t`, `luaL_Reg`,
  `mi_export_t` and `cmd_export_t` entries are quoted from those diffs;
- what replaced the `lua` warning — `sipapi.c:775-783` calls `param->free_fixup` and errors
  on failure, so the condition it warned about no longer arises;
- what `ratelimit` exports today — its `mi_export_t` array, confirmed against a running
  instance;
- three of the four failures were run, not inferred, each at its own failure point, and the
  output is quoted above; the fourth is stated as unrun with the reason;
- no file links to the removed anchors — repository-wide grep for each.
